### PR TITLE
Implement isOp for ConsoleCommandSender

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.5-R0.1-SNAPSHOT'
-gradle.ext.version = '0.27.0'
+gradle.ext.version = '0.28.0'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/src/main/java/be/seeseemelk/mockbukkit/command/ConsoleCommandSenderMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/command/ConsoleCommandSenderMock.java
@@ -132,15 +132,13 @@ public class ConsoleCommandSenderMock implements ConsoleCommandSender, MessageTa
 	@Override
 	public boolean isOp()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return true;
 	}
 
 	@Override
 	public void setOp(boolean value)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw new UnsupportedOperationException("Console is op and its status cannot be changed");
 	}
 
 	@Override
@@ -153,8 +151,7 @@ public class ConsoleCommandSenderMock implements ConsoleCommandSender, MessageTa
 	@Override
 	public String getName()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return "CONSOLE";
 	}
 
 	@Override

--- a/src/test/java/be/seeseemelk/mockbukkit/command/ConsoleCommandSenderMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/command/ConsoleCommandSenderMockTest.java
@@ -39,6 +39,16 @@ public class ConsoleCommandSenderMockTest
 	}
 
 	@Test
+	public void getName_IsConsole() {
+		assertEquals("CONSOLE", sender.getName());
+	}
+
+	@Test
+	public void assertIsOp() {
+		assertTrue(sender.isOp());
+	}
+
+	@Test
 	public void assertSaid_CorrectMessage_DoesNotAssert()
 	{
 		sender.sendMessage("A hello world");


### PR DESCRIPTION
# Description
As the console must always be considered op, I updated the getter for the console as well as its name.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
Before the pull request can be accepted, the version number stored in settings.gradle should be updated.
MockBukkit uses semantic-versioning (https://semver.org/)

 - If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
 - If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)
 - Make sure that unit tests are added which test the relevant changes.
 - Make sure that the changes follow the existing code format.

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.

The version number can be found in `settings.gradle`.
