### PR TITLE
Implement getKiller on LivingEntity and refactor entity death

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.5-R0.1-SNAPSHOT'
-gradle.ext.version = '0.34.2'
+gradle.ext.version = '0.35.0'
 
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.5-R0.1-SNAPSHOT'
-gradle.ext.version = '0.31.0'
+gradle.ext.version = '0.32.0'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.5-R0.1-SNAPSHOT'
-gradle.ext.version = '0.30.0'
+gradle.ext.version = '0.31.0'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -109,7 +109,8 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		alive = false;
 	}
 
-	public List<ItemStack> getDrops() {
+	public List<ItemStack> getDrops()
+	{
 		return new ArrayList<>();
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -44,7 +44,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 {
 
 	private static final double MAX_HEALTH = 20.0;
-	private double health;
+	protected double health;
 	private double maxHealth = MAX_HEALTH;
 	private int maxAirTicks = 300;
 	private int remainingAirTicks = 300;
@@ -79,44 +79,16 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	@Override
 	public void setHealth(double health)
 	{
-		if (health <= 0)
-		{
-			this.health = 0;
+		if (health <= 0) this.kill();
+		else this.health = Math.min(health, getMaxHealth());
+	}
 
-			if (this instanceof Player)
-			{
-				Player player = (Player) this;
-				List<ItemStack> drops = new ArrayList<>();
-				drops.addAll(Arrays.asList(player.getInventory().getContents()));
-				PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 0, getName() + " got killed");
-				Bukkit.getPluginManager().callEvent(event);
-
-				// Terminate any InventoryView and the cursor item
-				player.closeInventory();
-
-				// Clear the Inventory if keep-inventory is not enabled
-				if (!getWorld().getGameRuleValue(GameRule.KEEP_INVENTORY).booleanValue())
-				{
-					player.getInventory().clear();
-					// Should someone try to provoke a RespawnEvent, they will now find the Inventory to be empty
-				}
-
-				player.setLevel(0);
-				player.setExp(0);
-				player.setFoodLevel(0);
-			}
-			else
-			{
-				EntityDeathEvent event = new EntityDeathEvent(this, new ArrayList<>(), 0);
-				Bukkit.getPluginManager().callEvent(event);
-			}
-
-			alive = false;
-		}
-		else
-		{
-			this.health = Math.min(health, getMaxHealth());
-		}
+	public void kill() {
+		this.health = 0;
+		if (!this.alive) return;
+		EntityDeathEvent event = new EntityDeathEvent(this, new ArrayList<>(), 0);
+		Bukkit.getPluginManager().callEvent(event);
+		alive = false;
 	}
 
 	@Override
@@ -129,8 +101,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	public void setMaxHealth(double health)
 	{
 		getAttribute(Attribute.GENERIC_MAX_HEALTH).setBaseValue(health);
-		if (this.health > health)
-		{
+		if (this.health > health) {
 			this.health = health;
 		}
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -79,8 +79,10 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	@Override
 	public void setHealth(double health)
 	{
-		if (health <= 0) this.kill();
-		else this.health = Math.min(health, getMaxHealth());
+		if (health <= 0)
+			this.kill();
+		else
+			this.health = Math.min(health, getMaxHealth());
 	}
 
 	/**
@@ -93,8 +95,8 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		this.kill();
 	}
 
-	/*
-	 * Kills this entity and propagates the necessary event
+	/**
+	 * Kills this entity and propagates the necessary event.
 	 */
 	public void kill()
 	{

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -39,6 +39,7 @@ import com.google.common.base.Function;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.attribute.AttributeInstanceMock;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class LivingEntityMock extends EntityMock implements LivingEntity
 {
@@ -83,7 +84,21 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		else this.health = Math.min(health, getMaxHealth());
 	}
 
-	public void kill() {
+	/**
+	 * Simulates a kill by setting the killer of this entity and propagating the necessary event
+	 * @param player the player who killed this entity
+	 */
+	public void simulateKilledBy(@Nullable Player player)
+	{
+		this.setKiller(player);
+		this.kill();
+	}
+
+	/*
+	 * Kills this entity and propagates the necessary event
+	 */
+	public void kill()
+	{
 		this.health = 0;
 		if (!this.alive) return;
 		EntityDeathEvent event = new EntityDeathEvent(this, new ArrayList<>(), 0);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -101,9 +101,17 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	{
 		this.health = 0;
 		if (!this.alive) return;
-		EntityDeathEvent event = new EntityDeathEvent(this, new ArrayList<>(), 0);
+		EntityDeathEvent event = new EntityDeathEvent(this, getDrops(), getDroppedExp());
 		Bukkit.getPluginManager().callEvent(event);
 		alive = false;
+	}
+
+	public List<ItemStack> getDrops() {
+		return new ArrayList<>();
+	}
+
+	public int getDroppedExp() {
+		return 0;
 	}
 
 	@Override
@@ -329,7 +337,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		throw new UnimplementedOperationException();
 	}
 
-	public void setKiller(Player killer)
+	public void setKiller(@Nullable Player killer)
 	{
 		this.killer = killer;
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -114,7 +114,8 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		return new ArrayList<>();
 	}
 
-	public int getDroppedExp() {
+	public int getDroppedExp()
+	{
 		return 0;
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -50,6 +50,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	private int remainingAirTicks = 300;
 	protected boolean alive = true;
 	protected Map<Attribute, AttributeInstanceMock> attributes;
+	protected Player killer;
 
 	private final Set<ActivePotionEffect> activeEffects = new HashSet<>();
 
@@ -341,11 +342,14 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		throw new UnimplementedOperationException();
 	}
 
+	public void setKiller(Player killer) {
+		this.killer = killer;
+	}
+
 	@Override
 	public Player getKiller()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.killer;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -116,7 +116,8 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	public void setMaxHealth(double health)
 	{
 		getAttribute(Attribute.GENERIC_MAX_HEALTH).setBaseValue(health);
-		if (this.health > health) {
+		if (this.health > health)
+		{
 			this.health = health;
 		}
 	}
@@ -328,7 +329,8 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		throw new UnimplementedOperationException();
 	}
 
-	public void setKiller(Player killer) {
+	public void setKiller(Player killer)
+	{
 		this.killer = killer;
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -639,12 +639,14 @@ public class PlayerMock extends LivingEntityMock implements Player
 		this.closeInventory();
 
 		// Clear the Inventory if keep-inventory is not enabled
-		if (!event.getKeepInventory()) {
+		if (!event.getKeepInventory())
+		{
 			this.getInventory().clear();
 			// Should someone try to provoke a RespawnEvent, they will now find the Inventory to be empty
 		}
 
-		if (!event.getKeepLevel()) {
+		if (!event.getKeepLevel())
+		{
 			this.setLevel(0);
 			this.setExp(0);
 		}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -623,7 +623,8 @@ public class PlayerMock extends LivingEntityMock implements Player
 	}
 
 	@Override
-	public void kill() {
+	public void kill()
+	{
 		this.health = 0;
 
 		if (!this.alive) return;

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -23,6 +23,7 @@ import org.bukkit.entity.memory.MemoryKey;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockDamageEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
@@ -624,10 +625,34 @@ public class PlayerMock extends LivingEntityMock implements Player
 	}
 
 	@Override
-	public Player getKiller()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+	public void kill() {
+		this.health = 0;
+
+		if (!this.alive) return;
+
+		List<ItemStack> drops = Arrays.asList(this.getInventory().getContents());
+		PlayerDeathEvent event = new PlayerDeathEvent(this, drops, 0, getName() + " got killed");
+		Boolean keepInventory = getWorld().getGameRuleValue(GameRule.KEEP_INVENTORY);
+		event.setKeepInventory(keepInventory != null && keepInventory);
+		event.setKeepLevel(keepInventory != null && keepInventory);
+		Bukkit.getPluginManager().callEvent(event);
+
+		// Terminate any InventoryView and the cursor item
+		this.closeInventory();
+
+		// Clear the Inventory if keep-inventory is not enabled
+		if (!event.getKeepInventory()) {
+			this.getInventory().clear();
+			// Should someone try to provoke a RespawnEvent, they will now find the Inventory to be empty
+		}
+
+		if (!event.getKeepLevel()) {
+			this.setLevel(0);
+			this.setExp(0);
+		}
+
+		this.setFoodLevel(0);
+		this.alive = false;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -695,7 +695,8 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 	}
 
 	@Override
-	public List<ItemStack> getDrops() {
+	public List<ItemStack> getDrops()
+	{
 		return Arrays.asList(this.getInventory().getContents());
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -628,8 +628,7 @@ public class PlayerMock extends LivingEntityMock implements Player
 
 		if (!this.alive) return;
 
-		List<ItemStack> drops = Arrays.asList(this.getInventory().getContents());
-		PlayerDeathEvent event = new PlayerDeathEvent(this, drops, 0, getName() + " got killed");
+		PlayerDeathEvent event = new PlayerDeathEvent(this, getDrops(), getDroppedExp(), getName() + " got killed");
 		Boolean keepInventory = getWorld().getGameRuleValue(GameRule.KEEP_INVENTORY);
 		event.setKeepInventory(keepInventory != null && keepInventory);
 		event.setKeepLevel(keepInventory != null && keepInventory);
@@ -653,6 +652,11 @@ public class PlayerMock extends LivingEntityMock implements Player
 
 		this.setFoodLevel(0);
 		this.alive = false;
+	}
+
+	@Override
+	public List<ItemStack> getDrops() {
+		return Arrays.asList(this.getInventory().getContents());
 	}
 
 	@Override

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
@@ -10,14 +10,19 @@ import static org.junit.Assert.assertTrue;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
+import be.seeseemelk.mockbukkit.*;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.permissions.Permission;
@@ -29,11 +34,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.MockPlugin;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.WorldMock;
 
 public class EntityMockTest
 {

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
@@ -1,28 +1,15 @@
 package be.seeseemelk.mockbukkit.entity;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
-
-import be.seeseemelk.mockbukkit.*;
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.MockPlugin;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.WorldMock;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
-import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.permissions.Permission;
@@ -34,6 +21,18 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 
 public class EntityMockTest
 {

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -220,12 +220,14 @@ public class PlayerMockTest
 	}
 
 	@Test
-	public void kill_PLayerDeathEventDispatched() {
+	public void kill_PLayerDeathEventDispatched()
+	{
 		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
 		AtomicBoolean eventDispatched = new AtomicBoolean();
 		server.getPluginManager().registerEvents(new Listener() {
 			@EventHandler
-			public void onDeath(PlayerDeathEvent event) {
+			public void onDeath(PlayerDeathEvent event)
+			{
 				eventDispatched.set(true);
 			}
 		}, plugin);
@@ -235,7 +237,8 @@ public class PlayerMockTest
 	}
 
 	@Test
-	public void kill_NoKeepInventory_PlayerReset() {
+	public void kill_NoKeepInventory_PlayerReset()
+	{
 		player.getWorld().setGameRule(GameRule.KEEP_INVENTORY, false);
 		player.kill();
 
@@ -247,7 +250,8 @@ public class PlayerMockTest
 	}
 
 	@Test
-	public void kill_KeepInventory_inventoryKept() {
+	public void kill_KeepInventory_inventoryKept()
+	{
 		player.getWorld().setGameRule(GameRule.KEEP_INVENTORY, true);
 		player.getInventory().addItem(new ItemStack(Material.DIRT));
 		player.kill();
@@ -256,12 +260,14 @@ public class PlayerMockTest
 	}
 
 	@Test
-	public void getKiller_Default_null() {
+	public void getKiller_Default_null()
+	{
 		assertNull(player.getKiller());
 	}
 
 	@Test
-	public void getKiller_SomeValue_SetExactly() {
+	public void getKiller_SomeValue_SetExactly()
+	{
 		PlayerMock killer = server.addPlayer();
 		player.setKiller(killer);
 		assertEquals(killer, player.getKiller());

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -219,6 +219,18 @@ public class PlayerMockTest
 	}
 
 	@Test
+	public void getKiller_Default_null() {
+		assertNull(player.getKiller());
+	}
+
+	@Test
+	public void getKiller_SomeValue_SetExactly() {
+		PlayerMock killer = server.addPlayer();
+		player.setKiller(killer);
+		assertEquals(killer, player.getKiller());
+	}
+
+	@Test
 	public void damage_LessThanHealth_DamageTaken()
 	{
 		double health = player.getHealth();

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -223,17 +223,8 @@ public class PlayerMockTest
 	public void kill_PLayerDeathEventDispatched()
 	{
 		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
-		AtomicBoolean eventDispatched = new AtomicBoolean();
-		server.getPluginManager().registerEvents(new Listener() {
-			@EventHandler
-			public void onDeath(PlayerDeathEvent event)
-			{
-				eventDispatched.set(true);
-			}
-		}, plugin);
-
 		player.kill();
-		assertTrue(eventDispatched.get());
+		server.getPluginManager().assertEventFired(PlayerDeathEvent.class);
 	}
 
 	@Test

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/ZombieMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/ZombieMockTest.java
@@ -2,18 +2,16 @@ package be.seeseemelk.mockbukkit.entity;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.TestPlugin;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class ZombieMockTest
 {
@@ -36,20 +34,11 @@ public class ZombieMockTest
 	@Test
 	public void simulateKilledBy_GivenPlayer()
 	{
-		AtomicBoolean eventDispatched = new AtomicBoolean();
-		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
 		PlayerMock player = server.addPlayer();
 
-		server.getPluginManager().registerEvents(new Listener() {
-			@EventHandler
-			public void onDeath(EntityDeathEvent event)
-			{
-				eventDispatched.set(true);
-			}
-		}, plugin);
 		zombie.simulateKilledBy(player);
 
-		assertTrue(eventDispatched.get());
+		server.getPluginManager().assertEventFired(EntityDeathEvent.class);
 		assertEquals(player, zombie.getKiller());
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/ZombieMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/ZombieMockTest.java
@@ -1,0 +1,61 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.TestPlugin;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.*;
+
+public class ZombieMockTest {
+	private ServerMock server;
+	private ZombieMock zombie;
+
+	@Before
+	public void setUp()
+	{
+		server = MockBukkit.mock();
+		zombie = new ZombieMock(server, UUID.randomUUID());
+	}
+
+	@After
+	public void tearDown()
+	{
+		MockBukkit.unmock();
+	}
+
+	@Test
+	public void simulateKilledBy_GivenPlayer()
+	{
+		AtomicBoolean eventDispatched = new AtomicBoolean();
+		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
+		PlayerMock player = server.addPlayer();
+
+		server.getPluginManager().registerEvents(new Listener() {
+			@EventHandler
+			public void onDeath(EntityDeathEvent event) {
+				eventDispatched.set(true);
+			}
+		}, plugin);
+		zombie.simulateKilledBy(player);
+
+		assertTrue(eventDispatched.get());
+		assertEquals(player, zombie.getKiller());
+	}
+
+	@Test
+	public void simulateKilledBy_NoPlayer()
+	{
+		zombie.simulateKilledBy(null);
+		assertNull(zombie.getKiller());
+		assertTrue(zombie.isDead());
+	}
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/ZombieMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/ZombieMockTest.java
@@ -15,7 +15,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.*;
 
-public class ZombieMockTest {
+public class ZombieMockTest
+{
 	private ServerMock server;
 	private ZombieMock zombie;
 
@@ -41,7 +42,8 @@ public class ZombieMockTest {
 
 		server.getPluginManager().registerEvents(new Listener() {
 			@EventHandler
-			public void onDeath(EntityDeathEvent event) {
+			public void onDeath(EntityDeathEvent event)
+			{
 				eventDispatched.set(true);
 			}
 		}, plugin);


### PR DESCRIPTION
# Description
I added an implementation for the `getKiller` method in `LivingEntity` and refactor the death logic so every entity can override the death behavior.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
Before the pull request can be accepted, the version number stored in settings.gradle should be updated.
MockBukkit uses semantic-versioning (https://semver.org/)

 - If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
 - If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)
 - Make sure that unit tests are added which test the relevant changes.
 - Make sure that the changes follow the existing code format.

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.

The version number can be found in `settings.gradle`.
