### PR TITLE
Fix a NPE and follow the description of getPlayerUniqueId

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -351,7 +351,7 @@ public class ServerMock extends Server.Spigot implements Server
 	@Override
 	public @Nullable UUID getPlayerUniqueId(@NotNull String playerName)
 	{
-		return playerList.getPlayer(playerName).getUniqueId();
+		return playerList.getOfflinePlayer(playerName).getUniqueId();
 	}
 
 	/**

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -618,6 +618,13 @@ class ServerMockTest
 	}
 
 	@Test
+	void testGetPlayerUniqueID_OfflineMode()
+	{
+		OfflinePlayer player = new OfflinePlayerMock("OfflinePlayer");
+		assertEquals(player.getUniqueId(), server.getPlayerUniqueId(player.getName()));
+	}
+
+	@Test
 	void testSetMaxPlayers()
 	{
 		server.setMaxPlayers(69420);


### PR DESCRIPTION
# Description
Currently, a NullPointerException is thrown when the player is not online. To fix this and better match what this method is supposed to do, I use `getOfflinePlayer` instead. See the [Paper implementation](https://github.com/PaperMC/Paper/blob/0c1643c02cf702cc54fd2bcdc69d5ea586925973/patches/server/0181-getPlayerUniqueId-API.patch#L21) that checks the profile cache when the player is not online.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
