### PR TITLE
Fix serialized ItemMeta keys

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -489,12 +489,12 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 
 		if (this.displayName != null)
 		{
-			map.put("displayName", this.displayName);
+			map.put("display-name", this.displayName);
 		}
 
 		if (this.localizedName != null)
 		{
-			map.put("localizedName", this.localizedName);
+			map.put("loc-name", this.localizedName);
 		}
 
 		if (this.lore != null)
@@ -504,7 +504,7 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 
 		if (this.customModelData != null)
 		{
-			map.put("customModelData", this.customModelData);
+			map.put("custom-model-data", this.customModelData);
 		}
 
 		map.put("enchants", this.enchants);
@@ -512,14 +512,14 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 		/* Not implemented.
 		if (hasAttributeModifiers())
 		{
-			map.put("attributeModifiers", this.attributeModifiers);
+			map.put("attribute-modifiers", this.attributeModifiers);
 		}
 		*/
 
-		map.put("repairCost", this.repairCost);
-		map.put("itemFlags", this.hideFlags);
-		map.put("unbreakable", this.unbreakable);
-		map.put("damage", this.damage);
+		map.put("repair-cost", this.repairCost);
+		map.put("ItemFlags", this.hideFlags);
+		map.put("Unbreakable", this.unbreakable);
+		map.put("Damage", this.damage);
 
 		/* Not implemented.
 		if (!this.customTagContainer.isEmpty())
@@ -528,7 +528,7 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 		}
 		*/
 
-		map.put("persistentDataContainer", this.persistentDataContainer.serialize());
+		map.put("PublicBukkitValues", this.persistentDataContainer.serialize());
 
 		// Return map
 		return map;
@@ -545,19 +545,19 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	{
 		ItemMetaMock serialMock = new ItemMetaMock();
 
-		serialMock.displayName = (String) args.get("displayName");
+		serialMock.displayName = (String) args.get("display-name");
 		serialMock.lore = (List<String>) args.get("lore");
-		serialMock.localizedName = (String) args.get("localizedName");
+		serialMock.localizedName = (String) args.get("loc-name");
 		serialMock.enchants = (Map<Enchantment, Integer>) args.get("enchants");
-		serialMock.hideFlags = (Set<ItemFlag>) args.get("itemFlags");
-		serialMock.unbreakable = (boolean) args.get("unbreakable");
+		serialMock.hideFlags = (Set<ItemFlag>) args.get("ItemFlags");
+		serialMock.unbreakable = (boolean) args.get("Unbreakable");
 		// serialMock.setAttributeModifiers(); // AttributeModifiers are unimplemented in mock
 		// customTagContainer is also unimplemented in mock.
-		serialMock.customModelData = (Integer) args.get("customModelData");
-		Map<String, Object> map = (Map<String, Object>) args.get("persistentDataContainer");
+		serialMock.customModelData = (Integer) args.get("custom-model-data");
+		Map<String, Object> map = (Map<String, Object>) args.get("PublicBukkitValues");
 		serialMock.persistentDataContainer = PersistentDataContainerMock.deserialize(map);
-		serialMock.damage = (Integer) args.get("damage");
-		serialMock.repairCost = (Integer) args.get("repairCost");
+		serialMock.damage = (int) args.get("Damage");
+		serialMock.repairCost = (int) args.get("repair-cost");
 		return serialMock;
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMockTest.java
@@ -593,11 +593,11 @@ class ItemMetaMockTest
 		Map<String, Object> actual = meta.serialize();
 
 		// Perform tests
-		assertEquals(expected.get("displayName"), actual.get("displayName"));
+		assertEquals(expected.get("displayName"), actual.get("display-name"));
 		assertEquals(expected.get("lore"), actual.get("lore"));
-		assertEquals(expected.get("unbreakable"), actual.get("unbreakable"));
-		assertEquals(expected.get("damage"), actual.get("damage"));
-		assertEquals(expected.get("repairCost"), actual.get("repairCost"));
+		assertEquals(expected.get("unbreakable"), actual.get("Unbreakable"));
+		assertEquals(expected.get("damage"), actual.get("Damage"));
+		assertEquals(expected.get("repairCost"), actual.get("repair-cost"));
 
 	}
 


### PR DESCRIPTION
# Description
The current implementation of `ItemMeta#serialize` has our own naming scheme for the keys it returns. This brings those in-line with [CraftBukkit](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/browse/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java#229-230,232-235,240-241,257,259,261,264,1219,1222,1226,1230,1236-1237,1240,1245,1248,1252,1256,1276).

# Checklist
The following items should be checked before the pull request can be merged.
- [ ] Unit tests added.
- [x] Code follows existing code format.