### PR TITLE
gradle: bump version of Jacoco

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,10 @@ jacocoTestReport {
     }
 }
 
+jacoco {
+	toolVersion = "0.8.6"
+}
+
 group = 'com.github.seeseemelk'
 version = gradle.ext.version
 


### PR DESCRIPTION
# Description
This bumps the version of Jacoco so that MockBukkit unit tests can be run when using Java 15.
It fixes the following exception when running unit tests:
```
Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 59
        at org.jacoco.agent.rt.internal_43f5073.asm.ClassReader.<init>(ClassReader.java:195)
        at org.jacoco.agent.rt.internal_43f5073.asm.ClassReader.<init>(ClassReader.java:176)
        at org.jacoco.agent.rt.internal_43f5073.asm.ClassReader.<init>(ClassReader.java:162)
        at org.jacoco.agent.rt.internal_43f5073.core.internal.instr.InstrSupport.classReaderFor(InstrSupport.java:280)
        at org.jacoco.agent.rt.internal_43f5073.core.instr.Instrumenter.instrument(Instrumenter.java:75)
        at org.jacoco.agent.rt.internal_43f5073.core.instr.Instrumenter.instrument(Instrumenter.java:107)
```