### PR TITLE
Fix BlockStateMock copy constructors not cloning all values

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BarrelMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BarrelMock.java
@@ -36,6 +36,7 @@ public class BarrelMock extends ContainerMock implements Barrel
 	protected BarrelMock(@NotNull BarrelMock state)
 	{
 		super(state);
+		this.isOpen = state.isOpen;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
@@ -20,23 +20,26 @@ import be.seeseemelk.mockbukkit.metadata.MetadataTable;
 public class BlockStateMock implements BlockState, Cloneable
 {
 
-	private final MetadataTable metadataTable = new MetadataTable();
+	private final MetadataTable metadataTable;
 	private Block block;
 	private Material material;
 
 	public BlockStateMock(@NotNull Material material)
 	{
+		this.metadataTable = new MetadataTable();
 		this.material = material;
 	}
 
 	protected BlockStateMock(@NotNull Block block)
 	{
+		this.metadataTable = new MetadataTable();
 		this.block = block;
 		this.material = block.getType();
 	}
 
 	protected BlockStateMock(@NotNull BlockStateMock state)
 	{
+		this.metadataTable = new MetadataTable(state.metadataTable);
 		this.material = state.getType();
 		this.block = state.isPlaced() ? state.getBlock() : null;
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ChestMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ChestMock.java
@@ -38,6 +38,7 @@ public class ChestMock extends ContainerMock implements Chest
 	protected ChestMock(@NotNull ChestMock state)
 	{
 		super(state);
+		this.isOpen = state.isOpen;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ContainerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ContainerMock.java
@@ -39,6 +39,8 @@ public abstract class ContainerMock extends TileStateMock implements Container
 	{
 		super(state);
 		this.inventory = state.getInventory();
+		this.customName = state.getCustomName();
+		this.lock = state.getLock();
 	}
 
 	protected abstract InventoryMock createInventory();

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/EnderChestMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/EnderChestMock.java
@@ -30,6 +30,7 @@ public class EnderChestMock extends TileStateMock implements EnderChest
 	protected EnderChestMock(@NotNull EnderChestMock state)
 	{
 		super(state);
+		this.isOpen = state.isOpen;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/LecternMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/LecternMock.java
@@ -33,6 +33,7 @@ public class LecternMock extends ContainerMock implements Lectern
 	protected LecternMock(@NotNull LecternMock state)
 	{
 		super(state);
+		this.currentPage = state.currentPage;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ShulkerBoxMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ShulkerBoxMock.java
@@ -42,6 +42,7 @@ public class ShulkerBoxMock extends ContainerMock implements ShulkerBox
 	{
 		super(state);
 		this.color = state.color;
+		this.isOpen = state.isOpen;
 	}
 
 	@Nullable

--- a/src/main/java/be/seeseemelk/mockbukkit/metadata/MetadataTable.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/metadata/MetadataTable.java
@@ -11,7 +11,17 @@ import org.bukkit.plugin.Plugin;
 
 public class MetadataTable implements Metadatable
 {
-	private final Map<String, Map<Plugin, MetadataValue>> metadata = new HashMap<>();
+	private final Map<String, Map<Plugin, MetadataValue>> metadata;
+
+	public MetadataTable()
+	{
+		metadata = new HashMap<>();
+	}
+
+	public MetadataTable(MetadataTable table)
+	{
+		this.metadata = new HashMap<>(table.metadata);
+	}
 
 	@Override
 	public void setMetadata(String metadataKey, MetadataValue newMetadataValue)


### PR DESCRIPTION
# Description
Fixes `BlockStateMock` copy constructors not cloning all values.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.