### PR TITLE
Fixed #76, deprecated build.gradle, and incomplete javadocs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java-library'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
 apply plugin: 'jacoco'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 sourceCompatibility = 1.8
@@ -16,7 +16,7 @@ repositories {
     }
 
     maven {
-        url 'http://repo.md-5.net/content/groups/public/'
+        url 'https://repo.md-5.net/content/groups/public/'
     }
 }
 
@@ -43,52 +43,65 @@ artifacts {
 }
 
 signing {
-    sign configurations.archives
+    sign publishing.publications
 }
 
 jacocoTestReport {
-	reports {
-		xml.enabled true
-	}
+    reports {
+        xml.enabled true
+    }
 }
 
 group = 'com.github.seeseemelk'
 version = '0.3.1-SNAPSHOT'
 
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            beforeDeployment {
-                MavenDeployment deployment -> signing.signPom(deployment)
-            }
-            repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
-                authentication(userName: findProperty('ossrhUsername'), password: findProperty('ossrhPassword'))
-            }
-            snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots/') {
-                authentication(userName: findProperty('ossrhUsername'), password: findProperty('ossrhPassword'))
-            }
-            pom.project {
-                name 'MockBukkit-v1.15'
-                packaging 'jar'
-                description 'MockBukkit is a mocking framework for bukkit to allow the easy unit testing of Bukkit plugins.'
-                url 'https://github.com/seeseemelk/MockBukkit'
-                scm {
-                    connection 'scm:git:git://github.com/seeseemelk/MockBukkit.git'
-                    developerConnection 'scm:git:ssh://github.com:seeseemelk/MockBukkit.git'
-                    url 'https://github.com/seeseemelk/MockBukkit/tree/v1.15-spigot'
-                }
-                licenses {
-                    license {
-                        name 'MIT License'
-                        url 'https://github.com/seeseemelk/MockBukkit/blob/v1.15/LICENSE'
+configurations {
+    publishing {
+        publications {
+            mockBukkit(MavenPublication) {
+                from components.java
+                pom {
+                    name = 'MockBukkit-v1.15'
+                    packaging = 'jar'
+                    description = 'MockBukkit is a mocking framework for bukkit to allow the easy unit testing of Bukkit plugins.'
+                    url = 'https://github.com/seeseemelk/MockBukkit'
+                    scm {
+                        connection = 'scm:git:git://github.com/seeseemelk/MockBukkit.git'
+                        developerConnection = 'scm:git:ssh://github.com:seeseemelk/MockBukkit.git'
+                        url = 'https://github.com/seeseemelk/MockBukkit/tree/v1.15-spigot'
+                    }
+                    licenses {
+                        license {
+                            name = 'MIT License'
+                            url = 'https://github.com/seeseemelk/MockBukkit/blob/v1.15/LICENSE'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = 'seeseemelk'
+                            name = 'Sebastiaan de Schaetzen'
+                            email = 'sebastiaan.de.schaetzen@gmail.com'
+                        }
                     }
                 }
-                developers {
-                    developer {
-                        id 'seeseemelk'
-                        name 'Sebastiaan de Schaetzen'
-                        email 'sebastiaan.de.schaetzen@gmail.com'
-                    }
+            }
+        }
+
+        repositories {
+            maven {
+                name = 'repository'
+                url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+                credentials {
+                    username = findProperty('ossrhUsername')
+                    password = findProperty('ossrhPassword')
+                }
+            }
+            maven {
+                name = 'snapshotRepository'
+                url = 'https://oss.sonatype.org/content/repositories/snapshots/'
+                credentials {
+                    username = findProperty('ossrhUsername')
+                    password = findProperty('ossrhPassword')
                 }
             }
         }

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ZombieMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ZombieMock.java
@@ -6,6 +6,7 @@ import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Villager;
 import org.bukkit.entity.Zombie;
+import org.jetbrains.annotations.Contract;
 
 import java.util.UUID;
 
@@ -52,7 +53,7 @@ public class ZombieMock extends MonsterMock implements Zombie
 	/**
 	 * This are unimplemented because they Bukkit specifies they should always fail? (@Contract Tag)
 	 * 
-	 * @param villager
+	 * @param villager If the zombie is a village
 	 */
 	@Override
 	public void setVillager(boolean villager)
@@ -64,12 +65,11 @@ public class ZombieMock extends MonsterMock implements Zombie
 	/**
 	 * This are unimplemented because they Bukkit specifies they should always fail? (@Contract Tag)
 	 * 
-	 * @param profession
+	 * @param profession Villager profession to use
 	 */
 	@Override
 	public void setVillagerProfession(Villager.Profession profession)
 	{
-		this.profession = profession;
 		throw new UnimplementedOperationException();
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/InventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/InventoryMock.java
@@ -126,8 +126,6 @@ public abstract class InventoryMock implements Inventory
 	@Override
 	public ItemStack getItem(int index)
 	{
-		if (items[index] == null)
-			items[index] = new ItemStack(Material.AIR);
 		return items[index];
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -257,7 +257,7 @@ public class ItemMetaMock implements ItemMeta, Damageable {
 
 	/**
 	 * Required method for Bukkit deserialization.
-	 * @param args A serialized ItemMetaMock object in a Map<String, Object> format.
+	 * @param args A serialized ItemMetaMock object in a Map&lt;String, Object&gt; format.
 	 * @return A new instance of the ItemMetaMock class.
 	 */
 	@SuppressWarnings("unchecked")

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -820,7 +820,7 @@ public class PlayerMockTest
 
 		// The Player should have lost their inventory
 		assertTrue(player.isDead());
-		assertEquals(Material.AIR, player.getInventory().getItem(0).getType());
+		assertNull(player.getInventory().getItem(0));
 	}
 
 	@Test

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/InventoryMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/InventoryMockTest.java
@@ -9,12 +9,14 @@ import static org.junit.Assert.assertArrayEquals;
 
 import java.util.HashMap;
 import java.util.ListIterator;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.bukkit.Material;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.ItemStack;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -52,13 +54,12 @@ public class InventoryMockTest
 	}
 
 	@Test
-	public void getItem_Default_AllAir()
+	public void getItem_Default_AllNull()
 	{
 		for (int i = 0; i < inventory.getSize(); i++)
 		{
 			ItemStack item = inventory.getItem(i);
-			assertNotNull(item);
-			assertEquals(Material.AIR, item.getType());
+			assertNull(item);
 		}
 	}
 
@@ -75,8 +76,7 @@ public class InventoryMockTest
 		for (int i = 0; i < inventory.getSize(); i++)
 		{
 			ItemStack item = inventory.getItem(i);
-			assertNotNull(item);
-			assertEquals(Material.AIR, item.getType());
+			assertNull(item);
 		}
 	}
 
@@ -87,7 +87,7 @@ public class InventoryMockTest
 		assertEquals(Material.DIAMOND, inventory.getItem(0).getType());
 
 		inventory.clear(0);
-		assertEquals(Material.AIR, inventory.getItem(0).getType());
+		assertNull(inventory.getItem(0));
 	}
 
 	@Test
@@ -112,8 +112,7 @@ public class InventoryMockTest
 		ItemStack stored = inventory.getItem(0);
 		assertEquals(stored.getAmount(), 64);
 		ItemStack next = inventory.getItem(1);
-		assertNotNull(next);
-		assertEquals(Material.AIR, next.getType());
+		assertNull(next);
 	}
 
 	@Test
@@ -187,23 +186,20 @@ public class InventoryMockTest
 
 		ItemStack item = new ItemStack(Material.DIRT, 32);
 
-		inventory.setContents(new ItemStack[]
-		{ item });
+		inventory.setContents(new ItemStack[] { item });
 
 		assertTrue(item.isSimilar(inventory.getItem(0)));
 		for (int i = 1; i < inventory.getSize(); i++)
 		{
 			ItemStack emptyItem = inventory.getItem(i);
-			assertNotNull(emptyItem);
-			assertEquals(Material.AIR, emptyItem.getType());
+			assertNull(emptyItem);
 		}
 	}
 
 	@Test
 	public void setContents_ArrayWithNulls_NullsIgnores()
 	{
-		inventory.setContents(new ItemStack[]
-		{ null });
+		inventory.setContents(new ItemStack[] { null });
 	}
 
 	@Test
@@ -222,14 +218,14 @@ public class InventoryMockTest
 	@Test
 	public void assertTrueForAll_ChecksIfNullOnEmptyInventory_DoesNotAssert()
 	{
-		inventory.assertTrueForAll(itemstack -> itemstack == null);
+		inventory.assertTrueForAll(Objects::isNull);
 	}
 
 	@Test(expected = AssertionError.class)
 	public void assertTrueForAll_ChecksIfNullOnNonEmptyInventory_Asserts()
 	{
 		inventory.addItem(new ItemStack(Material.DIRT, 1));
-		inventory.assertTrueForAll(itemstack -> itemstack == null);
+		inventory.assertTrueForAll(Objects::isNull);
 	}
 
 	@Test


### PR DESCRIPTION
I didn't update the gradle wrapper from 6.3 to 6.5, but the build.gradle is not compatible with Gradle 7.

I made it so the jar isn't automatically signed on build, but it is signed on publish (publishMockBukkitToRepository/publishMockBukkitToSnapshotRepository).

#76 is fixed too.