### PR TITLE
Change simulate methods in PlayerMock to return the event they fired. Change build.gradle to run tests.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,6 +133,10 @@ publishing {
     }
 }
 
+test {
+    useJUnitPlatform()
+}
+
 eclipse.classpath.downloadJavadoc = true
 eclipse.classpath.downloadSources = true
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ gradle.ext.apiVersionFull = '1.16.5-R0.1-SNAPSHOT'
   Every new update should bump the version below according to
   the conventions.
 */
-gradle.ext.version = '1.1.0'
+gradle.ext.version = '1.2.0'
 
 /*
   This is the name of our MockBukkit artifact, it includes

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -186,7 +186,7 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 	 * @return {@code true} if the block was damaged, {@code false} if the event was cancelled or the player was not in
 	 *         survival gamemode.
 	 */
-	public boolean simulateBlockDamage(Block block)
+	public @Nullable BlockDamageEvent simulateBlockDamage(Block block)
 	{
 		if (gamemode == GameMode.SURVIVAL)
 		{
@@ -199,11 +199,11 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 					block.setType(Material.AIR);
 			}
 
-			return !event.isCancelled();
+			return event;
 		}
 		else
 		{
-			return false;
+			return null;
 		}
 	}
 
@@ -215,17 +215,17 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 	 * @return {@code true} if the block was broken, {@code false} if it wasn't or if the player was in adventure mode
 	 *         or in spectator mode.
 	 */
-	public boolean simulateBlockBreak(Block block)
+	public @Nullable BlockBreakEvent simulateBlockBreak(Block block)
 	{
 		if ((gamemode == GameMode.SPECTATOR || gamemode == GameMode.ADVENTURE)
 		        || (gamemode == GameMode.SURVIVAL && simulateBlockDamagePure(block).isCancelled()))
-			return false;
+			return null;
 
 		BlockBreakEvent event = new BlockBreakEvent(block, this);
 		Bukkit.getPluginManager().callEvent(event);
 		if (!event.isCancelled())
 			block.setType(Material.AIR);
-		return !event.isCancelled();
+		return event;
 	}
 
 	/**
@@ -283,12 +283,13 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 	 *
 	 * @param moveLocation Location to move player to
 	 */
-	public void simulatePlayerMove(@NotNull Location moveLocation)
+	public PlayerMoveEvent simulatePlayerMove(@NotNull Location moveLocation)
 	{
 		PlayerMoveEvent event = new PlayerMoveEvent(this, this.getLocation(), moveLocation);
 		Bukkit.getPluginManager().callEvent(event);
 		if (!event.isCancelled())
 			this.setLocation(event.getTo());
+		return event;
 	}
 
 	@Override
@@ -972,7 +973,7 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 		this.sneaking = sneaking;
 	}
 
-	public void simulateSneak(boolean sneak)
+	public PlayerToggleSneakEvent simulateSneak(boolean sneak)
 	{
 		PlayerToggleSneakEvent event = new PlayerToggleSneakEvent(this, sneak);
 		Bukkit.getPluginManager().callEvent(event);
@@ -980,6 +981,7 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 		{
 			this.sneaking = event.isSneaking();
 		}
+		return event;
 	}
 
 	@Override
@@ -994,7 +996,7 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 		this.sprinting = sprinting;
 	}
 
-	public void simulateSprint(boolean sprint)
+	public PlayerToggleSprintEvent simulateSprint(boolean sprint)
 	{
 		PlayerToggleSprintEvent event = new PlayerToggleSprintEvent(this, sprint);
 		Bukkit.getPluginManager().callEvent(event);
@@ -1002,6 +1004,7 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 		{
 			this.sprinting = event.isSprinting();
 		}
+		return event;
 	}
 
 	@Override
@@ -1538,7 +1541,7 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 		this.flying = value;
 	}
 
