### PR TITLE
Implemented Inventory#getStorageContents()

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/InventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/InventoryMock.java
@@ -253,15 +253,13 @@ public abstract class InventoryMock implements Inventory
 	@Override
 	public ItemStack[] getStorageContents()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return getContents();
 	}
 
 	@Override
 	public void setStorageContents(ItemStack[] items) throws IllegalArgumentException
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		setContents(items);
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryMock.java
@@ -11,6 +11,8 @@ import org.bukkit.inventory.PlayerInventory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+
 public class PlayerInventoryMock extends InventoryMock implements PlayerInventory
 {
 	protected static final int HOTBAR = 0;
@@ -31,6 +33,19 @@ public class PlayerInventoryMock extends InventoryMock implements PlayerInventor
 	public HumanEntity getHolder()
 	{
 		return (HumanEntity) super.getHolder();
+	}
+
+	@Override
+	public ItemStack[] getStorageContents()
+	{
+		return Arrays.copyOfRange(getContents(), 0, 36);
+	}
+
+	@Override
+	public void setStorageContents(ItemStack[] items) throws IllegalArgumentException
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException("setStorageContests has not been implemented for Player Inventories");
 	}
 
 	@Override

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/InventoryMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/InventoryMockTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertArrayEquals;
 
 import java.util.HashMap;
 import java.util.ListIterator;
@@ -42,11 +43,11 @@ public class InventoryMockTest
 		assertEquals(9, new SimpleInventoryMock(null, 9, InventoryType.CHEST).getSize());
 		assertEquals(18, new SimpleInventoryMock(null, 18, InventoryType.CHEST).getSize());
 	}
-	
+
 	@Test
 	public void constructor_SetsType()
 	{
-		assertEquals(InventoryType.CHEST, new SimpleInventoryMock(null,  9, InventoryType.CHEST).getType());
+		assertEquals(InventoryType.CHEST, new SimpleInventoryMock(null, 9, InventoryType.CHEST).getType());
 		assertEquals(InventoryType.DROPPER, new SimpleInventoryMock(null, 9, InventoryType.DROPPER).getType());
 	}
 
@@ -61,46 +62,46 @@ public class InventoryMockTest
 		}
 	}
 
-    @Test
-    public void testClearInventory()
-    {
-        for (int i = 0; i < inventory.getSize(); i++)
-        {
-            inventory.addItem(new ItemStack(Material.DIRT, 64));
-        }
-        
-        inventory.clear();
-        
-        for (int i = 0; i < inventory.getSize(); i++)
-        {
-            ItemStack item = inventory.getItem(i);
-            assertNotNull(item);
-            assertEquals(Material.AIR, item.getType());
-        }
-    }
+	@Test
+	public void testClearInventory()
+	{
+		for (int i = 0; i < inventory.getSize(); i++)
+		{
+			inventory.addItem(new ItemStack(Material.DIRT, 64));
+		}
 
-    @Test
-    public void testClearSlot()
-    {
-        inventory.setItem(0, new ItemStack(Material.DIAMOND));
-        assertEquals(Material.DIAMOND, inventory.getItem(0).getType());
+		inventory.clear();
 
-        inventory.clear(0);
-        assertEquals(Material.AIR, inventory.getItem(0).getType());
-    }
+		for (int i = 0; i < inventory.getSize(); i++)
+		{
+			ItemStack item = inventory.getItem(i);
+			assertNotNull(item);
+			assertEquals(Material.AIR, item.getType());
+		}
+	}
 
-    @Test
-    public void testFirstEmpty()
-    {
-        for (int i = 0; i < inventory.getSize(); i++)
-        {
-            inventory.addItem(new ItemStack(Material.DIRT, 64));
-        }
-        
-        assertEquals(-1, inventory.firstEmpty());
-        inventory.clear();
-        assertEquals(0, inventory.firstEmpty());
-    }
+	@Test
+	public void testClearSlot()
+	{
+		inventory.setItem(0, new ItemStack(Material.DIAMOND));
+		assertEquals(Material.DIAMOND, inventory.getItem(0).getType());
+
+		inventory.clear(0);
+		assertEquals(Material.AIR, inventory.getItem(0).getType());
+	}
+
+	@Test
+	public void testFirstEmpty()
+	{
+		for (int i = 0; i < inventory.getSize(); i++)
+		{
+			inventory.addItem(new ItemStack(Material.DIRT, 64));
+		}
+
+		assertEquals(-1, inventory.firstEmpty());
+		inventory.clear();
+		assertEquals(0, inventory.firstEmpty());
+	}
 
 	@Test
 	public void addItem_EmptyInventoryAddsOneStack_OneStackUsed()
@@ -186,7 +187,8 @@ public class InventoryMockTest
 
 		ItemStack item = new ItemStack(Material.DIRT, 32);
 
-		inventory.setContents(new ItemStack[] { item });
+		inventory.setContents(new ItemStack[]
+		{ item });
 
 		assertTrue(item.isSimilar(inventory.getItem(0)));
 		for (int i = 1; i < inventory.getSize(); i++)
@@ -200,7 +202,8 @@ public class InventoryMockTest
 	@Test
 	public void setContents_ArrayWithNulls_NullsIgnores()
 	{
-		inventory.setContents(new ItemStack[] { null });
+		inventory.setContents(new ItemStack[]
+		{ null });
 	}
 
 	@Test
@@ -234,8 +237,7 @@ public class InventoryMockTest
 	{
 		inventory.addItem(new ItemStack(Material.DIRT, 1));
 		AtomicInteger calls = new AtomicInteger(0);
-		inventory.assertTrueForNonNulls(itemstack ->
-		{
+		inventory.assertTrueForNonNulls(itemstack -> {
 			calls.incrementAndGet();
 			return true;
 		});
@@ -289,5 +291,11 @@ public class InventoryMockTest
 	{
 		inventory.addItem(new ItemStack(Material.GRASS, 3));
 		inventory.assertContainsAtLeast(new ItemStack(Material.DIRT), 4);
+	}
+
+	@Test
+	public void testContentsAndStorageContentsEqual()
+	{
+		assertArrayEquals(inventory.getContents(), inventory.getStorageContents());
 	}
 }


### PR DESCRIPTION
This is a very simple addition, the methods `getStorageContents()` and `setStorageContents(...)` behave equal to `getContents()` and `setContents(...)`.
Player and Crafting Inventories are an exception though, result, off hand and armor slots are ignored here. I have implemented these methods for the default Inventory mock and also `getStorageContents()` for the PlayerInventoryMock. `setStorageContents(...)`  for Player Inventories will still remain a todo for now.

Anyway, just a very small PR since I got a test on my project skipping because of this method missing.