### PR TITLE
feat(entity): implement removeAttachment(permission)

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.3-R0.1-SNAPSHOT'
-gradle.ext.version = '0.18.0'
+gradle.ext.version = '0.19.0'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.3-R0.1-SNAPSHOT'
-gradle.ext.version = '0.17.0'
+gradle.ext.version = '0.18.0'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.3-R0.1-SNAPSHOT'
-gradle.ext.version = '0.19.0'
+gradle.ext.version = '0.20.0'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -23,6 +23,7 @@ import java.util.logging.LogManager;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import be.seeseemelk.mockbukkit.help.HelpMapMock;
 import org.apache.commons.lang.Validate;
 import org.bukkit.BanEntry;
 import org.bukkit.BanList;
@@ -131,12 +132,14 @@ public class ServerMock implements Server
 	private ConsoleCommandSender consoleSender;
 	private GameMode defaultGameMode = GameMode.SURVIVAL;
 	private MockCommandMap commandMap;
+	private HelpMapMock helpMap;
 
 	public ServerMock()
 	{
 		mainThread = Thread.currentThread();
 		logger = Logger.getLogger("ServerMock");
 		commandMap = new MockCommandMap(this);
+		helpMap = new HelpMapMock();
 		ServerMock.registerSerializables();
 
 		// Register default Minecraft Potion Effect Types
@@ -1157,8 +1160,7 @@ public class ServerMock implements Server
 	@Override
 	public HelpMap getHelpMap()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return helpMap;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -842,7 +842,7 @@ public class ServerMock implements Server
 		String[] commands = commandLine.split(" ");
 		String commandLabel = commands[0];
 		String[] args = Arrays.copyOfRange(commands, 1, commands.length);
-		Command command = getPluginCommand(commandLabel);
+		Command command = getCommandMap().getCommand(commandLabel);
 		if (command != null)
 			return command.execute(sender, commandLabel, args);
 		else

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -27,6 +27,7 @@ import org.bukkit.metadata.MetadataValue;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.permissions.PermissionAttachmentInfo;
+import org.bukkit.permissions.PermissionRemovedExecutor;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.util.BoundingBox;
@@ -376,9 +377,22 @@ public abstract class EntityMock implements Entity, MessageTarget
 	@Override
 	public void removeAttachment(PermissionAttachment attachment)
 	{
-		// TODO Auto-generated constructor stub
-		throw new UnimplementedOperationException();
+		if (attachment == null) {
+			throw new IllegalArgumentException("Attachment cannot be null");
+		}
 
+		if (permissionAttachments.contains(attachment)) {
+			permissionAttachments.remove(attachment);
+			PermissionRemovedExecutor ex = attachment.getRemovalCallback();
+
+			if (ex != null) {
+				ex.attachmentRemoved(attachment);
+			}
+
+			recalculatePermissions();
+		} else {
+			throw new IllegalArgumentException("Given attachment is not part of Permissible object " + this);
+		}
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -377,20 +377,25 @@ public abstract class EntityMock implements Entity, MessageTarget
 	@Override
 	public void removeAttachment(PermissionAttachment attachment)
 	{
-		if (attachment == null) {
+		if (attachment == null)
+		{
 			throw new IllegalArgumentException("Attachment cannot be null");
 		}
 
-		if (permissionAttachments.contains(attachment)) {
+		if (permissionAttachments.contains(attachment))
+		{
 			permissionAttachments.remove(attachment);
 			PermissionRemovedExecutor ex = attachment.getRemovalCallback();
 
-			if (ex != null) {
+			if (ex != null)
+			{
 				ex.attachmentRemoved(attachment);
 			}
 
 			recalculatePermissions();
-		} else {
+		}
+		else
+		{
 			throw new IllegalArgumentException("Given attachment is not part of Permissible object " + this);
 		}
 	}
@@ -405,11 +410,15 @@ public abstract class EntityMock implements Entity, MessageTarget
 	public Set<PermissionAttachmentInfo> getEffectivePermissions()
 	{
 		HashSet<PermissionAttachmentInfo> permissionAttachmentInfos = new HashSet<>();
-		for (PermissionAttachment permissionAttachment : permissionAttachments) {
-			for (Map.Entry<String, Boolean> entry : permissionAttachment.getPermissions().entrySet()) {
+
+		for (PermissionAttachment permissionAttachment : permissionAttachments)
+		{
+			for (Map.Entry<String, Boolean> entry : permissionAttachment.getPermissions().entrySet())
+			{
 				permissionAttachmentInfos.add(new PermissionAttachmentInfo(this, entry.getKey(), permissionAttachment, entry.getValue()));
 			}
 		}
+
 		return permissionAttachmentInfos;
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
@@ -316,6 +316,20 @@ public class EntityMockTest
 	}
 
 	@Test
+	public void removeAttachment_RemovesPermission()
+	{
+		MockPlugin plugin = MockBukkit.createMockPlugin();
+		Permission permission = new Permission("mockbukkit.perm");
+		server.getPluginManager().addPermission(permission);
+		PermissionAttachment attachment = entity.addAttachment(plugin);
+		attachment.setPermission(permission.getName(), true);
+		assertTrue(entity.hasPermission("mockbukkit.perm"));
+
+		entity.removeAttachment(attachment);
+		assertFalse(entity.hasPermission("mockbukkit.perm"));
+	}
+
+	@Test
 	public void entityDamage_By_Player()
 	{
 		World world = new WorldMock(Material.GRASS_BLOCK, 10);


### PR DESCRIPTION
# Description
Permissible EntityMock now implements removeAttachment to remove permissions from a mock player.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.