### PR TITLE
Added basic functionality of Block#breakNaturally

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.3-R0.1-SNAPSHOT'
-gradle.ext.version = '0.11.2'
+gradle.ext.version = '0.11.0'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.3-R0.1-SNAPSHOT'
-gradle.ext.version = '0.10.2'
+gradle.ext.version = '0.11.2'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/src/main/java/be/seeseemelk/mockbukkit/block/BlockMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/BlockMock.java
@@ -344,15 +344,18 @@ public class BlockMock implements Block
 	@Override
 	public boolean breakNaturally()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		if (this.isEmpty())
+		{
+			return false;
+		}
+		this.setType(Material.AIR);
+		return true;
 	}
 
 	@Override
 	public boolean breakNaturally(ItemStack tool)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.breakNaturally();
 	}
 
 	@Override

--- a/src/test/java/be/seeseemelk/mockbukkit/block/BlockMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/BlockMockTest.java
@@ -174,4 +174,12 @@ public class BlockMockTest
 		block.setType(Material.STONE);
 		assertFalse(block.isEmpty());
 	}
+
+	@Test
+	public void testBreakNaturally()
+	{
+		block.setType(Material.STONE);
+		block.breakNaturally();
+		assertTrue(block.isEmpty());
+	}
 }


### PR DESCRIPTION
# Description
Added basic functionality of Block#breakNaturally (breaks block, no event).
This does not include block drops that can be picked up by the player.
This PR fixes #126

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
Before the pull request can be accepted, the version number stored in settings.gradle should be updated.
MockBukkit uses semantic-versioning (https://semver.org/)

 - If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
 - If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)
 - Make sure that unit tests are added which test the relevant changes.
 - Make sure that the changes follow the existing code format.

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.

The version number can be found in `settings.gradle`.
