### PR TITLE
Implement ServerMock#getWarningState

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ gradle.ext.apiVersionFull = '1.18.2-R0.1-SNAPSHOT'
   Every new update should bump the version below according to
   the conventions.
 */
-gradle.ext.version = '1.20.2'
+gradle.ext.version = '1.21.0'
 
 /*
   This is the name of our MockBukkit artifact, it includes

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ gradle.ext.apiVersionFull = '1.18.2-R0.1-SNAPSHOT'
   Every new update should bump the version below according to
   the conventions.
 */
-gradle.ext.version = '1.20.1'
+gradle.ext.version = '1.20.2'
 
 /*
   This is the name of our MockBukkit artifact, it includes

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -137,6 +137,7 @@ public class ServerMock extends Server.Spigot implements Server
 	private GameMode defaultGameMode = GameMode.SURVIVAL;
 	private ConsoleCommandSender consoleSender;
 	private int spawnRadius = 16;
+	private WarningState warningState = WarningState.DEFAULT;
 
 	public ServerMock()
 	{
@@ -1223,11 +1224,14 @@ public class ServerMock extends Server.Spigot implements Server
 		throw new UnimplementedOperationException();
 	}
 
+	public void setWarningState(WarningState warningState) {
+		this.warningState = warningState;
+	}
+
 	@Override
-	public WarningState getWarningState()
+	public @NotNull WarningState getWarningState()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.warningState;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -1224,6 +1224,11 @@ public class ServerMock extends Server.Spigot implements Server
 		throw new UnimplementedOperationException();
 	}
 
+	/**
+	 * Sets the return value of {@link #getWarningState}.
+	 *
+	 * @param warningState The {@link WarningState} to set.
+	 */
 	public void setWarningState(@NotNull WarningState warningState)
 	{
 		this.warningState = warningState;

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -1224,7 +1224,8 @@ public class ServerMock extends Server.Spigot implements Server
 		throw new UnimplementedOperationException();
 	}
 
-	public void setWarningState(WarningState warningState) {
+	public void setWarningState(@NotNull WarningState warningState)
+	{
 		this.warningState = warningState;
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -1231,6 +1231,7 @@ public class ServerMock extends Server.Spigot implements Server
 	 */
 	public void setWarningState(@NotNull WarningState warningState)
 	{
+		Validate.notNull(warningState, "Warning state cannot be null");
 		this.warningState = warningState;
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.Warning;
 import org.bukkit.WorldCreator;
 import org.bukkit.WorldType;
 import org.bukkit.World;
@@ -577,6 +578,14 @@ class ServerMockTest
 		UUID uuid = entity.getUniqueId();
 		server.registerEntity(entity);
 		assertNotNull(server.getEntity(uuid));
+	}
+
+	@Test
+	void testWarningState()
+	{
+		assertEquals(Warning.WarningState.DEFAULT, server.getWarningState());
+		server.setWarningState(Warning.WarningState.ON);
+		assertEquals(Warning.WarningState.ON, server.getWarningState());
 	}
 
 }


### PR DESCRIPTION
# Description
Implements `ServerMock#getWarningState` and adds `ServerMock#setWarningState` which prevents tests from getting skipped when registering a deprecated listener. Closes #285.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle` and `Readme.md`.
- [x] Unit tests added.
- [x] Code follows existing code format.