### PR TITLE
Added equals method to BlockStateMock. Fixed player hashCode method.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.3-R0.1-SNAPSHOT'
-gradle.ext.version = '0.21.0'
+gradle.ext.version = '0.21.1'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/src/main/java/be/seeseemelk/mockbukkit/PlayerList.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/PlayerList.java
@@ -22,10 +22,10 @@ import be.seeseemelk.mockbukkit.entity.PlayerMock;
 
 /**
  * Replica of the Bukkit internal PlayerList and CraftPlayerList implementation
- * 
+ *
  * @author seeseemelk
  * @author TheBusyBiscuit
- * 
+ *
  */
 public class PlayerList
 {
@@ -75,7 +75,7 @@ public class PlayerList
 	public Set<OfflinePlayer> getOperators()
 	{
 		return Stream.concat(onlinePlayers.stream(), offlinePlayers.stream()).filter(OfflinePlayer::isOp)
-				.collect(Collectors.toSet());
+		       .collect(Collectors.toSet());
 	}
 
 	@NotNull
@@ -99,16 +99,16 @@ public class PlayerList
 	public List<Player> matchPlayer(@NotNull String name)
 	{
 		return onlinePlayers.stream().filter(
-				player -> player.getName().toLowerCase(Locale.ENGLISH).startsWith(name.toLowerCase(Locale.ENGLISH)))
-				.collect(Collectors.toList());
+		           player -> player.getName().toLowerCase(Locale.ENGLISH).startsWith(name.toLowerCase(Locale.ENGLISH)))
+		       .collect(Collectors.toList());
 	}
 
 	@Nullable
 	public Player getPlayerExact(@NotNull String name)
 	{
 		return onlinePlayers.stream()
-				.filter(player -> player.getName().toLowerCase(Locale.ENGLISH).equals(name.toLowerCase(Locale.ENGLISH)))
-				.findFirst().orElse(null);
+		       .filter(player -> player.getName().toLowerCase(Locale.ENGLISH).equals(name.toLowerCase(Locale.ENGLISH)))
+		       .findFirst().orElse(null);
 	}
 
 	@Nullable

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
@@ -293,4 +293,17 @@ public class BlockStateMock implements BlockState, Cloneable
 			return new BlockStateMock(block);
 		}
 	}
+
+	@Override
+	public boolean equals(Object other) {
+		if(other == null) {return false;}
+		if(!(other instanceof BlockState)) {return false;}
+
+		BlockState otherState = (BlockState) other;
+		if(!(otherState.getType() == getType())) {return false;}
+		if(otherState.isPlaced() != isPlaced()) {return false;}
+		if(!isPlaced()) {return true;}
+
+		return otherState.getBlock().getLocation().equals(getBlock().getLocation());
+	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
@@ -296,20 +296,37 @@ public class BlockStateMock implements BlockState, Cloneable
 	}
 
 	@Override
