### PR TITLE
Do not publish package when no release label was given

### DIFF
--- a/.github/workflows/push_tag.yml
+++ b/.github/workflows/push_tag.yml
@@ -62,12 +62,14 @@ jobs:
 # End of build workflow
 
       - name: Store Private key
+        if: ${{ steps.bump-semver.outputs.new_version != null }}
         uses: DamianReeves/write-file-action@v1.0
         with:
           path: private.key
           contents: ${{ secrets.PRIV_KEY }}
           write-mode: overwrite
       - name: Publish
+        if: ${{ steps.bump-semver.outputs.new_version != null }}
         env:
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           SIGN_KEY: ${{ secrets.PRIV_KEY_PASS }}
@@ -79,7 +81,7 @@ jobs:
           gpg --batch --import private.key
           gpg --batch --export-secret-keys --passphrase $SIGN_KEY "Sebastiaan de Schaetzen <sebastiaan.de.schaetzen@gmail.com>" > private.gpg
 
-          NEW_VERSION=$(echo ${{ github.event.push.ref }} | 's:refs/tags/v::')
+          NEW_VERSION=$(echo ${{ github.event.push.ref }} | sed -e 's:refs/tags/v::')
 
           ./gradlew publishMockBukkitPublicationToRepositoryRepository \
             -Pmockbukkit.version=$NEW_VERSION \


### PR DESCRIPTION
# Description
A new package should not be published on maven central if the pull request is labeled with `release/none`.

# Checklist
The following items should be checked before the pull request can be merged.
- [ ] Unit tests added.
- [ ] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
