### PR TITLE
Fix the player messaging correct message test failing on some machines

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ gradle.ext.apiVersionFull = '1.18.1-R0.1-SNAPSHOT'
   Every new update should bump the version below according to
   the conventions.
 */
-gradle.ext.version = '1.16.0'
+gradle.ext.version = '1.16.1'
 
 /*
   This is the name of our MockBukkit artifact, it includes

--- a/src/test/java/be/seeseemelk/mockbukkit/command/PlayerMessagingTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/command/PlayerMessagingTest.java
@@ -33,7 +33,7 @@ class PlayerMessagingTest
 	void assertSaid_CorrectMessage_spigot_api_DoesNotAssert()
 	{
 		sender.spigot().sendMessage(TextComponent.fromLegacyText("Spigot message"));
-		sender.assertSaid("§fSpigot message");
+		sender.assertSaid("\u00A7fSpigot message");
 	}
 
 	@Test

--- a/src/test/java/be/seeseemelk/mockbukkit/command/PlayerMessagingTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/command/PlayerMessagingTest.java
@@ -1,5 +1,6 @@
 package be.seeseemelk.mockbukkit.command;
 
+import org.bukkit.ChatColor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,7 +34,7 @@ class PlayerMessagingTest
 	void assertSaid_CorrectMessage_spigot_api_DoesNotAssert()
 	{
 		sender.spigot().sendMessage(TextComponent.fromLegacyText("Spigot message"));
-		sender.assertSaid("\u00A7fSpigot message");
+		sender.assertSaid(ChatColor.COLOR_CHAR + "fSpigot message");
 	}
 
 	@Test


### PR DESCRIPTION
# Description
Replaces the `§` character with its Unicode code (`U+00A7`).

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle` and `Readme.md`.
- [x] Unit tests added.
- [x] Code follows existing code format.