-	public boolean equals(Object other) {
-		if(other == null) {return false;}
-		if(!(other instanceof BlockState)) {return false;}
+	public boolean equals(Object other)
+	{
+		if (other == null)
+		{
+			return false;
+		}
+		if (!(other instanceof BlockState))
+		{
+			return false;
+		}
 
 		BlockState otherState = (BlockState) other;
-		if(otherState.getType() != getType()) {return false;}
-		if(otherState.isPlaced() != isPlaced()) {return false;}
-		if(!isPlaced()) {return true;}
+		if (otherState.getType() != getType())
+		{
+			return false;
+		}
+		if (otherState.isPlaced() != isPlaced())
+		{
+			return false;
+		}
+		if (!isPlaced())
+		{
+			return true;
+		}
 
 		return otherState.getBlock().getLocation().equals(getBlock().getLocation());
 	}
 
 	@Override
-	public int hashCode() {
+	public int hashCode()
+	{
 		return Objects.hash(material, block == null ? null : block.getLocation());
 	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
@@ -300,7 +300,7 @@ public class BlockStateMock implements BlockState, Cloneable
 		if(!(other instanceof BlockState)) {return false;}
 
 		BlockState otherState = (BlockState) other;
-		if(!(otherState.getType() == getType())) {return false;}
+		if(otherState.getType() != getType()) {return false;}
 		if(otherState.isPlaced() != isPlaced()) {return false;}
 		if(!isPlaced()) {return true;}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
@@ -1,6 +1,7 @@
 package be.seeseemelk.mockbukkit.block.state;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.bukkit.Chunk;
 import org.bukkit.Location;
@@ -305,5 +306,10 @@ public class BlockStateMock implements BlockState, Cloneable
 		if(!isPlaced()) {return true;}
 
 		return otherState.getBlock().getLocation().equals(getBlock().getLocation());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(material, block == null ? null : block.getLocation());
 	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -118,12 +118,7 @@ public class PlayerMock extends LivingEntityMock implements Player
 	@Override
 	public int hashCode()
 	{
-		final int prime = 31;
-		int result = super.hashCode();
-		result = prime * result + Objects.hash(attributes, exp, expLevel, expTotal, displayName, gamemode, getHealth(),
-				foodLevel, saturation, inventory, enderChest, inventoryView, getMaxHealth(), online, whitelisted,
-				compassTarget, bedSpawnLocation, cursor, firstPlayed, lastPlayed);
-		return result;
+		return Objects.hash(getUniqueId());
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/help/HelpMapMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/help/HelpMapMock.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 /**
  * The {@link HelpMapMock} is our mock of Bukkit's {@link HelpMap}.
- * 
+ *
  * @author NeumimTo
  *
  */

--- a/src/main/java/be/seeseemelk/mockbukkit/tags/TagParser.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/tags/TagParser.java
@@ -44,7 +44,7 @@ public class TagParser implements Keyed
 
 	/**
 	 * This constructs a new {@link TagParser}.
-	 * 
+	 *
 	 * @param registry The {@link TagRegistry} for the resulting {@link Tag}
 	 * @param key      The {@link NamespacedKey} of the resulting {@link Tag}
 	 */

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -455,7 +455,7 @@ public class ServerMockTest
 		PlayerMock player = new PlayerMock(server, "operator");
 		server.addPlayer(player);
 		player.setOp(true);
-		
+
 		assertTrue(server.getOperators().contains(player));
 		assertEquals(1, server.getOperators().size());
 	}

--- a/src/test/java/be/seeseemelk/mockbukkit/block/state/BlockStateMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/state/BlockStateMockTest.java
@@ -108,7 +108,7 @@ public class BlockStateMockTest
 		Block blockB = new BlockMock(Material.AIR, new Location(null, 0, 65, 0));
 		Block blockC = new BlockMock(Material.STONE, new Location(null, 0, 65, 0));
 
-		assertNotEquals(blockA.getState(), blockB.getState());
+		assertNotEquals(blockA.getState(), blockC.getState());
 		assertNotEquals(blockB.getState(), blockC.getState());
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/block/state/BlockStateMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/state/BlockStateMockTest.java
@@ -94,7 +94,8 @@ public class BlockStateMockTest
 
 	// Tests that different instances of the placed block state of a block, both with the same material, are equal
 	@Test
-	public void testEqualsAndHashCode() {
+	public void testEqualsAndHashCode()
+	{
 		Block block = new BlockMock(Material.STONE, new Location(null, 0, 64, 0));
 
 		BlockState stateA = block.getState();
@@ -106,7 +107,8 @@ public class BlockStateMockTest
 	// Tests that different instances of the placed block state of a block, with different materials, are unequal
 	// Also tests that block states with the same material, but with different parent blocks are unequal
 	@Test
-	public void testNotEquals() {
+	public void testNotEquals()
+	{
 		Block blockA = new BlockMock(Material.STONE, new Location(null, 0, 64, 0));
 		Block blockB = new BlockMock(Material.AIR, new Location(null, 0, 65, 0));
 		Block blockC = new BlockMock(Material.STONE, new Location(null, 0, 65, 0));
@@ -117,7 +119,8 @@ public class BlockStateMockTest
 
 	// Tests that unplaced block states are equal if they have the same material
 	@Test
-	public void testEqualsAndHashCodeUnplaced() {
+	public void testEqualsAndHashCodeUnplaced()
+	{
 		BlockState stateA = new BlockStateMock(Material.STONE);
 		BlockState stateB = new BlockStateMock(Material.STONE);
 
@@ -127,7 +130,8 @@ public class BlockStateMockTest
 
 	// Tests that unplaced block states are unequal if they have the same material
 	@Test
-	public void testNotEqualsUnplaced() {
+	public void testNotEqualsUnplaced()
+	{
 		assertNotEquals(new BlockStateMock(Material.STONE), new BlockStateMock(Material.AIR));
 	}
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/block/state/BlockStateMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/state/BlockStateMockTest.java
@@ -92,6 +92,7 @@ public class BlockStateMockTest
 		assertTrue(block.getState() instanceof Chest);
 	}
 
+	// Tests that different instances of the placed block state of a block, both with the same material, are equal
 	@Test
 	public void testEquals() {
 		Block block = new BlockMock(Material.STONE, new Location(null, 0, 64, 0));
@@ -99,6 +100,8 @@ public class BlockStateMockTest
 		assertEquals(block.getState(), block.getState());
 	}
 
+	// Tests that different instances of the placed block state of a block, with different materials, are unequal
+	// Also tests that block states with the same material, but with different parent blocks are unequal
 	@Test
 	public void testNotEquals() {
 		Block blockA = new BlockMock(Material.STONE, new Location(null, 0, 64, 0));
@@ -109,11 +112,13 @@ public class BlockStateMockTest
 		assertNotEquals(blockB.getState(), blockC.getState());
 	}
 
+	// Tests that unplaced block states are equal if they have the same material
 	@Test
 	public void testEqualsUnplaced() {
 		assertEquals(new BlockStateMock(Material.STONE), new BlockStateMock(Material.STONE));
 	}
 
+	// Tests that unplaced block states are unequal if they have the same material
 	@Test
 	public void testNotEqualsUnplaced() {
 		assertNotEquals(new BlockStateMock(Material.STONE), new BlockStateMock(Material.AIR));

--- a/src/test/java/be/seeseemelk/mockbukkit/block/state/BlockStateMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/state/BlockStateMockTest.java
@@ -1,10 +1,5 @@
 package be.seeseemelk.mockbukkit.block.state;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -17,6 +12,8 @@ import org.junit.Test;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.WorldMock;
 import be.seeseemelk.mockbukkit.block.BlockMock;
+
+import static org.junit.Assert.*;
 
 public class BlockStateMockTest
 {
@@ -103,7 +100,22 @@ public class BlockStateMockTest
 	}
 
 	@Test
+	public void testNotEquals() {
+		Block blockA = new BlockMock(Material.STONE, new Location(null, 0, 64, 0));
+		Block blockB = new BlockMock(Material.AIR, new Location(null, 0, 65, 0));
+		Block blockC = new BlockMock(Material.STONE, new Location(null, 0, 65, 0));
+
+		assertNotEquals(blockA.getState(), blockB.getState());
+		assertNotEquals(blockB.getState(), blockC.getState());
+	}
+
+	@Test
 	public void testEqualsUnplaced() {
 		assertEquals(new BlockStateMock(Material.STONE), new BlockStateMock(Material.STONE));
+	}
+
+	@Test
+	public void testNotEqualsUnplaced() {
+		assertNotEquals(new BlockStateMock(Material.STONE), new BlockStateMock(Material.AIR));
 	}
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/block/state/BlockStateMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/state/BlockStateMockTest.java
@@ -94,4 +94,16 @@ public class BlockStateMockTest
 		assertTrue(chest.update(true));
 		assertTrue(block.getState() instanceof Chest);
 	}
+
+	@Test
+	public void testEquals() {
+		Block block = new BlockMock(Material.STONE, new Location(null, 0, 64, 0));
+
+		assertEquals(block.getState(), block.getState());
+	}
+
+	@Test
+	public void testEqualsUnplaced() {
+		assertEquals(new BlockStateMock(Material.STONE), new BlockStateMock(Material.STONE));
+	}
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/block/state/BlockStateMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/state/BlockStateMockTest.java
@@ -94,10 +94,13 @@ public class BlockStateMockTest
 
 	// Tests that different instances of the placed block state of a block, both with the same material, are equal
 	@Test
-	public void testEquals() {
+	public void testEqualsAndHashCode() {
 		Block block = new BlockMock(Material.STONE, new Location(null, 0, 64, 0));
 
-		assertEquals(block.getState(), block.getState());
+		BlockState stateA = block.getState();
+		BlockState stateB = block.getState();
+		assertEquals(stateA, stateB);
+		assertEquals(stateA.hashCode(), stateB.hashCode());
 	}
 
 	// Tests that different instances of the placed block state of a block, with different materials, are unequal
@@ -114,8 +117,12 @@ public class BlockStateMockTest
 
 	// Tests that unplaced block states are equal if they have the same material
 	@Test
-	public void testEqualsUnplaced() {
-		assertEquals(new BlockStateMock(Material.STONE), new BlockStateMock(Material.STONE));
+	public void testEqualsAndHashCodeUnplaced() {
+		BlockState stateA = new BlockStateMock(Material.STONE);
+		BlockState stateB = new BlockStateMock(Material.STONE);
+
+		assertEquals(stateA, stateB);
+		assertEquals(stateA.hashCode(), stateB.hashCode());
 	}
 
 	// Tests that unplaced block states are unequal if they have the same material


### PR DESCRIPTION
# Description
- Added an equals method to BlockStateMock to make comparing it in unit tests work.
- Changed the player hashCode method to just hash the unique ID, as CraftBukkit does it. This is important since otherwise those storing players in a map won't work, and will just return null if _anything_ about the player changes. (the exact reason I forked this actually)
If either of these are intended, then I'm sorry.

# Checklist
The following items should be checked before the pull request can be merged.
- [Done] Version number updated in `settings.gradle`.
- [Done] Unit tests added.
- [Done] Code follows existing code format.


