### PR TITLE
feat(core): overload mock() to allow custom ServerMock implementations

### DIFF
--- a/docs/custom_server_mock.rst
+++ b/docs/custom_server_mock.rst
@@ -1,0 +1,10 @@
+Using a custom ServerMock implementation
+=====================
+Sometimes it may be needed to use a custom implementation of the `ServerMock` class.
+This could be if you want to implement some of the unimplemented methods or simply provide your own mocks for certain methods.
+
+To do that you can simply pass your custom mock that extends `ServerMock` to the `MockBukkit.mock(yourServerMock)` method.
+
+    MyCustomServerMock server = MockBukkit.mock(new MyCustomServerMock());
+
+Note that `MockBukkit.getMock()` will return a reference to your instance.

--- a/docs/first_tests.rst
+++ b/docs/first_tests.rst
@@ -76,3 +76,8 @@ These exception extends ``AssumationException`` and will cause the test to be sk
 
 These exceptions should just be ignored, though pull requests that add functionality
 to MockBukkit are always welcome!
+
+As an alternative you can always extend `ServerMock` and implement those missing methods.
+Simply pass your custom implementation of ServerMock to the `MockBukkit.mock(...)` method.
+
+    MyCustomServerMock server = MockBukkit.mock(new MyCustomServerMock());

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,4 +24,5 @@ testing of plugins that use timers or delays.
    entity_mock.rst
    message_target.rst
    dependencies.rst
+   custom_server_mock.rst
 

--- a/src/main/java/be/seeseemelk/mockbukkit/MockBukkit.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockBukkit.java
@@ -56,7 +56,6 @@ public class MockBukkit
 	 * @param serverMockImplementation your custom {@link ServerMock} implementation.
 	 * @return The provided {@link ServerMock}.
 	 */
-	@SuppressWarnings("unchecked")
 	public static <TServerMock extends ServerMock> TServerMock mock(TServerMock serverMockImplementation)
 	{
 		if (mock != null)
@@ -71,7 +70,7 @@ public class MockBukkit
 		Bukkit.setServer(mock);
 		mock.getLogger().setLevel(defaultLevel);
 
-		return (TServerMock) mock;
+		return serverMockImplementation;
 	}
 	
 	/**

--- a/src/main/java/be/seeseemelk/mockbukkit/MockBukkit.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockBukkit.java
@@ -45,19 +45,33 @@ public class MockBukkit
 	 */
 	public static ServerMock mock()
 	{
+		return mock(new ServerMock());
+	}
+
+	/**
+	 * Start mocking the <code>Bukkit</code> singleton.
+	 * You can pass your own implementation of the {@link ServerMock} instance.
+	 * The instance you passed is returned.
+	 *
+	 * @param serverMockImplementation your custom {@link ServerMock} implementation.
+	 * @return The provided {@link ServerMock}.
+	 */
+	@SuppressWarnings("unchecked")
+	public static <TServerMock extends ServerMock> TServerMock mock(TServerMock serverMockImplementation)
+	{
 		if (mock != null)
 		{
 			throw new IllegalStateException("Already mocking");
 		}
-		
-		mock = new ServerMock();
-		
+
+		mock = serverMockImplementation;
+
 		Level defaultLevel = mock.getLogger().getLevel();
 		mock.getLogger().setLevel(Level.WARNING);
 		Bukkit.setServer(mock);
 		mock.getLogger().setLevel(defaultLevel);
-		
-		return mock;
+
+		return (TServerMock) mock;
 	}
 	
 	/**

--- a/src/test/java/be/seeseemelk/mockbukkit/MockBukkitTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/MockBukkitTest.java
@@ -51,6 +51,15 @@ public class MockBukkitTest
 		assertEquals(server, MockBukkit.getMock());
 		assertEquals(server, Bukkit.getServer());
 	}
+
+	@Test
+	public void mock_CustomServerMocked()
+	{
+		CustomServerMock server = MockBukkit.mock(new CustomServerMock());
+		assertNotNull(server);
+		assertEquals(server, MockBukkit.getMock());
+		assertEquals(server, Bukkit.getServer());
+	}
 	
 	@Test
 	public void isMocked_ServerNotMocked_False()
@@ -145,5 +154,8 @@ public class MockBukkitTest
 		assertThat(plugins.length, equalTo(1));
 		assertThat(plugins[0].getName(), equalTo("TestPlugin"));
 	}
-	
+
+	public static class CustomServerMock extends ServerMock
+	{
+	}
 }


### PR DESCRIPTION
Implemented #61 

* Overloaded `MockBukkit.mock(...)` to accept custom implementations of `ServerMock`
* Added documentation on how to use this