### PR TITLE
Updated ItemMetaMock serialization

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ gradle.ext.apiVersionFull = '1.17.1-R0.1-SNAPSHOT'
   Every new update should bump the version below according to
   the conventions.
 */
-gradle.ext.version = '1.7.0'
+gradle.ext.version = '1.7.1'
 
 /*
   This is the name of our MockBukkit artifact, it includes

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -2044,6 +2044,13 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 	}
 
 	@Override
+	public void sendSignChange(@NotNull Location loc, @Nullable String[] lines, @NotNull DyeColor dyeColor, boolean hasGlowingText) throws IllegalArgumentException
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
 	public void openBook(@NotNull ItemStack book)
 	{
 		// TODO Auto-generated method stub

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -360,7 +360,7 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 		{
 			map.put("localizedName", this.localizedName);
 		}
-	 	*/
+		*/
 
 		if (this.lore != null)
 		{
@@ -379,7 +379,7 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 		{
 			map.put("attributeModifiers", this.attributeModifiers);
 		}
-	 	*/
+		*/
 
 		map.put("repairCost", this.repairCost);
 		map.put("itemFlags", this.hideFlags);
@@ -391,7 +391,7 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 		{
 			map.put("customTagContainer", this.customTagContainer);
 		}
-	 	*/
+		*/
 
 		map.put("persistentDataContainer", this.persistentDataContainer.serialize());
 

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.bukkit.NamespacedKey;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.enchantments.Enchantment;
@@ -43,7 +44,7 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	private int repairCost = 0;
 	private Map<Enchantment, Integer> enchants = new HashMap<>();
 	private Set<ItemFlag> hideFlags = EnumSet.noneOf(ItemFlag.class);
-	private PersistentDataContainer persistentDataContainer = new PersistentDataContainerMock();
+	private PersistentDataContainerMock persistentDataContainer = new PersistentDataContainerMock();
 	private boolean unbreakable = false;
 	private Integer customModelData = null;
 
@@ -340,7 +341,7 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 
 	/**
 	 * Serializes the properties of an ItemMetaMock to a HashMap.
-	 * Unimplemented methods have values of null.
+	 * Unimplemented properties are not present in the map.
 	 * @return A HashMap of String, Object pairs representing the ItemMetaMock.
 	 */
 	@Override
@@ -348,18 +349,52 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	{
 		// Make new map and add relevant properties to it.
 		Map<String, Object> map = new HashMap<>();
-		map.put("displayName", this.displayName);
-		map.put("lore", this.lore);
-		map.put("localizedName", null); // Not implemented.
+
+		if (this.displayName != null)
+		{
+			map.put("displayName", this.displayName);
+		}
+
+		/* Not implemented.
+		if (this.localizedName != null)
+		{
+			map.put("localizedName", this.localizedName);
+		}
+	 	*/
+
+		if (this.lore != null)
+		{
+			map.put("lore", this.lore);
+		}
+
+		if (this.customModelData != null)
+		{
+			map.put("customModelData", this.customModelData);
+		}
+
 		map.put("enchants", this.enchants);
+
+		/* Not implemented.
+		if (hasAttributeModifiers())
+		{
+			map.put("attributeModifiers", this.attributeModifiers);
+		}
+	 	*/
+
+		map.put("repairCost", this.repairCost);
 		map.put("itemFlags", this.hideFlags);
 		map.put("unbreakable", this.unbreakable);
-		map.put("attributeModifiers", null); // Not implemented.
-		map.put("customTagContainer", null); // Not implemented.
-		map.put("customModelData", this.customModelData);
-		map.put("persistentDataContainer", this.persistentDataContainer);
 		map.put("damage", this.damage);
-		map.put("repairCost", this.repairCost);
+
+		/* Not implemented.
+		if (!this.customTagContainer.isEmpty())
+		{
+			map.put("customTagContainer", this.customTagContainer);
+		}
+	 	*/
+
+		map.put("persistentDataContainer", this.persistentDataContainer.serialize());
+
 		// Return map
 		return map;
 	}
@@ -383,7 +418,8 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 		// serialMock.setAttributeModifiers(); // AttributeModifiers are unimplemented in mock
 		// customTagContainer is also unimplemented in mock.
 		serialMock.customModelData = (Integer) args.get("customModelData");
-		serialMock.persistentDataContainer = (PersistentDataContainer) args.get("persistentDataContainer");
+		Map<String, Object> map = (Map<String, Object>) args.get("persistentDataContainer");
+		serialMock.persistentDataContainer = PersistentDataContainerMock.deserialize(map);
 		serialMock.damage = (Integer) args.get("damage");
 		serialMock.repairCost = (Integer) args.get("repairCost");
 		return serialMock;

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.bukkit.NamespacedKey;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.enchantments.Enchantment;

--- a/src/main/java/be/seeseemelk/mockbukkit/persistence/PersistentDataContainerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/persistence/PersistentDataContainerMock.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.bukkit.NamespacedKey;
 import org.bukkit.persistence.PersistentDataAdapterContext;
@@ -110,6 +111,21 @@ public class PersistentDataContainerMock implements PersistentDataContainer
 	public Set<NamespacedKey> getKeys()
 	{
 		return Collections.unmodifiableSet(map.keySet());
+	}
+
+	public Map<String, Object> serialize()
+	{
+		return map.entrySet().stream().collect(Collectors.toMap(e -> e.getKey().toString(), Map.Entry::getValue));
+	}
+
+	public static PersistentDataContainerMock deserialize(Map<String, Object> args)
+	{
+		PersistentDataContainerMock mock = new PersistentDataContainerMock();
+		for (Map.Entry<String, Object> entry : args.entrySet())
+		{
+			mock.map.put(NamespacedKey.fromString(entry.getKey()), entry.getValue());
+		}
+		return mock;
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/scoreboard/TeamMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scoreboard/TeamMock.java
@@ -233,8 +233,8 @@ public class TeamMock implements Team
 		return board;
 	}
 
-	/** @deprecated */
 	@Override
+	@Deprecated
 	public void addPlayer(OfflinePlayer offlinePlayer)
 	{
 		if (!registered)throw new IllegalStateException("Team not registered");

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMockTest.java
@@ -6,6 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -20,6 +23,8 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.Repairable;
 import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.util.io.BukkitObjectInputStream;
+import org.bukkit.util.io.BukkitObjectOutputStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -588,4 +593,31 @@ class ItemMetaMockTest
 		Map<String, Object> actual = meta.serialize();
 		assertEquals(meta, ItemMetaMock.deserialize(actual));
 	}
+
+	@Test
+	void testBukkitSerialization() throws IOException, ClassNotFoundException
+	{
+		ItemMetaMock empty = new ItemMetaMock();
+		ItemMetaMock modified = new ItemMetaMock();
+
+		modified.setDisplayName("Test name");
+		modified.setLore(Arrays.asList("Test lore"));
+		modified.setUnbreakable(true);
+		modified.setDamage(5);
+		modified.setRepairCost(3);
+		modified.setCustomModelData(2);
+
+		ByteArrayOutputStream byteOutput = new ByteArrayOutputStream();
+		BukkitObjectOutputStream bukkitOutput = new BukkitObjectOutputStream(byteOutput);
+
+		bukkitOutput.writeObject(empty);
+		bukkitOutput.writeObject(modified);
+
+		ByteArrayInputStream byteInput = new ByteArrayInputStream(byteOutput.toByteArray());
+		BukkitObjectInputStream bukkitInput = new BukkitObjectInputStream(byteInput);
+
+		assertEquals(empty, bukkitInput.readObject());
+		assertEquals(modified, bukkitInput.readObject());
+	}
+
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMockTest.java
@@ -618,6 +618,9 @@ class ItemMetaMockTest
 
 		assertEquals(empty, bukkitInput.readObject());
 		assertEquals(modified, bukkitInput.readObject());
+
+		bukkitOutput.close();
+		bukkitInput.close();
 	}
 
 }


### PR DESCRIPTION
# Description
Updated the serialize and deserialize methods of ItemMetaMock so that they work properly with the Bukkit serialization api. I also added some methods to PersistentDataContainerMock so that it would work correctly. Im not sure about how clean the implementation is so im open to suggestion. I also added a new test which tests serialization of ItemMetaMocks with the Bukkit serialization api.

I also added an unimplemented method and added an @ deprecated to a method, it wouldn't compile without it.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
Before the pull request can be accepted, the version number stored in settings.gradle should be updated.
MockBukkit uses semantic-versioning (https://semver.org/)

 - If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
 - If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)
 - Make sure that unit tests are added which test the relevant changes.
 - Make sure that the changes follow the existing code format.

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.

The version number can be found in `settings.gradle`.
