### PR TITLE
Implemented a Thread-safe PlayerList

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.3-R0.1-SNAPSHOT'
-gradle.ext.version = '0.22.0'
+gradle.ext.version = '0.23.0'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.3-R0.1-SNAPSHOT'
-gradle.ext.version = '0.21.1'
+gradle.ext.version = '0.22.0'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/src/main/java/be/seeseemelk/mockbukkit/PlayerList.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/PlayerList.java
@@ -1,19 +1,43 @@
 package be.seeseemelk.mockbukkit;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.bukkit.BanList;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
 
 /**
  * Replica of the Bukkit internal PlayerList and CraftPlayerList implementation
+ * 
+ * @author seeseemelk
+ * @author TheBusyBiscuit
+ * 
  */
 public class PlayerList
 {
-
 	private int maxPlayers = Integer.MAX_VALUE;
+
+	private final List<PlayerMock> onlinePlayers = new CopyOnWriteArrayList<>();
+	private final Set<OfflinePlayer> offlinePlayers = Collections.synchronizedSet(new HashSet<>());
+
 	private BanList ipBans = new MockBanList();
 	private BanList profileBans = new MockBanList();
 
 	public void setMaxPlayers(int maxPlayers)
 	{
+		// TODO: The maxPlayers setting is currently not enforced.
 		this.maxPlayers = maxPlayers;
 	}
 
@@ -22,13 +46,89 @@ public class PlayerList
 		return this.maxPlayers;
 	}
 
+	@NotNull
 	public BanList getIPBans()
 	{
 		return this.ipBans;
 	}
 
