### PR TITLE
Update ItemFactoryMock.java

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ gradle.ext.apiVersionFull = '1.16.5-R0.1-SNAPSHOT'
   Every new update should bump the version below according to
   the conventions.
 */
-gradle.ext.version = '1.2.0'
+gradle.ext.version = '1.2.1'
 
 /*
   This is the name of our MockBukkit artifact, it includes

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/ItemFactoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/ItemFactoryMock.java
@@ -94,13 +94,13 @@ public class ItemFactoryMock implements ItemFactory
 	@Override
 	public boolean equals(ItemMeta meta1, ItemMeta meta2)
 	{
-		if (meta1 != null && meta2 != null)
+		if (meta1 == null)
 		{
-			return meta1.equals(meta2);
+			return meta2 == null;
 		}
 		else
 		{
-			return false;
+			return meta1.equals(meta2);
 		}
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/ItemFactoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/ItemFactoryMock.java
@@ -2,6 +2,7 @@ package be.seeseemelk.mockbukkit.inventory;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Objects;
 
 import org.bukkit.Color;
 import org.bukkit.Material;
@@ -94,14 +95,8 @@ public class ItemFactoryMock implements ItemFactory
 	@Override
 	public boolean equals(ItemMeta meta1, ItemMeta meta2)
 	{
-		if (meta1 == null)
-		{
-			return meta2 == null;
-		}
-		else
-		{
-			return meta1.equals(meta2);
-		}
+		// Returns true if both metas are null or equal.
+		return Objects.equals(meta1, meta2);
 	}
 
 	@Override

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/ItemFactoryMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/ItemFactoryMockTest.java
@@ -79,9 +79,9 @@ class ItemFactoryMockTest
 	}
 
 	@Test
-	void equals_NullAndNull_False()
+	void equals_NullAndNull_True()
 	{
-		assertFalse(factory.equals(null, null));
+		assertTrue(factory.equals(null, null));
 	}
 
 	@Test


### PR DESCRIPTION
# Description
Corrected the functionality of `ItemFactoryMock#equals(ItemMeta, ItemMeta)` so that it returns true when both values are null.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
Before the pull request can be accepted, the version number stored in settings.gradle should be updated.
MockBukkit uses semantic-versioning (https://semver.org/)

 - If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
 - If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)
 - Make sure that unit tests are added which test the relevant changes.
 - Make sure that the changes follow the existing code format.

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.

The version number can be found in `settings.gradle`.
