### PR TITLE
Fix build error involving BlockMock

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 gradle.ext.apiVersion = '1.16'
 gradle.ext.apiVersionFull = '1.16.5-R0.1-SNAPSHOT'
-gradle.ext.version = '0.34.1'
+gradle.ext.version = '0.34.2'
 
 
 rootProject.name = 'MockBukkit-' + gradle.ext.apiVersion

--- a/src/main/java/be/seeseemelk/mockbukkit/block/BlockMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/BlockMock.java
@@ -438,4 +438,11 @@ public class BlockMock implements Block
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
 	}
+
+	@Override
+	public boolean isPreferredTool(ItemStack tool)
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
 }


### PR DESCRIPTION
# Description
This fixes a build error because Bukkit changed an interface, again...

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [ ] Unit tests added.
- [x] Code follows existing code format.