### PR TITLE
Refactor LivingEntityMock

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -1,7 +1,6 @@
 package be.seeseemelk.mockbukkit.entity;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.HashSet;
@@ -13,7 +12,6 @@ import java.util.UUID;
 
 import org.bukkit.Bukkit;
 import org.bukkit.FluidCollisionMode;
-import org.bukkit.GameRule;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
@@ -27,8 +25,6 @@ import org.bukkit.entity.Projectile;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
-import org.bukkit.event.entity.PlayerDeathEvent;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.RayTraceResult;
@@ -45,7 +41,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 {
 
 	private static final double MAX_HEALTH = 20.0;
-	private double health;
+	protected double health;
 	private double maxHealth = MAX_HEALTH;
 	private int maxAirTicks = 300;
 	private int remainingAirTicks = 300;
@@ -79,44 +75,18 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	@Override
 	public void setHealth(double health)
 	{
-		if (health <= 0)
-		{
-			this.health = 0;
-
-			if (this instanceof Player)
-			{
-				Player player = (Player) this;
-				List<ItemStack> drops = new ArrayList<>();
-				drops.addAll(Arrays.asList(player.getInventory().getContents()));
-				PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 0, getName() + " got killed");
-				Bukkit.getPluginManager().callEvent(event);
-
-				// Terminate any InventoryView and the cursor item
-				player.closeInventory();
-
-				// Clear the Inventory if keep-inventory is not enabled
-				if (!getWorld().getGameRuleValue(GameRule.KEEP_INVENTORY).booleanValue())
-				{
-					player.getInventory().clear();
-					// Should someone try to provoke a RespawnEvent, they will now find the Inventory to be empty
-				}
-
-				player.setLevel(0);
-				player.setExp(0);
-				player.setFoodLevel(0);
-			}
-			else
-			{
-				EntityDeathEvent event = new EntityDeathEvent(this, new ArrayList<>(), 0);
-				Bukkit.getPluginManager().callEvent(event);
-			}
-
-			alive = false;
-		}
-		else
+		if (health > 0)
 		{
 			this.health = Math.min(health, getMaxHealth());
+			return;
 		}
+
+		this.health = 0;
+
+		EntityDeathEvent event = new EntityDeathEvent(this, new ArrayList<>(), 0);
+		Bukkit.getPluginManager().callEvent(event);
+
+		alive = false;
 	}
 
 	@Override
@@ -145,21 +115,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	@Override
 	public void damage(double amount)
 	{
-		Map<EntityDamageEvent.DamageModifier, Double> modifiers = new EnumMap<>(EntityDamageEvent.DamageModifier.class);
-		modifiers.put(EntityDamageEvent.DamageModifier.BASE, 1.0);
-		Map<EntityDamageEvent.DamageModifier, Function<Double, Double>> modifierFunctions = new EnumMap<>(
-		    EntityDamageEvent.DamageModifier.class);
-		modifierFunctions.put(EntityDamageEvent.DamageModifier.BASE, damage -> damage);
-
-		EntityDamageEvent event = new EntityDamageEvent(this, EntityDamageEvent.DamageCause.CUSTOM, modifiers,
-		        modifierFunctions);
-		event.setDamage(amount);
-		Bukkit.getPluginManager().callEvent(event);
-		if (!event.isCancelled())
-		{
-			amount = event.getDamage();
-			setHealth(health - amount);
-		}
+		damage(amount, null);
 	}
 
 	@SuppressWarnings("deprecation")
@@ -172,8 +128,13 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		    EntityDamageEvent.DamageModifier.class);
 		modifierFunctions.put(EntityDamageEvent.DamageModifier.BASE, damage -> damage);
 
