### PR TITLE
Fixes #59, implements serialization for the ItemMetaMock

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -22,6 +22,7 @@ import java.util.logging.LogManager;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import be.seeseemelk.mockbukkit.inventory.meta.ItemMetaMock;
 import org.bukkit.*;
 import org.bukkit.BanList.Type;
 import org.bukkit.Warning.WarningState;
@@ -36,6 +37,8 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.command.PluginCommand;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.configuration.serialization.ConfigurationSerialization;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
@@ -98,6 +101,7 @@ public class ServerMock implements Server
 		mainThread = Thread.currentThread();
 		logger = Logger.getLogger("ServerMock");
 		commandMap = new MockCommandMap(this);
+		ServerMock.registerSerializables();
 		try
 		{
 			InputStream stream = ClassLoader.getSystemResourceAsStream("logger.properties");
@@ -653,6 +657,14 @@ public class ServerMock implements Server
 		for (Player player : players)
 			player.sendMessage(message);
 		return players.size();
+	}
+
+	/**
+	 * Registers any classes that are serializable with the ConfigurationSerializable system of Bukkit.
+	 */
+	public static void registerSerializables()
+	{
+		ConfigurationSerialization.registerClass(ItemMetaMock.class);
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -21,7 +21,7 @@ import java.util.*;
 import static java.util.Objects.nonNull;
 
 @SuppressWarnings("deprecation")
-public class ItemMetaMock implements ItemMeta, Damageable, ConfigurationSerializable {
+public class ItemMetaMock implements ItemMeta, Damageable {
     
     private String displayName = null;
     private List<String> lore = null;

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -7,6 +7,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemFlag;
@@ -30,7 +31,6 @@ public class ItemMetaMock implements ItemMeta, Damageable {
     private PersistentDataContainer persistentDataContainer = new PersistentDataContainerMock();
     private boolean unbreakable = false;
     private Integer customModelData = null;
-
 
     public ItemMetaMock() {
     }
@@ -245,6 +245,28 @@ public class ItemMetaMock implements ItemMeta, Damageable {
 	    map.put("damage", this.damage);
 	    // Return map
 	    return map;
+    }
+
+	/**
+	 * Required method for Bukkit deserialization.
+	 * @param args A serialized ItemMetaMock object in a Map<String, Object> format.
+	 * @return A new instance of the ItemMetaMock class.
+	 */
+	public static ItemMetaMock deserialize(Map<String, Object> args) {
+		ItemMetaMock serialMock = new ItemMetaMock();
+
+		serialMock.displayName = (String) args.get("displayName");
+		serialMock.lore = (List<String>) args.get("lore");
+		// serialMock.setLocalizedName(); // localizedName is unimplemented in mock
+		serialMock.enchants = (Map<Enchantment, Integer>) args.get("enchants");
+		serialMock.hideFlags = (Set<ItemFlag>) args.get("itemFlags");
+		serialMock.unbreakable = (boolean) args.get("unbreakable");
+		// serialMock.setAttributeModifiers(); // AttributeModifiers are unimplemented in mock
+	    // customTagContainer is also unimplemented in mock.
+	    serialMock.customModelData = (Integer) args.get("customModelData");
+	    serialMock.persistentDataContainer = (PersistentDataContainer) args.get("persistentDataContainer");
+	    serialMock.damage = (Integer) args.get("damage");
+	    return serialMock;
     }
 
     @Override

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -21,7 +21,7 @@ import java.util.*;
 import static java.util.Objects.nonNull;
 
 @SuppressWarnings("deprecation")
-public class ItemMetaMock implements ItemMeta, Damageable {
+public class ItemMetaMock implements ItemMeta, Damageable, ConfigurationSerializable {
     
     private String displayName = null;
     private List<String> lore = null;

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -4,6 +4,7 @@ import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.persistence.PersistentDataContainerMock;
 
 import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.enchantments.Enchantment;
@@ -222,10 +223,28 @@ public class ItemMetaMock implements ItemMeta, Damageable {
         }
     }
 
-    @Override
+	/**
+	 * Serializes the properties of an ItemMetaMock to a HashMap.
+	 * Unimplemented methods have values of null.
+	 * @return A HashMap of String, Object pairs representing the ItemMetaMock.
+	 */
+	@Override
     public Map<String, Object> serialize() {
-        // TODO Auto-generated method stub
-        throw new UnimplementedOperationException();
+		// Make new map and add relevant properties to it.
+	    HashMap<String, Object> map = new HashMap<String, Object>();
+	    map.put("displayName", this.displayName);
+	    map.put("lore", this.lore);
+	    map.put("localizedName", null); // Not implemented.
+	    map.put("enchants", this.enchants);
+	    map.put("itemFlags", this.hideFlags);
+	    map.put("unbreakable", this.unbreakable);
+	    map.put("attributeModifiers", null); // Not implemented.
+	    map.put("customTagContainer", null); // Not implemented.
+	    map.put("customModelData", this.customModelData);
+	    map.put("persistentDataContainer", this.persistentDataContainer);
+	    map.put("damage", this.damage);
+	    // Return map
+	    return map;
     }
 
     @Override

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMockTest.java
@@ -4,9 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
@@ -344,5 +342,31 @@ public class ItemMetaMockTest {
 		meta.setCustomModelData(100);
 		assertTrue(meta.hasCustomModelData());
 		assertEquals(100, meta.getCustomModelData());
+	}
+
+	@Test
+	public void assertSerialize() {
+
+		// Tests for displayName, Lore, enchants, unbreakable status, and damage
+		meta.setDisplayName("Test name");
+		meta.setLore(new ArrayList<String>() {{ add("Test lore"); }});
+		meta.setUnbreakable(true);
+		meta.setDamage(5);
+
+		HashMap<String, Object> expected = new HashMap<String, Object>() {
+			{
+				put("displayName","Test name");
+				put("lore", new ArrayList<String>() {{ add("Test lore"); }});
+				put("unbreakable", true);
+				put("damage", 5);
+			}
+		};
+		Map<String, Object> actual = meta.serialize();
+
+		// Perform tests
+		assertEquals(expected.get("displayName"), actual.get("displayName"));
+		assertEquals(expected.get("lore"), actual.get("lore"));
+		assertEquals(expected.get("unbreakable"), actual.get("unbreakable"));
+		assertEquals(expected.get("damage"), actual.get("damage"));
 	}
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMockTest.java
@@ -349,14 +349,14 @@ public class ItemMetaMockTest {
 
 		// Tests for displayName, Lore, enchants, unbreakable status, and damage
 		meta.setDisplayName("Test name");
-		meta.setLore(new ArrayList<String>() {{ add("Test lore"); }});
+		meta.setLore(Arrays.asList("Test lore"));
 		meta.setUnbreakable(true);
 		meta.setDamage(5);
 
 		HashMap<String, Object> expected = new HashMap<String, Object>() {
 			{
 				put("displayName","Test name");
-				put("lore", new ArrayList<String>() {{ add("Test lore"); }});
+				put("lore", Arrays.asList("Test lore"));
 				put("unbreakable", true);
 				put("damage", 5);
 			}

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMockTest.java
@@ -363,10 +363,20 @@ public class ItemMetaMockTest {
 		};
 		Map<String, Object> actual = meta.serialize();
 
-		// Perform tests
-		assertEquals(expected.get("displayName"), actual.get("displayName"));
-		assertEquals(expected.get("lore"), actual.get("lore"));
-		assertEquals(expected.get("unbreakable"), actual.get("unbreakable"));
-		assertEquals(expected.get("damage"), actual.get("damage"));
+			// Perform tests
+			assertEquals(expected.get("displayName"), actual.get("displayName"));
+			assertEquals(expected.get("lore"), actual.get("lore"));
+			assertEquals(expected.get("unbreakable"), actual.get("unbreakable"));
+			assertEquals(expected.get("damage"), actual.get("damage"));
+
+	}
+
+	@Test
+	public void assertDeserialize() {
+
+		Map<String, Object> actual = meta.serialize();
+
+		assertEquals(meta, ItemMetaMock.deserialize(actual));
+
 	}
 }


### PR DESCRIPTION
Fixes #59 
Implemented the `serialize()` and `deserialize()` methods for `ItemMetaMock` and wrote tests for them. `ServerMock` was modified to register the `ItemMetaMock` as being serializable with the `ConfigurationSerializable` interface.