### PR TITLE
Fix ContainerMock not overriding #customName

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BarrelMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BarrelMock.java
@@ -91,7 +91,7 @@ public class BarrelMock extends ContainerMock implements Barrel
 	}
 
 	@Override
-	public BlockState getSnapshot()
+	public @NotNull BlockState getSnapshot()
 	{
 		return new BarrelMock(this);
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
@@ -65,7 +65,7 @@ public class BlockStateMock implements BlockState, Cloneable
 	}
 
 	@Override
-	public Block getBlock()
+	public @NotNull Block getBlock()
 	{
 		if (block == null)
 		{

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ChestMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ChestMock.java
@@ -99,7 +99,7 @@ public class ChestMock extends ContainerMock implements Chest
 	}
 
 	@Override
-	public BlockState getSnapshot()
+	public @NotNull BlockState getSnapshot()
 	{
 		return new ChestMock(this);
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ContainerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ContainerMock.java
@@ -55,8 +55,7 @@ public abstract class ContainerMock extends TileStateMock implements Container
 	}
 
 	@Override
-	@NotNull
-	public String getLock()
+	public @NotNull String getLock()
 	{
 		return this.lock;
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ContainerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ContainerMock.java
@@ -1,5 +1,8 @@
 package be.seeseemelk.mockbukkit.block.state;
 
+import be.seeseemelk.mockbukkit.inventory.InventoryMock;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
@@ -8,19 +11,16 @@ import org.bukkit.inventory.Inventory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import be.seeseemelk.mockbukkit.inventory.InventoryMock;
-
 /**
  * The {@link ContainerMock} is an extension of a {@link TileStateMock} which can also hold an {@link Inventory}.
  *
  * @author TheBusyBiscuit
- *
  */
 public abstract class ContainerMock extends TileStateMock implements Container
 {
 
 	private final Inventory inventory;
-	private String customName;
+	private Component customName;
 	private String lock = "";
 
 	protected ContainerMock(@NotNull Material material)
@@ -39,61 +39,69 @@ public abstract class ContainerMock extends TileStateMock implements Container
 	{
 		super(state);
 		this.inventory = state.getInventory();
+		this.customName = state.customName();
+		this.lock = state.getLock();
 	}
 
 	protected abstract InventoryMock createInventory();
 
 	@Override
-	public abstract BlockState getSnapshot();
+	public abstract @NotNull BlockState getSnapshot();
 
 	@Override
 	public boolean isLocked()
 	{
-		return !lock.isEmpty();
+		return !this.lock.isEmpty();
 	}
 
 	@Override
 	@NotNull
 	public String getLock()
 	{
-		return lock;
+		return this.lock;
 	}
 
 	@Override
 	public void setLock(String key)
 	{
-		if (key == null)
-		{
-			lock = "";
-		}
-		else
-		{
-			lock = key;
-		}
+		this.lock = key == null ? "" : key;
+	}
+
+	@Override
+	public @Nullable Component customName()
+	{
+		return this.customName;
+	}
+
+	@Override
+	public void customName(@Nullable Component customName)
+	{
+		this.customName = customName;
 	}
 
 	@Override
 	@Nullable
 	public String getCustomName()
 	{
-		return customName;
+		return this.customName == null ? null : LegacyComponentSerializer.legacySection().serialize(this.customName);
 	}
 
 	@Override
-	public void setCustomName(String name)
+	public void setCustomName(@Nullable String name)
 	{
-		this.customName = name;
+		this.customName = name == null ? null : LegacyComponentSerializer.legacySection().deserialize(name);
 	}
 
 	@Override
-	public Inventory getInventory()
+	public @NotNull Inventory getInventory()
 	{
-		return inventory;
+		return this.inventory;
 	}
 
 	@Override
-	public Inventory getSnapshotInventory()
+	public @NotNull Inventory getSnapshotInventory()
 	{
-		return ((InventoryMock) inventory).getSnapshot();
+		return ((InventoryMock) this.inventory).getSnapshot();
 	}
+
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/DispenserMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/DispenserMock.java
@@ -73,7 +73,7 @@ public class DispenserMock extends ContainerMock implements Dispenser
 	}
 
 	@Override
-	public BlockState getSnapshot()
+	public @NotNull BlockState getSnapshot()
 	{
 		return new DispenserMock(this);
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/DropperMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/DropperMock.java
@@ -74,7 +74,7 @@ public class DropperMock extends ContainerMock implements Dropper
 	}
 
 	@Override
-	public BlockState getSnapshot()
+	public @NotNull BlockState getSnapshot()
 	{
 		return new DropperMock(this);
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/HopperMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/HopperMock.java
@@ -74,7 +74,7 @@ public class HopperMock extends ContainerMock implements Hopper
 	}
 
 	@Override
-	public BlockState getSnapshot()
+	public @NotNull BlockState getSnapshot()
 	{
 		return new HopperMock(this);
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/LecternMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/LecternMock.java
@@ -42,7 +42,7 @@ public class LecternMock extends ContainerMock implements Lectern
 	}
 
 	@Override
-	public BlockState getSnapshot()
+	public @NotNull BlockState getSnapshot()
 	{
 		return new LecternMock(this);
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ShulkerBoxMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ShulkerBoxMock.java
@@ -141,7 +141,7 @@ public class ShulkerBoxMock extends ContainerMock implements ShulkerBox
 	}
 
 	@Override
-	public BlockState getSnapshot()
+	public @NotNull BlockState getSnapshot()
 	{
 		return new ShulkerBoxMock(this);
 	}


### PR DESCRIPTION
# Description
Fixes ContainerMock not overriding `#customName`.

# Checklist
The following items should be checked before the pull request can be merged.
- [ ] Unit tests added.
- [x] Code follows existing code format.