### PR TITLE
Changes to GetTabComplete

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -922,7 +922,7 @@ public class ServerMock extends Server.Spigot implements Server
 		}
 	}
 
-	public List<String> getCommandTabComplete(CommandSender sender, String commandLabel, String[] args)
+	public List<String> getCommandTabComplete(CommandSender sender, String commandLine)
 	{
 		AsyncCatcher.catchOp("command tabcomplete");
 		Command command = getCommandMap().getCommand(commandLabel);

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -922,12 +922,9 @@ public class ServerMock extends Server.Spigot implements Server
 		}
 	}
 
-	public List<String> getCommandTabComplete(CommandSender sender, String commandLine)
+	public List<String> getCommandTabComplete(CommandSender sender, String commandLabel, String[] args)
 	{
-		AsyncCatcher.catchOp("command dispatch");
-		String[] commands = commandLine.split(" ");
-		String commandLabel = commands[0];
-		String[] args = Arrays.copyOfRange(commands, 1, commands.length);
+		AsyncCatcher.catchOp("command tabcomplete");
 		Command command = getCommandMap().getCommand(commandLabel);
 
 		if (command != null)

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -925,6 +925,9 @@ public class ServerMock extends Server.Spigot implements Server
 	public List<String> getCommandTabComplete(CommandSender sender, String commandLine)
 	{
 		AsyncCatcher.catchOp("command tabcomplete");
+		int idx = commandLine.indexOf(' ');
+		String commandLabel = commandLine.substring(0, idx);
+		String[] args = commandLine.substring(idx + 1).split(" ", -1);
 		Command command = getCommandMap().getCommand(commandLabel);
 
 		if (command != null)

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -649,8 +649,8 @@ class ServerMockTest
 	{
 		MockBukkit.load(TestPlugin.class);
 		Player player = server.addPlayer();
-		assertEquals(Arrays.asList("Tab", "Complete", "Results"), server.getCommandTabComplete(player, "mockcommand", new String[]{ "argA" }));
-		assertEquals(Arrays.asList("Other", "Results"), server.getCommandTabComplete(player, "mockcommand", new String[]{ "argA", "argB" }));
+		assertEquals(Arrays.asList("Other", "Results"), server.getCommandTabComplete(player, "mockcommand argA"));
+		assertEquals(Arrays.asList("Tab", "Complete", "Results"), server.getCommandTabComplete(player, "mockcommand argA argB"));
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -649,8 +649,8 @@ class ServerMockTest
 	{
 		MockBukkit.load(TestPlugin.class);
 		Player player = server.addPlayer();
-		assertEquals(Arrays.asList("Other", "Results"), server.getCommandTabComplete(player, "mockcommand argA"));
-		assertEquals(Arrays.asList("Tab", "Complete", "Results"), server.getCommandTabComplete(player, "mockcommand argA argB"));
+		assertEquals(Arrays.asList("Tab", "Complete", "Results"), server.getCommandTabComplete(player, "mockcommand "));
+		assertEquals(Arrays.asList("Other", "Results"), server.getCommandTabComplete(player, "mockcommand argA "));
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -649,7 +649,8 @@ class ServerMockTest
 	{
 		MockBukkit.load(TestPlugin.class);
 		Player player = server.addPlayer();
-		assertEquals(Arrays.asList("Tab", "Complete", "Results"), server.getCommandTabComplete(player, "mockcommand argA argB"));
+		assertEquals(Arrays.asList("Tab", "Complete", "Results"), server.getCommandTabComplete(player, "mockcommand", new String[]{ "argA" }));
+		assertEquals(Arrays.asList("Other", "Results"), server.getCommandTabComplete(player, "mockcommand", new String[]{ "argA", "argB" }));
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/TestPlugin.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/TestPlugin.java
@@ -80,7 +80,10 @@ public class TestPlugin extends JavaPlugin implements Listener
 	@Override
 	public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args)
 	{
-		return Arrays.asList("Tab", "Complete", "Results");
+		if(args.length==1){
+			return Arrays.asList("Tab", "Complete", "Results");
+		}
+		return Arrays.asList("Other", "Results");
 	}
 
 	public void unannotatedEventHandler(PlayerInteractEvent event)

--- a/src/test/java/be/seeseemelk/mockbukkit/TestPlugin.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/TestPlugin.java
@@ -80,7 +80,8 @@ public class TestPlugin extends JavaPlugin implements Listener
 	@Override
 	public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args)
 	{
-		if(args.length==1){
+		if (args.length == 1)
+		{
 			return Arrays.asList("Tab", "Complete", "Results");
 		}
 		return Arrays.asList("Other", "Results");


### PR DESCRIPTION
# Description
I realised that the old implementation (https://github.com/MockBukkit/MockBukkit/pull/426) didnt work as I wanted it to.

If I tried to test the auto complete for the command "test argument " this would transform into an array ["test", "argument"] when we would want it to transform into ["test", "argument", ""] as a result of this the method was returning the wrong autocompletes 

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
