### PR TITLE
Fix PlayerTeleportEvent not firing when player is teleported.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ gradle.ext.apiVersionFull = '1.16.5-R0.1-SNAPSHOT'
   Every new update should bump the version below according to
   the conventions.
 */
-gradle.ext.version = '1.2.1'
+gradle.ext.version = '1.3.0'
 
 /*
   This is the name of our MockBukkit artifact, it includes

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ gradle.ext.apiVersionFull = '1.16.5-R0.1-SNAPSHOT'
   Every new update should bump the version below according to
   the conventions.
 */
-gradle.ext.version = '1.2.0'
+gradle.ext.version = '1.2.1'
 
 /*
   This is the name of our MockBukkit artifact, it includes

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -2181,18 +2181,6 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 	}
 
 	@Override
-	public boolean teleport(@NotNull Location location)
-	{
-		PlayerTeleportEvent playerTeleportEvent = new PlayerTeleportEvent(this, getLocation(), location);
-		Bukkit.getPluginManager().callEvent(playerTeleportEvent);
-
-		if (playerTeleportEvent.isCancelled()) {
-			return false;
-		}
-		return super.teleport(location);
-	}
-
-	@Override
 	public boolean teleport(@NotNull Location location, PlayerTeleportEvent.@NotNull TeleportCause cause)
 	{
 		Validate.notNull(location, "Location cannot be null");

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -2189,7 +2189,8 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 		PlayerTeleportEvent playerTeleportEvent = new PlayerTeleportEvent(this, getLocation(), location, cause);
 		Bukkit.getPluginManager().callEvent(playerTeleportEvent);
 
-		if (playerTeleportEvent.isCancelled()) {
+		if (playerTeleportEvent.isCancelled())
+		{
 			return false;
 		}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 import java.util.HashMap;
 import java.util.function.Predicate;
 
+import org.apache.commons.lang.Validate;
 import org.bukkit.BanList;
 import org.bukkit.Bukkit;
 import org.bukkit.DyeColor;
@@ -61,6 +62,7 @@ import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerLevelChangeEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.player.PlayerToggleFlightEvent;
 import org.bukkit.event.player.PlayerToggleSneakEvent;
 import org.bukkit.event.player.PlayerToggleSprintEvent;
@@ -2177,6 +2179,35 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 		 */
 		return 0;
 	}
+
+	@Override
+	public boolean teleport(@NotNull Location location)
+	{
+		PlayerTeleportEvent playerTeleportEvent = new PlayerTeleportEvent(this, getLocation(), location);
+		Bukkit.getPluginManager().callEvent(playerTeleportEvent);
+
+		if (playerTeleportEvent.isCancelled()) {
+			return false;
+		}
+		return super.teleport(location);
+	}
+
+	@Override
+	public boolean teleport(@NotNull Location location, PlayerTeleportEvent.@NotNull TeleportCause cause)
+	{
+		Validate.notNull(location, "Location cannot be null");
+		Validate.notNull(cause, "Cause cannot be null");
+
+		PlayerTeleportEvent playerTeleportEvent = new PlayerTeleportEvent(this, getLocation(), location, cause);
+		Bukkit.getPluginManager().callEvent(playerTeleportEvent);
+
+		if (playerTeleportEvent.isCancelled()) {
+			return false;
+		}
+
+		return super.teleport(playerTeleportEvent.getTo(), cause);
+	}
+
 
 	@Override
 	public @NotNull PlayerSpigotMock spigot()

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -2181,7 +2181,7 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 	}
 
 	@Override
