### PR TITLE
Added Experience Orb mock + some fixes

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
@@ -495,11 +495,17 @@ public class WorldMock implements World
 	public Entity spawnEntity(Location loc, EntityType type)
 	{
 		EntityMock entity = null;
+
 		switch (type)
 		{
 		case ZOMBIE:
 			entity = new ZombieMock(server, UUID.randomUUID());
 			break;
+		case FIREWORK:
+			entity = new FireworkMock(server, UUID.randomUUID());
+			break;
+		case PLAYER:
+			throw new IllegalArgumentException("Player Entities cannot be spawned, use ServerMock#addPlayer(...)");
 		case DROPPED_ITEM:
 			throw new IllegalArgumentException("Items must be spawned using World#dropItem(...)");
 		case ARROW:
@@ -512,8 +518,6 @@ public class WorldMock implements World
 		case AREA_EFFECT_CLOUD:
 		case EXPERIENCE_ORB:
 		case UNKNOWN:
-		case PLAYER:
-			throw new IllegalArgumentException("Player Entities cannot be spawned, use ServerMock#addPlayer(...)");
 		case LIGHTNING:
 		case FISHING_HOOK:
 		case FOX:
@@ -592,9 +596,6 @@ public class WorldMock implements World
 		case SHULKER_BULLET:
 		case SPECTRAL_ARROW:
 		case HUSK:
-		case FIREWORK:
-			entity = new FireworkMock(server, UUID.randomUUID());
-			break;
 		case FALLING_BLOCK:
 		case PRIMED_TNT:
 		case WITHER_SKULL:
@@ -610,11 +611,13 @@ public class WorldMock implements World
 		default:
 			throw new UnimplementedOperationException();
 		}
+
 		if (entity != null)
 		{
 			entity.setLocation(loc);
 			server.registerEntity(entity);
 		}
+
 		return entity;
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
@@ -60,6 +60,7 @@ import org.jetbrains.annotations.NotNull;
 
 import be.seeseemelk.mockbukkit.block.BlockMock;
 import be.seeseemelk.mockbukkit.entity.EntityMock;
+import be.seeseemelk.mockbukkit.entity.ExperienceOrbMock;
 import be.seeseemelk.mockbukkit.entity.FireworkMock;
 import be.seeseemelk.mockbukkit.entity.ItemEntityMock;
 import be.seeseemelk.mockbukkit.entity.ZombieMock;
@@ -494,131 +495,32 @@ public class WorldMock implements World
 	@Override
 	public Entity spawnEntity(Location loc, EntityType type)
 	{
-		EntityMock entity = null;
+		EntityMock entity = mockEntity(type);
+		entity.setLocation(loc);
+		server.registerEntity(entity);
 
+		return entity;
+	}
+
+	private EntityMock mockEntity(@NotNull EntityType type)
+	{
 		switch (type)
 		{
 		case ZOMBIE:
-			entity = new ZombieMock(server, UUID.randomUUID());
-			break;
+			return new ZombieMock(server, UUID.randomUUID());
 		case FIREWORK:
-			entity = new FireworkMock(server, UUID.randomUUID());
-			break;
+			return new FireworkMock(server, UUID.randomUUID());
+		case EXPERIENCE_ORB:
+			return new ExperienceOrbMock(server, UUID.randomUUID());
 		case PLAYER:
 			throw new IllegalArgumentException("Player Entities cannot be spawned, use ServerMock#addPlayer(...)");
 		case DROPPED_ITEM:
 			throw new IllegalArgumentException("Items must be spawned using World#dropItem(...)");
-		case ARROW:
-		case PAINTING:
-		case LEASH_HITCH:
-		case EGG:
-		case STRAY:
-		case WITHER_SKELETON:
-		case ELDER_GUARDIAN:
-		case AREA_EFFECT_CLOUD:
-		case EXPERIENCE_ORB:
-		case UNKNOWN:
-		case LIGHTNING:
-		case FISHING_HOOK:
-		case FOX:
-		case WANDERING_TRADER:
-		case TRADER_LLAMA:
-		case RAVAGER:
-		case PILLAGER:
-		case PANDA:
-		case CAT:
-		case DOLPHIN:
-		case DROWNED:
-		case TROPICAL_FISH:
-		case PUFFERFISH:
-		case SALMON:
-		case COD:
-		case TRIDENT:
-		case PHANTOM:
-		case TURTLE:
-		case ENDER_CRYSTAL:
-		case VILLAGER:
-		case PARROT:
-		case LLAMA_SPIT:
-		case LLAMA:
-		case POLAR_BEAR:
-		case RABBIT:
-		case HORSE:
-		case IRON_GOLEM:
-		case OCELOT:
-		case SNOWMAN:
-		case MUSHROOM_COW:
-		case WOLF:
-		case SQUID:
-		case CHICKEN:
-		case COW:
-		case SHEEP:
-		case PIG:
-		case SHULKER:
-		case GUARDIAN:
-		case ENDERMITE:
-		case WITCH:
-		case BAT:
-		case WITHER:
-		case ENDER_DRAGON:
-		case MAGMA_CUBE:
-		case BLAZE:
-		case SILVERFISH:
-		case CAVE_SPIDER:
-		case ENDERMAN:
-		case PIG_ZOMBIE:
-		case GHAST:
-		case SLIME:
-		case GIANT:
-		case SPIDER:
-		case SKELETON:
-		case CREEPER:
-		case MINECART_MOB_SPAWNER:
-		case MINECART_HOPPER:
-		case MINECART_TNT:
-		case MINECART_FURNACE:
-		case MINECART_CHEST:
-		case MINECART:
-		case BOAT:
-		case MINECART_COMMAND:
-		case ILLUSIONER:
-		case VINDICATOR:
-		case VEX:
-		case EVOKER:
-		case EVOKER_FANGS:
-		case MULE:
-		case DONKEY:
-		case ARMOR_STAND:
-		case ZOMBIE_HORSE:
-		case SKELETON_HORSE:
-		case ZOMBIE_VILLAGER:
-		case DRAGON_FIREBALL:
-		case SHULKER_BULLET:
-		case SPECTRAL_ARROW:
-		case HUSK:
-		case FALLING_BLOCK:
-		case PRIMED_TNT:
-		case WITHER_SKULL:
-		case ITEM_FRAME:
-		case THROWN_EXP_BOTTLE:
-		case SPLASH_POTION:
-		case ENDER_SIGNAL:
-		case ENDER_PEARL:
-		case SMALL_FIREBALL:
-		case FIREBALL:
-		case SNOWBALL:
-			break;
 		default:
+			// If that specific Mob Type has not been implemented yet, it may be better
+			// to throw an UnimplementedOperationException for consistency
 			throw new UnimplementedOperationException();
 		}
-
-		if (entity != null)
-		{
-			entity.setLocation(loc);
-			server.registerEntity(entity);
-		}
-
-		return entity;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ExperienceOrbMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ExperienceOrbMock.java
@@ -1,0 +1,53 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import java.util.UUID;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.ExperienceOrb;
+import org.jetbrains.annotations.NotNull;
+
+import be.seeseemelk.mockbukkit.ServerMock;
+
+/**
+ * This is a simple mock of the {@link ExperienceOrb} {@link Entity}.
+ * 
+ * @author TheBusyBiscuit
+ *
+ */
+public class ExperienceOrbMock extends EntityMock implements ExperienceOrb
+{
+
+	private int experience;
+
+	public ExperienceOrbMock(@NotNull ServerMock server, @NotNull UUID uuid)
+	{
+		this(server, uuid, 0);
+	}
+
+	public ExperienceOrbMock(@NotNull ServerMock server, @NotNull UUID uuid, int experience)
+	{
+		super(server, uuid);
+
+		this.experience = experience;
+	}
+
+	@Override
+	public EntityType getType()
+	{
+		return EntityType.EXPERIENCE_ORB;
+	}
+
+	@Override
+	public int getExperience()
+	{
+		return experience;
+	}
+
+	@Override
+	public void setExperience(int value)
+	{
+		this.experience = value;
+	}
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/FireworkMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/FireworkMock.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import org.apache.commons.lang.Validate;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Firework;
 import org.bukkit.inventory.meta.FireworkMeta;
 import org.jetbrains.annotations.NotNull;
@@ -35,6 +36,12 @@ public class FireworkMock extends EntityMock implements Firework
 		super(server, uuid);
 
 		this.meta = meta.clone();
+	}
+
+	@Override
+	public EntityType getType()
+	{
+		return EntityType.FIREWORK;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ItemEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ItemEntityMock.java
@@ -2,6 +2,7 @@ package be.seeseemelk.mockbukkit.entity;
 
 import java.util.UUID;
 
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Item;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -26,6 +27,12 @@ public class ItemEntityMock extends EntityMock implements Item
 	{
 		super(server, uuid);
 		this.item = item.clone();
+	}
+
+	@Override
+	public EntityType getType()
+	{
+		return EntityType.DROPPED_ITEM;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/FireworkMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/FireworkMetaMock.java
@@ -60,7 +60,10 @@ public class FireworkMetaMock extends ItemMetaMock implements FireworkMeta
 	public FireworkMetaMock clone()
 	{
 		FireworkMetaMock mock = (FireworkMetaMock) super.clone();
+
+		mock.effects.clear();
 		mock.effects.addAll(this.effects);
+
 		return mock;
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/ExperienceOrbMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/ExperienceOrbMockTest.java
@@ -1,0 +1,78 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.UUID;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.ExperienceOrb;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.WorldMock;
+
+public class ExperienceOrbMockTest
+{
+
+	private ServerMock server;
+	private World world;
+
+	@Before
+	public void setUp()
+	{
+		server = MockBukkit.mock();
+		world = new WorldMock();
+	}
+
+	@After
+	public void tearDown()
+	{
+		MockBukkit.unmock();
+	}
+
+	@Test
+	public void testEntityType()
+	{
+		ExperienceOrb orb = new ExperienceOrbMock(server, UUID.randomUUID());
+		assertEquals(EntityType.EXPERIENCE_ORB, orb.getType());
+	}
+
+	@Test
+	public void testEntitySpawning()
+	{
+		Location location = new Location(world, 100, 100, 100);
+		ExperienceOrb orb = (ExperienceOrb) world.spawnEntity(location, EntityType.EXPERIENCE_ORB);
+
+		// Does our Firework exist in the correct World?
+		assertTrue(world.getEntities().contains(orb));
+
+		// 0 experience by default?
+		assertEquals(0, orb.getExperience());
+
+		// Is it at the right location?
+		assertEquals(location, orb.getLocation());
+	}
+
+	@Test
+	public void testSecondConstructor()
+	{
+		ExperienceOrb orb = new ExperienceOrbMock(server, UUID.randomUUID(), 10);
+		assertEquals(10, orb.getExperience());
+	}
+
+	@Test
+	public void testSetExperience()
+	{
+		ExperienceOrb orb = new ExperienceOrbMock(server, UUID.randomUUID(), 0);
+
+		assertEquals(0, orb.getExperience());
+		orb.setExperience(10);
+		assertEquals(10, orb.getExperience());
+	}
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/FireworkMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/FireworkMockTest.java
@@ -61,6 +61,13 @@ public class FireworkMockTest
 	}
 
 	@Test
+	public void testEntityType()
+	{
+		Firework firework = new FireworkMock(server, UUID.randomUUID());
+		assertEquals(EntityType.FIREWORK, firework.getType());
+	}
+
+	@Test
 	public void testSecondConstructor()
 	{
 		FireworkMeta meta = new FireworkMetaMock();

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/ItemEntityMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/ItemEntityMockTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.UUID;
+
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -15,17 +17,19 @@ import org.junit.Before;
 import org.junit.Test;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.WorldMock;
 
 public class ItemEntityMockTest
 {
 
+	private ServerMock server;
 	private World world;
 
 	@Before
 	public void setUp()
 	{
-		MockBukkit.mock();
+		server = MockBukkit.mock();
 		world = new WorldMock();
 	}
 
@@ -76,6 +80,13 @@ public class ItemEntityMockTest
 	{
 		Location location = new Location(world, 300, 100, 300);
 		world.spawnEntity(location, EntityType.DROPPED_ITEM);
+	}
+
+	@Test
+	public void testEntityType()
+	{
+		Item item = new ItemEntityMock(server, UUID.randomUUID(), new ItemStack(Material.STONE));
+		assertEquals(EntityType.DROPPED_ITEM, item.getType());
 	}
 
 	@Test


### PR DESCRIPTION
This Pull Request adds a mock for the `ExperienceOrb` entity.

I have also fixed some issues with my previous PR and inconsistencies in general:
1. Each Entity Mock now returns the proper `EntityType`.
2. Fixed the switch/case overflowing cases into the Firework entity because I missed a `break;` there
3. I have changed the `WorldMock#spawnEntity(...)` method so that it would now **always** throw an `UnimplementedOperationException` if the underlying Entity has not been implemented yet. To me this is much more consistent with what this exception represents and the rest of the codebase. Returning null for unimplemented entities could have lead to NullPointerExceptions anyway, making the test fail rather than skip.