### PR TITLE
Don't override ContainerMock#customName

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BarrelMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BarrelMock.java
@@ -3,14 +3,12 @@ package be.seeseemelk.mockbukkit.block.state;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.inventory.BarrelInventoryMock;
 import be.seeseemelk.mockbukkit.inventory.InventoryMock;
-import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
 import org.bukkit.block.Barrel;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.loot.LootTable;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * This {@link ContainerMock} represents a {@link Barrel}
@@ -95,20 +93,6 @@ public class BarrelMock extends ContainerMock implements Barrel
 	public @NotNull BlockState getSnapshot()
 	{
 		return new BarrelMock(this);
-	}
-
-	@Override
-	public @Nullable Component customName()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public void customName(@Nullable Component customName)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ChestMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ChestMock.java
@@ -3,7 +3,6 @@ package be.seeseemelk.mockbukkit.block.state;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.inventory.ChestInventoryMock;
 import be.seeseemelk.mockbukkit.inventory.InventoryMock;
-import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
@@ -167,20 +166,5 @@ public class ChestMock extends ContainerMock implements Chest
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
 	}
-
-	@Override
-	public @Nullable Component customName()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public void customName(@Nullable Component customName)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/DispenserMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/DispenserMock.java
@@ -3,7 +3,6 @@ package be.seeseemelk.mockbukkit.block.state;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.inventory.DispenserInventoryMock;
 import be.seeseemelk.mockbukkit.inventory.InventoryMock;
-import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
@@ -161,17 +160,4 @@ public class DispenserMock extends ContainerMock implements Dispenser
 		throw new UnimplementedOperationException();
 	}
 
-	@Override
-	public @Nullable Component customName()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public void customName(@Nullable Component customName)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/DropperMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/DropperMock.java
@@ -1,6 +1,5 @@
 package be.seeseemelk.mockbukkit.block.state;
 
-import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
@@ -144,20 +143,6 @@ public class DropperMock extends ContainerMock implements Dropper
 
 	@Override
 	public long setNextRefill(long refillAt)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public @Nullable Component customName()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public void customName(@Nullable Component customName)
 	{
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/HopperMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/HopperMock.java
@@ -1,6 +1,5 @@
 package be.seeseemelk.mockbukkit.block.state;
 
-import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
@@ -142,17 +141,4 @@ public class HopperMock extends ContainerMock implements Hopper
 		throw new UnimplementedOperationException();
 	}
 
-	@Override
-	public @Nullable Component customName()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public void customName(@Nullable Component customName)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/LecternMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/LecternMock.java
@@ -1,7 +1,5 @@
 package be.seeseemelk.mockbukkit.block.state;
 
-import be.seeseemelk.mockbukkit.UnimplementedOperationException;
-import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
@@ -13,7 +11,6 @@ import org.jetbrains.annotations.NotNull;
 
 import be.seeseemelk.mockbukkit.inventory.InventoryMock;
 import be.seeseemelk.mockbukkit.inventory.LecternInventoryMock;
-import org.jetbrains.annotations.Nullable;
 
 public class LecternMock extends ContainerMock implements Lectern
 {
@@ -81,20 +78,6 @@ public class LecternMock extends ContainerMock implements Lectern
 		{
 			return 1;
 		}
-	}
-
-	@Override
-	public @Nullable Component customName()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public void customName(@Nullable Component customName)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ShulkerBoxMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ShulkerBoxMock.java
@@ -3,7 +3,6 @@ package be.seeseemelk.mockbukkit.block.state;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.inventory.InventoryMock;
 import be.seeseemelk.mockbukkit.inventory.ShulkerBoxInventoryMock;
-import net.kyori.adventure.text.Component;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -219,20 +218,6 @@ public class ShulkerBoxMock extends ContainerMock implements ShulkerBox
 
 	@Override
 	public long setNextRefill(long refillAt)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public @Nullable Component customName()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public void customName(@Nullable Component customName)
 	{
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();


### PR DESCRIPTION
# Description
Little fix related to #441 where some `BlockStateMock`'s were overriding the `#customName` method and skipping tests.

# Checklist
The following items should be checked before the pull request can be merged.
- [ ] Unit tests added.
- [x] Code follows existing code format.