### PR TITLE
Update scoreboard methods and implement proper state and argument validation

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.5-R0.1-SNAPSHOT'
-gradle.ext.version = '0.24.1'
+gradle.ext.version = '0.25.0'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/src/main/java/be/seeseemelk/mockbukkit/scoreboard/ObjectiveMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scoreboard/ObjectiveMock.java
@@ -3,16 +3,19 @@ package be.seeseemelk.mockbukkit.scoreboard;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang.Validate;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.scoreboard.DisplaySlot;
 import org.bukkit.scoreboard.Objective;
 import org.bukkit.scoreboard.RenderType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 
 public class ObjectiveMock implements Objective
 {
-	private final ScoreboardMock scoreboard;
+	private ScoreboardMock scoreboard;
 	private final String name;
 	private final String criteria;
 	private final Map<String, ScoreMock> scores = new HashMap<>();
@@ -20,43 +23,63 @@ public class ObjectiveMock implements Objective
 	private DisplaySlot displaySlot;
 	private RenderType renderType;
 
-	public ObjectiveMock(ScoreboardMock scoreboard, String name, String criteria)
+	public ObjectiveMock(@NotNull ScoreboardMock scoreboard, @NotNull String name, @NotNull String displayName,
+			@NotNull String criteria, @NotNull RenderType renderType)
 	{
+		Validate.notNull(scoreboard, "When registering an Objective to the Scoreboard the scoreboard cannot be null.");
+		Validate.notNull(name, "The name cannot be null");
+		Validate.notNull(criteria, "The criteria cannot be null");
+
 		this.scoreboard = scoreboard;
 		this.name = name;
-		this.displayName = name;
+		this.displayName = displayName;
 		this.criteria = criteria;
+		this.renderType = renderType;
+	}
+
+	/**
+	 * This method checks if this {@link ObjectiveMock} is still valid. If it has been unregistered, the method will
+	 * throw an {@link IllegalStateException}.
+	 * 
+	 * @throws IllegalStateException if this objective has been unregistered.
+	 */
+	private void validate() throws IllegalStateException
+	{
+		if (!isRegistered())
+		{
+			throw new IllegalStateException("This objective is no longer registered.");
+		}
 	}
 
 	@Override
 	public String getName() throws IllegalStateException
 	{
+		validate();
 		return name;
 	}
 
 	@Override
 	public String getDisplayName() throws IllegalStateException
 	{
+		validate();
 		return displayName;
 	}
 
 	@Override
 	public void setDisplayName(String displayName) throws IllegalStateException, IllegalArgumentException
 	{
+		Validate.notNull(displayName, "The display name cannot be null");
+		Validate.isTrue(displayName.length() <= 128, "The display name cannot be longer than 128 characters");
+
+		validate();
 		this.displayName = displayName;
 	}
 
 	@Override
 	public String getCriteria() throws IllegalStateException
 	{
+		validate();
 		return criteria;
-	}
-
-	@Override
-	public boolean isModifiable() throws IllegalStateException
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
 	}
 
 	@Override
@@ -68,21 +91,27 @@ public class ObjectiveMock implements Objective
 	@Override
 	public void unregister() throws IllegalStateException
 	{
+		// To unregister the Objective... it must be registered :o
+		validate();
+
 		scoreboard.unregister(this);
+		scoreboard = null;
 	}
 
 	/**
 	 * Checks if the objective is still registered.
+	 * 
 	 * @return {@code true} if the objective is still registered, {@code false} if it has been unregistered.
 	 */
 	public boolean isRegistered()
 	{
-		return scoreboard.getObjectives().contains(this);
+		return scoreboard != null && scoreboard.getObjectives().contains(this);
 	}
 
 	@Override
-	public void setDisplaySlot(DisplaySlot slot) throws IllegalStateException
+	public void setDisplaySlot(@Nullable DisplaySlot slot) throws IllegalStateException
 	{
+		validate();
 		displaySlot = slot;
 		scoreboard.setDisplaySlot(this, slot);
 	}
@@ -90,38 +119,60 @@ public class ObjectiveMock implements Objective
 	@Override
 	public DisplaySlot getDisplaySlot() throws IllegalStateException
 	{
+		validate();
 		return displaySlot;
 	}
 
 	@Override
-	public ScoreMock getScore(OfflinePlayer player) throws IllegalArgumentException, IllegalStateException
+	public void setRenderType(@NotNull RenderType renderType) throws IllegalStateException
 	{
+		validate();
+		this.renderType = renderType;
+	}
+
+	@Override
+	public RenderType getRenderType() throws IllegalStateException
+	{
+		validate();
+		return renderType;
+	}
+
+	@Override
+	@Deprecated
+	public ScoreMock getScore(@NotNull OfflinePlayer player) throws IllegalArgumentException, IllegalStateException
+	{
+		Validate.notNull(player, "The player cannot be null");
+		validate();
+
 		return getScore(player.getName());
 	}
 
 	@Override
-	public ScoreMock getScore(String entry) throws IllegalArgumentException, IllegalStateException
+	public ScoreMock getScore(@NotNull String entry) throws IllegalArgumentException, IllegalStateException
 	{
-		if (scores.containsKey(entry))
-			return scores.get(entry);
+		Validate.notNull(entry, "The entry cannot be null");
+		Validate.isTrue(entry.length() <= 40, "Objective entries cannot be longer than 40 characters");
+		validate();
+
+		ScoreMock score = scores.get(entry);
+
+		if (score != null)
+		{
+			return score;
+		}
 		else
 		{
-			ScoreMock score = new ScoreMock(this, entry);
+			score = new ScoreMock(this, entry);
 			scores.put(entry, score);
 			return score;
 		}
 	}
 
 	@Override
-	public void setRenderType(RenderType renderType) throws IllegalStateException
+	public boolean isModifiable() throws IllegalStateException
 	{
-		this.renderType =  renderType;
-	}
-
-	@Override
-	public RenderType getRenderType() throws IllegalStateException
-	{
-		return renderType;
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/scoreboard/ObjectiveMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/scoreboard/ObjectiveMockTest.java
@@ -56,9 +56,10 @@ public class ObjectiveMockTest
 	@Test
 	public void unregister_ObjectiveWasRegistered_ObjectiveIsRemoved()
 	{
-		assumeNotNull("Objective was not registered", scoreboard.getObjective(objective.getName()));
+		String name = objective.getName();
+		assumeNotNull("Objective was not registered", scoreboard.getObjective(name));
 		objective.unregister();
-		assertNull("Objective was not registered", scoreboard.getObjective(objective.getName()));
+		assertNull("Objective was not registered", scoreboard.getObjective(name));
 	}
 
 	@Test
@@ -94,18 +95,3 @@ public class ObjectiveMockTest
 	}
 
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
# Description
This pull request implements the overloaded `ScoreboardMock#registerNewObjective()` methods which are long overdue for implementation.
This implementation gap was discovered by a user on discord in the `#mockbukkit-help` channel.
I also took this oppurtunity to implement all the state and argument validations that the documented `@throws` clauses dictate.
An `IllegalStateException` will be thrown for any `ObjectiveMock` method that is invoked while the objective is not registered.
Furthermore, argument validation was implemented by the usage of Apache's `Validate` class which throws an `IllegalArgumentException` (inline with the Bukkit documentation).
Even character limits are now enforced.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [ ] Unit tests added.
- [x] Code follows existing code format.