### PR TITLE
Don't sign jar when building on Jitpack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ artifacts {
 def isFork = isFork()
 
 signing {
-    required { !isFork }
+    required { !isFork && System.getenv('JITPACK') == null }
     sign publishing.publications
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.3-R0.1-SNAPSHOT'
-gradle.ext.version = '0.21.1'
+gradle.ext.version = '0.21.2'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion


### PR DESCRIPTION
# Description
Builds are [broken](https://jitpack.io/com/github/seeseemelk/MockBukkit/v1.16-f7107abd49-1/build.log) on Jitpack due to the signing requirement. This simple PR checks for the presence of $JITPACK, and if it exists, doesn't sign.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
Before the pull request can be accepted, the version number stored in settings.gradle should be updated.
MockBukkit uses semantic-versioning (https://semver.org/)

 - If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
 - If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)
 - Make sure that unit tests are added which test the relevant changes.
 - Make sure that the changes follow the existing code format.

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.

The version number can be found in `settings.gradle`.
