### PR TITLE
Prevent having objectives or teams with the same name

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/scoreboard/ScoreboardMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scoreboard/ScoreboardMock.java
@@ -61,6 +61,10 @@ public class ScoreboardMock implements Scoreboard
 	public ObjectiveMock registerNewObjective(String name, String criteria, String displayName, RenderType renderType)
 	throws IllegalArgumentException
 	{
+		if (objectives.containsKey(name))
+		{
+			throw new IllegalArgumentException("An objective of name '" + name + "' already exists");
+		}
 		ObjectiveMock objective = new ObjectiveMock(this, name, displayName, criteria, renderType);
 		objectives.put(name, objective);
 		return objective;
@@ -161,6 +165,10 @@ public class ScoreboardMock implements Scoreboard
 	@Override
 	public Team registerNewTeam(String name) throws IllegalArgumentException
 	{
+		if (teams.containsKey(name))
+		{
+			throw new IllegalArgumentException("Team name '" + name + "' is already in use");
+		}
 		Team team = new TeamMock(name, this);
 		teams.put(name, team);
 		return team;
@@ -245,6 +253,16 @@ public class ScoreboardMock implements Scoreboard
 		}
 
 		objectives.remove(objectiveMock.getName());
+	}
+
+	/**
+	 * Removes a team from this scoreboard.
+	 *
+	 * @param teamMock The team to remove.
+	 */
+	protected void unregister(@NotNull TeamMock teamMock)
+	{
+		teams.remove(teamMock.getName());
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/scoreboard/TeamMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scoreboard/TeamMock.java
@@ -34,14 +34,12 @@ public class TeamMock implements Team
 	private final HashSet<String> entries;
 	private boolean canSeeFriendly = true;
 	private EnumMap<Option, OptionStatus> options = new EnumMap<>(Option.class);
-	private boolean registered;
-	private Scoreboard board;
+	private ScoreboardMock board;
 
-	public TeamMock(String name, Scoreboard board)
+	public TeamMock(String name, ScoreboardMock board)
 	{
 		this.name = name;
 		this.board = board;
-		registered = true;
 		entries = new HashSet<>();
 		options.put(Option.NAME_TAG_VISIBILITY, OptionStatus.ALWAYS);
 	}
@@ -49,7 +47,7 @@ public class TeamMock implements Team
 	@Override
 	public String getName() throws IllegalStateException
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 
 		return name;
 	}
@@ -120,7 +118,7 @@ public class TeamMock implements Team
 	@Override
 	public String getDisplayName() throws IllegalStateException
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 
 		return displayName;
 	}
@@ -128,7 +126,7 @@ public class TeamMock implements Team
 	@Override
 	public void setDisplayName(String s)
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 
 		this.displayName = s;
 	}
@@ -136,7 +134,7 @@ public class TeamMock implements Team
 	@Override
 	public String getPrefix() throws IllegalStateException
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 
 		return prefix;
 	}
@@ -144,7 +142,7 @@ public class TeamMock implements Team
 	@Override
 	public void setPrefix(String s)
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 
 		this.prefix = s;
 	}
@@ -152,7 +150,7 @@ public class TeamMock implements Team
 	@Override
 	public String getSuffix() throws IllegalStateException
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 
 		return suffix;
 	}
@@ -160,7 +158,7 @@ public class TeamMock implements Team
 	@Override
 	public void setSuffix(String s)
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 
 		this.suffix = s;
 	}
@@ -168,7 +166,7 @@ public class TeamMock implements Team
 	@Override
 	public ChatColor getColor() throws IllegalStateException
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 
 		return color;
 	}
@@ -176,7 +174,7 @@ public class TeamMock implements Team
 	@Override
 	public void setColor(ChatColor chatColor)
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 
 		this.color = chatColor;
 	}
@@ -184,7 +182,7 @@ public class TeamMock implements Team
 	@Override
 	public boolean allowFriendlyFire() throws IllegalStateException
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 
 		return allowFriendlyFire;
 	}
@@ -192,7 +190,7 @@ public class TeamMock implements Team
 	@Override
 	public void setAllowFriendlyFire(boolean b) throws IllegalStateException
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 
 		this.allowFriendlyFire = b;
 	}
@@ -200,7 +198,7 @@ public class TeamMock implements Team
 	@Override
 	public boolean canSeeFriendlyInvisibles() throws IllegalStateException
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 
 		return canSeeFriendly;
 	}
@@ -208,7 +206,7 @@ public class TeamMock implements Team
 	@Override
 	public void setCanSeeFriendlyInvisibles(boolean b) throws IllegalStateException
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 
 		this.canSeeFriendly = b;
 	}
@@ -218,7 +216,7 @@ public class TeamMock implements Team
 	@Deprecated
 	public NameTagVisibility getNameTagVisibility()
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 
 		OptionStatus s = options.get(Option.NAME_TAG_VISIBILITY);
 		switch (s)
