### PR TITLE
Add move player instantly function.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.5-R0.1-SNAPSHOT'
-gradle.ext.version = '0.32.1'
+gradle.ext.version = '0.33.0'
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -54,6 +54,7 @@ import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerChatEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerLevelChangeEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.inventory.EntityEquipment;
@@ -264,6 +265,13 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 		setHealth(getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue());
 		setLocation(event.getRespawnLocation().clone());
 		alive = true;
+	}
+
+	public void moveInstantly(Location moveLocation) {
+		PlayerMoveEvent event = new PlayerMoveEvent(this, this.getLocation(), moveLocation);
+		Bukkit.getPluginManager().callEvent(event);
+		if(event.isCancelled() == false)
+			this.setLocation(moveLocation.clone());
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -267,7 +267,12 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 		alive = true;
 	}
 
-	public void simulatePlayerMove(@NotNull Location moveLocation)
+	/**
+	 * This method moves player instantly with respect to PlayerMoveEvent
+	 *
+	 * @param moveLocation Location to move player to
+	 */
+	public void fakeMove(@NotNull Location moveLocation)
 	{
 		PlayerMoveEvent event = new PlayerMoveEvent(this, this.getLocation(), moveLocation);
 		Bukkit.getPluginManager().callEvent(event);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -272,7 +272,7 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 		PlayerMoveEvent event = new PlayerMoveEvent(this, this.getLocation(), moveLocation);
 		Bukkit.getPluginManager().callEvent(event);
 		if(event.isCancelled() == false)
-			this.setLocation(moveLocation.clone());
+			this.setLocation(event.getTo());
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -271,7 +271,7 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 	{
 		PlayerMoveEvent event = new PlayerMoveEvent(this, this.getLocation(), moveLocation);
 		Bukkit.getPluginManager().callEvent(event);
-		if(event.isCancelled() == false)
+		if (!event.isCancelled())
 			this.setLocation(event.getTo());
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -267,7 +267,8 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 		alive = true;
 	}
 
-	public void moveInstantly(Location moveLocation) {
+	public void simulatePlayerMove(@NotNull Location moveLocation)
+	{
 		PlayerMoveEvent event = new PlayerMoveEvent(this, this.getLocation(), moveLocation);
 		Bukkit.getPluginManager().callEvent(event);
 		if(event.isCancelled() == false)

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -272,7 +272,7 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 	 *
 	 * @param moveLocation Location to move player to
 	 */
-	public void fakeMove(@NotNull Location moveLocation)
+	public void simulatePlayerMove(@NotNull Location moveLocation)
 	{
 		PlayerMoveEvent event = new PlayerMoveEvent(this, this.getLocation(), moveLocation);
 		Bukkit.getPluginManager().callEvent(event);

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -39,6 +39,7 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerExpChangeEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerLevelChangeEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
@@ -1058,5 +1059,39 @@ public class PlayerMockTest
 		boolean worked = player.simulateBlockPlace(Material.STONE, location);
 		player.setGameMode(originalGM);
 		assertFalse(worked);
+	}
+	@Test
+	public void testPlayerMoveInstantly(){
+		World world = server.addSimpleWorld("world");
+		Location moveLocation = new Location(world, 10.0,-20.0,30.0);
+		player.setLocation(new Location(world, 0, 0, 0));
+		player.moveInstantly(moveLocation);
+		server.getPluginManager().assertEventFired(PlayerMoveEvent.class);
+
+		assertTrue(player.getLocation().getX() == 10.0);
+		assertTrue(player.getLocation().getY() == -20.0);
+		assertTrue(player.getLocation().getZ() == 30.0);
+	}
+
+	@Test
+	public void testPlayerMoveInstantly_EventCancelled(){
+		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
+		Bukkit.getPluginManager().registerEvents(new Listener()
+		{
+			@EventHandler
+			public void onPlayerMove(PlayerMoveEvent event)
+			{
+				event.setCancelled(true);
+			}
+		}, plugin);
+		World world = server.addSimpleWorld("world");
+		Location moveLocation = new Location(world, 10,-20,30, 10, 20);
+		player.setLocation(new Location(world, 0, 0, 0));
+		player.moveInstantly(moveLocation);
+		server.getPluginManager().assertEventFired(PlayerMoveEvent.class);
+
+		assertTrue(player.getLocation().getX() == 0.0);
+		assertTrue(player.getLocation().getY() == 0.0);
+		assertTrue(player.getLocation().getZ() == 0.0);
 	}
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -1062,7 +1062,7 @@ public class PlayerMockTest
 	}
 
 	@Test
-	public void testPlayerMoveInstantly(){
+	public void testSimulatePlayerMove(){
 		World world = server.addSimpleWorld("world");
 		player.setLocation(new Location(world, 0, 0, 0));
 		player.simulatePlayerMove(new Location(world, 10,0,0));
@@ -1071,7 +1071,7 @@ public class PlayerMockTest
 	}
 
 	@Test
-	public void testPlayerMoveInstantly_EventCancelled(){
+	public void testSimulatePlayerMove_EventCancelled(){
 		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
 		Bukkit.getPluginManager().registerEvents(new Listener()
 		{

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -1066,7 +1066,7 @@ public class PlayerMockTest
 		World world = server.addSimpleWorld("world");
 		Location moveLocation = new Location(world, 10.0,-20.0,30.0);
 		player.setLocation(new Location(world, 0, 0, 0));
-		player.moveInstantly(moveLocation);
+		player.fakeMove(moveLocation);
 		server.getPluginManager().assertEventFired(PlayerMoveEvent.class);
 
 		assertTrue(player.getLocation().getX() == 10.0);
@@ -1088,7 +1088,7 @@ public class PlayerMockTest
 		World world = server.addSimpleWorld("world");
 		Location moveLocation = new Location(world, 10,-20,30, 10, 20);
 		player.setLocation(new Location(world, 0, 0, 0));
-		player.moveInstantly(moveLocation);
+		player.fakeMove(moveLocation);
 		server.getPluginManager().assertEventFired(PlayerMoveEvent.class);
 
 		assertTrue(player.getLocation().getX() == 0.0);

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -1064,14 +1064,10 @@ public class PlayerMockTest
 	@Test
 	public void testPlayerMoveInstantly(){
 		World world = server.addSimpleWorld("world");
-		Location moveLocation = new Location(world, 10.0,-20.0,30.0);
 		player.setLocation(new Location(world, 0, 0, 0));
-		player.simulatePlayerMove(moveLocation);
+		player.simulatePlayerMove(new Location(world, 10,0,0));
 		server.getPluginManager().assertEventFired(PlayerMoveEvent.class);
-
 		assertTrue(player.getLocation().getX() == 10.0);
-		assertTrue(player.getLocation().getY() == -20.0);
-		assertTrue(player.getLocation().getZ() == 30.0);
 	}
 
 	@Test
@@ -1086,13 +1082,9 @@ public class PlayerMockTest
 			}
 		}, plugin);
 		World world = server.addSimpleWorld("world");
-		Location moveLocation = new Location(world, 10,-20,30, 10, 20);
 		player.setLocation(new Location(world, 0, 0, 0));
-		player.simulatePlayerMove(moveLocation);
+		player.simulatePlayerMove(new Location(world, 10,0,0));
 		server.getPluginManager().assertEventFired(PlayerMoveEvent.class);
-
 		assertTrue(player.getLocation().getX() == 0.0);
-		assertTrue(player.getLocation().getY() == 0.0);
-		assertTrue(player.getLocation().getZ() == 0.0);
 	}
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -1066,7 +1066,7 @@ public class PlayerMockTest
 		World world = server.addSimpleWorld("world");
 		Location moveLocation = new Location(world, 10.0,-20.0,30.0);
 		player.setLocation(new Location(world, 0, 0, 0));
-		player.fakeMove(moveLocation);
+		player.simulatePlayerMove(moveLocation);
 		server.getPluginManager().assertEventFired(PlayerMoveEvent.class);
 
 		assertTrue(player.getLocation().getX() == 10.0);
@@ -1088,7 +1088,7 @@ public class PlayerMockTest
 		World world = server.addSimpleWorld("world");
 		Location moveLocation = new Location(world, 10,-20,30, 10, 20);
 		player.setLocation(new Location(world, 0, 0, 0));
-		player.fakeMove(moveLocation);
+		player.simulatePlayerMove(moveLocation);
 		server.getPluginManager().assertEventFired(PlayerMoveEvent.class);
 
 		assertTrue(player.getLocation().getX() == 0.0);

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -1060,6 +1060,7 @@ public class PlayerMockTest
 		player.setGameMode(originalGM);
 		assertFalse(worked);
 	}
+
 	@Test
 	public void testPlayerMoveInstantly(){
 		World world = server.addSimpleWorld("world");


### PR DESCRIPTION
# Description
Added method moveInstantly simply by moving player from place to place by teleporting him and executing move event. If the event will be canceled, it will not move player.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.
