### PR TITLE
Fix hashCode and equals in ItemMetaMock

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.5-R0.1-SNAPSHOT'
-gradle.ext.version = '0.31.0'
+gradle.ext.version = '0.31.1'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -33,6 +33,10 @@ import be.seeseemelk.mockbukkit.persistence.PersistentDataContainerMock;
 public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 {
 
+	/*
+	 * If you add a new field, you need to add it to #hashCode, #equals, #serialize, and #deserialize.
+	 * If it's a mutable object, it also needs to be handled in #clone.
+	 */
 	private String displayName = null;
 	private List<String> lore = null;
 	private int damage = 0;
@@ -169,26 +173,72 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 		int result = 1;
 		result = prime * result + ((displayName == null) ? 0 : displayName.hashCode());
 		result = prime * result + ((lore == null) ? 0 : lore.hashCode());
-		result = prime * result + Boolean.hashCode(unbreakable);
-		result = prime * result + enchants.hashCode();
-		result = prime * result + persistentDataContainer.hashCode();
 		result = prime * result + ((customModelData == null) ? 0 : customModelData.hashCode());
-		result = prime * result + repairCost;
+		result = prime * result + (enchants.isEmpty() ? 0 : enchants.hashCode());
+		result = prime * result + (hasRepairCost() ? this.repairCost : 0);
+		result = prime * result + (!persistentDataContainer.isEmpty() ? persistentDataContainer.hashCode() : 0);
+		result = prime * result + (hideFlags.isEmpty() ? 0 : hideFlags.hashCode());
+		result = prime * result + Boolean.hashCode(unbreakable);
+		result = prime * result + (hasDamage() ? this.damage : 0);
 		return result;
 	}
 
 	@Override
 	public boolean equals(Object obj)
 	{
-		if (obj instanceof ItemMeta)
-		{
-			ItemMeta meta = (ItemMeta) obj;
-			return isLoreEquals(meta) && isDisplayNameEqual(meta);
-		}
-		else
+		if (!(obj instanceof ItemMeta))
 		{
 			return false;
 		}
+
+		ItemMeta meta = (ItemMeta) obj;
+
+		if (!isDisplayNameEqual(meta))
+		{
+			return false;
+		}
+		if (!isLoreEquals(meta))
+		{
+			return false;
+		}
+		if (obj instanceof Damageable)
+		{
+			Damageable damageable = (Damageable) obj;
+			if (hasDamage() != damageable.hasDamage() || hasDamage() && getDamage() != damageable.getDamage())
+			{
+				return false;
+			}
+		}
+		else if (hasDamage())
+		{
+			return false;
+		}
+		// Comparing using equals is fine - AbstractMap#equals only cares about content, not Map implementation.
+		if (!enchants.equals(meta.getEnchants()))
+		{
+			return false;
+		}
+		// Same as above - AbstractSet#equals only compares content.
+		if (!hideFlags.equals(meta.getItemFlags()))
+		{
+			return false;
+		}
+		// MockPDC does care about PDC impl, but this is in line with CB's equality comparison.
+		if (!persistentDataContainer.equals(meta.getPersistentDataContainer()))
+		{
+			return false;
+		}
+		if (unbreakable != meta.isUnbreakable())
+		{
+			return false;
+		}
+		if (hasCustomModelData() != meta.hasCustomModelData()
+				|| hasCustomModelData() && getCustomModelData() != meta.getCustomModelData())
+		{
+			return false;
+		}
+
+		return true;
 	}
 
 	@Override

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMockTest.java
@@ -2,19 +2,24 @@ package be.seeseemelk.mockbukkit.inventory.meta;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import be.seeseemelk.mockbukkit.MockPlugin;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.Repairable;
+import org.bukkit.persistence.PersistentDataType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -79,7 +84,7 @@ public class ItemMetaMockTest
 	public void equals_SameWithoutDisplayName_True()
 	{
 		ItemMetaMock meta2 = new ItemMetaMock();
-		assertTrue(meta.equals(meta2));
+		assertEquals(meta, meta2);
 		assertEquals(meta.hashCode(), meta2.hashCode());
 	}
 