-	public void simulateToggleFlight(boolean fly)
+	public PlayerToggleFlightEvent simulateToggleFlight(boolean fly)
 	{
 		PlayerToggleFlightEvent event = new PlayerToggleFlightEvent(this, fly);
 		Bukkit.getPluginManager().callEvent(event);
@@ -1546,6 +1549,7 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 		{
 			this.flying = event.isFlying();
 		}
+		return event;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -1526,7 +1526,7 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 	public boolean canSee(@NotNull Player player)
 	{
 		return !hiddenPlayers.containsKey(player.getUniqueId()) &&
-				!hiddenPlayersDeprecated.contains(player.getUniqueId());
+		       !hiddenPlayersDeprecated.contains(player.getUniqueId());
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -183,7 +183,7 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 	 * {@link BlockBreakEvent}.
 	 *
 	 * @param block The block to damage.
-	 * @return {@code true} if the block was damaged, {@code false} if the event was cancelled or the player was not in
+	 * @return the event that was fired, {@code null} if the player was not in
 	 *         survival gamemode.
 	 */
 	public @Nullable BlockDamageEvent simulateBlockDamage(Block block)
@@ -212,7 +212,7 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 	 * spectator mode. If the player is in survival mode, the player will first damage the block.
 	 *
 	 * @param block The block to break.
-	 * @return {@code true} if the block was broken, {@code false} if it wasn't or if the player was in adventure mode
+	 * @return The event that was fired, {@code null} if it wasn't or if the player was in adventure mode
 	 *         or in spectator mode.
 	 */
 	public @Nullable BlockBreakEvent simulateBlockBreak(Block block)
@@ -234,19 +234,19 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 	 *
 	 * @param material The material of the location to set to
 	 * @param location The location of the material to set to
-	 * @return {@code true} if the block was placed, {@code false} if it wasn't or the player was in adventure
+	 * @return The event that was fired. {@code null} if it wasn't or the player was in adventure
 	 * 			mode.
 	 */
-	public boolean simulateBlockPlace(Material material, Location location)
+	public @Nullable BlockPlaceEvent simulateBlockPlace(Material material, Location location)
 	{
 		if (gamemode == GameMode.ADVENTURE || gamemode == GameMode.SPECTATOR)
-			return false;
+			return null;
 		Block block = location.getBlock();
 		BlockPlaceEvent event = new BlockPlaceEvent(block, null, null, null, this, true, null);
 		Bukkit.getPluginManager().callEvent(event);
 		if (!event.isCancelled())
 			block.setType(material);
-		return !event.isCancelled();
+		return event;
 	}
 
 	/**
@@ -282,8 +282,9 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 	 * This method moves player instantly with respect to PlayerMoveEvent
 	 *
 	 * @param moveLocation Location to move player to
+	 * @return The event that is fired
 	 */
-	public PlayerMoveEvent simulatePlayerMove(@NotNull Location moveLocation)
+	public @NotNull PlayerMoveEvent simulatePlayerMove(@NotNull Location moveLocation)
 	{
 		PlayerMoveEvent event = new PlayerMoveEvent(this, this.getLocation(), moveLocation);
 		Bukkit.getPluginManager().callEvent(event);
@@ -973,7 +974,7 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 		this.sneaking = sneaking;
 	}
 
-	public PlayerToggleSneakEvent simulateSneak(boolean sneak)
+	public @NotNull PlayerToggleSneakEvent simulateSneak(boolean sneak)
 	{
 		PlayerToggleSneakEvent event = new PlayerToggleSneakEvent(this, sneak);
 		Bukkit.getPluginManager().callEvent(event);
@@ -996,7 +997,7 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 		this.sprinting = sprinting;
 	}
 
-	public PlayerToggleSprintEvent simulateSprint(boolean sprint)
+	public @NotNull PlayerToggleSprintEvent simulateSprint(boolean sprint)
 	{
 		PlayerToggleSprintEvent event = new PlayerToggleSprintEvent(this, sprint);
 		Bukkit.getPluginManager().callEvent(event);
@@ -1541,7 +1542,7 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 		this.flying = value;
 	}
 
-	public PlayerToggleFlightEvent simulateToggleFlight(boolean fly)
+	public @NotNull PlayerToggleFlightEvent simulateToggleFlight(boolean fly)
 	{
 		PlayerToggleFlightEvent event = new PlayerToggleFlightEvent(this, fly);
 		Bukkit.getPluginManager().callEvent(event);

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -68,6 +68,8 @@ import be.seeseemelk.mockbukkit.inventory.InventoryMock;
 import be.seeseemelk.mockbukkit.inventory.InventoryViewMock;
 import be.seeseemelk.mockbukkit.inventory.SimpleInventoryViewMock;
 import be.seeseemelk.mockbukkit.plugin.PluginManagerMock;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class PlayerMockTest
 {
@@ -314,7 +316,9 @@ class PlayerMockTest
 		player.setGameMode(GameMode.SURVIVAL);
 		BlockMock block = server.addSimpleWorld("world").getBlockAt(0, 0, 0);
 		block.setType(Material.STONE);
-		assertTrue(player.simulateBlockBreak(block));
+		BlockBreakEvent event = player.simulateBlockBreak(block);
+		assertNotNull(event);
+		assertFalse(event.isCancelled());
 		server.getPluginManager().assertEventFired(BlockDamageEvent.class);
 		server.getPluginManager().assertEventFired(BlockBreakEvent.class);
 		block.assertType(Material.AIR);
@@ -327,7 +331,9 @@ class PlayerMockTest
 		player.setGameMode(GameMode.CREATIVE);
 		BlockMock block = server.addSimpleWorld("world").getBlockAt(0, 0, 0);
 		block.setType(Material.STONE);
-		assertTrue(player.simulateBlockBreak(block));
+		BlockBreakEvent event = player.simulateBlockBreak(block);
+		assertNotNull(event);
+		assertFalse(event.isCancelled());
 		server.getPluginManager().assertEventFired(BlockBreakEvent.class);
 		block.assertType(Material.AIR);
 	}
@@ -339,7 +345,7 @@ class PlayerMockTest
 		player.setGameMode(GameMode.SPECTATOR);
 		BlockMock block = server.addSimpleWorld("world").getBlockAt(0, 0, 0);
 		block.setType(Material.STONE);
-		assertFalse(player.simulateBlockBreak(block));
+		assertNull(player.simulateBlockBreak(block));
 		block.assertType(Material.STONE);
 	}
 
@@ -350,7 +356,7 @@ class PlayerMockTest
 		player.setGameMode(GameMode.ADVENTURE);
 		BlockMock block = server.addSimpleWorld("world").getBlockAt(0, 0, 0);
 		block.setType(Material.STONE);
-		assertFalse(player.simulateBlockBreak(block));
+		assertNull(player.simulateBlockBreak(block));
 		block.assertType(Material.STONE);
 	}
 
@@ -368,7 +374,9 @@ class PlayerMockTest
 		}, plugin);
 		BlockMock block = server.addSimpleWorld("world").getBlockAt(0, 0, 0);
 		block.setType(Material.STONE);
