### PR TITLE
fix(player): getOfflinePlayer returns random player with different id

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ gradle.ext.apiVersionFull = '1.17.1-R0.1-SNAPSHOT'
   Every new update should bump the version below according to
   the conventions.
 */
-gradle.ext.version = '1.12.0'
+gradle.ext.version = '1.12.1'
 
 /*
   This is the name of our MockBukkit artifact, it includes

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -1111,7 +1111,7 @@ public class ServerMock extends Server.Spigot implements Server
 		}
 		else
 		{
-			return playerFactory.createRandomOfflinePlayer();
+			return playerFactory.createOfflinePlayer(id);
 		}
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMockFactory.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMockFactory.java
@@ -62,7 +62,7 @@ public final class PlayerMockFactory
 	 * @param uuid the id of the offline player
 	 * @return A newly created offline player mock object.
 	 */
-	public @NotNull OfflinePlayerMock createOfflinePlayer(UUID uuid)
+	public @NotNull OfflinePlayerMock createOfflinePlayer(@NotNull UUID uuid)
 	{
 		return new OfflinePlayerMock(uuid, getUniqueRandomName());
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMockFactory.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMockFactory.java
@@ -56,4 +56,14 @@ public final class PlayerMockFactory
 	{
 		return new OfflinePlayerMock(getUniqueRandomName());
 	}
+
+	/**
+	 * Create a random {@link OfflinePlayerMock} object with a unique name and the given id.
+	 * @param uuid the id of the offline player
+	 * @return A newly created offline player mock object.
+	 */
+	public @NotNull OfflinePlayerMock createOfflinePlayer(UUID uuid)
+	{
+		return new OfflinePlayerMock(uuid, getUniqueRandomName());
+	}
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -2,6 +2,7 @@ package be.seeseemelk.mockbukkit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -17,9 +18,11 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryType;
@@ -159,6 +162,14 @@ class ServerMockTest
 		server.setPlayers(1);
 		server.setOfflinePlayers(2);
 		assertEquals(3, server.getOfflinePlayers().length);
+	}
+
+	@Test
+	void getOfflinePlayerByUnknownId_returnsOfflinePlayerWithGivenId()
+	{
+		UUID id = UUID.randomUUID();
+		OfflinePlayer offlinePlayer = server.getOfflinePlayer(id);
+		assertThat(offlinePlayer.getUniqueId(), equalTo(id));
 	}
 
 	@ParameterizedTest


### PR DESCRIPTION
# Description
Querying for an `OfflinePlayer` with `ServerMock.getOfflinePlayer(UUID)` returns a random offline player that has a different id. This can lead to an endless loop.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle`.
- [X] Unit tests added.
- [X] Code follows existing code format.
