### PR TITLE
Fixed not null return values in PlayerInventory to match CraftBukkit implementation

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.3-R0.1-SNAPSHOT'
-gradle.ext.version = '0.13.0'
+gradle.ext.version = '0.13.1'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/src/main/java/be/seeseemelk/mockbukkit/ChunkMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ChunkMock.java
@@ -2,6 +2,7 @@ package be.seeseemelk.mockbukkit;
 
 import java.util.Collection;
 
+import be.seeseemelk.mockbukkit.persistence.PersistentDataContainerMock;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Chunk;
 import org.bukkit.ChunkSnapshot;
@@ -10,6 +11,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Entity;
+import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.plugin.Plugin;
 
 public class ChunkMock implements Chunk
@@ -18,6 +20,7 @@ public class ChunkMock implements Chunk
 	private final int x;
 	private final int z;
 	private boolean loaded = true;
+	private final PersistentDataContainer persistentDataContainer = new PersistentDataContainerMock();
 
 	protected ChunkMock(final World world, final int x, final int z)
 	{
@@ -48,7 +51,7 @@ public class ChunkMock implements Chunk
 	public Block getBlock(int x, int y, int z)
 	{
 		Validate.isTrue(x >= 0 && x <= 15, "x is out of range (expected 0-15)");
-		Validate.isTrue(x >= 0 && x <= 255, "y is out of range (expected 0-255)");
+		Validate.isTrue(y >= 0 && y <= 255, "y is out of range (expected 0-255)");
 		Validate.isTrue(z >= 0 && z <= 15, "z is out of range (expected 0-15)");
 		return world.getBlockAt(x << 4, y, z << 4);
 	}
@@ -196,4 +199,9 @@ public class ChunkMock implements Chunk
 		throw new UnimplementedOperationException();
 	}
 
