### PR TITLE
Don't implement Cloneable in BlockStateMock

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
@@ -17,7 +17,7 @@ import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.block.BlockMock;
 import be.seeseemelk.mockbukkit.metadata.MetadataTable;
 
-public class BlockStateMock implements BlockState, Cloneable
+public class BlockStateMock implements BlockState
 {
 
 	private final MetadataTable metadataTable = new MetadataTable();


### PR DESCRIPTION
# Description
Makes `BlockStateMock` no longer implement Cloneable since `#clone()` was never overridden and CraftBukkit's `CraftBlockState` doesn't implement it.

# Checklist
The following items should be checked before the pull request can be merged.
- [ ] Unit tests added.
- [x] Code follows existing code format.