### PR TITLE
Set type with BlockData

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.5-R0.1-SNAPSHOT'
-gradle.ext.version = '0.30.0'
+gradle.ext.version = '0.30.1'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/src/main/java/be/seeseemelk/mockbukkit/block/BlockMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/BlockMock.java
@@ -381,6 +381,7 @@ public class BlockMock implements Block
 	@Override
 	public void setBlockData(@NotNull BlockData data)
 	{
+		this.material = data.getMaterial();
 		this.blockData = data;
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/block/BlockMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/BlockMockTest.java
@@ -143,6 +143,7 @@ public class BlockMockTest
 
 		block.setBlockData(blockData);
 		Assert.assertEquals(blockData, block.getBlockData());
+		Assert.assertEquals(blockData.getMaterial(), block.getType());
 		block.setType(oldType);
 	}
 


### PR DESCRIPTION
# Description
When setting data, the block's type is [supposed to be set as well](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/browse/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java?at=bf3d7207140a295c35d4024a43cd188824c5a359#184).

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.