### PR TITLE
Fix MockBukkit#unmock hanging forever if repeating tasks are running

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ gradle.ext.apiVersionFull = '1.18.1-R0.1-SNAPSHOT'
   Every new update should bump the version below according to
   the conventions.
 */
-gradle.ext.version = '1.16.0'
+gradle.ext.version = '1.16.1'
 
 /*
   This is the name of our MockBukkit artifact, it includes

--- a/src/main/java/be/seeseemelk/mockbukkit/MockBukkit.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockBukkit.java
@@ -306,17 +306,17 @@ public class MockBukkit
 			return;
 		}
 
+		if (mock.getPluginManager() != null)
+		{
+			mock.getPluginManager().disablePlugins();
+		}
+
 		try
 		{
 			mock.getScheduler().shutdown();
 		}
 		finally
 		{
-			if (mock.getPluginManager() != null)
-			{
-				mock.getPluginManager().disablePlugins();
-			}
-
 			mock.getPluginManager().unload();
 			setServerInstanceToNull();
 		}

--- a/src/main/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -1,9 +1,7 @@
 package be.seeseemelk.mockbukkit.scheduler;
 
-import java.util.ArrayList;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -155,6 +153,15 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	 */
 	public void waitAsyncTasksFinished()
 	{
+		// Cancel repeating tasks so they don't run forever.
+		for (Map.Entry<Integer, ScheduledTask> entry : scheduledTasks.tasks.entrySet())
+		{
+			if (entry.getValue() instanceof RepeatingTask)
+			{
+				scheduledTasks.cancelTask(entry.getKey());
+			}
+		}
+
 		// Make sure all tasks get to execute. (except for repeating asynchronous tasks, they only will fire once)
 		while (scheduledTasks.getScheduledTaskCount() > 0)
 		{


### PR DESCRIPTION
# Description
Fixes MockBukkit#unmock hanging forever if repeating tasks are running. It will also now disable plugins before shutting down the scheduler, which is what Bukkit does. Closes #263.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle` and `Readme.md`.
- [x] Unit tests added.
- [x] Code follows existing code format.