### PR TITLE
Added a simple Item Entity Mock + Player first/last played

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -124,7 +124,7 @@ public class ServerMock implements Server
 		logger = Logger.getLogger("ServerMock");
 		commandMap = new MockCommandMap(this);
 		ServerMock.registerSerializables();
-		
+
 		// Register default Minecraft Potion Effect Types
 		createPotionEffectTypes();
 
@@ -196,9 +196,9 @@ public class ServerMock implements Server
 		PlayerJoinEvent playerJoinEvent = new PlayerJoinEvent(player,
 				String.format(JOIN_MESSAGE, player.getDisplayName()));
 		Bukkit.getPluginManager().callEvent(playerJoinEvent);
+
+		player.setLastPlayed(getCurrentServerTime());
 		registerEntity(player);
-		
-		player.setLastPlayed(System.currentTimeMillis());
 	}
 
 	/**
@@ -1264,20 +1264,22 @@ public class ServerMock implements Server
 	}
 
 	/**
-	 * This registers Minecrafts default {@link PotionEffectType PotionEffectTypes}. 
-	 * It also prevents any new effects to be created afterwards.
+	 * This registers Minecrafts default {@link PotionEffectType PotionEffectTypes}. It also prevents any new effects to
+	 * be created afterwards.
 	 */
 	private void createPotionEffectTypes()
 	{
-		for (PotionEffectType type : PotionEffectType.values()) {
+		for (PotionEffectType type : PotionEffectType.values())
+		{
 			// We probably already registered all Potion Effects
 			// otherwise this would be null
-			if (type != null) {
+			if (type != null)
+			{
 				// This is not perfect, but it works.
 				return;
 			}
 		}
-		
+
 		registerPotionEffectType(1, "SPEED", false, 8171462);
 		registerPotionEffectType(2, "SLOWNESS", false, 5926017);
 		registerPotionEffectType(3, "HASTE", false, 14270531);
@@ -1429,5 +1431,15 @@ public class ServerMock implements Server
 		}
 
 		return false;
+	}
+
+	/**
+	 * This returns the current time of the {@link Server} in milliseconds
+	 * 
+	 * @return The current {@link Server} time
+	 */
+	protected long getCurrentServerTime()
+	{
+		return System.currentTimeMillis();
 	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -197,6 +197,8 @@ public class ServerMock implements Server
 				String.format(JOIN_MESSAGE, player.getDisplayName()));
 		Bukkit.getPluginManager().callEvent(playerJoinEvent);
 		registerEntity(player);
+		
+		player.setLastPlayed(System.currentTimeMillis());
 	}
 
 	/**

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -17,9 +17,11 @@ import org.bukkit.Bukkit;
 import org.bukkit.EntityEffect;
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.block.BlockFace;
 import org.bukkit.block.PistonMoveReaction;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Pose;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.metadata.MetadataValue;
@@ -28,6 +30,7 @@ import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.permissions.PermissionAttachmentInfo;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.util.BoundingBox;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
@@ -52,7 +55,7 @@ public abstract class EntityMock implements Entity, MessageTarget
 	private final Set<PermissionAttachment> permissionAttachments = new HashSet<>();
 	private Vector velocity = new Vector(0, 0, 0);
 
-	public EntityMock(ServerMock server, UUID uuid)
+	public EntityMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		this.server = server;
 		this.uuid = uuid;
@@ -741,4 +744,40 @@ public abstract class EntityMock implements Entity, MessageTarget
 		throw new UnimplementedOperationException();
 	}
 
+
+
+	@Override
+	public BoundingBox getBoundingBox()
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public boolean isPersistent()
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public void setPersistent(boolean persistent)
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public BlockFace getFacing()
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public Pose getPose()
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ItemEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ItemEntityMock.java
@@ -31,6 +31,8 @@ public class ItemEntityMock extends EntityMock implements Item
 	@Override
 	public void setItemStack(ItemStack stack)
 	{
+		// "stack" is actually nullable here, but it seems like Spigot also throws an Exception
+		// in that case anyway. Besides a "null" Item does not really make sense anyway.
 		this.item = stack.clone();
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ItemEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ItemEntityMock.java
@@ -1,0 +1,49 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import java.util.UUID;
+
+import org.bukkit.entity.Item;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import be.seeseemelk.mockbukkit.ServerMock;
+
+public class ItemEntityMock extends EntityMock implements Item
+{
+
+	private ItemStack item;
+
+	// The default pickup delay
+	private int delay = 10;
+
+	public ItemEntityMock(@NotNull ServerMock server, @NotNull UUID uuid, @NotNull ItemStack item)
+	{
+		super(server, uuid);
+		this.item = item.clone();
+	}
+
+	@Override
+	public ItemStack getItemStack()
+	{
+		return item;
+	}
+
+	@Override
+	public void setItemStack(ItemStack stack)
+	{
+		this.item = stack.clone();
+	}
+
+	@Override
+	public int getPickupDelay()
+	{
+		return delay;
+	}
+
+	@Override
+	public void setPickupDelay(int delay)
+	{
+		this.delay = Math.min(delay, 32767);
+	}
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -19,7 +19,6 @@ import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -32,7 +31,6 @@ import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-import org.bukkit.util.BoundingBox;
 import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
 
@@ -189,34 +187,6 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 			return attributes.get(attribute);
 		else
 			throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public BoundingBox getBoundingBox()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public boolean isPersistent()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public void setPersistent(boolean persistent)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public BlockFace getFacing()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/MobMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/MobMock.java
@@ -4,7 +4,6 @@ import java.util.UUID;
 
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Mob;
-import org.bukkit.entity.Pose;
 import org.bukkit.entity.memory.MemoryKey;
 import org.bukkit.loot.LootTable;
 
@@ -91,13 +90,6 @@ public abstract class MobMock extends LivingEntityMock implements Mob
 
 	@Override
 	public void setAbsorptionAmount(double amount)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public Pose getPose()
 	{
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -101,6 +101,8 @@ public class PlayerMock extends LivingEntityMock implements Player
 	private Location compassTarget;
 	private Location bedSpawnLocation;
 	private ItemStack cursor = null;
+	private long firstPlayed = 0;
+	private long lastPlayed = 0;
 
 	private final List<AudioExperience> heardSounds = new LinkedList<>();
 
@@ -144,7 +146,7 @@ public class PlayerMock extends LivingEntityMock implements Player
 		int result = super.hashCode();
 		result = prime * result + Objects.hash(attributes, exp, expLevel, expTotal, displayName, gamemode, getHealth(),
 				foodLevel, saturation, inventory, enderChest, inventoryView, getMaxHealth(), online, whitelisted,
-				compassTarget, bedSpawnLocation, cursor);
+				compassTarget, bedSpawnLocation, cursor, firstPlayed, lastPlayed);
 		return result;
 	}
 
@@ -792,22 +794,33 @@ public class PlayerMock extends LivingEntityMock implements Player
 	@Override
 	public long getFirstPlayed()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return firstPlayed;
 	}
 
 	@Override
 	public long getLastPlayed()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return lastPlayed;
 	}
 
 	@Override
 	public boolean hasPlayedBefore()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return firstPlayed > 0;
+	}
+
+	public void setLastPlayed(long time)
+	{
+		if (time > 0)
+		{
+			lastPlayed = time;
+
+			// Set firstPlayed if this is the first time
+			if (firstPlayed == 0)
+			{
+				firstPlayed = time;
+			}
+		}
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -159,7 +159,6 @@ public class PlayerMock extends LivingEntityMock implements Player
 			return false;
 		if (!(obj instanceof PlayerMock))
 			return false;
-
 		PlayerMock other = (PlayerMock) obj;
 		return Objects.equals(attributes, other.attributes) && Objects.equals(displayName, other.displayName)
 				&& gamemode == other.gamemode
@@ -167,7 +166,8 @@ public class PlayerMock extends LivingEntityMock implements Player
 				&& Objects.equals(inventory, other.inventory) && Objects.equals(inventoryView, other.inventoryView)
 				&& Objects.equals(cursor, other.cursor)
 				&& Double.doubleToLongBits(getMaxHealth()) == Double.doubleToLongBits(other.getMaxHealth())
-				&& online == other.online && whitelisted == other.whitelisted && isDead() == other.isDead();
+				&& online == other.online && whitelisted == other.whitelisted && isDead() == other.isDead()
+				&& firstPlayed == other.firstPlayed && lastPlayed == other.lastPlayed;
 	}
 
 	/**

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -540,13 +540,14 @@ public class ServerMockTest
 		assertNull(Tag.BEDS);
 		assertNull(Tag.BANNERS);
 	}
-	
+
 	@Test
 	public void testDefaultPotionEffects()
 	{
 		assertEquals(32, PotionEffectType.values().length);
-		
-		for (PotionEffectType type : PotionEffectType.values()) {
+
+		for (PotionEffectType type : PotionEffectType.values())
+		{
 			assertNotNull(type);
 		}
 	}

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -928,4 +928,30 @@ public class PlayerMockTest
 			assertTrue(player.hasPotionEffect(effect.getType()));
 		}
 	}
+
+	@Test
+	public void testFirstPlayed() throws InterruptedException
+	{
+		PlayerMock player = new PlayerMock(server, "FirstPlayed123");
+
+		assertFalse(player.hasPlayedBefore());
+		assertEquals(0, player.getFirstPlayed());
+		assertEquals(0, player.getLastPlayed());
+		
+		server.addPlayer(player);
+		long firstPlayed = player.getFirstPlayed();
+		
+		assertTrue(player.hasPlayedBefore());
+		assertTrue(firstPlayed > 0);
+		assertEquals(player.getFirstPlayed(), player.getLastPlayed());
+		
+		// This forces the time to be different by at least 1ms
+		Thread.sleep(1);
+		
+		// Player reconnects
+		server.addPlayer(player);
+		
+		assertEquals(firstPlayed, player.getFirstPlayed());
+		assertNotEquals(player.getFirstPlayed(), player.getLastPlayed());
+	}
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -75,7 +75,22 @@ public class PlayerMockTest
 	@Before
 	public void setUp()
 	{
-		server = MockBukkit.mock();
+		server = MockBukkit.mock(new ServerMock()
+		{
+
+			private long ticks = 0;
+
+			@Override
+			protected long getCurrentServerTime()
+			{
+				// This will force the current server time to always be different to
+				// any prior invocations, this is much more elegant than simply doing
+				// Thread.sleep!
+				ticks++;
+				return super.getCurrentServerTime() + ticks;
+			}
+		});
+
 		uuid = UUID.randomUUID();
 		player = new PlayerMock(server, "player", uuid);
 	}
@@ -937,20 +952,17 @@ public class PlayerMockTest
 		assertFalse(player.hasPlayedBefore());
 		assertEquals(0, player.getFirstPlayed());
 		assertEquals(0, player.getLastPlayed());
-		
+
 		server.addPlayer(player);
 		long firstPlayed = player.getFirstPlayed();
-		
+
 		assertTrue(player.hasPlayedBefore());
 		assertTrue(firstPlayed > 0);
 		assertEquals(player.getFirstPlayed(), player.getLastPlayed());
-		
-		// This forces the time to be different by at least 1ms
-		Thread.sleep(1);
-		
+
 		// Player reconnects
 		server.addPlayer(player);
-		
+
 		assertEquals(firstPlayed, player.getFirstPlayed());
 		assertNotEquals(player.getFirstPlayed(), player.getLastPlayed());
 	}


### PR DESCRIPTION
A simple Item Entity mock has been added.
It is a pretty small class and only really holds the ItemStack, as it is supposed to.
I have also moved some methods up to the EntityMock class since they belong to the Entity class, not to LivingEntity.

I have also implemented the methods `getFirstPlayed()`,  `getLastPlayed()` and  `hasPlayedBefore()`.
The "lastPlayed" time will be set everytime ServerMock#addPlayer() is invoked. "firstPlayed" will only be set on the first invocation. I have also included a Unit Test to test this behaviour.