### PR TITLE
Decrease chance of BukkitSchedulerMockTest randomly failing

### DIFF
--- a/src/test/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMockTest.java
@@ -29,6 +29,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class BukkitSchedulerMockTest
 {
 
+	/**
+	 * How long, in milliseconds, to sleep when testing async tasks.
+	 */
 	private static final long SLEEP_TIME = 50L;
 
 	private BukkitSchedulerMock scheduler;

--- a/src/test/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMockTest.java
@@ -229,7 +229,7 @@ class BukkitSchedulerMockTest
 			{
 				try
 				{
-					Thread.sleep(10L);
+					Thread.sleep(50L);
 				}
 				catch (InterruptedException e)
 				{
@@ -243,7 +243,7 @@ class BukkitSchedulerMockTest
 			{
 				try
 				{
-					Thread.sleep(10L);
+					Thread.sleep(50L);
 				}
 				catch (InterruptedException e)
 				{
@@ -280,7 +280,7 @@ class BukkitSchedulerMockTest
 				}
 				try
 				{
-					Thread.sleep(10L);
+					Thread.sleep(50L);
 				}
 				catch (InterruptedException e)
 				{

--- a/src/test/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMockTest.java
@@ -28,6 +28,9 @@ import org.junit.jupiter.api.Test;
 
 class BukkitSchedulerMockTest
 {
+
+	private static final long SLEEP_TIME = 50L;
+
 	private BukkitSchedulerMock scheduler;
 
 	@BeforeEach
@@ -229,7 +232,7 @@ class BukkitSchedulerMockTest
 			{
 				try
 				{
-					Thread.sleep(50L);
+					Thread.sleep(SLEEP_TIME);
 				}
 				catch (InterruptedException e)
 				{
@@ -243,7 +246,7 @@ class BukkitSchedulerMockTest
 			{
 				try
 				{
-					Thread.sleep(50L);
+					Thread.sleep(SLEEP_TIME);
 				}
 				catch (InterruptedException e)
 				{
@@ -280,7 +283,7 @@ class BukkitSchedulerMockTest
 				}
 				try
 				{
-					Thread.sleep(50L);
+					Thread.sleep(SLEEP_TIME);
 				}
 				catch (InterruptedException e)
 				{
@@ -311,7 +314,7 @@ class BukkitSchedulerMockTest
 			@EventHandler
 			public void onChat(AsyncChatEvent event) throws Exception
 			{
-				Thread.sleep(50);
+				Thread.sleep(SLEEP_TIME);
 				done.set(true);
 			}
 		}, MockBukkit.createMockPlugin());


### PR DESCRIPTION
# Description
Increases the sleep time of `BukkitSchedulerMockTest#longScheduledRunningTask_Throws_RunTimeException` from 10ms to 50ms to decrease the change of it randomly failing.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.