### PR TITLE
Add Automatic-Module-Name manifest attribute

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,12 @@ dependencies {
     implementation 'org.apache.maven.resolver:maven-resolver-transport-http:1.8.0'
 }
 
+jar {
+    manifest {
+        attributes 'Automatic-Module-Name': "be.seeseemelk.mockbukkit"
+    }
+}
+
 task javadocJar(type: Jar) {
     classifier('javadoc')
     from javadoc


### PR DESCRIPTION
# Description
Adds the Automatic-Module-Name manifest attribute allowing MockBukkit to be used in Java 9 module projects. Closes #291.

# Checklist
The following items should be checked before the pull request can be merged.
- [ ] Unit tests added.
- [x] Code follows existing code format.