### PR TITLE
Fix/clear slot

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ gradle.ext.apiVersionFull = '1.16.5-R0.1-SNAPSHOT'
   Every new update should bump the version below according to
   the conventions.
 */
-gradle.ext.version = '1.4.0'
+gradle.ext.version = '1.5.0'
 
 /*
   This is the name of our MockBukkit artifact, it includes

--- a/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
@@ -330,7 +330,7 @@ public class PluginManagerMock implements PluginManager
 			arguments[2] = createTemporaryDirectory(
 			                   "MockBukkit-" + description.getName() + "-" + description.getVersion());
 			arguments[3] = createTemporaryPluginFile(
-					           "MockBukkit-" + description.getName() + "-" + description.getVersion());
+			                   "MockBukkit-" + description.getName() + "-" + description.getVersion());
 			System.arraycopy(parameters, 0, arguments, 4, parameters.length);
 
 			JavaPlugin plugin = constructor.newInstance(arguments);

--- a/src/main/java/be/seeseemelk/mockbukkit/scoreboard/ScoreboardMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scoreboard/ScoreboardMock.java
@@ -175,13 +175,7 @@ public class ScoreboardMock implements Scoreboard
 	@Override
 	public void clearSlot(DisplaySlot slot) throws IllegalArgumentException
 	{
-		Objective o = objectivesByDisplaySlot.remove(slot);
-
-		if (o != null)
-		{
-			objectives.remove(o.getName());
-		}
-
+		objectivesByDisplaySlot.remove(slot);
 	}
 
 	/**

--- a/src/main/java/be/seeseemelk/mockbukkit/statistic/StatisticsMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/statistic/StatisticsMock.java
@@ -119,7 +119,8 @@ public class StatisticsMock
 	{
 		Validate.isTrue(statistic.getType() == Type.ITEM || statistic.getType() == Type.BLOCK, "statistic must take a material parameter");
 		Map<Material, Integer> map = materialStatistics.get(statistic);
-		if (map == null) {
+		if (map == null)
+		{
 			return 0;
 		}
 		return map.getOrDefault(material, 0);
@@ -132,7 +133,8 @@ public class StatisticsMock
 	{
 		Validate.isTrue(statistic.getType() == Type.ENTITY, "statistic must take an entity parameter");
 		Map<EntityType, Integer> map = entityStatistics.get(statistic);
-		if (map == null) {
+		if (map == null)
+		{
 			return 0;
 		}
 		return map.getOrDefault(entity, 0);

--- a/src/test/java/be/seeseemelk/mockbukkit/scoreboard/ScoreboardMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/scoreboard/ScoreboardMockTest.java
@@ -74,4 +74,13 @@ class ScoreboardMockTest
 		assertSame(objective, scoreboard.getObjective(DisplaySlot.SIDEBAR));
 	}
 
+	@Test
+	void clearSlot_NotUnregisterObjectives()
+	{
+		ObjectiveMock objective = scoreboard.registerNewObjective("Objective", "dummy");
+		assertTrue(objective.isRegistered());
+		objective.setDisplaySlot(DisplaySlot.SIDEBAR);
+		scoreboard.clearSlot(DisplaySlot.SIDEBAR);
+		assertTrue(objective.isRegistered());
+	}
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/statistic/StatisticsTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/statistic/StatisticsTest.java
@@ -115,49 +115,53 @@ public class StatisticsTest
 	}
 
 	@Test
-	public void testNegativeIncrement() {
+	public void testNegativeIncrement()
+	{
 		player.setStatistic(Statistic.DEATHS, 7);
 
 		assertThrows(IllegalArgumentException.class, () ->
-			player.incrementStatistic(Statistic.DEATHS, -1));
+		             player.incrementStatistic(Statistic.DEATHS, -1));
 
 		assertThrows(IllegalArgumentException.class, () ->
-			player.incrementStatistic(Statistic.DEATHS, 0));
+		             player.incrementStatistic(Statistic.DEATHS, 0));
 	}
 
 	@Test
-	public void testNegativeDecrement() {
+	public void testNegativeDecrement()
+	{
 		player.setStatistic(Statistic.DEATHS, 7);
 
 		assertThrows(IllegalArgumentException.class, () ->
-			player.decrementStatistic(Statistic.DEATHS, -1));
+		             player.decrementStatistic(Statistic.DEATHS, -1));
 
 		assertThrows(IllegalArgumentException.class, () ->
-			player.decrementStatistic(Statistic.DEATHS, 0));
+		             player.decrementStatistic(Statistic.DEATHS, 0));
 	}
 
 	@Test
-	public void testNegativeSet() {
+	public void testNegativeSet()
+	{
 		player.setStatistic(Statistic.DEATHS, 5);
 
 		assertThrows(IllegalArgumentException.class, () ->
-			player.setStatistic(Statistic.DEATHS, -1));
+		             player.setStatistic(Statistic.DEATHS, -1));
 
 		player.setStatistic(Statistic.DEATHS, 0);
 	}
 
 	@Test
-	public void testType() {
+	public void testType()
+	{
 		assertThrows(IllegalArgumentException.class, () ->
-			player.setStatistic(Statistic.DEATHS, Material.ACACIA_LOG, 5));
+		             player.setStatistic(Statistic.DEATHS, Material.ACACIA_LOG, 5));
 
 		assertThrows(IllegalArgumentException.class, () ->
-			player.setStatistic(Statistic.DEATHS, EntityType.SQUID, 4));
+		             player.setStatistic(Statistic.DEATHS, EntityType.SQUID, 4));
 
 		assertThrows(IllegalArgumentException.class, () ->
-			player.setStatistic(Statistic.MINE_BLOCK, 10));
+		             player.setStatistic(Statistic.MINE_BLOCK, 10));
 
 		assertThrows(IllegalArgumentException.class, () ->
-			player.setStatistic(Statistic.MINE_BLOCK, EntityType.BAT, 10));
+		             player.setStatistic(Statistic.MINE_BLOCK, EntityType.BAT, 10));
 	}
 }


### PR DESCRIPTION
# Description
Scoreboard#clearSlot(DisplaySlot) should not unregister the Objective

[See Bukkit method here](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/browse/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java#193)

# Checklist
The following items should be checked before the pull request can be merged.
- [ ] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.

