### PR TITLE
Bump Gradle to 7.3 and Java to 17.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 16
+    - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
-        java-version: 16
+        java-version: 17
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ task sourcesJar(type: Jar) {
 }
 
 tasks.withType(JavaCompile) {
-    options.release.set(16)
+    options.release.set(17)
 }
 
 artifacts {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
@@ -18,7 +18,7 @@ import org.bukkit.plugin.PluginDescriptionFile;
 public class MockUnsafeValues implements UnsafeValues
 {
 
-	private final Set<String> compatibleApiVersions = new HashSet<>(Arrays.asList("1.13", "1.14", "1.15", "1.16", "1.17"));
+	private final Set<String> compatibleApiVersions = new HashSet<>(Arrays.asList("1.13", "1.14", "1.15", "1.16", "1.17", "1.18"));
 
 	@Override
 	public Material toLegacy(Material material)


### PR DESCRIPTION
Bump Gradle to 7.3 and Java to 17 to remain compatible with Spigot 1.18.

     - Bump Gradle to 7.3 (provides support for Java 17).
     - Bump Java to 17 (Spigot now uses Java 17).
     - Change possible compatibleApiVersions to include 1.18 api-version.

# Description
Bump versions. 