### PR TITLE
Add PlayerMock#getAttackCooldown()

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -1925,4 +1925,11 @@ public class PlayerMock extends LivingEntityMock implements Player
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
 	}
+
+	@Override
+	public float getAttackCooldown()
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
 }


### PR DESCRIPTION
Bukkit added `Player#getAttackCooldown()' upstream. As usual, they published it without bumping any version number. This means MockBukkit will randomly break when Bukkit feels like it...