-		assertFalse(player.simulateBlockBreak(block));
+		BlockBreakEvent event = player.simulateBlockBreak(block);
+		assertNotNull(event);
+		assertTrue(event.isCancelled());
 		block.assertType(Material.STONE);
 	}
 
@@ -386,7 +394,7 @@ class PlayerMockTest
 		}, plugin);
 		BlockMock block = server.addSimpleWorld("world").getBlockAt(0, 0, 0);
 		block.setType(Material.STONE);
-		assertFalse(player.simulateBlockBreak(block));
+		assertNull(player.simulateBlockBreak(block));
 		block.assertType(Material.STONE);
 	}
 
@@ -405,7 +413,9 @@ class PlayerMockTest
 		}, plugin);
 		BlockMock block = server.addSimpleWorld("world").getBlockAt(0, 0, 0);
 		block.setType(Material.STONE);
-		assertFalse(player.simulateBlockBreak(block));
+		BlockBreakEvent event = player.simulateBlockBreak(block);
+		assertNotNull(event);
+		assertTrue(event.isCancelled());
 		block.assertType(Material.STONE);
 	}
 
@@ -424,7 +434,9 @@ class PlayerMockTest
 		}, plugin);
 		BlockMock block = server.addSimpleWorld("world").getBlockAt(0, 0, 0);
 		block.setType(Material.STONE);
