### PR TITLE
Correctly copy ItemFlags when copying an ItemMetaMock

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.3-R0.1-SNAPSHOT'
-gradle.ext.version = '0.15.0'
+gradle.ext.version = '0.15.1'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -47,7 +47,8 @@ public class ItemMetaMock implements ItemMeta, Damageable {
         unbreakable = meta.isUnbreakable();
         enchants = new HashMap<>(meta.getEnchants());
         customModelData = meta.hasCustomModelData() ? meta.getCustomModelData() : null;
-        
+        hideFlags.addAll(meta.getItemFlags());
+
         if (meta.hasDisplayName()) {
             displayName = meta.getDisplayName();
         }

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMockTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.junit.After;
@@ -42,11 +43,13 @@ public class ItemMetaMockTest
 		meta.setDisplayName("Some name");
 		meta.setLore(Arrays.asList("lore"));
 		meta.setUnbreakable(true);
+		meta.addItemFlags(ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_ATTRIBUTES);
 		ItemMetaMock meta2 = new ItemMetaMock(meta);
 		meta2.setLore(Arrays.asList("lore"));
 		assertTrue(meta2.equals(meta));
 		assertTrue(meta.equals(meta2));
 		assertEquals(meta.hashCode(), meta2.hashCode());
+		assertEquals(meta.getItemFlags(), meta2.getItemFlags());
 	}
 
 	@Test


### PR DESCRIPTION
# Description
Currently, the ItemMetaMock copy constructor does not copy the `ItemFlags`, which actually prevents assigning `ItemFlags` to an `ItemStack` since the `ItemMeta` is often copied upon assignation in `setItemMeta()`.

This PR fixes this issue and expands the copy constructor unit test accordingly.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
Before the pull request can be accepted, the version number stored in settings.gradle should be updated.
MockBukkit uses semantic-versioning (https://semver.org/)

 - If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
 - If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)
 - Make sure that unit tests are added which test the relevant changes.
 - Make sure that the changes follow the existing code format.

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.

The version number can be found in `settings.gradle`.
