### PR TITLE
Implement ArmorStandMock pose methods

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ gradle.ext.apiVersionFull = '1.18.1-R0.1-SNAPSHOT'
   Every new update should bump the version below according to
   the conventions.
 */
-gradle.ext.version = '1.16.0'
+gradle.ext.version = '1.17.0'
 
 /*
   This is the name of our MockBukkit artifact, it includes

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ArmorStandMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ArmorStandMock.java
@@ -14,6 +14,7 @@ import org.bukkit.util.EulerAngle;
 
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * This is the mock of an {@link ArmorStand}.
@@ -31,6 +32,13 @@ public class ArmorStandMock extends LivingEntityMock implements ArmorStand
 	private boolean isMarker = false;
 	private boolean hasBasePlate = true;
 	private boolean isVisible = true;
+
+	private EulerAngle headPose = EulerAngle.ZERO;
+	private EulerAngle bodyPose = EulerAngle.ZERO;
+	private EulerAngle leftArmPose = new EulerAngle(Math.toRadians(-10.0f), 0.0f, Math.toRadians(-10.0f));
+	private EulerAngle rightArmPose = new EulerAngle(Math.toRadians(-15.0f), 0.0f, Math.toRadians(10.0f));
+	private EulerAngle leftLegPose = new EulerAngle(Math.toRadians(-1.0f), 0.0f, Math.toRadians(-1.0f));
+	private EulerAngle rightLegPose = new EulerAngle(Math.toRadians(1.0f), 0.0f, Math.toRadians(1.0f));
 
 	public ArmorStandMock(ServerMock server, UUID uuid)
 	{
@@ -120,87 +128,75 @@ public class ArmorStandMock extends LivingEntityMock implements ArmorStand
 	}
 
 	@Override
-	public EulerAngle getBodyPose()
+	public @NotNull EulerAngle getBodyPose()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return bodyPose;
 	}
 
 	@Override
-	public void setBodyPose(EulerAngle pose)
+	public void setBodyPose(@NotNull EulerAngle pose)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.bodyPose = pose;
 	}
 
 	@Override
-	public EulerAngle getLeftArmPose()
+	public @NotNull EulerAngle getLeftArmPose()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return leftArmPose;
 	}
 
 	@Override
-	public void setLeftArmPose(EulerAngle pose)
+	public void setLeftArmPose(@NotNull EulerAngle pose)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.leftArmPose = pose;
 	}
 
 	@Override
-	public EulerAngle getRightArmPose()
+	public @NotNull EulerAngle getRightArmPose()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return rightArmPose;
 	}
 
 	@Override
-	public void setRightArmPose(EulerAngle pose)
+	public void setRightArmPose(@NotNull EulerAngle pose)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.rightArmPose = pose;
 	}
 
 	@Override
-	public EulerAngle getLeftLegPose()
+	public @NotNull EulerAngle getLeftLegPose()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return leftLegPose;
 	}
 
 	@Override
-	public void setLeftLegPose(EulerAngle pose)
+	public void setLeftLegPose(@NotNull EulerAngle pose)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.leftLegPose = pose;
 	}
 
 	@Override
-	public EulerAngle getRightLegPose()
+	public @NotNull EulerAngle getRightLegPose()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return rightLegPose;
 	}
 
 	@Override
-	public void setRightLegPose(EulerAngle pose)
+	public void setRightLegPose(@NotNull EulerAngle pose)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.rightLegPose = pose;
 	}
 
 	@Override
-	public EulerAngle getHeadPose()
+	public @NotNull EulerAngle getHeadPose()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return headPose;
 	}
 
 	@Override
-	public void setHeadPose(EulerAngle pose)
+	public void setHeadPose(@NotNull EulerAngle pose)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.headPose = pose;
 	}
 
 	@Override

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/ArmorStandMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/ArmorStandMockTest.java
@@ -11,6 +11,7 @@ import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.EntityType;
+import org.bukkit.util.EulerAngle;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -119,4 +120,59 @@ class ArmorStandMockTest
 		armorStand.setVisible(false);
 		assertFalse(armorStand.isVisible());
 	}
+
+	@Test
+	void testHeadPose()
+	{
+		ArmorStand armorStand = new ArmorStandMock(server, UUID.randomUUID());
+
+		armorStand.setHeadPose(new EulerAngle(5, 5, 5));
+		assertEquals(armorStand.getHeadPose(), new EulerAngle(5, 5, 5));
+	}
+
+	@Test
+	void testBodyPose()
+	{
+		ArmorStand armorStand = new ArmorStandMock(server, UUID.randomUUID());
+
+		armorStand.setBodyPose(new EulerAngle(5, 5, 5));
+		assertEquals(armorStand.getBodyPose(), new EulerAngle(5, 5, 5));
+	}
+
+	@Test
+	void testLeftArm()
+	{
+		ArmorStand armorStand = new ArmorStandMock(server, UUID.randomUUID());
+
+		armorStand.setLeftArmPose(new EulerAngle(5, 5, 5));
+		assertEquals(armorStand.getLeftArmPose(), new EulerAngle(5, 5, 5));
+	}
+
+	@Test
+	void testRightArm()
+	{
+		ArmorStand armorStand = new ArmorStandMock(server, UUID.randomUUID());
+
+		armorStand.setRightArmPose(new EulerAngle(5, 5, 5));
+		assertEquals(armorStand.getRightArmPose(), new EulerAngle(5, 5, 5));
+	}
+
+	@Test
+	void testLeftLeg()
+	{
+		ArmorStand armorStand = new ArmorStandMock(server, UUID.randomUUID());
+
+		armorStand.setLeftLegPose(new EulerAngle(5, 5, 5));
+		assertEquals(armorStand.getLeftLegPose(), new EulerAngle(5, 5, 5));
+	}
+
+	@Test
+	void testRightLeg()
+	{
+		ArmorStand armorStand = new ArmorStandMock(server, UUID.randomUUID());
+
+		armorStand.setRightLegPose(new EulerAngle(5, 5, 5));
+		assertEquals(armorStand.getRightLegPose(), new EulerAngle(5, 5, 5));
+	}
+
 }


### PR DESCRIPTION
# Description
Implements the pose getters and setters for ArmorStandMock head, body, and limbs.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle` and `Readme.md`.
- [x] Unit tests added.
- [x] Code follows existing code format.