-		EntityDamageByEntityEvent event = new EntityDamageByEntityEvent(source, this,
-		        EntityDamageEvent.DamageCause.ENTITY_ATTACK, modifiers, modifierFunctions);
+		EntityDamageEvent event = source != null ?
+				new EntityDamageByEntityEvent(source, this,
+						EntityDamageEvent.DamageCause.ENTITY_ATTACK, modifiers, modifierFunctions)
+				:
+				new EntityDamageEvent(this, EntityDamageEvent.DamageCause.CUSTOM, modifiers,
+						modifierFunctions)
+				;
 		event.setDamage(amount);
 		Bukkit.getPluginManager().callEvent(event);
 		if (!event.isCancelled())
@@ -391,15 +352,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	@Override
 	public boolean hasPotionEffect(PotionEffectType type)
 	{
-		for (PotionEffect effect : getActivePotionEffects())
-		{
-			if (effect.getType().equals(type))
-			{
-				return true;
-			}
-		}
-
-		return false;
+		return getPotionEffect(type) != null;
 	}
 
 	@Override
@@ -419,17 +372,8 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	@Override
 	public void removePotionEffect(PotionEffectType type)
 	{
-		Iterator<ActivePotionEffect> iterator = activeEffects.iterator();
 
-		while (iterator.hasNext())
-		{
-			ActivePotionEffect effect = iterator.next();
-
-			if (effect.hasExpired() || effect.getPotionEffect().getType().equals(type))
-			{
-				iterator.remove();
-			}
-		}
+		activeEffects.removeIf(effect -> effect.hasExpired() || effect.getPotionEffect().getType().equals(type));
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.fail;
 
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -21,6 +22,7 @@ import org.bukkit.DyeColor;
 import org.bukkit.Effect;
 import org.bukkit.FluidCollisionMode;
 import org.bukkit.GameMode;
+import org.bukkit.GameRule;
 import org.bukkit.Instrument;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -46,10 +48,10 @@ import org.bukkit.entity.Player;
 import org.bukkit.entity.Pose;
 import org.bukkit.entity.Villager;
 import org.bukkit.entity.memory.MemoryKey;
-import org.bukkit.event.Event;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockDamageEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
@@ -1598,6 +1600,38 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 	{
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public void setHealth(double health) {
+		if (health > 0)
+		{
+			this.health = Math.min(health, getMaxHealth());
+			return;
+		}
+
+		this.health = 0;
+
+		List<ItemStack> drops = new ArrayList<>();
+		drops.addAll(Arrays.asList(getInventory().getContents()));
+		PlayerDeathEvent event = new PlayerDeathEvent(this, drops, 0, getName() + " got killed");
+		Bukkit.getPluginManager().callEvent(event);
+
+		// Terminate any InventoryView and the cursor item
+		closeInventory();
+
+		// Clear the Inventory if keep-inventory is not enabled
+		if (!getWorld().getGameRuleValue(GameRule.KEEP_INVENTORY).booleanValue())
+		{
+			getInventory().clear();
+			// Should someone try to provoke a RespawnEvent, they will now find the Inventory to be empty
+		}
+
+		setLevel(0);
+		setExp(0);
+		setFoodLevel(0);
+
+		alive = false;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -1603,7 +1603,8 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 	}
 
 	@Override
-	public void setHealth(double health) {
+	public void setHealth(double health)
+	{
 		if (health > 0)
 		{
 			this.health = Math.min(health, getMaxHealth());


### PR DESCRIPTION
# Description
I saw https://github.com/seeseemelk/MockBukkit/issues/112 and thought that I could contribute by refactoring the `LivingEntityMock` class. This is the list of the changes I've done:

1. Overwritten the setHealth method in the `PlayerMock` class to avoid having to check if `(this instanceof Player)` inside `LivingEntityMock`.
2. Merged `damage(double amount)` and `damage(double amount, Entity source)` into one.
3. Simplied `hasPotionEffect(PotionEffectType type)` by making use `getPotionEffect(PotionEffectType type)`
3. Simplied `removePotionEffect(PotionEffectType type)`

# Checklist
The following items should be checked before the pull request can be merged.
- [ ] Version number updated in `settings.gradle`.
- [ ] Unit tests added.
- [x] Code follows existing code format.
