### PR TITLE
Fixed a null file argument provided to the plugin constructor

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ gradle.ext.apiVersionFull = '1.16.5-R0.1-SNAPSHOT'
   Every new update should bump the version below according to
   the conventions.
 */
-gradle.ext.version = '1.2.0'
+gradle.ext.version = '1.2.1'
 
 /*
   This is the name of our MockBukkit artifact, it includes

--- a/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
@@ -92,7 +92,7 @@ public class PluginManagerMock implements PluginManager
 		{
 			try
 			{
-				FileUtils.deleteDirectory(file);
+				FileUtils.forceDelete(file);
 			}
 			catch (IOException e)
 			{
@@ -274,6 +274,22 @@ public class PluginManagerMock implements PluginManager
 	}
 
 	/**
+	 * Tries to create a temporary plugin file.
+	 *
+	 * @param name The name of the plugin.
+	 * @return The created temporary file.
+	 * @throws IOException when the file could not be created.
+	 */
+	private @NotNull File createTemporaryPluginFile(@NotNull String name) throws IOException
+	{
+		Random random = ThreadLocalRandom.current();
+		File pluginFile = Files.createTempFile(name + "-" + random.nextInt(), ".jar").toFile();
+		pluginFile.createNewFile();
+		temporaryFiles.add(pluginFile);
+		return pluginFile;
+	}
+
+	/**
 	 * Registers a plugin that has already been loaded. This is necessary to register plugins loaded from external jars.
 	 *
 	 * @param plugin The plugin that has been loaded.
@@ -313,6 +329,8 @@ public class PluginManagerMock implements PluginManager
 			arguments[1] = description;
 			arguments[2] = createTemporaryDirectory(
 			                   "MockBukkit-" + description.getName() + "-" + description.getVersion());
+			arguments[3] = createTemporaryPluginFile(
+					           "MockBukkit-" + description.getName() + "-" + description.getVersion());
 			System.arraycopy(parameters, 0, arguments, 4, parameters.length);
 
 			JavaPlugin plugin = constructor.newInstance(arguments);


### PR DESCRIPTION
# Description
Added a non-null `file` argument in the `JavaPlugin` constructor used by MockBukkit.

In plain Java, having a null argument works fine, even if it is annotated as `@NotNull`, because annotations are not checks, only annotations.
However, it will not work when plugins are developed using Kotlin. It has very strict null-checks in place, and especially with these kind of annotations. Using MockBukkit with Kotlin results in a NullPointerException thrown by the constructor, which only accepts non-null parameters.

This PR aims at adding a non-null `file` argument, so that this error will not be thrown.

Note: I cannot unit-test this, as the getter method to retrieve this file is protected.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
Before the pull request can be accepted, the version number stored in settings.gradle should be updated.
MockBukkit uses semantic-versioning (https://semver.org/)

 - If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
 - If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)
 - Make sure that unit tests are added which test the relevant changes.
 - Make sure that the changes follow the existing code format.

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.

The version number can be found in `settings.gradle`.
