### PR TITLE
feat(events): add waitAsyncEventsFinished to wait for async event execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ repositories {
 }
 
 dependencies {
-	testImplementation 'com.github.seeseemelk:MockBukkit-v1.17:1.7.0'
+	testImplementation 'com.github.seeseemelk:MockBukkit-v1.17:1.11.0'
 }
 ```
 
@@ -79,7 +79,7 @@ You won't need to add any additional repositories since MockBukkit is served via
   <dependency>
     <groupId>com.github.seeseemelk</groupId>
     <artifactId>MockBukkit-v1.17</artifactId>
-    <version>1.7.0</version>
+    <version>1.11.0</version>
     <scope>test</scope>
   </dependency>
 </dependencies>

--- a/build.gradle
+++ b/build.gradle
@@ -22,10 +22,12 @@ repositories {
 
 dependencies {
     api "org.spigotmc:spigot-api:${gradle.ext.apiVersionFull}"
-    implementation 'org.junit.jupiter:junit-jupiter:5.7.2'
+    implementation 'org.junit.jupiter:junit-jupiter:5.8.1'
     implementation 'org.hamcrest:hamcrest-library:2.2'
     implementation 'commons-io:commons-io:2.11.0'
-    implementation 'org.jetbrains:annotations:21.0.1'
+    implementation 'org.jetbrains:annotations:22.0.0'
+
+    testImplementation 'org.mockito:mockito-core:4.0.0'
 }
 
 task javadocJar(type: Jar) {

--- a/ensure-java-16
+++ b/ensure-java-16
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+JV=`java -version 2>&1 >/dev/null | head -1`
+echo $JV | sed -E 's/^.*version "([^".]*)\.[^"]*".*$/\1/'
+
+if [ "$JV" != 16 ]; then
+	case "$1" in
+	install)
+		echo "Installing SDKMAN..."
+		curl -s "https://get.sdkman.io" | bash
+		source ~/.sdkman/bin/sdkman-init.sh
+		sdk version
+		sdk install java 16.0.2-open
+		;;
+	use)
+		echo "must source ~/.sdkman/bin/sdkman-init.sh"
+		exit 1
+		;;
+	esac
+fi

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,11 @@
+jdk:
+  - openjdk16
+before_install:
+  - echo "Before Install"
+  - bash ensure-java-16 install
+install:
+  - echo "Install"
+  - if ! bash ensure-java-16 use; then source ~/.sdkman/bin/sdkman-init.sh; fi
+  - java -version
+  - chmod +x ./gradlew
+  - ./gradlew publishToMavenLocal

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ gradle.ext.apiVersionFull = '1.17.1-R0.1-SNAPSHOT'
   Every new update should bump the version below according to
   the conventions.
 */
-gradle.ext.version = '1.10.3'
+gradle.ext.version = '1.11.0'
 
 /*
   This is the name of our MockBukkit artifact, it includes

--- a/src/main/java/be/seeseemelk/mockbukkit/ThreadAccessException.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ThreadAccessException.java
@@ -13,4 +13,9 @@ public class ThreadAccessException extends RuntimeException
 	{
 		super(message);
 	}
+
+	public ThreadAccessException(String message, Exception exception)
+	{
+		super(message, exception);
+	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
@@ -1,33 +1,9 @@
 package be.seeseemelk.mockbukkit.plugin;
 
-import static org.junit.jupiter.api.Assertions.fail;
-
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.net.URL;
-import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Random;
-import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.function.Predicate;
-import java.util.logging.Level;
-import java.util.stream.Collectors;
-
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.ThreadAccessException;
+import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import be.seeseemelk.mockbukkit.scheduler.BukkitSchedulerMock;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.Validate;
 import org.bukkit.command.PluginCommand;
@@ -58,9 +34,35 @@ import org.bukkit.plugin.java.JavaPluginLoader;
 import org.bukkit.plugin.java.JavaPluginUtils;
 import org.jetbrains.annotations.NotNull;
 
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.UnimplementedOperationException;
-import be.seeseemelk.mockbukkit.scheduler.BukkitSchedulerMock;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Predicate;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class PluginManagerMock implements PluginManager
 {
@@ -877,5 +879,4 @@ public class PluginManagerMock implements PluginManager
 	{
 		return false;
 	}
-
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
@@ -1,33 +1,9 @@
 package be.seeseemelk.mockbukkit.plugin;
 
-import static org.junit.jupiter.api.Assertions.fail;
-
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.net.URL;
-import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Random;
-import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.function.Predicate;
-import java.util.logging.Level;
-import java.util.stream.Collectors;
-
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.ThreadAccessException;
+import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import be.seeseemelk.mockbukkit.scheduler.BukkitSchedulerMock;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.Validate;
 import org.bukkit.command.PluginCommand;
@@ -58,9 +34,35 @@ import org.bukkit.plugin.java.JavaPluginLoader;
 import org.bukkit.plugin.java.JavaPluginUtils;
 import org.jetbrains.annotations.NotNull;
 
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.UnimplementedOperationException;
-import be.seeseemelk.mockbukkit.scheduler.BukkitSchedulerMock;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Predicate;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class PluginManagerMock implements PluginManager
 {
@@ -72,6 +74,7 @@ public class PluginManagerMock implements PluginManager
 	private final List<File> temporaryFiles = new LinkedList<>();
 	private final List<Permission> permissions = new ArrayList<>();
 	private final Map<Permissible, Set<String>> permissionSubscriptions = new HashMap<>();
+	private final List<Future<?>> queuedAsyncEvents = new ArrayList<>();
 	private Map<String, List<Listener>> listeners = new HashMap<>();
 
 	private final List<Class<?>> pluginConstructorTypes = Arrays.asList(JavaPluginLoader.class,
@@ -433,7 +436,30 @@ public class PluginManagerMock implements PluginManager
 		}
 
 		// Our Scheduler will call the Event on a dedicated Event Thread Executor
-		server.getScheduler().executeAsyncEvent(event);
+		queuedAsyncEvents.add(server.getScheduler().executeAsyncEvent(event));
+	}
+
+	public void waitAsyncEventsFinished()
+	{
+		for (Future<?> futureEvent : List.copyOf(queuedAsyncEvents))
+		{
+			if (futureEvent.isDone())
+			{
+				queuedAsyncEvents.remove(futureEvent);
+			}
+			else
+			{
+				try
+				{
+					queuedAsyncEvents.remove(futureEvent);
+					futureEvent.get();
+				}
+				catch (InterruptedException | ExecutionException e)
+				{
+					throw new ThreadAccessException("Failed to wait for async events: " + e.getMessage(), e);
+				}
+			}
+		}
 	}
 
 	private void callRegisteredListener(@NotNull RegisteredListener registration, @NotNull Event event)
@@ -877,5 +903,4 @@ public class PluginManagerMock implements PluginManager
 	{
 		return false;
 	}
-
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -1,21 +1,15 @@
 package be.seeseemelk.mockbukkit.scheduler;
 
 import java.util.ArrayList;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.*;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ThreadAccessException;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 
 import org.apache.commons.lang.Validate;
@@ -35,6 +29,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	        60L, TimeUnit.SECONDS,
 	        new SynchronousQueue<>());
 	private final ExecutorService asyncEventExecutor = Executors.newCachedThreadPool();
+	private final List<Future<?>> queuedAsyncEvents = new ArrayList<>();
 	private final TaskList scheduledTasks = new TaskList();
 	private final AtomicReference<Exception> asyncException = new AtomicReference<>();
 	private long currentTick = 0;
@@ -74,7 +69,9 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	public @NotNull Future<?> executeAsyncEvent(Event event)
 	{
 		Validate.notNull(event, "Cannot schedule an Event that is null!");
-		return asyncEventExecutor.submit(() -> MockBukkit.getMock().getPluginManager().callEvent(event));
+		Future<?> future = asyncEventExecutor.submit(() -> MockBukkit.getMock().getPluginManager().callEvent(event));
+		queuedAsyncEvents.add(future);
+		return future;
 	}
 
 	/**
@@ -190,6 +187,29 @@ public class BukkitSchedulerMock implements BukkitScheduler
 					}
 				}
 				pool.shutdownNow();
+			}
+		}
+	}
+
+	public void waitAsyncEventsFinished()
+	{
+		for (Future<?> futureEvent : List.copyOf(queuedAsyncEvents))
+		{
+			if (futureEvent.isDone())
+			{
+				queuedAsyncEvents.remove(futureEvent);
+			}
+			else
+			{
+				try
+				{
+					queuedAsyncEvents.remove(futureEvent);
+					futureEvent.get();
+				}
+				catch (InterruptedException | ExecutionException e)
+				{
+					throw new ThreadAccessException("Failed to wait for async events: " + e.getMessage(), e);
+				}
 			}
 		}
 	}

--- a/src/test/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMockTest.java
@@ -1,18 +1,14 @@
 package be.seeseemelk.mockbukkit.plugin;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import java.util.Collection;
-import java.util.Iterator;
-
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.TestPlugin;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.permissions.Permission;
@@ -21,11 +17,22 @@ import org.bukkit.plugin.Plugin;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.TestPlugin;
+import java.util.Collection;
+import java.util.Iterator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 class PluginManagerMockTest
 {
@@ -227,5 +234,4 @@ class PluginManagerMockTest
 		Plugin[] plugins = pluginManager.getPlugins();
 		assertEquals(0, plugins.length);
 	}
-
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMockTest.java
@@ -6,7 +6,11 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
 
+import java.util.HashSet;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
@@ -15,11 +19,19 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.TestPlugin;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import be.seeseemelk.mockbukkit.plugin.PluginManagerMock;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scheduler.BukkitTask;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class BukkitSchedulerMockTest
@@ -295,5 +307,41 @@ class BukkitSchedulerMockTest
 		{
 			scheduler.shutdown();
 		});
+	}
+
+	@Nested
+	class AsyncEvents
+	{
+		private ServerMock server;
+		private ChatListener listener;
+
+		@BeforeEach
+		public void setUp()
+		{
+			server = MockBukkit.mock();
+			TestPlugin plugin = MockBukkit.load(TestPlugin.class);
+			listener = spy(new ChatListener());
+			server.getPluginManager().registerEvents(listener, plugin);
+		}
+
+		@AfterEach
+		public void tearDown()
+		{
+			MockBukkit.unmock();
+		}
+
+		@Test
+		void chat_callsAsyncChatEvent_afterWaitingForTask()
+		{
+			server.addPlayer().chat("test");
+			server.getScheduler().waitAsyncEventsFinished();
+			verify(listener).onAsyncChat(any());
+		}
+
+		public static class ChatListener implements Listener
+		{
+			@EventHandler
+			public void onAsyncChat(AsyncPlayerChatEvent event) {}
+		}
 	}
 }


### PR DESCRIPTION
# Description
Added the method `Scheduler.waitAsyncEventsFinished` that waits for all async event workers to finish their task execution. This is useful for testing `AsyncPlayerChatEvent` events and other async events that run on a different thread.

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Version number updated in `settings.gradle`.
- [X] Unit tests added.
- [X] Code follows existing code format.

Closes #251