### PR TITLE
Added Saturation and Potion Effects

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ActivePotionEffect.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ActivePotionEffect.java
@@ -1,0 +1,39 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import java.util.concurrent.TimeUnit;
+
+import org.bukkit.potion.PotionEffect;
+
+class ActivePotionEffect
+{
+
+	private final PotionEffect effect;
+	private final long timestamp;
+
+	ActivePotionEffect(PotionEffect effect)
+	{
+		this.effect = effect;
+		this.timestamp = System.currentTimeMillis();
+	}
+
+	/**
+	 * This returns whether this {@link PotionEffect} has expired.
+	 * 
+	 * @return Whether the effect wore off.
+	 */
+	public boolean hasExpired()
+	{
+		return timestamp + TimeUnit.SECONDS.toMillis(effect.getDuration() * 20) < System.currentTimeMillis();
+	}
+
+	/**
+	 * This method returns the underlying {@link PotionEffect}
+	 * 
+	 * @return The actual {@link PotionEffect}.
+	 */
+	public PotionEffect getPotionEffect()
+	{
+		return effect;
+	}
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ActivePotionEffect.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ActivePotionEffect.java
@@ -23,7 +23,8 @@ class ActivePotionEffect
 	 */
 	public boolean hasExpired()
 	{
-		return timestamp + TimeUnit.SECONDS.toMillis(effect.getDuration() * 20) < System.currentTimeMillis();
+		int ticks = effect.getDuration() * 20;
+		return ticks < 1 || timestamp + TimeUnit.SECONDS.toMillis(ticks) < System.currentTimeMillis();
 	}
 
 	/**

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -391,6 +391,8 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	{
 		if (effect != null)
 		{
+			// Bukkit now allows multiple effects of the same type,
+			// the force/success attributes are now obsolete
 			activeEffects.add(new ActivePotionEffect(effect));
 			return true;
 		}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,11 +44,14 @@ import be.seeseemelk.mockbukkit.attribute.AttributeInstanceMock;
 
 public abstract class LivingEntityMock extends EntityMock implements LivingEntity
 {
+
 	private static final double MAX_HEALTH = 20.0;
 	private double health;
 	private double maxHealth = MAX_HEALTH;
 	protected boolean alive = true;
 	protected Map<Attribute, AttributeInstanceMock> attributes;
+
+	private final Set<ActivePotionEffect> activeEffects = new HashSet<>();
 
 	public LivingEntityMock(ServerMock server, UUID uuid)
 	{
@@ -377,50 +382,105 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	@Override
 	public boolean addPotionEffect(PotionEffect effect)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return addPotionEffect(effect, false);
 	}
 
 	@Override
+	@Deprecated
 	public boolean addPotionEffect(PotionEffect effect, boolean force)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		if (effect != null)
+		{
+			activeEffects.add(new ActivePotionEffect(effect));
+			return true;
+		}
+		else
+		{
+			return false;
+		}
 	}
 
 	@Override
 	public boolean addPotionEffects(Collection<PotionEffect> effects)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		boolean successful = true;
+
+		for (PotionEffect effect : effects)
+		{
+			if (!addPotionEffect(effect))
+			{
+				successful = false;
+			}
+		}
+
+		return successful;
 	}
 
 	@Override
 	public boolean hasPotionEffect(PotionEffectType type)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		for (PotionEffect effect : getActivePotionEffects())
+		{
+			if (effect.getType().equals(type))
+			{
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	@Override
 	public PotionEffect getPotionEffect(PotionEffectType type)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		for (PotionEffect effect : getActivePotionEffects())
+		{
+			if (effect.getType().equals(type))
+			{
+				return effect;
+			}
+		}
+
+		return null;
 	}
 
 	@Override
 	public void removePotionEffect(PotionEffectType type)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Iterator<ActivePotionEffect> iterator = activeEffects.iterator();
+
+		while (iterator.hasNext())
+		{
+			ActivePotionEffect effect = iterator.next();
+
+			if (effect.hasExpired() || effect.getPotionEffect().getType().equals(type))
+			{
+				iterator.remove();
+			}
+		}
 	}
 
 	@Override
 	public Collection<PotionEffect> getActivePotionEffects()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Set<PotionEffect> effects = new HashSet<>();
+		Iterator<ActivePotionEffect> iterator = activeEffects.iterator();
+
+		while (iterator.hasNext())
+		{
+			ActivePotionEffect effect = iterator.next();
+
+			if (effect.hasExpired())
+			{
+				iterator.remove();
+			}
+			else
+			{
+				effects.add(effect.getPotionEffect());
+			}
+		}
+
+		return effects;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -1,7 +1,7 @@
 package be.seeseemelk.mockbukkit.entity;
 
-import static org.junit.Assert.fail;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
@@ -66,8 +66,6 @@ import org.bukkit.inventory.Merchant;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.map.MapView;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.util.BoundingBox;
 import org.bukkit.util.RayTraceResult;
@@ -632,55 +630,6 @@ public class PlayerMock extends LivingEntityMock implements Player
 
 	@Override
 	public Player getKiller()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public boolean addPotionEffect(PotionEffect effect)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public boolean addPotionEffect(PotionEffect effect, boolean force)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public boolean addPotionEffects(Collection<PotionEffect> effects)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public boolean hasPotionEffect(PotionEffectType type)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public PotionEffect getPotionEffect(PotionEffectType type)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public void removePotionEffect(PotionEffectType type)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public Collection<PotionEffect> getActivePotionEffects()
 	{
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -94,6 +94,7 @@ public class PlayerMock extends LivingEntityMock implements Player
 	private int expTotal = 0;
 	private float exp = 0;
 	private int foodLevel = 20;
+	private float saturation = 5.0F;
 	private int expLevel = 0;
 	private boolean sneaking = false;
 	private boolean whitelisted = true;
@@ -144,8 +145,8 @@ public class PlayerMock extends LivingEntityMock implements Player
 		final int prime = 31;
 		int result = super.hashCode();
 		result = prime * result + Objects.hash(attributes, exp, expLevel, expTotal, displayName, gamemode, getHealth(),
-				inventory, enderChest, inventoryView, getMaxHealth(), online, whitelisted, compassTarget,
-				bedSpawnLocation, cursor);
+				foodLevel, saturation, inventory, enderChest, inventoryView, getMaxHealth(), online, whitelisted,
+				compassTarget, bedSpawnLocation, cursor);
 		return result;
 	}
 
@@ -1430,15 +1431,14 @@ public class PlayerMock extends LivingEntityMock implements Player
 	@Override
 	public float getSaturation()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return saturation;
 	}
 
 	@Override
 	public void setSaturation(float value)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		// Saturation is constrained by the current food level
+		this.saturation = Math.min(getFoodLevel(), value);
 	}
 
 	@Override

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -10,6 +10,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.TimeUnit;
@@ -42,6 +44,8 @@ import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -886,4 +890,42 @@ public class PlayerMockTest
 		assertEquals(20.0F, player.getSaturation(), 0.1F);
 	}
 
+	@Test
+	public void testPotionEffects()
+	{
+		PotionEffect effect = new PotionEffect(PotionEffectType.CONFUSION, 3, 1);
+		assertTrue(player.addPotionEffect(effect));
+
+		assertTrue(player.hasPotionEffect(effect.getType()));
+		assertTrue(player.getActivePotionEffects().contains(effect));
+
+		assertEquals(effect, player.getPotionEffect(effect.getType()));
+
+		player.removePotionEffect(effect.getType());
+		assertFalse(player.hasPotionEffect(effect.getType()));
+		assertFalse(player.getActivePotionEffects().contains(effect));
+
+	}
+
+	@Test
+	public void testInstantEffect()
+	{
+		PotionEffect instant = new PotionEffect(PotionEffectType.HEAL, 0, 1);
+		assertTrue(player.addPotionEffect(instant));
+		assertFalse(player.hasPotionEffect(instant.getType()));
+	}
+
+	@Test
+	public void testMultiplePotionEffects()
+	{
+		Collection<PotionEffect> effects = Arrays.asList(new PotionEffect(PotionEffectType.BAD_OMEN, 3, 1),
+				new PotionEffect(PotionEffectType.LUCK, 5, 2));
+
+		assertTrue(player.addPotionEffects(effects));
+
+		for (PotionEffect effect : effects)
+		{
+			assertTrue(player.hasPotionEffect(effect.getType()));
+		}
+	}
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -870,4 +870,20 @@ public class PlayerMockTest
 		assertNull(player.getItemOnCursor());
 	}
 
+	@Test
+	public void testSaturation()
+	{
+		// Default level
+		assertEquals(5.0F, player.getSaturation(), 0.1F);
+
+		player.setFoodLevel(20);
+		player.setSaturation(8);
+		assertEquals(8.0F, player.getSaturation(), 0.1F);
+
+		// Testing the constraint
+		player.setFoodLevel(20);
+		player.setSaturation(10000);
+		assertEquals(20.0F, player.getSaturation(), 0.1F);
+	}
+
 }


### PR DESCRIPTION
This pull request adds the `saturation` attribute to the PlayerMock class and also implements Potion Effects (with expiration!) to the LivingEntityMock.

Also added Unit Tests respectively :)