### PR TITLE
UnsafeValues checkVersion

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.3-R0.1-SNAPSHOT'
-gradle.ext.version = '0.21.0'
+gradle.ext.version = '0.21.1'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
@@ -17,6 +17,9 @@ import org.bukkit.plugin.PluginDescriptionFile;
 @SuppressWarnings("deprecation")
 public class MockUnsafeValues implements UnsafeValues
 {
+
+	private final Set<String> compatibleApiVersions = new HashSet<>(Arrays.asList("1.13", "1.14", "1.15", "1.16"));
+
 	@Override
 	public Material toLegacy(Material material)
 	{
@@ -68,15 +71,13 @@ public class MockUnsafeValues implements UnsafeValues
 		throw new UnimplementedOperationException();
 	}
 
-	private static final Set<String> COMPATIBLE_API_VERSIONS = new HashSet<>(Arrays.asList("1.13", "1.14", "1.15", "1.16"));
-
 	@Override
 	public void checkSupported(PluginDescriptionFile pdf) throws InvalidPluginException
 	{
 		if (pdf.getAPIVersion() == null)
 			throw new InvalidPluginException("Plugin does not specify 'api-version' in plugin.yml");
 
-		if (!COMPATIBLE_API_VERSIONS.contains(pdf.getAPIVersion()))
+		if (!compatibleApiVersions.contains(pdf.getAPIVersion()))
 			throw new InvalidPluginException(String.format("Plugin api version %s is incompatible with the current MockBukkit version", pdf.getAPIVersion()));
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
@@ -1,5 +1,7 @@
 package be.seeseemelk.mockbukkit;
 
+import java.util.Set;
+
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.UnsafeValues;
@@ -64,14 +66,16 @@ public class MockUnsafeValues implements UnsafeValues
 		throw new UnimplementedOperationException();
 	}
 
+	private static final Set<String> COMPATIBLE_API_VERSIONS = Set.of("1.13", "1.14", "1.15", "1.16");
+
 	@Override
 	public void checkSupported(PluginDescriptionFile pdf) throws InvalidPluginException
 	{
 		if (pdf.getAPIVersion() == null)
 			throw new InvalidPluginException("Plugin does not specify 'api-version' in plugin.yml");
 
-		if (!pdf.getAPIVersion().equals("1.15"))
-			throw new InvalidPluginException("This version of MockBukkit required API 1.15");
+		if (!COMPATIBLE_API_VERSIONS.contains(pdf.getAPIVersion()))
+			throw new InvalidPluginException(String.format("Plugin api version %s is incompatible with the current MockBukkit version", pdf.getAPIVersion()));
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
@@ -1,5 +1,7 @@
 package be.seeseemelk.mockbukkit;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 
 import org.bukkit.Material;
@@ -66,7 +68,7 @@ public class MockUnsafeValues implements UnsafeValues
 		throw new UnimplementedOperationException();
 	}
 
-	private static final Set<String> COMPATIBLE_API_VERSIONS = Set.of("1.13", "1.14", "1.15", "1.16");
+	private static final Set<String> COMPATIBLE_API_VERSIONS = new HashSet<>(Arrays.asList("1.13", "1.14", "1.15", "1.16"));
 
 	@Override
 	public void checkSupported(PluginDescriptionFile pdf) throws InvalidPluginException

--- a/src/test/java/be/seeseemelk/mockbukkit/UnsafeValuesTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/UnsafeValuesTest.java
@@ -1,0 +1,64 @@
+package be.seeseemelk.mockbukkit;
+
+import java.io.StringReader;
+import java.util.regex.Pattern;
+
+import org.bukkit.plugin.InvalidDescriptionException;
+import org.bukkit.plugin.InvalidPluginException;
+import org.bukkit.plugin.PluginDescriptionFile;
+import org.junit.Before;
+import org.junit.Test;
+
+public class UnsafeValuesTest {
+
+    private static final String PLUGIN_INFO_FORMAT = "name: VersionTest\nversion: 1.0\nmain: not.exists\napi-version: %s";
+
+    private MockUnsafeValues mockUnsafeValues;
+
+    @Before
+    public void setUp() {
+        mockUnsafeValues = new MockUnsafeValues();
+    }
+
+    private void checkVersion(String version) throws InvalidPluginException {
+        String pluginInfo = String.format(PLUGIN_INFO_FORMAT, version);
+        try (StringReader stringReader = new StringReader(pluginInfo)) {
+            PluginDescriptionFile pluginDescriptionFile = new PluginDescriptionFile(stringReader);
+            mockUnsafeValues.checkSupported(pluginDescriptionFile);
+        } catch (InvalidDescriptionException ex) {
+            //exception shouldn't ever be thrown
+            ex.printStackTrace();
+        }
+    }
+
+    @Test
+    public void checkSupported_currentServerVersion() throws InvalidPluginException {
+        String currentVersion = MockBukkit.getOrCreateMock().getBukkitVersion();
+        // if version is in pattern MAJOR.MINOR.FIX, transform to MAJOR.MINOR
+        if(Pattern.matches(".{1,3}\\..{1,3}\\..*", currentVersion)) {
+            currentVersion = currentVersion.substring(0, currentVersion.indexOf(".", currentVersion.indexOf(".") + 1));
+        }
+
+        checkVersion(currentVersion);
+
+        if (MockBukkit.isMocked()) {
+            MockBukkit.unmock();
+        }
+    }
+
+    @Test
+    public void checkSupported_supportedVersion() throws InvalidPluginException {
+        checkVersion("1.13");
+    }
+
+    @Test(expected = InvalidPluginException.class)
+    public void checkSupported_unsupportedVersion() throws InvalidPluginException {
+        checkVersion("1.8");
+    }
+
+    @Test(expected = InvalidPluginException.class)
+    public void checkSupported_noSpecifiedVersion() throws InvalidPluginException {
+        PluginDescriptionFile pluginDescriptionFile = new PluginDescriptionFile("VersionTest", "1.0", "not.exists");
+        mockUnsafeValues.checkSupported(pluginDescriptionFile);
+    }
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/UnsafeValuesTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/UnsafeValuesTest.java
@@ -9,55 +9,65 @@ import org.bukkit.plugin.PluginDescriptionFile;
 import org.junit.Before;
 import org.junit.Test;
 
-public class UnsafeValuesTest {
-
+public class UnsafeValuesTest
+{
     private static final String PLUGIN_INFO_FORMAT = "name: VersionTest\nversion: 1.0\nmain: not.exists\napi-version: %s";
 
     private MockUnsafeValues mockUnsafeValues;
 
     @Before
-    public void setUp() {
+    public void setUp()
+    {
         mockUnsafeValues = new MockUnsafeValues();
     }
 
-    private void checkVersion(String version) throws InvalidPluginException {
+    private void checkVersion(String version) throws InvalidPluginException
+    {
         String pluginInfo = String.format(PLUGIN_INFO_FORMAT, version);
-        try (StringReader stringReader = new StringReader(pluginInfo)) {
+        try (StringReader stringReader = new StringReader(pluginInfo))
+        {
             PluginDescriptionFile pluginDescriptionFile = new PluginDescriptionFile(stringReader);
             mockUnsafeValues.checkSupported(pluginDescriptionFile);
-        } catch (InvalidDescriptionException ex) {
+        } catch (InvalidDescriptionException ex)
+        {
             //exception shouldn't ever be thrown
             ex.printStackTrace();
         }
     }
 
     @Test
-    public void checkSupported_currentServerVersion() throws InvalidPluginException {
+    public void checkSupported_currentServerVersion() throws InvalidPluginException
+    {
         String currentVersion = MockBukkit.getOrCreateMock().getBukkitVersion();
         // if version is in pattern MAJOR.MINOR.FIX, transform to MAJOR.MINOR
-        if(Pattern.matches(".{1,3}\\..{1,3}\\..*", currentVersion)) {
+        if (Pattern.matches(".{1,3}\\..{1,3}\\..*", currentVersion))
+        {
             currentVersion = currentVersion.substring(0, currentVersion.indexOf(".", currentVersion.indexOf(".") + 1));
         }
 
         checkVersion(currentVersion);
 
-        if (MockBukkit.isMocked()) {
+        if (MockBukkit.isMocked())
+        {
             MockBukkit.unmock();
         }
     }
 
     @Test
-    public void checkSupported_supportedVersion() throws InvalidPluginException {
+    public void checkSupported_supportedVersion() throws InvalidPluginException
+    {
         checkVersion("1.13");
     }
 
     @Test(expected = InvalidPluginException.class)
-    public void checkSupported_unsupportedVersion() throws InvalidPluginException {
+    public void checkSupported_unsupportedVersion() throws InvalidPluginException
+    {
         checkVersion("1.8");
     }
 
     @Test(expected = InvalidPluginException.class)
-    public void checkSupported_noSpecifiedVersion() throws InvalidPluginException {
+    public void checkSupported_noSpecifiedVersion() throws InvalidPluginException
+    {
         PluginDescriptionFile pluginDescriptionFile = new PluginDescriptionFile("VersionTest", "1.0", "not.exists");
         mockUnsafeValues.checkSupported(pluginDescriptionFile);
     }


### PR DESCRIPTION
# Description
According to the problem mentioned in #149 this pull request fixes the version check to pass on upwards compatible plugins. To accomplish this, the plugin version is compared to a list of compatible versions like Bukkit itself does it. I added unit tests for this as well.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.