-	public boolean teleport(@NotNull Location location, PlayerTeleportEvent.@NotNull TeleportCause cause)
+	public boolean teleport(@NotNull Location location, @NotNull PlayerTeleportEvent.TeleportCause cause)
 	{
 		Validate.notNull(location, "Location cannot be null");
 		Validate.notNull(cause, "Cause cannot be null");

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -1,25 +1,17 @@
 package be.seeseemelk.mockbukkit.entity;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.UUID;
-import java.util.concurrent.BrokenBarrierException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.MockPlugin;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.TestPlugin;
+import be.seeseemelk.mockbukkit.WorldMock;
+import be.seeseemelk.mockbukkit.block.BlockMock;
+import be.seeseemelk.mockbukkit.inventory.ChestInventoryMock;
+import be.seeseemelk.mockbukkit.inventory.EnderChestInventoryMock;
+import be.seeseemelk.mockbukkit.inventory.InventoryMock;
+import be.seeseemelk.mockbukkit.inventory.InventoryViewMock;
+import be.seeseemelk.mockbukkit.inventory.SimpleInventoryViewMock;
+import be.seeseemelk.mockbukkit.plugin.PluginManagerMock;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.GameRule;
@@ -57,21 +49,28 @@ import org.bukkit.potion.PotionEffectType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.MockPlugin;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.TestPlugin;
-import be.seeseemelk.mockbukkit.WorldMock;
-import be.seeseemelk.mockbukkit.block.BlockMock;
-import be.seeseemelk.mockbukkit.inventory.ChestInventoryMock;
-import be.seeseemelk.mockbukkit.inventory.EnderChestInventoryMock;
-import be.seeseemelk.mockbukkit.inventory.InventoryMock;
-import be.seeseemelk.mockbukkit.inventory.InventoryViewMock;
-import be.seeseemelk.mockbukkit.inventory.SimpleInventoryViewMock;
-import be.seeseemelk.mockbukkit.plugin.PluginManagerMock;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.UUID;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class PlayerMockTest
 {
@@ -1250,21 +1249,24 @@ class PlayerMockTest
 	}
 
 	@Test
-	public void testPlayerTeleport_WithCause_EventFired() {
+	public void testPlayerTeleport_WithCause_EventFired()
+	{
 		player.teleport(player.getLocation().add(10, 10, 10), PlayerTeleportEvent.TeleportCause.CHORUS_FRUIT);
 
 		server.getPluginManager().assertEventFired(PlayerTeleportEvent.class);
 	}
 
 	@Test
-	public void testPlayerTeleport_WithoutCause_EventFired() {
+	public void testPlayerTeleport_WithoutCause_EventFired()
+	{
 		player.teleport(player.getLocation().add(10, 10, 10));
 
 		server.getPluginManager().assertEventFired(PlayerTeleportEvent.class);
 	}
 
 	@Test
-	public void testPlayerTeleport_NotCanceled_PlayerTeleported() {
+	public void testPlayerTeleport_NotCanceled_PlayerTeleported()
+	{
 		Location teleportLocation = player.getLocation().add(10, 10, 10);
 		player.teleport(teleportLocation);
 
@@ -1272,7 +1274,8 @@ class PlayerMockTest
 	}
 
 	@Test
-	public void testPlayerTeleport_Canceled_PlayerNotTeleported() {
+	public void testPlayerTeleport_Canceled_PlayerNotTeleported()
+	{
 		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
 		Bukkit.getPluginManager().registerEvents(new Listener()
 		{

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -45,6 +45,7 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerLevelChangeEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.player.PlayerToggleFlightEvent;
 import org.bukkit.event.player.PlayerToggleSneakEvent;
 import org.bukkit.event.player.PlayerToggleSprintEvent;
@@ -1247,4 +1248,48 @@ class PlayerMockTest
 		player.showPlayer(plugin1, player2);
 		assertTrue(player.canSee(player2));
 	}
+
+	@Test
+	public void testPlayerTeleport_WithCause_EventFired() {
+		player.teleport(player.getLocation().add(10, 10, 10), PlayerTeleportEvent.TeleportCause.CHORUS_FRUIT);
+
+		server.getPluginManager().assertEventFired(PlayerTeleportEvent.class);
+	}
+
+	@Test
+	public void testPlayerTeleport_WithoutCause_EventFired() {
+		player.teleport(player.getLocation().add(10, 10, 10));
+
+		server.getPluginManager().assertEventFired(PlayerTeleportEvent.class);
+	}
+
+	@Test
+	public void testPlayerTeleport_NotCanceled_PlayerTeleported() {
+		Location teleportLocation = player.getLocation().add(10, 10, 10);
+		player.teleport(teleportLocation);
+
+		player.assertTeleported(teleportLocation, 0);
+	}
+
+	@Test
+	public void testPlayerTeleport_Canceled_PlayerNotTeleported() {
+		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
+		Bukkit.getPluginManager().registerEvents(new Listener()
+		{
+			@EventHandler
+			public void onPlayerTeleport(PlayerTeleportEvent event)
+			{
+				event.setCancelled(true);
+			}
+		}, plugin);
+
+		Location originalLocation = player.getLocation();
+
+		player.teleport(player.getLocation().add(10, 10, 10));
+
+		player.assertNotTeleported();
+		player.assertLocation(originalLocation, 0);
+
+	}
+
 }


### PR DESCRIPTION
# Description
State the changes of the pull request here.
Fixes the player teleport event not firing when a player is teleported

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
Before the pull request can be accepted, the version number stored in settings.gradle should be updated.
MockBukkit uses semantic-versioning (https://semver.org/)

 - If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
 - If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)
 - Make sure that unit tests are added which test the relevant changes.
 - Make sure that the changes follow the existing code format.

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.

The version number can be found in `settings.gradle`.