+	@NotNull
 	public BanList getProfileBans()
 	{
 		return this.profileBans;
+	}
+
+	public void addPlayer(@NotNull PlayerMock player)
+	{
+		onlinePlayers.add(player);
+		offlinePlayers.add(player);
+	}
+
+	public void addOfflinePlayer(@NotNull OfflinePlayer player)
+	{
+		offlinePlayers.add(player);
+	}
+
+	@NotNull
+	public Set<OfflinePlayer> getOperators()
+	{
+		return Stream.concat(onlinePlayers.stream(), offlinePlayers.stream()).filter(OfflinePlayer::isOp)
+				.collect(Collectors.toSet());
+	}
+
+	@NotNull
+	public Collection<PlayerMock> getOnlinePlayers()
+	{
+		return Collections.unmodifiableList(onlinePlayers);
+	}
+
+	@NotNull
+	public OfflinePlayer[] getOfflinePlayers()
+	{
+		return offlinePlayers.toArray(new OfflinePlayer[0]);
+	}
+
+	public boolean isSomeoneOnline()
+	{
+		return !onlinePlayers.isEmpty();
+	}
+
+	@NotNull
+	public List<Player> matchPlayer(@NotNull String name)
+	{
+		return onlinePlayers.stream().filter(
+				player -> player.getName().toLowerCase(Locale.ENGLISH).startsWith(name.toLowerCase(Locale.ENGLISH)))
+				.collect(Collectors.toList());
+	}
+
+	@Nullable
+	public Player getPlayerExact(@NotNull String name)
+	{
+		return onlinePlayers.stream()
+				.filter(player -> player.getName().toLowerCase(Locale.ENGLISH).equals(name.toLowerCase(Locale.ENGLISH)))
+				.findFirst().orElse(null);
+	}
+
+	@NotNull
+	public PlayerMock getPlayer(int num)
+	{
+		if (num < 0 || num >= onlinePlayers.size())
+		{
+			throw new ArrayIndexOutOfBoundsException();
+		}
+		else
+		{
+			return onlinePlayers.get(num);
+		}
+	}
+
+	public void clearOnlinePlayers()
+	{
+		onlinePlayers.clear();
+	}
+
+	public void clearOfflinePlayers()
+	{
+		offlinePlayers.clear();
 	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/PlayerList.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/PlayerList.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -16,6 +17,7 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import be.seeseemelk.mockbukkit.entity.OfflinePlayerMock;
 import be.seeseemelk.mockbukkit.entity.PlayerMock;
 
 /**
@@ -109,6 +111,50 @@ public class PlayerList
 				.findFirst().orElse(null);
 	}
 
+	@Nullable
+	public Player getPlayer(@NotNull String name)
+	{
+		Player player = getPlayerExact(name);
+
+		if (player != null)
+		{
+			return player;
+		}
+
+		final String lowercase = name.toLowerCase(Locale.ENGLISH);
+		int delta = Integer.MAX_VALUE;
+
+		for (Player namedPlayer : onlinePlayers)
+		{
+			if (namedPlayer.getName().toLowerCase(Locale.ENGLISH).startsWith(lowercase))
+			{
+				int currentDelta = Math.abs(namedPlayer.getName().length() - lowercase.length());
+
+				if (currentDelta < delta)
+				{
+					delta = currentDelta;
+					player = namedPlayer;
+				}
+			}
+		}
+
+		return player;
+	}
+
+	@Nullable
+	public Player getPlayer(@NotNull UUID id)
+	{
+		for (Player player : onlinePlayers)
+		{
+			if (id.equals(player.getUniqueId()))
+			{
+				return player;
+			}
+		}
+
+		return null;
+	}
+
 	@NotNull
 	public PlayerMock getPlayer(int num)
 	{
@@ -120,6 +166,48 @@ public class PlayerList
 		{
 			return onlinePlayers.get(num);
 		}
+	}
+
+	@NotNull
+	public OfflinePlayer getOfflinePlayer(@NotNull String name)
+	{
+		Player player = getPlayer(name);
+
+		if (player != null)
+		{
+			return player;
+		}
+
+		for (OfflinePlayer offlinePlayer : offlinePlayers)
+		{
+			if (offlinePlayer.getName().equals(name))
+			{
+				return offlinePlayer;
+			}
+		}
+
+		return new OfflinePlayerMock(name);
+	}
+
+	@Nullable
+	public OfflinePlayer getOfflinePlayer(@NotNull UUID id)
+	{
+		Player player = getPlayer(id);
+
+		if (player != null)
+		{
+			return player;
+		}
+
+		for (OfflinePlayer offlinePlayer : getOfflinePlayers())
+		{
+			if (offlinePlayer.getUniqueId().equals(id))
+			{
+				return offlinePlayer;
+			}
+		}
+
+		return null;
 	}
 
 	public void clearOnlinePlayers()

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -450,6 +450,17 @@ public class ServerMockTest
 	}
 
 	@Test
+	public void getOperators_OneOperator()
+	{
+		PlayerMock player = new PlayerMock(server, "operator");
+		server.addPlayer(player);
+		player.setOp(true);
+		
+		assertTrue(server.getOperators().contains(player));
+		assertEquals(1, server.getOperators().size());
+	}
+
+	@Test
 	public void getScoreboardManager_NotNull()
 	{
 		ScoreboardManager manager = server.getScoreboardManager();


### PR DESCRIPTION
## Description
I recently made changes to my code to make it work in a multi-threaded situation, my code invoked `Bukkit.getPlayer()` which resulted in MockBukkit throwing an exception. On an actual Server, this operation was totally thread-safe since Spigot purposefully uses a concurrent `CopyOnWriteArrayList` internally.
This PR is supposed to implement the same thread-safe behaviours into MockBukkit.

```
be.seeseemelk.mockbukkit.scheduler.AsyncTaskException: be.seeseemelk.mockbukkit.ThreadAccessException: The Bukkit API was accessed from asynchronous code.
		at be.seeseemelk.mockbukkit.scheduler.BukkitSchedulerMock.shutdown(BukkitSchedulerMock.java:43)
		at be.seeseemelk.mockbukkit.MockBukkit.unmock(MockBukkit.java:319)
```

## Changes
* Refactoring: Moved playerList and offlinePlayerList (and their related methods) into our `PlayerList` class (makes more sense imho and also mirrors Spigot's usage of that class), this also cleans up the pretty big `ServerMock` class
* Made `getOnlinePlayers()` and any other Player operations in the Server class thread-safe.
* Adding Players still requires to be done on the main thread due to the `PlayerJoinEvent` being a sync-only event.
* Added a missing `Server#getOperators()` Unit Test

## Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.

## Info on creating a pull request
Before the pull request can be accepted, the version number stored in settings.gradle should be updated.
MockBukkit uses semantic-versioning (https://semver.org/)

 - If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
 - If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)
 - Make sure that unit tests are added which test the relevant changes.
 - Make sure that the changes follow the existing code format.

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.

The version number can be found in `settings.gradle`.
