### PR TITLE
Fix PlayerMock#isGliding skipping tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ repositories {
 }
 
 dependencies {
-	testImplementation 'com.github.seeseemelk:MockBukkit-v1.18:2.0.0'
+	testImplementation 'com.github.seeseemelk:MockBukkit-v1.18:2.0.1'
 }
 ```
 
@@ -79,7 +79,7 @@ You won't need to add any additional repositories since MockBukkit is served via
   <dependency>
     <groupId>com.github.seeseemelk</groupId>
     <artifactId>MockBukkit-v1.18</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <scope>test</scope>
   </dependency>
 </dependencies>

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ gradle.ext.apiVersionFull = '1.18.2-R0.1-SNAPSHOT'
   Every new update should bump the version below according to
   the conventions.
 */
-gradle.ext.version = '2.0.0'
+gradle.ext.version = '2.0.1'
 
 /*
   This is the name of our MockBukkit artifact, it includes

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -987,20 +987,6 @@ public class PlayerMock extends LivingEntityMock implements Player, SoundReceive
 	}
 
 	@Override
-	public boolean isGliding()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public void setGliding(boolean gliding)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
 	public void setAI(boolean ai)
 	{
 		// I am sorry Dave, I'm afraid I can't do that


### PR DESCRIPTION
# Description
`PlayerMock#isGliding` got reimplemented as a stub overriding `LivingEntityMock#isGliding`

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Version number updated in `settings.gradle` and `Readme.md`.
- [ ] Unit tests added.
- [x] Code follows existing code format.