+	@Override
+	public PersistentDataContainer getPersistentDataContainer()
+	{
+		return persistentDataContainer;
+	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/command/ConsoleCommandSenderMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/command/ConsoleCommandSenderMock.java
@@ -13,6 +13,7 @@ import org.bukkit.plugin.Plugin;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.Set;
+import java.util.UUID;
 
 public class ConsoleCommandSenderMock implements ConsoleCommandSender, MessageTarget
 {
@@ -21,11 +22,23 @@ public class ConsoleCommandSenderMock implements ConsoleCommandSender, MessageTa
 	@Override
 	public void sendMessage(String message)
 	{
-		messages.add(message);
+		sendMessage(null, message);
 	}
-	
+
 	@Override
 	public void sendMessage(String[] messages)
+	{
+		sendMessage(null, messages);
+	}
+
+	@Override
+	public void sendMessage(UUID sender, String message)
+	{
+		messages.add(message);
+	}
+
+	@Override
+	public void sendMessage(UUID sender, String[] messages)
 	{
 		for (String message : messages)
 		{
@@ -181,6 +194,12 @@ public class ConsoleCommandSenderMock implements ConsoleCommandSender, MessageTa
 	
 	@Override
 	public void sendRawMessage(String message)
+	{
+		sendRawMessage(null, message);
+	}
+
+	@Override
+	public void sendRawMessage(UUID sender, String message)
 	{
 		messages.add(message);
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -272,11 +272,23 @@ public abstract class EntityMock implements Entity, MessageTarget
 	@Override
 	public void sendMessage(String message)
 	{
-		messages.add(message);
+		sendMessage(null, message);
 	}
 
 	@Override
 	public void sendMessage(String[] messages)
+	{
+		sendMessage(null, messages);
+	}
+
+	@Override
+	public void sendMessage(UUID sender, String message)
+	{
+		messages.add(message);
+	}
+
+	@Override
+	public void sendMessage(UUID sender, String[] messages)
 	{
 		for (String message : messages)
 		{

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ItemEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ItemEntityMock.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Item;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
 
 import be.seeseemelk.mockbukkit.ServerMock;
@@ -60,6 +61,34 @@ public class ItemEntityMock extends EntityMock implements Item
 	public void setPickupDelay(int delay)
 	{
 		this.delay = Math.min(delay, 32767);
+	}
+
+	@Override
+	public void setOwner(@Nullable UUID owner)
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public @Nullable UUID getOwner()
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public void setThrower(@Nullable UUID thrower)
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public @Nullable UUID getThrower()
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -905,7 +905,14 @@ public class PlayerMock extends LivingEntityMock implements Player
 	}
 
 	@Override
-	public void sendRawMessage(String message)
+	public void sendRawMessage(@Nullable String message)
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public void sendRawMessage(@Nullable UUID sender, @NotNull String message)
 	{
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryMock.java
@@ -134,9 +134,9 @@ public class PlayerInventoryMock extends InventoryMock implements PlayerInventor
 	}
 
 	@Override
-	public ItemStack getItemInMainHand()
+	public @NotNull ItemStack getItemInMainHand()
 	{
-		return getItem(SLOT_BAR + mainHandSlot);
+		return notNull(getItem(SLOT_BAR + mainHandSlot));
 	}
 
 	@Override
@@ -146,9 +146,9 @@ public class PlayerInventoryMock extends InventoryMock implements PlayerInventor
 	}
 
 	@Override
-	public ItemStack getItemInOffHand()
+	public @NotNull ItemStack getItemInOffHand()
 	{
-		return getItem(OFF_HAND);
+		return notNull(getItem(OFF_HAND));
 	}
 
 	@Override
@@ -160,7 +160,7 @@ public class PlayerInventoryMock extends InventoryMock implements PlayerInventor
 
 	@Deprecated
 	@Override
-	public ItemStack getItemInHand()
+	public @NotNull ItemStack getItemInHand()
 	{
 		return getItemInMainHand();
 	}
@@ -173,8 +173,18 @@ public class PlayerInventoryMock extends InventoryMock implements PlayerInventor
 
 	}
 
+	/**
+	 * Gets the {@link ItemStack} at the given equipment slot in the inventory.
+	 *
+	 * <p>Implementation note: only the contents of the main hand
+	 * and the off hand are guaranteed not to be {@code null},
+	 * despite the annotation present in the Bukkit api.</p>
+	 *
+	 * @param slot the slot to get the {@link ItemStack}
+	 * @return the {@link ItemStack} in the given slot
+	 */
 	@Override
-	public @NotNull ItemStack getItem(@NotNull EquipmentSlot slot)
+	public @Nullable ItemStack getItem(@NotNull EquipmentSlot slot)
 	{
 		switch (slot)
 		{
@@ -235,5 +245,10 @@ public class PlayerInventoryMock extends InventoryMock implements PlayerInventor
 		if (slot < 0 || slot > 8)
 			throw new ArrayIndexOutOfBoundsException("Slot should be within [0-8] (was: " + slot + ")");
 		mainHandSlot = slot;
+	}
+
+	private @NotNull ItemStack notNull(@Nullable ItemStack itemStack)
+	{
+		return itemStack == null ? new ItemStack(Material.AIR) : itemStack;
 	}
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryMockTest.java
@@ -1,9 +1,12 @@
 package be.seeseemelk.mockbukkit.inventory;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 import org.bukkit.Material;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.junit.After;
 import org.junit.Before;
@@ -256,6 +259,19 @@ public class PlayerInventoryMockTest
 		inventory.setExtraContents(new ItemStack[2]);
 	}
 
+	@Test
+	public void getItem_Nullability()
+	{
+		inventory.setItemInMainHand(null);
+		inventory.setItemInOffHand(null);
+		inventory.setChestplate(null);
+		assertNotNull(inventory.getItem(EquipmentSlot.HAND));
+		assertNotNull(inventory.getItemInMainHand());
+		assertNotNull(inventory.getItem(EquipmentSlot.OFF_HAND));
+		assertNotNull(inventory.getItemInOffHand());
+		assertNull(inventory.getItem(EquipmentSlot.CHEST));
+		assertNull(inventory.getChestplate());
+	}
 }
 
 


### PR DESCRIPTION
# Description
When trying to call `player.getInventory().getItemInMainHand()`, the CraftBukkit implementation returns an ItemStack with air, while MockBukkit returns null. It only affects both hands. CraftBukkit doesn't make much sense here...

This PR also fixes a validator in `ChunkMock#getBlock`.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
Before the pull request can be accepted, the version number stored in settings.gradle should be updated.
MockBukkit uses semantic-versioning (https://semver.org/)

 - If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
 - If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)
 - Make sure that unit tests are added which test the relevant changes.
 - Make sure that the changes follow the existing code format.

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.

The version number can be found in `settings.gradle`.