### PR TITLE
Fixed another exception

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.3-R0.1-SNAPSHOT'
-gradle.ext.version = '0.10.1'
+gradle.ext.version = '0.10.2'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/src/main/java/be/seeseemelk/mockbukkit/tags/TagsMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/tags/TagsMock.java
@@ -5,11 +5,13 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -116,9 +118,11 @@ public final class TagsMock
 	{
 		try
 		{
-			return FileSystems.newFileSystem(uri, Collections.emptyMap());
+			Map<String, String> env = new HashMap<>();
+			env.put("create", "true");
+			return FileSystems.newFileSystem(uri, env);
 		}
-		catch (IllegalArgumentException e)
+		catch (IllegalArgumentException | FileSystemAlreadyExistsException e)
 		{
 			return FileSystems.getDefault();
 		}


### PR DESCRIPTION
# Description
As a follow up of PR #124, the code is invoked more than once, so while the previous bug was fixed, it will now lead to a `java.nio.file.FileSystemAlreadyExistsException` which this PR addresses now too.
Let's cross our fingers and hope this will be the last one XD

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [ ] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
Before the pull request can be accepted, the version number stored in settings.gradle should be updated.
MockBukkit uses semantic-versioning (https://semver.org/)

 - If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
 - If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)
 - Make sure that unit tests are added which test the relevant changes.
 - Make sure that the changes follow the existing code format.

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.

The version number can be found in `settings.gradle`.
