### PR TITLE
Run build workflow on multiple branches

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ v1.17 ]
+    branches: [ v1.* ]
   pull_request:
-    branches: [ v1.17 ]
+    branches: [ v1.* ]
 
 jobs:
   build:
@@ -25,14 +25,14 @@ jobs:
       run: ./gradlew test
 
     - name: Store Private key
-      if: github.ref == 'refs/heads/v1.17' && github.repository == 'MockBukkit/MockBukkit'
+      if: startsWith(github.ref, 'refs/heads/v1.') && github.repository == 'MockBukkit/MockBukkit'
       uses: DamianReeves/write-file-action@v1.0
       with:
         path: private.key
         contents: ${{ secrets.PRIV_KEY }}
         write-mode: overwrite
     - name: Publish
-      if: github.ref == 'refs/heads/v1.17' && github.repository == 'MockBukkit/MockBukkit'
+      if: startsWith(github.ref, 'refs/heads/v1.') && github.repository == 'MockBukkit/MockBukkit'
       env:
         OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         SIGN_KEY: ${{ secrets.PRIV_KEY_PASS }}


### PR DESCRIPTION
# Description
This changes the github actoin workflow so that it runs on any branch whose name starts with 'v1.' instead of only on 'v1.17'