### PR TITLE
Added default Potion Effect Types

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -123,6 +123,9 @@ public class ServerMock implements Server
 		logger = Logger.getLogger("ServerMock");
 		commandMap = new MockCommandMap(this);
 		ServerMock.registerSerializables();
+		
+		// Register default Minecraft Potion Effect Types
+		createPotionEffectTypes();
 
 		try
 		{
@@ -1258,12 +1261,20 @@ public class ServerMock implements Server
 	}
 
 	/**
-	 * This registers Minecrafts default {@link PotionEffectType PotionEffectTypes}. If you somehow need to add your
-	 * own, override this method but make sure to run your code before calling this, as it prevents any new effects to
-	 * be created afterwards.
+	 * This registers Minecrafts default {@link PotionEffectType PotionEffectTypes}. 
+	 * It also prevents any new effects to be created afterwards.
 	 */
-	public void createPotionEffectTypes()
+	private void createPotionEffectTypes()
 	{
+		for (PotionEffectType type : PotionEffectType.values()) {
+			// We probably already registered all Potion Effects
+			// otherwise this would be null
+			if (type != null) {
+				// This is not perfect, but it works.
+				return;
+			}
+		}
+		
 		registerPotionEffectType(1, "SPEED", false, 8171462);
 		registerPotionEffectType(2, "SLOWNESS", false, 5926017);
 		registerPotionEffectType(3, "HASTE", false, 14270531);

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -28,6 +28,7 @@ import org.bukkit.BanEntry;
 import org.bukkit.BanList;
 import org.bukkit.BanList.Type;
 import org.bukkit.Bukkit;
+import org.bukkit.Color;
 import org.bukkit.GameMode;
 import org.bukkit.Keyed;
 import org.bukkit.Location;
@@ -1312,7 +1313,8 @@ public class ServerMock implements Server
 
 	private void registerPotionEffectType(int id, String name, boolean instant, int rgb)
 	{
-		PotionEffectType.registerPotionEffectType(new MockPotionEffectType(id, name, instant, rgb));
+		PotionEffectType type = new MockPotionEffectType(id, name, instant, Color.fromRGB(rgb));
+		PotionEffectType.registerPotionEffectType(type);
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -70,6 +70,7 @@ import org.bukkit.map.MapView;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.ServicesManager;
 import org.bukkit.plugin.messaging.Messenger;
+import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.CachedServerIcon;
 
 import be.seeseemelk.mockbukkit.command.CommandResult;
@@ -86,6 +87,7 @@ import be.seeseemelk.mockbukkit.inventory.ItemFactoryMock;
 import be.seeseemelk.mockbukkit.inventory.PlayerInventoryMock;
 import be.seeseemelk.mockbukkit.inventory.meta.ItemMetaMock;
 import be.seeseemelk.mockbukkit.plugin.PluginManagerMock;
+import be.seeseemelk.mockbukkit.potion.MockPotionEffectType;
 import be.seeseemelk.mockbukkit.scheduler.BukkitSchedulerMock;
 import be.seeseemelk.mockbukkit.scoreboard.ScoreboardManagerMock;
 
@@ -1253,6 +1255,53 @@ public class ServerMock implements Server
 
 		// Per definition this method should return null if the given tag does not exist.
 		return null;
+	}
+
+	/**
+	 * This registers Minecrafts default {@link PotionEffectType PotionEffectTypes}. If you somehow need to add your
+	 * own, override this method but make sure to run your code before calling this, as it prevents any new effects to
+	 * be created afterwards.
+	 */
+	public void createPotionEffectTypes()
+	{
+		registerPotionEffectType(1, "SPEED", false, 8171462);
+		registerPotionEffectType(2, "SLOWNESS", false, 5926017);
+		registerPotionEffectType(3, "HASTE", false, 14270531);
+		registerPotionEffectType(4, "MINING_FATIGUE", false, 4866583);
+		registerPotionEffectType(5, "STRENGTH", false, 9643043);
+		registerPotionEffectType(6, "INSTANT_HEALTH", true, 16262179);
+		registerPotionEffectType(7, "INSTANT_DAMAGE", true, 4393481);
+		registerPotionEffectType(8, "JUMP_BOOST", false, 2293580);
+		registerPotionEffectType(9, "NAUSEA", false, 5578058);
+		registerPotionEffectType(10, "REGENERATION", false, 13458603);
+		registerPotionEffectType(11, "RESISTANCE", false, 10044730);
+		registerPotionEffectType(12, "FIRE_RESISTANCE", false, 14981690);
+		registerPotionEffectType(13, "WATER_BREATHING", false, 3035801);
+		registerPotionEffectType(14, "INVISIBILITY", false, 8356754);
+		registerPotionEffectType(15, "BLINDNESS", false, 2039587);
+		registerPotionEffectType(16, "NIGHT_VISION", false, 2039713);
+		registerPotionEffectType(17, "HUNGER", false, 5797459);
+		registerPotionEffectType(18, "WEAKNESS", false, 4738376);
+		registerPotionEffectType(19, "POISON", false, 5149489);
+		registerPotionEffectType(20, "WITHER", false, 3484199);
+		registerPotionEffectType(21, "HEALTH_BOOST", false, 16284963);
+		registerPotionEffectType(22, "ABSORPTION", false, 2445989);
+		registerPotionEffectType(23, "SATURATION", true, 16262179);
+		registerPotionEffectType(24, "GLOWING", false, 9740385);
+		registerPotionEffectType(25, "LEVITATION", false, 13565951);
+		registerPotionEffectType(26, "LUCK", false, 3381504);
+		registerPotionEffectType(27, "UNLUCK", false, 12624973);
+		registerPotionEffectType(28, "SLOW_FALLING", false, 16773073);
+		registerPotionEffectType(29, "CONDUIT_POWER", false, 1950417);
+		registerPotionEffectType(30, "DOLPHINS_GRACE", false, 8954814);
+		registerPotionEffectType(31, "BAD_OMEN", false, 745784);
+		registerPotionEffectType(32, "HERO_OF_THE_VILLAGE", false, 45217);
+		PotionEffectType.stopAcceptingRegistrations();
+	}
+
+	private void registerPotionEffectType(int id, String name, boolean instant, int rgb)
+	{
+		PotionEffectType.registerPotionEffectType(new MockPotionEffectType(id, name, instant, rgb));
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/block/BlockMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/BlockMock.java
@@ -5,9 +5,6 @@ import static org.junit.Assert.fail;
 import java.util.Collection;
 import java.util.List;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.block.data.BlockDataMock;
-import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.FluidCollisionMode;
 import org.bukkit.Location;
@@ -26,11 +23,11 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.util.BoundingBox;
 import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
 
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import be.seeseemelk.mockbukkit.block.data.BlockDataMock;
 import junit.framework.AssertionFailedError;
-import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
 
 public class BlockMock implements org.bukkit.block.Block
 {

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ZombieMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ZombieMock.java
@@ -1,14 +1,13 @@
 package be.seeseemelk.mockbukkit.entity;
 
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import java.util.UUID;
 
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Villager;
 import org.bukkit.entity.Zombie;
-import org.jetbrains.annotations.Contract;
 
-import java.util.UUID;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 
 public class ZombieMock extends MonsterMock implements Zombie
 {

--- a/src/main/java/be/seeseemelk/mockbukkit/potion/MockPotionEffectType.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/potion/MockPotionEffectType.java
@@ -1,0 +1,55 @@
+package be.seeseemelk.mockbukkit.potion;
+
+import org.bukkit.Color;
+import org.bukkit.potion.PotionEffectType;
+
+/**
+ * This {@link MockPotionEffectType} mocks an actual {@link PotionEffectType} by taking an id,
+ * a name, whether it is instant and a RGB {@link Color} variable.
+ * 
+ * @author TheBusyBiscuit
+ *
+ */
+public class MockPotionEffectType extends PotionEffectType
+{
+
+	private final String name;
+	private final boolean instant;
+	private final Color color;
+
+	public MockPotionEffectType(int id, String name, boolean instant, int rgb)
+	{
+		super(id);
+
+		this.name = name;
+		this.instant = instant;
+		this.color = Color.fromRGB(rgb);
+	}
+
+	@Deprecated
+	@Override
+	public double getDurationModifier()
+	{
+		// This is deprecated and always returns 1.0
+		return 1.0;
+	}
+
+	@Override
+	public String getName()
+	{
+		return name;
+	}
+
+	@Override
+	public boolean isInstant()
+	{
+		return instant;
+	}
+
+	@Override
+	public Color getColor()
+	{
+		return color;
+	}
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/potion/MockPotionEffectType.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/potion/MockPotionEffectType.java
@@ -4,8 +4,8 @@ import org.bukkit.Color;
 import org.bukkit.potion.PotionEffectType;
 
 /**
- * This {@link MockPotionEffectType} mocks an actual {@link PotionEffectType} by taking an id,
- * a name, whether it is instant and a RGB {@link Color} variable.
+ * This {@link MockPotionEffectType} mocks an actual {@link PotionEffectType} by taking an id, a name, whether it is
+ * instant and a RGB {@link Color} variable.
  * 
  * @author TheBusyBiscuit
  *
@@ -17,13 +17,13 @@ public class MockPotionEffectType extends PotionEffectType
 	private final boolean instant;
 	private final Color color;
 
-	public MockPotionEffectType(int id, String name, boolean instant, int rgb)
+	public MockPotionEffectType(int id, String name, boolean instant, Color color)
 	{
 		super(id);
 
 		this.name = name;
 		this.instant = instant;
-		this.color = Color.fromRGB(rgb);
+		this.color = color;
 	}
 
 	@Deprecated
@@ -50,6 +50,23 @@ public class MockPotionEffectType extends PotionEffectType
 	public Color getColor()
 	{
 		return color;
+	}
+
+	@Override
+	public boolean equals(Object obj)
+	{
+		if (obj instanceof PotionEffectType)
+		{
+			return getId() == ((PotionEffectType) obj).getId();
+		}
+
+		return false;
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return getId();
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -28,6 +28,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.Recipe;
+import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scoreboard.ScoreboardManager;
 import org.junit.After;
 import org.junit.Before;
@@ -538,6 +539,16 @@ public class ServerMockTest
 		assertNull(Tag.BUTTONS);
 		assertNull(Tag.BEDS);
 		assertNull(Tag.BANNERS);
+	}
+	
+	@Test
+	public void testDefaultPotionEffects()
+	{
+		assertEquals(32, PotionEffectType.values().length);
+		
+		for (PotionEffectType type : PotionEffectType.values()) {
+			assertNotNull(type);
+		}
 	}
 }
 

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/InventoryMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/InventoryMockTest.java
@@ -1,11 +1,11 @@
 package be.seeseemelk.mockbukkit.inventory;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertArrayEquals;
 
 import java.util.HashMap;
 import java.util.ListIterator;
@@ -16,7 +16,6 @@ import org.bukkit.Material;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.ItemStack;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
This can be seen as a follow-up Pull Request to #75.
It turns out that, similar to the Material Tags, the Potion Effect Types need to be registered by the Server itself.
So I decided that it would be best to just register all default Potion Effect Types in the ServerMock class, with a - rather primitive - safeguard to avoid double-registration and IllegalArgumentExceptions.
Without this Pull Request, all Potion Effects would have to be registered manually before being able to use them inside a Unit Test, so this is definitely worth adding in my opinion.

I have also added a rather simple Unit Test for this.