### PR TITLE
Add ServerMock#get/setSpawnRadius

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ gradle.ext.apiVersionFull = '1.17.1-R0.1-SNAPSHOT'
   Every new update should bump the version below according to
   the conventions.
 */
-gradle.ext.version = '1.10.3'
+gradle.ext.version = '1.11.0'
 
 /*
   This is the name of our MockBukkit artifact, it includes

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -135,6 +135,7 @@ public class ServerMock extends Server.Spigot implements Server
 
 	private GameMode defaultGameMode = GameMode.SURVIVAL;
 	private ConsoleCommandSender consoleSender;
+	private int spawnRadius = 16;
 
 	public ServerMock()
 	{
@@ -1056,15 +1057,13 @@ public class ServerMock extends Server.Spigot implements Server
 	@Override
 	public int getSpawnRadius()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return spawnRadius;
 	}
 
 	@Override
-	public void setSpawnRadius(int value)
+	public void setSpawnRadius(int spawnRadius)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.spawnRadius = spawnRadius;
 	}
 
 	@Override

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -533,7 +533,12 @@ class ServerMockTest
 		}
 	}
 
-
+	@Test
+	void testSetSpawnRadius()
+	{
+		server.setSpawnRadius(51);
+		assertEquals(51, server.getSpawnRadius());
+	}
 }
 
 class TestRecipe implements Recipe


### PR DESCRIPTION
# Description
This adds a `ServerMock#getSpawnRadius()` and `ServerMock#setSpawnRadius()` method.
It fixes #255.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [x] Unit tests added.
- [x] Code follows existing code format.
