### PR TITLE
Implement Repairable in ItemMetaMock

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.3-R0.1-SNAPSHOT'
-gradle.ext.version = '0.21.0'
+gradle.ext.version = '0.22.0'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -20,6 +20,7 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.Repairable;
 import org.bukkit.inventory.meta.tags.CustomItemTagContainer;
 import org.bukkit.persistence.PersistentDataContainer;
 
@@ -29,11 +30,12 @@ import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.persistence.PersistentDataContainerMock;
 
 @SuppressWarnings("deprecation")
-public class ItemMetaMock implements ItemMeta, Damageable {
+public class ItemMetaMock implements ItemMeta, Damageable, Repairable {
     
     private String displayName = null;
     private List<String> lore = null;
     private int damage = 0;
+    private int repairCost = 0;
     private Map<Enchantment, Integer> enchants = new HashMap<>();
     private Set<ItemFlag> hideFlags = EnumSet.noneOf(ItemFlag.class);
     private PersistentDataContainer persistentDataContainer = new PersistentDataContainerMock();
@@ -57,6 +59,9 @@ public class ItemMetaMock implements ItemMeta, Damageable {
         }
         if (meta instanceof Damageable) {
             this.damage = ((Damageable) meta).getDamage();
+        }
+        if (meta instanceof Repairable) {
+            this.repairCost = ((Repairable) meta).getRepairCost();
         }
         if (meta instanceof ItemMetaMock) {
             this.persistentDataContainer = ((ItemMetaMock) meta).persistentDataContainer;
@@ -147,6 +152,7 @@ public class ItemMetaMock implements ItemMeta, Damageable {
         result = prime * result + enchants.hashCode();
         result = prime * result + persistentDataContainer.hashCode();
         result = prime * result + ((customModelData == null) ? 0 : customModelData.hashCode());
+        result = prime * result + repairCost;
         return result;
     }
 
@@ -170,6 +176,7 @@ public class ItemMetaMock implements ItemMeta, Damageable {
             meta.customModelData = customModelData;
             meta.enchants = new HashMap<>(enchants);
             meta.persistentDataContainer = new PersistentDataContainerMock((PersistentDataContainerMock) persistentDataContainer);
+            meta.repairCost = repairCost;
             return meta;
         } catch (CloneNotSupportedException e) {
             throw new RuntimeException(e);
@@ -252,6 +259,7 @@ public class ItemMetaMock implements ItemMeta, Damageable {
 	    map.put("customModelData", this.customModelData);
 	    map.put("persistentDataContainer", this.persistentDataContainer);
 	    map.put("damage", this.damage);
+        map.put("repairCost", this.repairCost);
 	    // Return map
 	    return map;
     }
@@ -276,6 +284,7 @@ public class ItemMetaMock implements ItemMeta, Damageable {
 	    serialMock.customModelData = (Integer) args.get("customModelData");
 	    serialMock.persistentDataContainer = (PersistentDataContainer) args.get("persistentDataContainer");
 	    serialMock.damage = (Integer) args.get("damage");
+        serialMock.repairCost = (Integer) args.get("repairCost");
 	    return serialMock;
     }
 
@@ -391,6 +400,21 @@ public class ItemMetaMock implements ItemMeta, Damageable {
     @Override
     public void setDamage(int damage) {
         this.damage = damage;
+    }
+
+    @Override
+    public boolean hasRepairCost() {
+        return repairCost > 0;
+    }
+
+    @Override
+    public int getRepairCost() {
+        return repairCost;
+    }
+
+    @Override
+    public void setRepairCost(int cost) {
+        this.repairCost = cost;
     }
 
     @Override

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMockTest.java
@@ -14,6 +14,7 @@ import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.Repairable;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -344,6 +345,33 @@ public class ItemMetaMockTest
 	}
 
 	@Test
+	public void assertRepairCostCorrectlySet()
+	{
+		int value = 10;
+		meta.setRepairCost(value);
+		ItemStack item = new ItemStack(Material.DIAMOND_SWORD);
+		item.setItemMeta(meta);
+
+		Repairable itemMeta = (Repairable) item.getItemMeta();
+		int repairCost = itemMeta.getRepairCost();
+		assertEquals(value, repairCost);
+		assertTrue(itemMeta.hasRepairCost());
+	}
+
+	@Test
+	public void assertNoRepairCost()
+	{
+		meta.setRepairCost(0);
+		ItemStack item = new ItemStack(Material.DIAMOND_SWORD);
+		item.setItemMeta(meta);
+
+		Repairable itemMeta = (Repairable) item.getItemMeta();
+		int repairCost = itemMeta.getRepairCost();
+		assertEquals(0, repairCost);
+		assertFalse(itemMeta.hasRepairCost());
+	}
+
+	@Test
 	public void assertCustomModelData()
 	{
 		meta.setCustomModelData(null);
@@ -363,12 +391,14 @@ public class ItemMetaMockTest
 		meta.setLore(Arrays.asList("Test lore"));
 		meta.setUnbreakable(true);
 		meta.setDamage(5);
+		meta.setRepairCost(3);
 
 		Map<String, Object> expected = new HashMap<>();
 		expected.put("displayName", "Test name");
 		expected.put("lore", Arrays.asList("Test lore"));
 		expected.put("unbreakable", true);
 		expected.put("damage", 5);
+		expected.put("repairCost", 3);
 
 		Map<String, Object> actual = meta.serialize();
 
@@ -377,6 +407,7 @@ public class ItemMetaMockTest
 		assertEquals(expected.get("lore"), actual.get("lore"));
 		assertEquals(expected.get("unbreakable"), actual.get("unbreakable"));
 		assertEquals(expected.get("damage"), actual.get("damage"));
+		assertEquals(expected.get("repairCost"), actual.get("repairCost"));
 
 	}
 


### PR DESCRIPTION
# Description
Implements `Repairable` in `ItemMetaMock`. All items should be `Repairable` - the interface represents a penalty for anvil operations, including renaming of items that cannot be damaged.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.

I followed existing formats, but the files are a mix of tabs and spaces. You may want to consider adding a `.editorconfig` and running a formatter pass over the project at some point for consistency. For `ItemMetaMock#serialize` and `ItemMetaMock#deserialize` I opted to go with the file's primary indentation style instead of the mix that the surrounding lines have.

I did not add repair cost in the meta equality check - only lore and display name are currently compared out of all of the features implemented, and I wasn't sure if that was intentional.