### PR TITLE
Fixes ChunkMock#getChunkSnapshot passing in oversized maps to ChunkSnapshotMock

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ChunkMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ChunkMock.java
@@ -97,8 +97,8 @@ public class ChunkMock implements Chunk
 	@SuppressWarnings("UnstableApiUsage")
 	public @NotNull ChunkSnapshot getChunkSnapshot(boolean includeMaxblocky, boolean includeBiome, boolean includeBiomeTempRain)
 	{
-		// Cubic size of the chunk.
-		int size = (16 << 4) * (16 << 4) * Math.abs((world.getMaxHeight() - world.getMinHeight()));
+		// Cubic size of the chunk. (16 * 16 * height, using a bitshift)
+		int size = (16 << 4) * Math.abs((world.getMaxHeight() - world.getMinHeight()));
 		ImmutableMap.Builder<Coordinate, BlockState> blockStates = ImmutableMap.builderWithExpectedSize(size);
 		ImmutableMap.Builder<Coordinate, Biome> biomes = ImmutableMap.builderWithExpectedSize(size);
 		for (int x = 0; x < 15; x++)

--- a/src/main/java/be/seeseemelk/mockbukkit/ChunkMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ChunkMock.java
@@ -97,8 +97,8 @@ public class ChunkMock implements Chunk
 	@SuppressWarnings("UnstableApiUsage")
 	public @NotNull ChunkSnapshot getChunkSnapshot(boolean includeMaxblocky, boolean includeBiome, boolean includeBiomeTempRain)
 	{
-		// Cubic size of the chunk. (16 * 16 * height, using a bitshift)
-		int size = (16 << 4) * Math.abs((world.getMaxHeight() - world.getMinHeight()));
+		// Cubic size of the chunk (w * w * h).
+		int size = (16 * 16) * Math.abs((world.getMaxHeight() - world.getMinHeight()));
 		ImmutableMap.Builder<Coordinate, BlockState> blockStates = ImmutableMap.builderWithExpectedSize(size);
 		ImmutableMap.Builder<Coordinate, Biome> biomes = ImmutableMap.builderWithExpectedSize(size);
 		for (int x = 0; x < 15; x++)


### PR DESCRIPTION
# Description
The size was being multiplied by an extra 256 😅

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.