### PR TITLE
Implemented keepInventory, added an OfflinePlayerMock and more methods to Player/Inventory Mocks

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
@@ -1255,11 +1255,10 @@ public class WorldMock implements World
 		throw new UnimplementedOperationException();
 	}
 	
-	@SuppressWarnings("unchecked")
 	@Override
 	public <T> T getGameRuleValue(GameRule<T> rule)
 	{
-		return (T) gameRules.get(rule);
+		return rule.getType().cast(gameRules.get(rule));
 	}
 	
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -468,8 +468,7 @@ public abstract class EntityMock implements Entity, MessageTarget
 	@Override
 	public boolean isValid()
 	{
-		// TODO Auto-generated constructor stub
-		throw new UnimplementedOperationException();
+		return !isDead();
 	}
 	
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -1,6 +1,7 @@
 package be.seeseemelk.mockbukkit.entity;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.List;
@@ -26,6 +27,7 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.BoundingBox;
@@ -75,11 +77,12 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		if (health <= 0)
 		{
 			this.health = 0;
-			EntityDeathEvent event;
 
 			if (this instanceof Player) {
 			    Player player = (Player) this;
-				event = new PlayerDeathEvent(player, new ArrayList<>(), 0, getName() + " got killed");
+			    List<ItemStack> drops = Arrays.asList(player.getInventory().getContents());
+				PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 0, getName() + " got killed");
+				Bukkit.getPluginManager().callEvent(event);
 
 				// Clear the Inventory if keep-inventory is not enabled
 				if (!getWorld().getGameRuleValue(GameRule.KEEP_INVENTORY).booleanValue()) {
@@ -87,10 +90,11 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 				    // Should someone try to provoke a RespawnEvent, they will now find the Inventory to be empty
 				}
 			} else {
-				event = new EntityDeathEvent(this, new ArrayList<>(), 0);
+			    EntityDeathEvent event = new EntityDeathEvent(this, new ArrayList<>(), 0);
+				Bukkit.getPluginManager().callEvent(event);
 			}
 			
-			Bukkit.getPluginManager().callEvent(event);
+			
 			alive = false;
 		}
 		else

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -1,11 +1,16 @@
 package be.seeseemelk.mockbukkit.entity;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
-import be.seeseemelk.mockbukkit.attribute.AttributeInstanceMock;
-import com.google.common.base.Function;
 import org.bukkit.Bukkit;
 import org.bukkit.FluidCollisionMode;
+import org.bukkit.GameRule;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
@@ -16,7 +21,6 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
-import org.bukkit.event.Event;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
@@ -28,14 +32,18 @@ import org.bukkit.util.BoundingBox;
 import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
 
