### PR TITLE
[FIX] getVersion()

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -426,7 +426,7 @@ public class ServerMock implements Server
 	@Override
 	public String getVersion()
 	{
-		return "0.1.0";
+		return BUKKIT_VERSION;
 	}
 
 	@Override
@@ -715,7 +715,7 @@ public class ServerMock implements Server
 
 		for (Player player : players)
 		{
-			if (player.hasPermission(permission)) 
+			if (player.hasPermission(permission))
 			{
 				player.sendMessage(message);
 				count++;

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -426,7 +426,7 @@ public class ServerMock implements Server
 	@Override
 	public String getVersion()
 	{
-		return BUKKIT_VERSION;
+		return String.format("MockBukkit (MC: %s)", BUKKIT_VERSION);
 	}
 
 	@Override


### PR DESCRIPTION
# Description
Testing with MockBukkit & ProtocolLib doesn't work because `Server#getVersion()` always returns 0.1.0 and ProtocolLib use this method to retrieve the [version of Minecraft used](https://github.com/dmulloy2/ProtocolLib/blob/97972acee84ec73c57866ed1d7edbda20f273a40/src/main/java/com/comphenix/protocol/utility/MinecraftVersion.java#L138)
This fix fixes the issue

# Checklist
The following items should be checked before the pull request can be merged.
- [ ] Version number updated in `settings.gradle`.
- [ ] Unit tests added.
- [X] Code follows existing code format.

# Info on creating a pull request
Before the pull request can be accepted, the version number stored in settings.gradle should be updated.
MockBukkit uses semantic-versioning (https://semver.org/)

 - If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
 - If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)
 - Make sure that unit tests are added which test the relevant changes.
 - Make sure that the changes follow the existing code format.

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.

The version number can be found in `settings.gradle`.
