### PR TITLE
Fix exception caused by out-dated jacoco

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ jacocoTestReport {
 }
 
 jacoco {
-	toolVersion = "0.8.6"
+	toolVersion = "0.8.7"
 }
 
 group = 'com.github.seeseemelk'

--- a/src/test/java/be/seeseemelk/mockbukkit/MockChunkDataTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/MockChunkDataTest.java
@@ -65,7 +65,7 @@ public class MockChunkDataTest
 	@Test
 	void test_pos_min_height()
 	{
-		WorldMock dummy = new WorldMock(Material.GRASS,60, 256, 70);
+		WorldMock dummy = new WorldMock(Material.GRASS, 60, 256, 70);
 		ChunkGenerator.ChunkData data = server.createChunkData(dummy);
 
 		data.setBlock(0, 80, 0, Material.OBSIDIAN);


### PR DESCRIPTION
# Description
This fixes an error when running the tests.
The specific error was caused because Jacoco 0.8.6 does not support Java 17 yet.

# Checklist
The following items should be checked before the pull request can be merged.
- [ ] Version number updated in `settings.gradle` and `Readme.md`.
- [ ] Unit tests added.
- [x] Code follows existing code format.
