### PR TITLE
Fix for Async task orphaned by the scheduler causing a lockup on shutdown during unit testing.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.5-R0.1-SNAPSHOT'
-gradle.ext.version = '0.30.0'
+gradle.ext.version = '0.30.1'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.5-R0.1-SNAPSHOT'
-gradle.ext.version = '0.27.0'
+gradle.ext.version = '0.28.0'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/src/main/java/be/seeseemelk/mockbukkit/PlayerList.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/PlayerList.java
@@ -22,10 +22,10 @@ import be.seeseemelk.mockbukkit.entity.PlayerMock;
 
 /**
  * Replica of the Bukkit internal PlayerList and CraftPlayerList implementation
- * 
+ *
  * @author seeseemelk
  * @author TheBusyBiscuit
- * 
+ *
  */
 public class PlayerList
 {
@@ -75,7 +75,7 @@ public class PlayerList
 	public Set<OfflinePlayer> getOperators()
 	{
 		return Stream.concat(onlinePlayers.stream(), offlinePlayers.stream()).filter(OfflinePlayer::isOp)
-				.collect(Collectors.toSet());
+		       .collect(Collectors.toSet());
 	}
 
 	@NotNull
@@ -99,16 +99,16 @@ public class PlayerList
 	public List<Player> matchPlayer(@NotNull String name)
 	{
 		return onlinePlayers.stream().filter(
-				player -> player.getName().toLowerCase(Locale.ENGLISH).startsWith(name.toLowerCase(Locale.ENGLISH)))
-				.collect(Collectors.toList());
+		           player -> player.getName().toLowerCase(Locale.ENGLISH).startsWith(name.toLowerCase(Locale.ENGLISH)))
+		       .collect(Collectors.toList());
 	}
 
 	@Nullable
 	public Player getPlayerExact(@NotNull String name)
 	{
 		return onlinePlayers.stream()
-				.filter(player -> player.getName().toLowerCase(Locale.ENGLISH).equals(name.toLowerCase(Locale.ENGLISH)))
-				.findFirst().orElse(null);
+		       .filter(player -> player.getName().toLowerCase(Locale.ENGLISH).equals(name.toLowerCase(Locale.ENGLISH)))
+		       .findFirst().orElse(null);
 	}
 
 	@Nullable

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -715,7 +715,7 @@ public class ServerMock implements Server
 
 		for (Player player : players)
 		{
-			if (player.hasPermission(permission)) 
+			if (player.hasPermission(permission))
 			{
 				player.sendMessage(message);
 				count++;
@@ -1516,34 +1516,34 @@ public class ServerMock implements Server
 	{
 		@NotNull
 		@Override
-        public YamlConfiguration getConfig()
+		public YamlConfiguration getConfig()
 		{
 			// TODO Auto-generated method stub
 			throw new UnimplementedOperationException();
-        }
+		}
 
-        @Override
-        public void broadcast(@NotNull BaseComponent component)
-        {
-    		for (Player player : getOnlinePlayers())
-    		{
-    			player.spigot().sendMessage(component);
-    		}
-        }
+		@Override
+		public void broadcast(@NotNull BaseComponent component)
+		{
+			for (Player player : getOnlinePlayers())
+			{
+				player.spigot().sendMessage(component);
+			}
+		}
 
-        @Override
-        public void broadcast(@NotNull BaseComponent... components)
-        {
-    		for (Player player : getOnlinePlayers())
-    		{
-    			player.spigot().sendMessage(components);
-    		}
-        }
+		@Override
+		public void broadcast(@NotNull BaseComponent... components)
+		{
+			for (Player player : getOnlinePlayers())
+			{
+				player.spigot().sendMessage(components);
+			}
+		}
 
-        @Override
-        public void restart()
-        {
-        	throw new UnsupportedOperationException("Not supported.");
-        }
+		@Override
+		public void restart()
+		{
+			throw new UnsupportedOperationException("Not supported.");
+		}
 	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ArmorStandMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ArmorStandMock.java
@@ -17,7 +17,7 @@ import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 
 /**
  * This is the mock of an {@link ArmorStand}.
- * 
+ *
  * @author TheBusyBiscuit
  *
  */

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityEquipmentMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityEquipmentMock.java
@@ -13,7 +13,7 @@ import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 /**
  * This mocks the {@link EntityEquipment} of a {@link LivingEntityMock}. Note that not every {@link LivingEntity} has
  * {@link EntityEquipment}, so only implement this where necessary.
- * 
+ *
  * @author TheBusyBiscuit
  *
  */
@@ -225,7 +225,7 @@ public class EntityEquipmentMock implements EntityEquipment
 	public ItemStack[] getArmorContents()
 	{
 		return new ItemStack[]
-		{ getHelmet(), getChestplate(), getLeggings(), getBoots() };
+		       { getHelmet(), getChestplate(), getLeggings(), getBoots() };
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -78,7 +78,7 @@ public abstract class EntityMock implements Entity, MessageTarget
 	@Override
 	public final boolean equals(Object obj)
 	{
-		if (obj instanceof EntityMock) 
+		if (obj instanceof EntityMock)
 		{
 			return uuid.equals(((EntityMock) obj).getUniqueId());
 		}

--- a/src/main/java/be/seeseemelk/mockbukkit/help/HelpMapMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/help/HelpMapMock.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 /**
  * The {@link HelpMapMock} is our mock of Bukkit's {@link HelpMap}.
- * 
+ *
  * @author NeumimTo
  *
  */

--- a/src/main/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -260,11 +260,13 @@ public class BukkitSchedulerMock implements BukkitScheduler
 		}
 	}
 
-	private void cancelTask(@NotNull ScheduledTask task){
+	private void cancelTask(@NotNull ScheduledTask task)
+	{
 
-		if(!task.isCancelled()) {
+		if (!task.isCancelled())
+		{
 			task.cancel();
-			if(asyncTasksQueued>0)
+			if (asyncTasksQueued > 0)
 			{
 				asyncTasksQueued--;
 			}
@@ -365,19 +367,22 @@ public class BukkitSchedulerMock implements BukkitScheduler
 		return scheduledTask;
 	}
 
-	private void checkForShutDown(ScheduledTask task){
-		if(shuttingDown) {
+	private void checkForShutDown(ScheduledTask task)
+	{
+		if (shuttingDown)
+		{
 			String name;
-			if(task.getOwner() != null)
+			if (task.getOwner() != null)
 			{
 				name = task.getOwner().getName();
-			} else
+			}
+			else
 			{
 				name = "";
 			}
 			Logger.getLogger(LOGGER_NAME).warning(
-					name + "(" + task.getRunnable().getClass().getSimpleName()
-					+  "): Scheduler is shutting down - why are you scheduling tasks - CANCELLED");
+			    name + "(" + task.getRunnable().getClass().getSimpleName()
+			    +  "): Scheduler is shutting down - why are you scheduling tasks - CANCELLED");
 			task.cancel();
 		}
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/scoreboard/ObjectiveMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scoreboard/ObjectiveMock.java
@@ -24,7 +24,7 @@ public class ObjectiveMock implements Objective
 	private RenderType renderType;
 
 	public ObjectiveMock(@NotNull ScoreboardMock scoreboard, @NotNull String name, @NotNull String displayName,
-			@NotNull String criteria, @NotNull RenderType renderType)
+	                     @NotNull String criteria, @NotNull RenderType renderType)
 	{
 		Validate.notNull(scoreboard, "When registering an Objective to the Scoreboard the scoreboard cannot be null.");
 		Validate.notNull(name, "The name cannot be null");
@@ -40,7 +40,7 @@ public class ObjectiveMock implements Objective
 	/**
 	 * This method checks if this {@link ObjectiveMock} is still valid. If it has been unregistered, the method will
 	 * throw an {@link IllegalStateException}.
-	 * 
+	 *
 	 * @throws IllegalStateException if this objective has been unregistered.
 	 */
 	private void validate() throws IllegalStateException
@@ -100,7 +100,7 @@ public class ObjectiveMock implements Objective
 
 	/**
 	 * Checks if the objective is still registered.
-	 * 
+	 *
 	 * @return {@code true} if the objective is still registered, {@code false} if it has been unregistered.
 	 */
 	public boolean isRegistered()

--- a/src/main/java/be/seeseemelk/mockbukkit/scoreboard/ScoreboardMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scoreboard/ScoreboardMock.java
@@ -32,14 +32,14 @@ public class ScoreboardMock implements Scoreboard
 
 	@Override
 	public ObjectiveMock registerNewObjective(String name, String criteria, String displayName)
-			throws IllegalArgumentException
+	throws IllegalArgumentException
 	{
 		return registerNewObjective(name, criteria, displayName, RenderType.INTEGER);
 	}
 
 	@Override
 	public ObjectiveMock registerNewObjective(String name, String criteria, String displayName, RenderType renderType)
-			throws IllegalArgumentException
+	throws IllegalArgumentException
 	{
 		ObjectiveMock objective = new ObjectiveMock(this, name, displayName, criteria, renderType);
 		objectives.put(name, objective);
@@ -56,7 +56,7 @@ public class ScoreboardMock implements Scoreboard
 	public Set<Objective> getObjectivesByCriteria(String criteria) throws IllegalArgumentException
 	{
 		return objectives.values().stream().filter(objective -> objective.getCriteria().equals(criteria))
-				.collect(Collectors.toSet());
+		       .collect(Collectors.toSet());
 	}
 
 	@Override
@@ -186,7 +186,7 @@ public class ScoreboardMock implements Scoreboard
 
 	/**
 	 * Sets the objective to a specific slot.
-	 * 
+	 *
 	 * @param objective The objective to set to the slot.
 	 * @param slot      The slot to set the objective to.
 	 */
@@ -197,7 +197,7 @@ public class ScoreboardMock implements Scoreboard
 
 	/**
 	 * Removes an objective off this scoreboard.
-	 * 
+	 *
 	 * @param objectiveMock The objective to remove.
 	 */
 	protected void unregister(@NotNull ObjectiveMock objectiveMock)

--- a/src/main/java/be/seeseemelk/mockbukkit/tags/TagParser.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/tags/TagParser.java
@@ -44,7 +44,7 @@ public class TagParser implements Keyed
 
 	/**
 	 * This constructs a new {@link TagParser}.
-	 * 
+	 *
 	 * @param registry The {@link TagRegistry} for the resulting {@link Tag}
 	 * @param key      The {@link NamespacedKey} of the resulting {@link Tag}
 	 */

--- a/src/test/java/be/seeseemelk/mockbukkit/EmptyPlugin.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/EmptyPlugin.java
@@ -11,13 +11,16 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Empty JavaPlugin used for testing only
  */
-public class EmptyPlugin extends JavaPlugin {
+public class EmptyPlugin extends JavaPlugin
+{
 
-	public EmptyPlugin() {
+	public EmptyPlugin()
+	{
 		super();
 	}
 
-	public EmptyPlugin(@NotNull JavaPluginLoader loader, @NotNull PluginDescriptionFile description, @NotNull File dataFolder, @NotNull File file) {
+	public EmptyPlugin(@NotNull JavaPluginLoader loader, @NotNull PluginDescriptionFile description, @NotNull File dataFolder, @NotNull File file)
+	{
 		super(loader, description, dataFolder, file);
 	}
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -455,7 +455,7 @@ public class ServerMockTest
 		PlayerMock player = new PlayerMock(server, "operator");
 		server.addPlayer(player);
 		player.setOp(true);
-		
+
 		assertTrue(server.getOperators().contains(player));
 		assertEquals(1, server.getOperators().size());
 	}

--- a/src/test/java/be/seeseemelk/mockbukkit/block/BlockMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/BlockMockTest.java
@@ -58,7 +58,8 @@ public class BlockMockTest
 	}
 
 	@Test
-	public void getChunk_LocalBlock_Matches() {
+	public void getChunk_LocalBlock_Matches()
+	{
 		WorldMock world = new WorldMock();
 		Location location = new Location(world, -10, 5, 30);
 		Block worldBlock = world.getBlockAt(location);

--- a/src/test/java/be/seeseemelk/mockbukkit/command/ConsoleCommandSenderMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/command/ConsoleCommandSenderMockTest.java
@@ -39,12 +39,14 @@ public class ConsoleCommandSenderMockTest
 	}
 
 	@Test
-	public void getName_IsConsole() {
+	public void getName_IsConsole()
+	{
 		assertEquals("CONSOLE", sender.getName());
 	}
 
 	@Test
-	public void assertIsOp() {
+	public void assertIsOp()
+	{
 		assertTrue(sender.isOp());
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMockTest.java
@@ -117,13 +117,14 @@ public class BukkitSchedulerMockTest
 	}
 
 	@Test
-	public void runScheduledTask_WhileScheduler_ShutDown(){
+	public void runScheduledTask_WhileScheduler_ShutDown()
+	{
 		AtomicInteger count = new AtomicInteger(0);
 		Runnable callback = () -> count.incrementAndGet();
 		scheduler.shutdown();
 		scheduler.runTaskTimer(null, callback, 0, 2L);
 		scheduler.performTicks(1L);
-		assertEquals(0,count.get());
+		assertEquals(0, count.get());
 	}
 
 	@Test
@@ -133,28 +134,30 @@ public class BukkitSchedulerMockTest
 		AtomicInteger count = new AtomicInteger();
 		CyclicBarrier barrier = new CyclicBarrier(2);
 
-		testTask = scheduler.runTaskLaterAsynchronously(null,()-> {
+		testTask = scheduler.runTaskLaterAsynchronously(null, ()->
+		{
 
-					assertNotEquals(mainThread, Thread.currentThread());
-					count.incrementAndGet();
+			assertNotEquals(mainThread, Thread.currentThread());
+			count.incrementAndGet();
 			try
 			{
 				barrier.await(3L, TimeUnit.SECONDS);
-			} catch (InterruptedException | BrokenBarrierException | TimeoutException e)
+			}
+			catch (InterruptedException | BrokenBarrierException | TimeoutException e)
 			{
 				throw new RuntimeException(e);
 			}
 
-		},2);
+		}, 2);
 		assertTrue(scheduler.isQueued(testTask.getTaskId()));
-		assertEquals(0,count.get());
+		assertEquals(0, count.get());
 		scheduler.performTicks(1L);
 		assertTrue(scheduler.isQueued(testTask.getTaskId()));
-		assertEquals(0,count.get());
+		assertEquals(0, count.get());
 		scheduler.performTicks(3);
 		barrier.await(3L, TimeUnit.SECONDS);
 		assertFalse(scheduler.isQueued(testTask.getTaskId()));
-		assertEquals(1,count.get());
+		assertEquals(1, count.get());
 
 	}
 
@@ -226,13 +229,14 @@ public class BukkitSchedulerMockTest
 	}
 
 	@Test
-	public void testPluginCancel(){
+	public void testPluginCancel()
+	{
 		MockBukkit.mock();
 		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
 		BukkitScheduler s = MockBukkit.getMock().getScheduler();
-		BukkitTask task = s.runTaskLaterAsynchronously(plugin,()->{},10);
-		BukkitTask task2 = s.runTaskLaterAsynchronously(plugin,()->{},10);
-		BukkitTask task3 = s.runTaskLaterAsynchronously(null,()->{},10);
+		BukkitTask task = s.runTaskLaterAsynchronously(plugin, ()-> {}, 10);
+		BukkitTask task2 = s.runTaskLaterAsynchronously(plugin, ()-> {}, 10);
+		BukkitTask task3 = s.runTaskLaterAsynchronously(null, ()-> {}, 10);
 
 		assertTrue(s.isQueued(task.getTaskId()));
 		assertTrue(s.isQueued(task2.getTaskId()));

--- a/src/test/java/be/seeseemelk/mockbukkit/services/ServicesManagerTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/services/ServicesManagerTest.java
@@ -12,30 +12,35 @@ import be.seeseemelk.mockbukkit.EmptyPlugin;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 
-public class ServicesManagerTest {
+public class ServicesManagerTest
+{
 	private ServerMock server;
 	private EmptyPlugin plugin;
 
 	@Before
-	public void setUp() {
+	public void setUp()
+	{
 		server = MockBukkit.mock();
 		plugin = MockBukkit.loadWith(EmptyPlugin.class, "empty_plugin.yml");
 	}
 
 	@After
-	public void tearDown() {
+	public void tearDown()
+	{
 		MockBukkit.unmock();
 	}
 
 	@Test
-	public void test_register_should_register() {
+	public void test_register_should_register()
+	{
 		// We use this class as the service class to avoid creating a useless class
 		server.getServicesManager().register(ServicesManagerTest.class, this, plugin, ServicePriority.Normal);
 		assertEquals(this, server.getServicesManager().load(ServicesManagerTest.class));
 	}
 
 	@Test
-	public void test_register_multiple_service() {
+	public void test_register_multiple_service()
+	{
 		Object obj = new Object();
 		Object obj2 = new Object();
 		Object obj3 = new Object();
@@ -51,12 +56,14 @@ public class ServicesManagerTest {
 	}
 
 	@Test
-	public void test_load_not_registered_object() {
+	public void test_load_not_registered_object()
+	{
 		assertNull(server.getServicesManager().load(Object.class));
 	}
 
 	@Test
-	public void test_load_registered_object() {
+	public void test_load_registered_object()
+	{
 		Object object = new Object();
 		server.getServicesManager().register(Object.class, object, plugin, ServicePriority.Normal);
 		assertNotNull(server.getServicesManager().load(Object.class));
@@ -64,12 +71,14 @@ public class ServicesManagerTest {
 	}
 
 	@Test
-	public void test_get_registration_not_registered_object() {
+	public void test_get_registration_not_registered_object()
+	{
 		assertNull(server.getServicesManager().getRegistration(Object.class));
 	}
 
 	@Test
-	public void test_get_registration_registered_object() {
+	public void test_get_registration_registered_object()
+	{
 		Object object = new Object();
 		server.getServicesManager().register(Object.class, object, plugin, ServicePriority.Normal);
 
@@ -79,7 +88,8 @@ public class ServicesManagerTest {
 	}
 
 	@Test
-	public void test_unregister_service_provider() {
+	public void test_unregister_service_provider()
+	{
 		Object obj = new Object();
 		Object obj2 = new Object();
 		Object obj3 = new Object();
@@ -95,7 +105,8 @@ public class ServicesManagerTest {
 	}
 
 	@Test
-	public void test_unregister() {
+	public void test_unregister()
+	{
 		Object obj = new Object();
 		Object obj2 = new Object();
 		Object obj3 = new Object();
@@ -118,7 +129,8 @@ public class ServicesManagerTest {
 	}
 
 	@Test
-	public void test_get_registrations() {
+	public void test_get_registrations()
+	{
 		Object obj = new Object();
 		Object obj2 = new Object();
 		server.getServicesManager().register(Object.class, obj, plugin, ServicePriority.Normal);
@@ -130,7 +142,8 @@ public class ServicesManagerTest {
 	}
 
 	@Test
-	public void test_get_known_services() {
+	public void test_get_known_services()
+	{
 		Object obj = new Object();
 		Object obj2 = new Object();
 		server.getServicesManager().register(Object.class, obj, plugin, ServicePriority.Normal);
@@ -143,7 +156,8 @@ public class ServicesManagerTest {
 	}
 
 	@Test
-	public void test_is_provided_for() {
+	public void test_is_provided_for()
+	{
 		Object obj = new Object();
 		Object obj2 = new Object();
 		server.getServicesManager().register(Object.class, obj, plugin, ServicePriority.Normal);


### PR DESCRIPTION
# Description
This PR was designed to go some way to fix the issues in #162.   In this PR we still wait for the queue but if the async queue count exceeds the actual list of tasks the plugin will cancel them and eject them logging an error to console.    

It will not fail the tests.  In Spigot and Paper, the scheduler doesn't wait but it will force shutdown of the queue if there was a long-running task doing something like:-

```java
while(true) {
   Thread.sleep(1000)
}
```

A fully fleshed out scheduler would be ideal but beyond the scope of this PR.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.