@@ -89,7 +94,7 @@ public class ItemMetaMockTest
 		ItemMetaMock meta2 = new ItemMetaMock();
 		meta.setDisplayName("Some name");
 		meta2.setDisplayName("Some name");
-		assertTrue(meta.equals(meta2));
+		assertEquals(meta, meta2);
 		assertEquals(meta.hashCode(), meta2.hashCode());
 	}
 
@@ -97,10 +102,10 @@ public class ItemMetaMockTest
 	public void equals_SameLore_True()
 	{
 		ItemMetaMock meta2 = new ItemMetaMock();
-		meta.setLore(Arrays.asList("lore"));
-		meta2.setLore(Arrays.asList("lore"));
-		assertTrue(meta.equals(meta2));
-		assertTrue(meta2.equals(meta));
+		meta.setLore(Collections.singletonList("lore"));
+		meta2.setLore(Collections.singletonList("lore"));
+		assertEquals(meta, meta2);
+		assertEquals(meta2, meta);
 		assertEquals(meta.hashCode(), meta2.hashCode());
 	}
 
@@ -110,7 +115,8 @@ public class ItemMetaMockTest
 		ItemMetaMock meta2 = new ItemMetaMock();
 		meta.setDisplayName("Some name");
 		meta2.setDisplayName("Different name");
-		assertFalse(meta.equals(meta2));
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
 	}
 
 	@Test
@@ -118,55 +124,220 @@ public class ItemMetaMockTest
 	{
 		ItemMetaMock meta2 = new ItemMetaMock();
 		meta.setDisplayName("Some name");
-		assertFalse(meta.equals(meta2));
-		assertFalse(meta2.equals(meta));
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
 	}
 
 	@Test
 	public void equals_OneWithLoreOneWithout_False()
 	{
 		ItemMetaMock meta2 = new ItemMetaMock();
-		meta.setLore(Arrays.asList("lore"));
-		assertFalse(meta.equals(meta2));
-		assertFalse(meta2.equals(meta));
+		meta.setLore(Collections.singletonList("lore"));
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
 	}
 
 	@Test
 	public void equals_DifferentSizedLore_False()
 	{
 		ItemMetaMock meta2 = new ItemMetaMock();
-		meta.setLore(Arrays.asList("lore"));
+		meta.setLore(Collections.singletonList("lore"));
 		meta2.setLore(Arrays.asList("lore", "more lore"));
-		assertFalse(meta.equals(meta2));
-		assertFalse(meta2.equals(meta));
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
 	}
 
 	@Test
 	public void equals_Null_False()
 	{
-		assertFalse(meta.equals(null));
+		assertNotEquals(meta, null);
+		assertNotEquals(null, meta);
 	}
 
 	@Test
