### PR TITLE
Fixed constructors for ItemMetas

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BookMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BookMetaMock.java
@@ -31,7 +31,7 @@ public class BookMetaMock extends ItemMetaMock implements BookMeta {
         
         this.title = meta.getTitle();
         this.author = meta.getAuthor();
-        this.pages = meta.getPages();
+        this.pages = new ArrayList<>(meta.getPages());
     }
 
     @Override

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BookMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BookMetaMock.java
@@ -21,6 +21,18 @@ public class BookMetaMock extends ItemMetaMock implements BookMeta {
     private String title;
     private List<String> pages = new ArrayList<>();
     private String author;
+    
+    public BookMetaMock() {
+        super();
+    }
+    
+    public BookMetaMock(BookMeta meta) {
+        super(meta);
+        
+        this.title = meta.getTitle();
+        this.author = meta.getAuthor();
+        this.pages = meta.getPages();
+    }
 
     @Override
 	public int hashCode()

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/EnchantedBookMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/EnchantedBookMetaMock.java
@@ -27,7 +27,7 @@ public class EnchantedBookMetaMock extends ItemMetaMock implements EnchantmentSt
     public EnchantedBookMetaMock(EnchantmentStorageMeta meta) {
         super(meta);
         
-        this.storedEnchantments = meta.getStoredEnchants();
+        this.storedEnchantments = new HashMap<>(meta.getStoredEnchants());
     }
     
     @Override

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/EnchantedBookMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/EnchantedBookMetaMock.java
@@ -20,6 +20,16 @@ public class EnchantedBookMetaMock extends ItemMetaMock implements EnchantmentSt
 
     private Map<Enchantment, Integer> storedEnchantments = new HashMap<>();
     
+    public EnchantedBookMetaMock() {
+        super();
+    }
+    
+    public EnchantedBookMetaMock(EnchantmentStorageMeta meta) {
+        super(meta);
+        
+        this.storedEnchantments = meta.getStoredEnchants();
+    }
+    
     @Override
     public int hashCode() {
         final int prime = 31;

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SkullMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SkullMetaMock.java
@@ -14,6 +14,16 @@ import org.bukkit.inventory.meta.SkullMeta;
  **/
 public class SkullMetaMock extends ItemMetaMock implements SkullMeta {
     private String owner;
+    
+    public SkullMetaMock() {
+        super();
+    }
+    
+    public SkullMetaMock(SkullMeta meta) {
+        super(meta);
+        
+        this.owner = meta.getOwningPlayer().getName();
+    }
 
     @Override
     public String getOwner() {


### PR DESCRIPTION
I first didn't realize the ItemMeta Mock classes would need constructors, since none of them had any.
However while writing Unit Tests for them I ran into a `NoSuchMethodException`.
Apparently every Mock ItemMeta class requires a second constructor which takes its original counterpart as an argument as seen here:
https://github.com/seeseemelk/MockBukkit/blob/v1.15/src/main/java/be/seeseemelk/mockbukkit/inventory/ItemFactoryMock.java#L102

This Pull Request adresses and fixes this.
Also had I written Unit Tests before, this would have been noticed quicker but oh well.

P.S. Sorry in advance for bombarding you with pull requests, there will be more down the line because I intend to use this library for a big project.