-		assertTrue(player.simulateBlockBreak(block));
+		BlockBreakEvent event = player.simulateBlockBreak(block);
+		assertNotNull(event);
+		assertFalse(event.isCancelled());
 		block.assertType(Material.AIR);
 	}
 
@@ -433,22 +445,18 @@ class PlayerMockTest
 	{
 		player.setGameMode(GameMode.SURVIVAL);
 		BlockMock block = server.addSimpleWorld("world").getBlockAt(0, 0, 0);
-		assertTrue(player.simulateBlockDamage(block));
+		BlockDamageEvent event = player.simulateBlockDamage(block);
+		assertNotNull(event);
+		assertFalse(event.isCancelled());
 	}
 
-	@Test
-	void simulateBlockDamage_NotSurvival_BlockNotDamaged()
+	@ParameterizedTest
+	@EnumSource(value = GameMode.class, mode = EnumSource.Mode.EXCLUDE, names = {"SURVIVAL"})
+	void simulateBlockDamage_NotSurvival_BlockNotDamaged(GameMode nonSurvivalGameMode)
 	{
-		GameMode[] nonSurvivalGameModes = { GameMode.CREATIVE, GameMode.ADVENTURE,
-		                                    GameMode.SPECTATOR
-		                                  };
-
-		for (GameMode gm : nonSurvivalGameModes)
-		{
-			player.setGameMode(gm);
-			Block block = server.addSimpleWorld("world").getBlockAt(0, 0, 0);
-			assertFalse(player.simulateBlockDamage(block), "Block was damaged while in gamemode " + gm.name());
-		}
+		player.setGameMode(nonSurvivalGameMode);
+		Block block = server.addSimpleWorld("world").getBlockAt(0, 0, 0);
+		assertNull(player.simulateBlockDamage(block), "Block was damaged while in gamemode " + nonSurvivalGameMode.name());
 	}
 
 	@Test
@@ -474,7 +482,11 @@ class PlayerMockTest
 
 		BlockMock block = server.addSimpleWorld("world").getBlockAt(0, 0, 0);
 		block.setType(Material.STONE);
-		assumeTrue(player.simulateBlockDamage(block));
+
+		BlockDamageEvent event = player.simulateBlockDamage(block);
+		assertNotNull(event);
+		assumeFalse(event.isCancelled());
+
 		assertFalse(wasBroken.get(), "BlockBreakEvent was fired");
 		block.assertType(Material.STONE);
 	}
@@ -502,7 +514,10 @@ class PlayerMockTest
 
 		BlockMock block = server.addSimpleWorld("world").getBlockAt(0, 0, 0);
 		block.setType(Material.STONE);
-		assumeTrue(player.simulateBlockDamage(block));
+		BlockDamageEvent event = player.simulateBlockDamage(block);
+		assertNotNull(event);
+		assumeFalse(event.isCancelled());
+
 		assertEquals(1, brokenCount.get(), "BlockBreakEvent was not fired only once");
 		block.assertType(Material.AIR);
 	}
@@ -530,7 +545,9 @@ class PlayerMockTest
 
 		BlockMock block = server.addSimpleWorld("world").getBlockAt(0, 0, 0);
 		block.setType(Material.STONE);
-		assumeTrue(player.simulateBlockBreak(block));
+		BlockBreakEvent event = player.simulateBlockBreak(block);
+		assertNotNull(event);
+		assumeFalse(event.isCancelled());
 		assertEquals(1, brokenCount.get(), "BlockBreakEvent was not fired only once");
 		block.assertType(Material.AIR);
 	}
@@ -1076,7 +1093,8 @@ class PlayerMockTest
 	{
 		World world = server.addSimpleWorld("world");
 		player.setLocation(new Location(world, 0, 0, 0));
-		player.simulatePlayerMove(new Location(world, 10, 0, 0));
+		PlayerMoveEvent event = player.simulatePlayerMove(new Location(world, 10, 0, 0));
+		assertFalse(event.isCancelled());
 		server.getPluginManager().assertEventFired(PlayerMoveEvent.class);
 		assertEquals(10.0, player.getLocation().getX());
 	}
