### PR TITLE
Support World#spawn

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ gradle.ext.apiVersionFull = '1.17.1-R0.1-SNAPSHOT'
   Every new update should bump the version below according to
   the conventions.
 */
-gradle.ext.version = '1.10.4'
+gradle.ext.version = '1.11.0'
 
 /*
   This is the name of our MockBukkit artifact, it includes

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ gradle.ext.apiVersionFull = '1.17.1-R0.1-SNAPSHOT'
   Every new update should bump the version below according to
   the conventions.
 */
-gradle.ext.version = '1.12.2'
+gradle.ext.version = '1.13.0'
 
 /*
   This is the name of our MockBukkit artifact, it includes

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ gradle.ext.apiVersionFull = '1.17.1-R0.1-SNAPSHOT'
   Every new update should bump the version below according to
   the conventions.
 */
-gradle.ext.version = '1.11.0'
+gradle.ext.version = '1.12.0'
 
 /*
   This is the name of our MockBukkit artifact, it includes

--- a/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
@@ -827,7 +827,7 @@ public class WorldMock implements World
 	public <T extends Entity> T spawn(@NotNull Location location, @NotNull Class<T> clazz) throws IllegalArgumentException
 	{
 		Validate.notNull(location, "The provided location must not be null.");
-		Validate.notNull(location, "The provided clazz must not be null.");
+		Validate.notNull(clazz, "The provided clazz must not be null.");
 
 		EntityMock entity = mockEntity(clazz);
 		entity.setLocation(location);

--- a/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
@@ -837,7 +837,7 @@ public class WorldMock implements World
 	}
 
 	@Override
-	public <T extends Entity> T spawn(@NotNull Location location, @NotNull Class<T> clazz, Consumer<T> function)
+	public <T extends Entity> T spawn(@NotNull Location location, @NotNull Class<T> clazz, @Nullable Consumer<T> function)
 	throws IllegalArgumentException
 	{
 		T entity = spawn(location, clazz);

--- a/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
@@ -40,14 +40,18 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.boss.DragonBattle;
 import org.bukkit.entity.AbstractArrow;
+import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.ExperienceOrb;
 import org.bukkit.entity.FallingBlock;
+import org.bukkit.entity.Firework;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Zombie;
 import org.bukkit.event.world.TimeSkipEvent;
 import org.bukkit.generator.BiomeProvider;
 import org.bukkit.generator.BlockPopulator;
@@ -549,11 +553,7 @@ public class WorldMock implements World
 	@Override
 	public Entity spawnEntity(Location loc, EntityType type)
 	{
-		EntityMock entity = mockEntity(type);
-		entity.setLocation(loc);
-		server.registerEntity(entity);
-
-		return entity;
+		return spawn(loc, type.getEntityClass());
 	}
 
 	@NotNull
@@ -565,24 +565,22 @@ public class WorldMock implements World
 
 	}
 
-	private EntityMock mockEntity(@NotNull EntityType type)
+	private <T extends Entity> EntityMock mockEntity(@NotNull Class<T> clazz)
 	{
-		switch (type)
-		{
-		case ARMOR_STAND:
+		if (clazz == ArmorStand.class) {
 			return new ArmorStandMock(server, UUID.randomUUID());
-		case ZOMBIE:
+		} else if (clazz == Zombie.class) {
 			return new ZombieMock(server, UUID.randomUUID());
-		case FIREWORK:
+		} else if (clazz == Firework.class) {
 			return new FireworkMock(server, UUID.randomUUID());
-		case EXPERIENCE_ORB:
+		} else if (clazz == ExperienceOrb.class) {
 			return new ExperienceOrbMock(server, UUID.randomUUID());
-		case PLAYER:
+		} else if (clazz == Player.class) {
 			throw new IllegalArgumentException("Player Entities cannot be spawned, use ServerMock#addPlayer(...)");
-		case DROPPED_ITEM:
+		} else if (clazz == Item.class) {
 			throw new IllegalArgumentException("Items must be spawned using World#dropItem(...)");
-		default:
-			// If that specific Mob Type has not been implemented yet, it may be better
+		} else {
+			// If that specific Mob Class has not been implemented yet, it may be better
 			// to throw an UnimplementedOperationException for consistency
 			throw new UnimplementedOperationException();
 		}
@@ -826,18 +824,27 @@ public class WorldMock implements World
 	}
 
 	@Override
-	public <T extends Entity> T spawn(Location location, Class<T> clazz) throws IllegalArgumentException
+	public <T extends Entity> T spawn(@NotNull Location location, @NotNull Class<T> clazz) throws IllegalArgumentException
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Validate.notNull(location, "The provided location must not be null.");
+		Validate.notNull(location, "The provided clazz must not be null.");
+
+		EntityMock entity = mockEntity(clazz);
+		entity.setLocation(location);
+		server.registerEntity(entity);
+
+		return (T) entity;
 	}
 
 	@Override
-	public <T extends Entity> T spawn(Location location, Class<T> clazz, Consumer<T> function)
+	public <T extends Entity> T spawn(@NotNull Location location, @NotNull Class<T> clazz, Consumer<T> function)
 	throws IllegalArgumentException
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		T entity = spawn(location, clazz);
+		if (function != null) {
+			function.accept(entity);
+		}
+		return entity;
 	}
 
 	@NotNull

--- a/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
@@ -827,7 +827,7 @@ public class WorldMock implements World
 	public <T extends Entity> T spawn(@NotNull Location location, @NotNull Class<T> clazz) throws IllegalArgumentException
 	{
 		Validate.notNull(location, "The provided location must not be null.");
-		Validate.notNull(clazz, "The provided clazz must not be null.");
+		Validate.notNull(clazz, "The provided class must not be null.");
 
 		EntityMock entity = mockEntity(clazz);
 		entity.setLocation(location);


### PR DESCRIPTION
# Description

- Changed `mockEntity` to use `Class<T extends Entity>` instead of `EntityType`.
- Changed to call `spawn` from `spawnEntity` as in NMS.
  (The internal `spawn` call is a bit different from NMS to simplify the code. No problem.)

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [ ] Unit tests added. (Tests using `spawnEntity` are `spawn` tests.)
- [x] Code follows existing code format.

# Info on creating a pull request
Before the pull request can be accepted, the version number stored in settings.gradle should be updated.
MockBukkit uses semantic-versioning (https://semver.org/)

 - If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
 - If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)
 - Make sure that unit tests are added which test the relevant changes.
 - Make sure that the changes follow the existing code format.

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.

The version number can be found in `settings.gradle`.