+import com.google.common.base.Function;
+
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import be.seeseemelk.mockbukkit.attribute.AttributeInstanceMock;
 
 public abstract class LivingEntityMock extends EntityMock implements LivingEntity
 {
 	private static final double MAX_HEALTH = 20.0;
 	private double health;
 	private double maxHealth = MAX_HEALTH;
+	private boolean alive = true;
 	protected Map<Attribute, AttributeInstanceMock> attributes;
 
 	public LivingEntityMock(ServerMock server, UUID uuid)
@@ -54,6 +62,12 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	{
 		return health;
 	}
+	
+	@Override
+	public boolean isDead() 
+	{
+	    return !alive;
+	}
 
 	@Override
 	public void setHealth(double health)
@@ -61,21 +75,27 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		if (health <= 0)
 		{
 			this.health = 0;
-			Event event;
-			if(this instanceof PlayerMock){
-				event = new PlayerDeathEvent((Player) this, new ArrayList<>(), 0, getName() + " got killed");
+			EntityDeathEvent event;
+
+			if (this instanceof Player) {
+			    Player player = (Player) this;
+				event = new PlayerDeathEvent(player, new ArrayList<>(), 0, getName() + " got killed");
+
+				// Clear the Inventory if keep-inventory is not enabled
+				if (!getWorld().getGameRuleValue(GameRule.KEEP_INVENTORY).booleanValue()) {
+				    player.getInventory().clear();
+				    // Should someone try to provoke a RespawnEvent, they will now find the Inventory to be empty
+				}
 			} else {
 				event = new EntityDeathEvent(this, new ArrayList<>(), 0);
 			}
+			
 			Bukkit.getPluginManager().callEvent(event);
-		}
-		else if (health > getMaxHealth())
-		{
-			this.health = getMaxHealth();
+			alive = false;
 		}
 		else
 		{
-			this.health = health;
+			this.health = Math.min(health, getMaxHealth());
 		}
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/OfflinePlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/OfflinePlayerMock.java
@@ -1,0 +1,229 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.Statistic;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+
+/**
+ * A Mock specifically for {@link OfflinePlayer}. Not interchangeable with {@link PlayerMock}.
+ * 
+ * 
+ * @author TheBusyBiscuit
+ * 
+ * @see PlayerMock
+ *
+ */
+public class OfflinePlayerMock implements OfflinePlayer {
+
+    private final UUID uuid;
+    private final String name;
+
+    public OfflinePlayerMock(UUID uuid, String name) {
+        this.uuid = uuid;
+        this.name = name;
+    }
+
+    public OfflinePlayerMock(String name) {
+        this(UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes()), name);
+    }
+
+    @Override
+    public boolean isOnline() {
+        return false;
+    }
+
+    @Override
+    public @Nullable String getName() {
+        return name;
+    }
+
+    @Override
+    public @NotNull UUID getUniqueId() {
+        return uuid;
+    }
+
+    @Override
+    public boolean isOp() {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public void setOp(boolean value) {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public @NotNull Map<String, Object> serialize() {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public boolean isBanned() {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public boolean isWhitelisted() {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public void setWhitelisted(boolean value) {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public @Nullable Player getPlayer() {
+        return MockBukkit.getMock().getPlayerExact(name);
+    }
+
+    @Override
+    public long getFirstPlayed() {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public long getLastPlayed() {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public boolean hasPlayedBefore() {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public @Nullable Location getBedSpawnLocation() {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public void incrementStatistic(@NotNull Statistic statistic) {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public void decrementStatistic(@NotNull Statistic statistic) {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public void incrementStatistic(@NotNull Statistic statistic, int amount) {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public void decrementStatistic(@NotNull Statistic statistic, int amount) {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public void setStatistic(@NotNull Statistic statistic, int newValue) {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public int getStatistic(@NotNull Statistic statistic) {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public void incrementStatistic(@NotNull Statistic statistic, @NotNull Material material) {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public void decrementStatistic(@NotNull Statistic statistic, @NotNull Material material) {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public int getStatistic(@NotNull Statistic statistic, @NotNull Material material) {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public void incrementStatistic(@NotNull Statistic statistic, @NotNull Material material, int amount) {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public void decrementStatistic(@NotNull Statistic statistic, @NotNull Material material, int amount) {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public void setStatistic(@NotNull Statistic statistic, @NotNull Material material, int newValue) {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public void incrementStatistic(@NotNull Statistic statistic, @NotNull EntityType entityType) {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public void decrementStatistic(@NotNull Statistic statistic, @NotNull EntityType entityType) {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public int getStatistic(@NotNull Statistic statistic, @NotNull EntityType entityType) {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public void incrementStatistic(@NotNull Statistic statistic, @NotNull EntityType entityType, int amount) {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public void decrementStatistic(@NotNull Statistic statistic, @NotNull EntityType entityType, int amount) {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+    @Override
+    public void setStatistic(@NotNull Statistic statistic, @NotNull EntityType entityType, int newValue) {
+        // TODO Auto-generated method stub
+        throw new UnimplementedOperationException();
+    }
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -64,6 +64,8 @@ import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.util.BoundingBox;
 import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
@@ -89,6 +91,9 @@ public class PlayerMock extends LivingEntityMock implements Player
 	private boolean whitelisted = true;
 	private InventoryView inventoryView;
 
+	private Location compassTarget;
+    private Location bedSpawnLocation;
+
 	public PlayerMock(ServerMock server, String name)
 	{
 		this(server, name, UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(StandardCharsets.UTF_8)));
@@ -106,6 +111,7 @@ public class PlayerMock extends LivingEntityMock implements Player
 			MockBukkit.getMock().addSimpleWorld("world");
 
 		setLocation(Bukkit.getWorlds().get(0).getSpawnLocation().clone());
+		setCompassTarget(getLocation());
 		closeInventory();
 	}
 
@@ -144,7 +150,7 @@ public class PlayerMock extends LivingEntityMock implements Player
 				&& Double.doubleToLongBits(getHealth()) == Double.doubleToLongBits(other.getHealth())
 				&& Objects.equals(inventory, other.inventory) && Objects.equals(inventoryView, other.inventoryView)
 				&& Double.doubleToLongBits(getMaxHealth()) == Double.doubleToLongBits(other.getMaxHealth())
-				&& online == other.online && whitelisted == other.whitelisted;
+				&& online == other.online && whitelisted == other.whitelisted && isDead() == other.isDead();
 	}
 
 	/**
@@ -854,17 +860,16 @@ public class PlayerMock extends LivingEntityMock implements Player
 	}
 
 	@Override
-	public void setCompassTarget(Location loc)
+	public void setCompassTarget(@NotNull Location loc)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+        this.compassTarget = loc;
 	}
 
+	@NotNull
 	@Override
 	public Location getCompassTarget()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.compassTarget;
 	}
 
 	@Override
@@ -1364,36 +1369,34 @@ public class PlayerMock extends LivingEntityMock implements Player
 	@Override
 	public int getFoodLevel()
 	{
-		// TODO Auto-generated method stub
 		return foodLevel;
 	}
 
 	@Override
 	public void setFoodLevel(int foodLevel)
 	{
-		// TODO Auto-generated method stub
 		this.foodLevel = foodLevel;
 	}
 
+	@Nullable
 	@Override
 	public Location getBedSpawnLocation()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return bedSpawnLocation;
 	}
 
 	@Override
-	public void setBedSpawnLocation(Location location)
+	public void setBedSpawnLocation(@Nullable Location loc)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+        setBedSpawnLocation(loc, false);
 	}
 
 	@Override
-	public void setBedSpawnLocation(Location location, boolean force)
+	public void setBedSpawnLocation(@Nullable Location loc, boolean force)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		if (force || loc == null || loc.getBlock().getType().name().endsWith("_BED")) {
+		    this.bedSpawnLocation = loc;
+		}
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/InventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/InventoryMock.java
@@ -337,8 +337,13 @@ public abstract class InventoryMock implements Inventory
 	@Override
 	public int firstEmpty()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		for (int i = 0; i < getSize(); i++) {
+		    if (items[i] == null || items[i].getType() == Material.AIR) {
+		        return i;
+		    }
+		}
+
+		return -1;
 	}
 	
 	@Override
@@ -358,15 +363,13 @@ public abstract class InventoryMock implements Inventory
 	@Override
 	public void clear(int index)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		items[index] = null;
 	}
 	
 	@Override
 	public void clear()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Arrays.fill(items, null);
 	}
 	
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -35,6 +35,10 @@ public class ItemMetaMock implements ItemMeta, Damageable {
     }
 
     public ItemMetaMock(ItemMeta meta) {
+        unbreakable = meta.isUnbreakable();
+        enchants = new HashMap<>(meta.getEnchants());
+        customModelData = meta.hasCustomModelData() ? meta.getCustomModelData() : null;
+        
         if (meta.hasDisplayName()) {
             displayName = meta.getDisplayName();
         }
@@ -43,6 +47,9 @@ public class ItemMetaMock implements ItemMeta, Damageable {
         }
         if (meta instanceof Damageable) {
             this.damage = ((Damageable) meta).getDamage();
+        }
+        if (meta instanceof ItemMetaMock) {
+            this.persistentDataContainer = ((ItemMetaMock) meta).persistentDataContainer;
         }
     }
 
@@ -126,6 +133,10 @@ public class ItemMetaMock implements ItemMeta, Damageable {
         int result = 1;
         result = prime * result + ((displayName == null) ? 0 : displayName.hashCode());
         result = prime * result + ((lore == null) ? 0 : lore.hashCode());
+        result = prime * result + Boolean.hashCode(unbreakable);
+        result = prime * result + enchants.hashCode();
+        result = prime * result + persistentDataContainer.hashCode();
+        result = prime * result + ((customModelData == null) ? 0 : customModelData.hashCode());
         return result;
     }
 
@@ -145,6 +156,10 @@ public class ItemMetaMock implements ItemMeta, Damageable {
             ItemMetaMock meta = (ItemMetaMock) super.clone();
             meta.displayName = displayName;
             meta.lore = lore;
+            meta.unbreakable = unbreakable;
+            meta.customModelData = customModelData;
+            meta.enchants = new HashMap<>(enchants);
+            meta.persistentDataContainer = new PersistentDataContainerMock((PersistentDataContainerMock) persistentDataContainer);
             return meta;
         } catch (CloneNotSupportedException e) {
             throw new RuntimeException(e);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SkullMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SkullMetaMock.java
@@ -1,28 +1,63 @@
 package be.seeseemelk.mockbukkit.inventory.meta;
 
-import com.google.common.base.Strings;
-
-import be.seeseemelk.mockbukkit.UnimplementedOperationException;
-
 import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.meta.SkullMeta;
 
+import com.google.common.base.Strings;
+
+import be.seeseemelk.mockbukkit.entity.OfflinePlayerMock;
+
 /**
+ * An {@link ItemMetaMock} for the {@link SkullMeta} interface.
+ * The owning {@link Player} is stored via his name.
+ * 
  * Created by SimplyBallistic on 27/10/2018
  *
  * @author SimplyBallistic
  **/
 public class SkullMetaMock extends ItemMetaMock implements SkullMeta {
+
     private String owner;
-    
+
     public SkullMetaMock() {
         super();
     }
-    
+
     public SkullMetaMock(SkullMeta meta) {
         super(meta);
-        
+
         this.owner = meta.getOwningPlayer().getName();
+    }
+
+    @Override
+    public SkullMetaMock clone() {
+        SkullMetaMock mock = (SkullMetaMock) super.clone();
+        mock.setOwner(owner);
+        return mock;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        return prime * result + owner.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!super.equals(obj)) {
+            return false;
+        }
+        if (!(obj instanceof SkullMeta)) {
+            return false;
+        }
+
+        SkullMeta other = (SkullMeta) obj;
+        return owner.equals(other.getOwningPlayer().getName());
     }
 
     @Override
@@ -42,23 +77,19 @@ public class SkullMetaMock extends ItemMetaMock implements SkullMeta {
     }
 
     @Override
-    public SkullMetaMock clone() {
-        SkullMetaMock mock = (SkullMetaMock) super.clone();
-        mock.setOwner(owner);
-        return mock;
+    public OfflinePlayer getOwningPlayer() {
+        if (hasOwner()) {
+            return new OfflinePlayerMock(owner);
+        }
+
+        return null;
     }
 
-	@Override
-	public OfflinePlayer getOwningPlayer()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
+    @Override
+    public boolean setOwningPlayer(OfflinePlayer owner) {
+        this.owner = owner.getName();
 
-	@Override
-	public boolean setOwningPlayer(OfflinePlayer owner)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
+        // CraftBukkits implementation also always returns true too, so there we go
+        return true;
+    }
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/InventoryMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/InventoryMockTest.java
@@ -61,6 +61,47 @@ public class InventoryMockTest
 		}
 	}
 
+    @Test
+    public void testClearInventory()
+    {
+        for (int i = 0; i < inventory.getSize(); i++)
+        {
+            inventory.addItem(new ItemStack(Material.DIRT, 64));
+        }
+        
+        inventory.clear();
+        
+        for (int i = 0; i < inventory.getSize(); i++)
+        {
+            ItemStack item = inventory.getItem(i);
+            assertNotNull(item);
+            assertEquals(Material.AIR, item.getType());
+        }
+    }
+
+    @Test
+    public void testClearSlot()
+    {
+        inventory.setItem(0, new ItemStack(Material.DIAMOND));
+        assertEquals(Material.DIAMOND, inventory.getItem(0).getType());
+
+        inventory.clear(0);
+        assertEquals(Material.AIR, inventory.getItem(0).getType());
+    }
+
+    @Test
+    public void testFirstEmpty()
+    {
+        for (int i = 0; i < inventory.getSize(); i++)
+        {
+            inventory.addItem(new ItemStack(Material.DIRT, 64));
+        }
+        
+        assertEquals(-1, inventory.firstEmpty());
+        inventory.clear();
+        assertEquals(0, inventory.firstEmpty());
+    }
+
 	@Test
 	public void addItem_EmptyInventoryAddsOneStack_OneStackUsed()
 	{

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/SkullMetaMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/SkullMetaMockTest.java
@@ -1,0 +1,68 @@
+package be.seeseemelk.mockbukkit.inventory.meta;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.entity.OfflinePlayerMock;
+
+public class SkullMetaMockTest {
+
+    @Before
+    public void setUp() {
+        ServerMock mock = MockBukkit.mock();
+    }
+
+    @After
+    public void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    public void testDefaultNoOwner() {
+        SkullMetaMock meta = new SkullMetaMock();
+
+        assertFalse(meta.hasOwner());
+        assertNull(meta.getOwner());
+        assertNull(meta.getOwningPlayer());
+    }
+
+    @Test
+    public void testSetOwner() {
+        SkullMetaMock meta = new SkullMetaMock();
+
+        assertTrue(meta.setOwner("TheBusyBiscuit"));
+        assertTrue(meta.hasOwner());
+        assertEquals("TheBusyBiscuit", meta.getOwner());
+        assertEquals("TheBusyBiscuit", meta.getOwningPlayer().getName());
+    }
+
+    @Test
+    public void testSetOwningPlayer() {
+        SkullMetaMock meta = new SkullMetaMock();
+
+        assertTrue(meta.setOwningPlayer(new OfflinePlayerMock("TheBusyBiscuit")));
+        assertTrue(meta.hasOwner());
+        assertEquals("TheBusyBiscuit", meta.getOwner());
+        assertEquals("TheBusyBiscuit", meta.getOwningPlayer().getName());
+    }
+
+    @Test
+    public void testClone() {
+        SkullMetaMock meta = new SkullMetaMock();
+
+        assertTrue(meta.setOwner("TheBusyBiscuit"));
+
+        SkullMetaMock clone = meta.clone();
+        assertEquals(meta, clone);
+        assertEquals("TheBusyBiscuit", clone.getOwner());
+    }
+
+}


### PR DESCRIPTION
Alright, here's the next batch.
For one of the changes I would like to hear your opinion on it:
As of now the Player interface is solely represented by PlayerMock and the Mock implementation for Server#getOfflinePlayer(...) seems to just refer to the Player implementation. For the time being I just added a OfflinePlayerMock class which has no relation to the PlayerMock class, it's only purpose is providing throwaway OfflinePlayer mocks for methods such as Skullmeta#getOwningPlayer().
This is by far not ideal and I would like to hear your opinion on this matter, for example on where the Server#getOfflinePlayer() method should return those mocks too or whether there is some way the PlayerMock and OfflinePlayerMock could work together without any issues.
Anyway, other than this little problem, the following things were introduced:

* KeepInventory Gamerule
  * Upon Player death the Inventory of the Player will be cleared unless KeepInventory was enabled in the current world, this allows Unit Tests to correctly get the state of the Player after death, since they would drop their inventory
  * The Inventory#clear() methods have also been implemented while I was at it
* The SkullMetaMock was finished (see above for the OfflinePlayerMock)
* Compass Targets and Bed Spawn locations were added to the PlayerMock class
* More Unit Tests (There is no such thing as "too much" unit tests anyway, is there?)