### PR TITLE
Use static import assertEquals method

### DIFF
--- a/src/test/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMockTest.java
@@ -19,7 +19,6 @@ import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
 import org.bukkit.plugin.Plugin;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -72,23 +71,23 @@ class PluginManagerMockTest
 	void test_ManualListener_Registration()
 	{
 		MockBukkit.getMock().getPluginManager().registerEvents(plugin, plugin);
-		Assertions.assertEquals(3, BlockBreakEvent.getHandlerList().getRegisteredListeners().length);
+		assertEquals(3, BlockBreakEvent.getHandlerList().getRegisteredListeners().length);
 		pluginManager.unregisterPluginEvents(plugin);
-		Assertions.assertEquals(0, BlockBreakEvent.getHandlerList().getRegisteredListeners().length);
+		assertEquals(0, BlockBreakEvent.getHandlerList().getRegisteredListeners().length);
 		MockBukkit.getMock().getPluginManager().registerEvents(plugin, plugin);
 		MockBukkit.getMock().getPluginManager().registerEvents(plugin, plugin);
-		Assertions.assertEquals(6, BlockBreakEvent.getHandlerList().getRegisteredListeners().length);
+		assertEquals(6, BlockBreakEvent.getHandlerList().getRegisteredListeners().length);
 		pluginManager.unregisterPluginEvents(plugin);
-		Assertions.assertEquals(0, BlockBreakEvent.getHandlerList().getRegisteredListeners().length);
+		assertEquals(0, BlockBreakEvent.getHandlerList().getRegisteredListeners().length);
 	}
 
 	@Test
 	void test_AutomaticListener_DeRegistration()
 	{
 		MockBukkit.getMock().getPluginManager().registerEvents(plugin, plugin);
-		Assertions.assertEquals(3, BlockBreakEvent.getHandlerList().getRegisteredListeners().length);
+		assertEquals(3, BlockBreakEvent.getHandlerList().getRegisteredListeners().length);
 		MockBukkit.unmock();
-		Assertions.assertEquals(0, BlockBreakEvent.getHandlerList().getRegisteredListeners().length);
+		assertEquals(0, BlockBreakEvent.getHandlerList().getRegisteredListeners().length);
 
 	}
 


### PR DESCRIPTION
# Description
Switching over to using the static imported method `assertEquals` instead of using the fully written way `Assertions.assertEquals(...)`

# Checklist
The following items should be checked before the pull request can be merged.
- Unit tests added. - nope just remove stuff
- [x] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
