### PR TITLE
Added time/environment methods to WorldMock

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -1084,8 +1084,7 @@ public class ServerMock implements Server
 	@Override
 	public boolean isPrimaryThread()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.isOnMainThread();
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
@@ -27,6 +27,7 @@ import org.bukkit.entity.Item;
 import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.world.TimeSkipEvent;
 import org.bukkit.generator.BlockPopulator;
 import org.bukkit.generator.ChunkGenerator;
 import org.bukkit.inventory.ItemStack;
@@ -54,10 +55,12 @@ public class WorldMock implements World
 	private String name = "World";
 	private UUID uuid = UUID.randomUUID();
 	private Location spawnLocation;
+	private long fullTime = 0;
 	private int weatherDuration = 0;
 	private int thunderDuration = 0;
 	private boolean storming = false;
 	private Map<GameRule<?>, Object> gameRules = new HashMap<>();
+	private Environment environment = Environment.NORMAL;
 
 	/**
 	 * Creates a new mock world.
@@ -632,29 +635,31 @@ public class WorldMock implements World
 	@Override
 	public long getTime()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.getFullTime() % 24000L;
 	}
 
 	@Override
 	public void setTime(long time)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		long base = this.getFullTime() - this.getFullTime() % 24000L;
+		this.setFullTime(base + time % 24000L);
 	}
 
 	@Override
 	public long getFullTime()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.fullTime;
 	}
 
 	@Override
 	public void setFullTime(long time)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		TimeSkipEvent event = new TimeSkipEvent(this, TimeSkipEvent.SkipReason.CUSTOM, time - this.getFullTime());
+		this.server.getPluginManager().callEvent(event);
+		if (!event.isCancelled())
+		{
+			this.fullTime += event.getSkipAmount();
+		}
 	}
 
 	@Override
@@ -743,8 +748,17 @@ public class WorldMock implements World
 	@Override
 	public Environment getEnvironment()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.environment;
+	}
+
+	/**
+	 * Set a new environment type for this world.
+	 *
+	 * @param environment The world environnement type.
+	 */
+	public void setEnvironment(Environment environment)
+	{
+		this.environment = environment;
 	}
 
 	@Override

--- a/src/test/java/be/seeseemelk/mockbukkit/WorldMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/WorldMockTest.java
@@ -17,6 +17,7 @@ import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
+import org.bukkit.event.world.TimeSkipEvent;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -240,6 +241,60 @@ public class WorldMockTest
 		assertEquals(zombie.getLocation().getBlockZ(), 50);
 		assertTrue(world.getEntities().size()>0);
 
+	}
+
+	@Test
+	public void onCreated_TimeSetToBeZero()
+	{
+		WorldMock world = new WorldMock();
+		assertEquals("World time should be zero", 0L, world.getFullTime());
+		assertEquals("Day time should be zero", 0L, world.getTime());
+	}
+
+	@Test
+	public void setTime_DayTimeValue()
+	{
+		WorldMock world = new WorldMock();
+		world.setTime(20L);
+		assertEquals(20L, world.getTime());
+		assertEquals(20L, world.getFullTime());
+	}
+
+	@Test
+	public void setTime_FullTimeValue()
+	{
+		WorldMock world = new WorldMock();
+		world.setFullTime(3L * 24000L + 20L);
+		assertEquals(20L, world.getTime());
+		assertEquals(3L * 24000L + 20L, world.getFullTime());
+	}
+
+	@Test
+	public void setTime_FullTimeShouldBeAdjustedWithDayTime()
+	{
+		WorldMock world = new WorldMock();
+		world.setFullTime(3L * 24000L + 20L);
+		world.setTime(12000L);
+		assertEquals(12000L, world.getTime());
+		assertEquals(3L * 24000L + 12000L, world.getFullTime());
+	}
+
+	@Test
+	public void setTime_Event_Triggered()
+	{
+		WorldMock world = new WorldMock();
+		world.setTime(6000L);
+		world.setTime(10000L);
+		server.getPluginManager().assertEventFired(TimeSkipEvent.class, event ->
+				event.getSkipAmount() == 4000L && event.getSkipReason().equals(TimeSkipEvent.SkipReason.CUSTOM)
+		);
+	}
+
+	@Test
+	public void onCreated_EnvironmentSetToBeNormal()
+	{
+		WorldMock world = new WorldMock();
+		assertEquals("World environment type should be normal", World.Environment.NORMAL, world.getEnvironment());
 	}
 }
 


### PR DESCRIPTION
This pull request adds the following things :
- an `Bukkit.isPrimaryThread()` implementation which redirects to the existing `#isOnMainThread()`  method
- an implementation of time-related methods in WorldMock
- environment getter and setter for WorldMock

I also added the corresponding unit tests.