@@ -1095,7 +1113,8 @@ class PlayerMockTest
 		}, plugin);
 		World world = server.addSimpleWorld("world");
 		player.setLocation(new Location(world, 0, 0, 0));
-		player.simulatePlayerMove(new Location(world, 10, 0, 0));
+		PlayerMoveEvent event = player.simulatePlayerMove(new Location(world, 10, 0, 0));
+		assertTrue(event.isCancelled());
 		server.getPluginManager().assertEventFired(PlayerMoveEvent.class);
 		assertEquals(0.0, player.getLocation().getX());
 	}
@@ -1117,7 +1136,8 @@ class PlayerMockTest
 	@Test
 	void testSneakEventFired()
 	{
-		player.simulateSneak(true);
+		PlayerToggleSneakEvent event = player.simulateSneak(true);
+		assertNotNull(event);
 		assertTrue(player.isSneaking());
 		server.getPluginManager().assertEventFired(PlayerToggleSneakEvent.class);
 	}
@@ -1125,7 +1145,8 @@ class PlayerMockTest
 	@Test
 	void testSprintEventFired()
 	{
-		player.simulateSprint(true);
+		PlayerToggleSprintEvent event = player.simulateSprint(true);
+		assertNotNull(event);
 		assertTrue(player.isSprinting());
 		server.getPluginManager().assertEventFired(PlayerToggleSprintEvent.class);
 	}
@@ -1133,7 +1154,8 @@ class PlayerMockTest
 	@Test
 	void testFlightEventFired()
 	{
-		player.simulateToggleFlight(true);
+		PlayerToggleFlightEvent event = player.simulateToggleFlight(true);
+		assertNotNull(event);
 		assertTrue(player.isFlying());
 		server.getPluginManager().assertEventFired(PlayerToggleFlightEvent.class);
 	}
@@ -1167,7 +1189,7 @@ class PlayerMockTest
 	}
 
 	@Test
-	public void testPlayerHide_OldAndNewPluginWorksSimultanously()
+	public void testPlayerHide_OldAndNewPluginWorksSimultaneously()
 	{
 		MockPlugin plugin1 = MockBukkit.createMockPlugin("plugin1");
 		PlayerMock player2 = server.addPlayer();

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -35,6 +35,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockDamageEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
@@ -1072,9 +1073,10 @@ class PlayerMockTest
 		Location location = new Location(player.getWorld(), 0, 100, 0);
 		GameMode originalGM = player.getGameMode();
 		player.setGameMode(GameMode.SURVIVAL);
-		boolean worked = player.simulateBlockPlace(Material.STONE, location);
+		BlockPlaceEvent event = player.simulateBlockPlace(Material.STONE, location);
 		player.setGameMode(originalGM);
-		assertTrue(worked);
+		assertNotNull(event);
+		assertFalse(event.isCancelled());
 	}
 
 	@Test
@@ -1083,9 +1085,9 @@ class PlayerMockTest
 		Location location = new Location(player.getWorld(), 0, 100, 0);
 		GameMode originalGM = player.getGameMode();
 		player.setGameMode(GameMode.ADVENTURE);
-		boolean worked = player.simulateBlockPlace(Material.STONE, location);
+		BlockPlaceEvent event = player.simulateBlockPlace(Material.STONE, location);
 		player.setGameMode(originalGM);
-		assertFalse(worked);
+		assertNull(event);
 	}
 
 	@Test


### PR DESCRIPTION
# Description
State the changes of the pull request here.
This pull request changed the simulate methods in `PlayerMock` to return the event that they fired to allow for better testing. This pull request also added the lines:
```
test {
    useJUnitPlatform()
}
```
to the build.gradle file so that the junit tests run when the test task is run. If this was intentional, let me know so that I can roll back the file.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
Before the pull request can be accepted, the version number stored in settings.gradle should be updated.
MockBukkit uses semantic-versioning (https://semver.org/)

 - If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
 - If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)
 - Make sure that unit tests are added which test the relevant changes.
 - Make sure that the changes follow the existing code format.

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.

The version number can be found in `settings.gradle`.