-	public void equals_SameUnbreakableProperty_True()
+	public void equals_DamageSame_True()
 	{
 		ItemMetaMock meta2 = new ItemMetaMock();
-		meta.setUnbreakable(false);
-		meta2.setUnbreakable(false);
-		assertTrue(meta.equals(meta2));
+		meta.setDamage(10);
+		meta2.setDamage(10);
+		assertEquals(meta, meta2);
+		assertEquals(meta2, meta);
+	}
+
+	@Test
+	public void equals_DamageDifferent_False()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.setDamage(10);
+		meta2.setDamage(20);
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
+	}
+
+	@Test
+	public void equals_DamageOneWithout_False()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.setDamage(10);
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
+	}
+
+	@Test
+	public void equals_EnchantsSame_True()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.addEnchant(Enchantment.DURABILITY, 5, true);
+		meta2.addEnchant(Enchantment.DURABILITY, 5, true);
+		assertEquals(meta, meta2);
+		assertEquals(meta2, meta);
+	}
+
+	@Test
+	public void equals_EnchantsDifferent_False()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.addEnchant(Enchantment.DURABILITY, 5, true);
+		meta2.addEnchant(Enchantment.DURABILITY, 5, true);
+		meta2.addEnchant(Enchantment.DAMAGE_ALL, 1, true);
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
+	}
+
+	@Test
+	public void equals_EnchantsDifferentLevel_False()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.addEnchant(Enchantment.DURABILITY, 5, true);
+		meta2.addEnchant(Enchantment.DURABILITY, 10, true);
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
+	}
+
+	@Test
+	public void equals_EnchantsOneEmpty_False()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.addEnchant(Enchantment.DURABILITY, 5, true);
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
+	}
+
+	@Test
+	public void equals_HideFlagsSame_True()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_DYE);
+		meta2.addItemFlags(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_DYE);
+		assertEquals(meta, meta2);
+		assertEquals(meta2, meta);
+	}
+
+	@Test
+	public void equals_HideFlagsDifferent_False()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_DYE);
+		meta2.addItemFlags(ItemFlag.HIDE_DESTROYS);
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
+	}
+
+	@Test
+	public void equals_HideFlagsOneEmpty_False()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
+	}
+
+	@Test
+	public void equals_PersistentDataSame_True()
+	{
+		MockPlugin plugin = MockBukkit.createMockPlugin();
+		ItemMetaMock meta2 = new ItemMetaMock();
+		NamespacedKey key = new NamespacedKey(plugin, "key");
+		meta.getPersistentDataContainer().set(key, PersistentDataType.LONG, 0L);
+		meta2.getPersistentDataContainer().set(key, PersistentDataType.LONG, 0L);
+		assertEquals(meta, meta2);
+		assertEquals(meta2, meta);
+	}
+
+	@Test
+	public void equals_PersistentDataDifferent_False()
+	{
+		MockPlugin plugin = MockBukkit.createMockPlugin();
+		ItemMetaMock meta2 = new ItemMetaMock();
+		NamespacedKey key = new NamespacedKey(plugin, "key");
+		meta.getPersistentDataContainer().set(key, PersistentDataType.LONG, 0L);
+		meta2.getPersistentDataContainer().set(key, PersistentDataType.LONG, 10L);
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
+	}
+
+	@Test
+	public void equals_PersistentDataOneEmpty_False()
+	{
+		MockPlugin plugin = MockBukkit.createMockPlugin();
+		ItemMetaMock meta2 = new ItemMetaMock();
+		NamespacedKey key = new NamespacedKey(plugin, "key");
+		meta.getPersistentDataContainer().set(key, PersistentDataType.LONG, 0L);
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
+	}
+
+	@Test
+	public void equals_UnbreakableSame_True()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
 		meta.setUnbreakable(true);
 		meta2.setUnbreakable(true);
-		assertTrue(meta.equals(meta2));
+		assertEquals(meta, meta2);
+		assertEquals(meta2, meta);
+		meta.setUnbreakable(false);
+		meta2.setUnbreakable(false);
+		assertEquals(meta, meta2);
+		assertEquals(meta2, meta);
 	}
 
 	@Test
-	public void equals_DifferentUnbreakableProperty_False()
+	public void equals_UnbreakableDifferent_False()
 	{
 		ItemMetaMock meta2 = new ItemMetaMock();
 		meta.setUnbreakable(true);
 		meta2.setUnbreakable(false);
-		assertTrue(meta.equals(meta2));
-		assertTrue(meta2.equals(meta));
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
+	}
+
+	@Test
+	public void equals_CustomModelDataSame_True()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.setCustomModelData(10);
+		meta2.setCustomModelData(10);
+		assertEquals(meta, meta2);
+		assertEquals(meta2, meta);
+	}
+
+	@Test
+	public void equals_CustomModelDataDifferent_False()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.setCustomModelData(10);
+		meta2.setCustomModelData(20);
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
+	}
+
+	@Test
+	public void equals_CustomModelDataOneWithout_False()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.setCustomModelData(10);
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
 	}
 
 	@Test


### PR DESCRIPTION
# Description
* Fixes `ItemMetaMock#equals` not taking into account properties other than display name and lore
* Fixes `ItemMetaMock#hashCode` missing fields
  * Reordered properties to match CB for easier future comparison

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.
