### PR TITLE
Initialize EntityEquipment items to air instead of null

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ gradle.ext.apiVersionFull = '1.18.1-R0.1-SNAPSHOT'
   Every new update should bump the version below according to
   the conventions.
 */
-gradle.ext.version = '1.16.0'
+gradle.ext.version = '1.16.1'
 
 /*
   This is the name of our MockBukkit artifact, it includes

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityEquipmentMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityEquipmentMock.java
@@ -1,6 +1,7 @@
 package be.seeseemelk.mockbukkit.entity;
 
 import org.apache.commons.lang.Validate;
+import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.inventory.EntityEquipment;
@@ -23,13 +24,13 @@ public class EntityEquipmentMock implements EntityEquipment
 
 	private final LivingEntityMock holder;
 
-	private ItemStack itemInMainHand;
-	private ItemStack itemInOffHand;
+	private ItemStack itemInMainHand = new ItemStack(Material.AIR);
+	private ItemStack itemInOffHand = new ItemStack(Material.AIR);
 
-	private ItemStack helmet;
-	private ItemStack chestPlate;
-	private ItemStack leggings;
-	private ItemStack boots;
+	private ItemStack helmet = new ItemStack(Material.AIR);
+	private ItemStack chestPlate = new ItemStack(Material.AIR);
+	private ItemStack leggings = new ItemStack(Material.AIR);
+	private ItemStack boots = new ItemStack(Material.AIR);
 
 	public EntityEquipmentMock(@NotNull LivingEntityMock holder)
 	{
@@ -47,55 +48,37 @@ public class EntityEquipmentMock implements EntityEquipment
 	{
 		switch (slot)
 		{
-		case HEAD:
-			setHelmet(item, silent);
-			break;
-		case CHEST:
-			setChestplate(item, silent);
-			break;
-		case LEGS:
-			setLeggings(item, silent);
-			break;
-		case FEET:
-			setBoots(item, silent);
-			break;
-		case HAND:
-			setItemInMainHand(item, silent);
-			break;
-		case OFF_HAND:
-			setItemInOffHand(item, silent);
-			break;
-		default:
-			// This should never be reached unless Mojang adds new slots
-			throw new UnimplementedOperationException("EquipmentSlot '" + slot + "' has no implementation!");
+			case HEAD -> setHelmet(item, silent);
+			case CHEST -> setChestplate(item, silent);
+			case LEGS -> setLeggings(item, silent);
+			case FEET -> setBoots(item, silent);
+			case HAND -> setItemInMainHand(item, silent);
+			case OFF_HAND -> setItemInOffHand(item, silent);
+			default ->
+					// This should never be reached unless Mojang adds new slots
+					throw new UnimplementedOperationException("EquipmentSlot '" + slot + "' has no implementation!");
 		}
 	}
 
 	@Override
-	public ItemStack getItem(@NotNull EquipmentSlot slot)
+	public @NotNull ItemStack getItem(@NotNull EquipmentSlot slot)
 	{
-		switch (slot)
-		{
-		case CHEST:
-			return getChestplate();
-		case FEET:
-			return getBoots();
-		case HAND:
-			return getItemInMainHand();
-		case HEAD:
-			return getHelmet();
-		case LEGS:
-			return getLeggings();
-		case OFF_HAND:
-			return getItemInOffHand();
-		default:
-			// This should never be reached unless Mojang adds new slots
-			throw new UnimplementedOperationException("EquipmentSlot '" + slot + "' has no implementation!");
-		}
+		return switch (slot)
+				{
+					case CHEST -> getChestplate();
+					case FEET -> getBoots();
+					case HAND -> getItemInMainHand();
+					case HEAD -> getHelmet();
+					case LEGS -> getLeggings();
+					case OFF_HAND -> getItemInOffHand();
+					default ->
+							// This should never be reached unless Mojang adds new slots
+							throw new UnimplementedOperationException("EquipmentSlot '" + slot + "' has no implementation!");
+				};
 	}
 
 	@Override
-	public ItemStack getItemInMainHand()
+	public @NotNull ItemStack getItemInMainHand()
 	{
 		return itemInMainHand;
 	}
@@ -114,7 +97,7 @@ public class EntityEquipmentMock implements EntityEquipment
 	}
 
 	@Override
-	public ItemStack getItemInOffHand()
+	public @NotNull ItemStack getItemInOffHand()
 	{
 		return itemInOffHand;
 	}
@@ -134,7 +117,7 @@ public class EntityEquipmentMock implements EntityEquipment
 
 	@Override
 	@Deprecated
-	public ItemStack getItemInHand()
+	public @NotNull ItemStack getItemInHand()
 	{
 		return getItemInMainHand();
 	}

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/EntityEquipmentMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/EntityEquipmentMockTest.java
@@ -1,6 +1,7 @@
 package be.seeseemelk.mockbukkit.entity;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.UUID;
@@ -39,9 +40,10 @@ class EntityEquipmentMockTest
 	{
 		ArmorStand armorStand = new ArmorStandMock(server, UUID.randomUUID());
 		EntityEquipment equipment = armorStand.getEquipment();
-		ItemStack item = new ItemStack(Material.DIAMOND);
 
-		assertNull(equipment.getItemInMainHand());
+		assertNotNull(equipment.getItemInMainHand());
+
+		ItemStack item = new ItemStack(Material.DIAMOND);
 		equipment.setItemInMainHand(item);
 
 		assertEquals(item, equipment.getItemInMainHand());
@@ -53,9 +55,10 @@ class EntityEquipmentMockTest
 	{
 		ArmorStand armorStand = new ArmorStandMock(server, UUID.randomUUID());
 		EntityEquipment equipment = armorStand.getEquipment();
-		ItemStack item = new ItemStack(Material.DIAMOND);
 
-		assertNull(equipment.getItemInOffHand());
+		assertNotNull(equipment.getItemInOffHand());
+
+		ItemStack item = new ItemStack(Material.DIAMOND);
 		equipment.setItemInOffHand(item);
 
 		assertEquals(item, equipment.getItemInOffHand());
@@ -67,9 +70,10 @@ class EntityEquipmentMockTest
 	{
 		ArmorStand armorStand = new ArmorStandMock(server, UUID.randomUUID());
 		EntityEquipment equipment = armorStand.getEquipment();
-		ItemStack item = new ItemStack(Material.DIAMOND);
 
-		assertNull(equipment.getHelmet());
+		assertNotNull(equipment.getHelmet());
+
+		ItemStack item = new ItemStack(Material.DIAMOND);
 		equipment.setHelmet(item);
 
 		assertEquals(item, equipment.getHelmet());
@@ -81,9 +85,10 @@ class EntityEquipmentMockTest
 	{
 		ArmorStand armorStand = new ArmorStandMock(server, UUID.randomUUID());
 		EntityEquipment equipment = armorStand.getEquipment();
-		ItemStack item = new ItemStack(Material.DIAMOND);
 
-		assertNull(equipment.getChestplate());
+		assertNotNull(equipment.getChestplate());
+
+		ItemStack item = new ItemStack(Material.DIAMOND);
 		equipment.setChestplate(item);
 
 		assertEquals(item, equipment.getChestplate());
@@ -95,9 +100,10 @@ class EntityEquipmentMockTest
 	{
 		ArmorStand armorStand = new ArmorStandMock(server, UUID.randomUUID());
 		EntityEquipment equipment = armorStand.getEquipment();
-		ItemStack item = new ItemStack(Material.DIAMOND);
 
-		assertNull(equipment.getLeggings());
+		assertNotNull(equipment.getLeggings());
+
+		ItemStack item = new ItemStack(Material.DIAMOND);
 		equipment.setLeggings(item);
 
 		assertEquals(item, equipment.getLeggings());
@@ -109,9 +115,10 @@ class EntityEquipmentMockTest
 	{
 		ArmorStand armorStand = new ArmorStandMock(server, UUID.randomUUID());
 		EntityEquipment equipment = armorStand.getEquipment();
-		ItemStack item = new ItemStack(Material.DIAMOND);
 
-		assertNull(equipment.getBoots());
+		assertNotNull(equipment.getBoots());
+
+		ItemStack item = new ItemStack(Material.DIAMOND);
 		equipment.setBoots(item);
 
 		assertEquals(item, equipment.getBoots());


### PR DESCRIPTION
# Description
Initializes the default `EntitiyEquipmentMock` items to air instead of null, mimicking Bukkit behavior. Also converts switches to the new Java 14 style. Closes #254.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle` and `Readme.md`.
- [x] Unit tests added.
- [x] Code follows existing code format.