### PR TITLE
Bump dependency versions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ repositories {
 }
 
 dependencies {
-	testImplementation 'com.github.seeseemelk:MockBukkit-v1.17:1.6.0'
+	testImplementation 'com.github.seeseemelk:MockBukkit-v1.17:1.7.0'
 }
 ```
 
@@ -79,7 +79,7 @@ You won't need to add any additional repositories since MockBukkit is served via
   <dependency>
     <groupId>com.github.seeseemelk</groupId>
     <artifactId>MockBukkit-v1.17</artifactId>
-    <version>1.6.0</version>
+    <version>1.7.0</version>
     <scope>test</scope>
   </dependency>
 </dependencies>


### PR DESCRIPTION
Change the two dependency examples to reference version 1.7.0 instead of 1.6.0 (which does not exist under MockBukkit-v1.17 as seen here: https://repo1.maven.org/maven2/com/github/seeseemelk/MockBukkit-v1.17/).
