### PR TITLE
Use command map instead of command array

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.5-R0.1-SNAPSHOT'
-gradle.ext.version = '0.27.0'
+gradle.ext.version = '0.27.1'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -346,7 +346,7 @@ public class ServerMock implements Server
 	public CommandResult executeConsole(String command, String... args)
 	{
 		assertMainThread();
-		return executeConsole(getPluginCommand(command), args);
+		return executeConsole(getCommandMap().getCommand(command), args);
 	}
 
 	/**
@@ -376,7 +376,7 @@ public class ServerMock implements Server
 	public CommandResult executePlayer(String command, String... args)
 	{
 		assertMainThread();
-		return executePlayer(getPluginCommand(command), args);
+		return executePlayer(getCommandMap().getCommand(command), args);
 	}
 
 	/**
@@ -411,7 +411,7 @@ public class ServerMock implements Server
 	public CommandResult execute(String command, CommandSender sender, String... args)
 	{
 		assertMainThread();
-		return execute(getPluginCommand(command), sender, args);
+		return execute(getCommandMap().getCommand(command), sender, args);
 	}
 
 	@Override
@@ -502,14 +502,8 @@ public class ServerMock implements Server
 	public PluginCommand getPluginCommand(String name)
 	{
 		assertMainThread();
-		for (PluginCommand command : getPluginManager().getCommands())
-		{
-			if (isLabelOfCommand(command, name))
-			{
-				return command;
-			}
-		}
-		return null;
+		Command command = getCommandMap().getCommand(name);
+		return command instanceof PluginCommand ? (PluginCommand) command : null;
 	}
 
 	@Override


### PR DESCRIPTION
# Description

I know a lot of command frameworks work with the `CommandMap` to dynamically introduce commands to bukkit. Though MockBukkit was only using its command array.
Hence this PR changes calls to `PluginManagerMock.getCommands` to `MockCommandMap.getCommand`.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
Before the pull request can be accepted, the version number stored in settings.gradle should be updated.
MockBukkit uses semantic-versioning (https://semver.org/)

 - If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
 - If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)
 - Make sure that unit tests are added which test the relevant changes.
 - Make sure that the changes follow the existing code format.

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.

The version number can be found in `settings.gradle`.