@@ -242,7 +240,7 @@ public class TeamMock implements Team
 	public void setNameTagVisibility(NameTagVisibility nameTagVisibility)
 	{
 		MockBukkit.getMock().getLogger().log(Level.WARNING, "Consider USE setOption() DEPRECATED");
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 
 		switch (nameTagVisibility)
 		{
@@ -269,7 +267,7 @@ public class TeamMock implements Team
 	public Set<OfflinePlayer> getPlayers() throws IllegalStateException
 	{
 
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 		Set<OfflinePlayer> players = new HashSet<>();
 		for (String s : entries)
 		{
@@ -291,7 +289,7 @@ public class TeamMock implements Team
 	@Override
 	public int getSize() throws IllegalStateException
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 		return entries.size();
 	}
 
@@ -305,7 +303,7 @@ public class TeamMock implements Team
 	@Deprecated
 	public void addPlayer(OfflinePlayer offlinePlayer)
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 
 		entries.add(offlinePlayer.getName());
 	}
@@ -313,7 +311,7 @@ public class TeamMock implements Team
 	@Override
 	public void addEntry(String s)
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 		entries.add(s);
 	}
 
@@ -336,7 +334,7 @@ public class TeamMock implements Team
 	@Deprecated
 	public boolean removePlayer(OfflinePlayer offlinePlayer)
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 
 		return entries.remove(offlinePlayer.getName());
 	}
@@ -344,9 +342,8 @@ public class TeamMock implements Team
 	@Override
 	public boolean removeEntry(String s)
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 		return entries.remove(s);
-
 	}
 
 	@Override
@@ -366,10 +363,10 @@ public class TeamMock implements Team
 	@Override
 	public void unregister() throws IllegalStateException
 	{
-		if (!registered)
-			throw new IllegalStateException("Team not registered");
+		checkRegistered();
 
-		registered = false;
+		board.unregister(this);
+		board = null;
 	}
 
 	/** @deprecated */
@@ -377,28 +374,28 @@ public class TeamMock implements Team
 	@Deprecated
 	public boolean hasPlayer(OfflinePlayer offlinePlayer)
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 		return entries.contains(offlinePlayer.getName());
 	}
 
 	@Override
 	public boolean hasEntry(String s)
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 		return entries.contains(s);
 	}
 
 	@Override
 	public OptionStatus getOption(Option option) throws IllegalStateException
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 		return options.get(option);
 	}
 
 	@Override
 	public void setOption(Option option, OptionStatus optionStatus) throws IllegalStateException
 	{
-		if (!registered)throw new IllegalStateException("Team not registered");
+		checkRegistered();
 
 		options.put(option, optionStatus);
 	}
@@ -422,5 +419,16 @@ public class TeamMock implements Team
 	{
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
+	}
+
+	/**
+	 * Throws an exception if the team is not registered.
+	 */
+	public void checkRegistered()
+	{
+		if (board == null)
+		{
+			throw new IllegalStateException("Team not registered");
+		}
 	}
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/scoreboard/ScoreboardMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/scoreboard/ScoreboardMockTest.java
@@ -1,9 +1,11 @@
 package be.seeseemelk.mockbukkit.scoreboard;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
@@ -82,5 +84,19 @@ class ScoreboardMockTest
 		objective.setDisplaySlot(DisplaySlot.SIDEBAR);
 		scoreboard.clearSlot(DisplaySlot.SIDEBAR);
 		assertTrue(objective.isRegistered());
+	}
+
+	@Test
+	void registerNewObjective_CheckForDuplicates()
+	{
+		assertDoesNotThrow(() -> scoreboard.registerNewObjective("Objective", "dummy"));
+		assertThrows(IllegalArgumentException.class, () -> scoreboard.registerNewObjective("Objective", "dummy"));
+	}
+
+	@Test
+	void registerNewTeam_CheckForDuplicates()
+	{
+		assertDoesNotThrow(() -> scoreboard.registerNewTeam("blue"));
+		assertThrows(IllegalArgumentException.class, () -> scoreboard.registerNewTeam("blue"));
 	}
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/scoreboard/TeamMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/scoreboard/TeamMockTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -39,7 +40,7 @@ class TeamMockTest
 		playerB = server.addPlayer();
 		ScoreboardManager managerMock = server.getScoreboardManager();
 		board = managerMock.getNewScoreboard();
-		team = new TeamMock("Test", board);
+		team = (TeamMock) board.registerNewTeam("Test");
 	}
 
 	@AfterEach
@@ -178,7 +179,9 @@ class TeamMockTest
 	@Test
 	void unregister_FirstUnregister_Works()
 	{
+		assertSame(team, board.getTeam("Test"), "Team was registered");
 		assertDoesNotThrow(team::unregister);
+		assertNull(board.getTeam("Test"), "Team is no longer registered");
 	}
 
 	@Test


### PR DESCRIPTION
# Description
Two teams or two objectives cannot be registered in the same scoreboard with the same name, since the name is a unique identifier. I added a check against this.

A team has the same life cycle as a objective in a scoreboard:
1. Creation and registration for the scoreboard
2. De-registration, the team should not be referenced or used anymore

A team could be retrieved by its name even if it had been unregistered. I added the removal of the team in the scoreboard when it is unregistered to fix this.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)