### PR TITLE
actions: don't run formatter on PR

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -6,8 +6,6 @@ name: Code style
 on:
   push:
     branches: [ v1.16 ]
-  pull_request:
-    branches: [ v1.16 ]
 
 jobs:
   formatter:


### PR DESCRIPTION
# Description
This changes the GitHub Actions to reformat the code so that it will not run when opening a pull request. It will fail when accessing external repositories, causing everyone (except mine) build's to fail.