### PR TITLE
Implement World#getChunk for Location and Block

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.5-R0.1-SNAPSHOT'
-gradle.ext.version = '0.28.1'
+gradle.ext.version = '0.29.0'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.5-R0.1-SNAPSHOT'
-gradle.ext.version = '0.29.0'
+gradle.ext.version = '0.30.0'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/src/main/java/be/seeseemelk/mockbukkit/ChunkMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ChunkMock.java
@@ -53,7 +53,7 @@ public class ChunkMock implements Chunk
 		Validate.isTrue(x >= 0 && x <= 15, "x is out of range (expected 0-15)");
 		Validate.isTrue(y >= 0 && y <= 255, "y is out of range (expected 0-255)");
 		Validate.isTrue(z >= 0 && z <= 15, "z is out of range (expected 0-15)");
-		return world.getBlockAt(x << 4, y, z << 4);
+		return world.getBlockAt((this.x << 4) + x, y, (this.z << 4) + z);
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
@@ -338,15 +338,13 @@ public class WorldMock implements World
 	@Override
 	public Chunk getChunkAt(Location location)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return getChunkAt(location.getBlockX() >> 4, location.getBlockZ() >> 4);
 	}
 
 	@Override
 	public Chunk getChunkAt(Block block)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return getChunkAt(block.getLocation());
 	}
 
 	@Override

--- a/src/test/java/be/seeseemelk/mockbukkit/block/BlockMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/BlockMockTest.java
@@ -58,7 +58,7 @@ public class BlockMockTest
 	}
 
 	@Test
-	public void getChunk_Matches() {
+	public void getChunk_LocalBlock_Matches() {
 		WorldMock world = new WorldMock();
 		Location location = new Location(world, -10, 5, 30);
 		Block worldBlock = world.getBlockAt(location);

--- a/src/test/java/be/seeseemelk/mockbukkit/block/BlockMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/BlockMockTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -54,6 +55,18 @@ public class BlockMockTest
 		Location location = new Location(world, 5, 2, 1);
 		block = new BlockMock(Material.AIR, location);
 		assertEquals(location, block.getLocation());
+	}
+
+	@Test
+	public void getChunk_Matches() {
+		WorldMock world = new WorldMock();
+		Location location = new Location(world, -10, 5, 30);
+		Block worldBlock = world.getBlockAt(location);
+		Chunk chunk = worldBlock.getChunk();
+		int localX = location.getBlockX() - (chunk.getX() << 4);
+		int localZ = location.getBlockZ() - (chunk.getZ() << 4);
+		Block chunkBlock = chunk.getBlock(localX, location.getBlockY(), localZ);
+		assertEquals(worldBlock, chunkBlock);
 	}
 
 	@Test


### PR DESCRIPTION
# Description
* Implement `World#getChunkAt(Location)` and `World#getChunkAt(Block)`
  * Fix `Block#getChunk`
* Fix `Chunk#getBlock` always returning a block in the column of the chunk's lowest block coordinate instead of proper local block

I threw the test in BlockMockTest because I discovered this trying to use `Block#getChunk`, but the argument could be made that it would fit better in `WorldMockTest` or `ChunkMockTest`.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.