### PR TITLE
Implement the remaining methods of Team

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -307,6 +307,16 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	}
 
 	/**
+	 * Gets the scoreboard entry for this entity.
+	 *
+	 * @return The scoreboard entry.
+	 */
+	public @NotNull String getScoreboardEntry()
+	{
+		return uuid.toString();
+	}
+
+	/**
 	 * Sets the name of this entity.
 	 *
 	 * @param name The new name of the entity.

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -967,6 +967,12 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	}
 
 	@Override
+	public @NotNull String getScoreboardEntry()
+	{
+		return getName();
+	}
+
+	@Override
 	public void playerListName(@Nullable Component name)
 	{
 		this.playerListName = name;

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -2070,7 +2070,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public @NotNull Scoreboard getScoreboard()
 	{
-		return scoreboard;
+		return this.scoreboard;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -155,6 +155,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	private final Queue<String> title = new LinkedTransferQueue<>();
 	private final Queue<String> subitles = new LinkedTransferQueue<>();
 
+	private Scoreboard scoreboard;
 	private final StatisticsMock statistics = new StatisticsMock();
 
 	private final Set<String> channels = new HashSet<>();
@@ -164,6 +165,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 		this(server, name, UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(StandardCharsets.UTF_8)));
 		this.online = false;
 		this.firstPlayed = 0;
+		this.scoreboard = server.getScoreboardManager().getMainScoreboard();
 	}
 
 	public PlayerMock(@NotNull ServerMock server, @NotNull String name, @NotNull UUID uuid)
@@ -187,6 +189,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 
 		Random random = ThreadLocalRandom.current();
 		address = new InetSocketAddress("192.0.2." + random.nextInt(255), random.nextInt(32768, 65535));
+		scoreboard = server.getScoreboardManager().getMainScoreboard();
 	}
 
 	/**
@@ -2061,15 +2064,14 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public @NotNull Scoreboard getScoreboard()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return scoreboard;
 	}
 
 	@Override
 	public void setScoreboard(@NotNull Scoreboard scoreboard)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkNotNull(scoreboard, "Scoreboard cannot be null");
+		this.scoreboard = scoreboard;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/scoreboard/TeamMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scoreboard/TeamMock.java
@@ -291,6 +291,7 @@ public class TeamMock implements Team
 	@Deprecated
 	public void addPlayer(@NotNull OfflinePlayer offlinePlayer)
 	{
+		Preconditions.checkNotNull(offlinePlayer, "OfflinePlayer cannot be null");
 		checkRegistered();
 		this.entries.add(offlinePlayer.getName());
 	}
@@ -298,6 +299,7 @@ public class TeamMock implements Team
 	@Override
 	public void addEntry(@NotNull String entry)
 	{
+		Preconditions.checkNotNull(entry, "Entry cannot be null");
 		checkRegistered();
 		this.entries.add(entry);
 	}
@@ -305,12 +307,14 @@ public class TeamMock implements Team
 	@Override
 	public void addEntities(@NotNull Collection<Entity> entities) throws IllegalStateException, IllegalArgumentException
 	{
+		Preconditions.checkNotNull(entities, "Entities cannot be null");
 		addEntries(entities.stream().map(entity -> ((EntityMock) entity).getScoreboardEntry()).toList());
 	}
 
 	@Override
 	public void addEntries(@NotNull Collection<String> entries) throws IllegalStateException, IllegalArgumentException
 	{
+		Preconditions.checkNotNull(entries, "Entries cannot be null");
 		checkRegistered();
 		this.entries.addAll(entries);
 	}
@@ -322,6 +326,7 @@ public class TeamMock implements Team
 	@Deprecated
 	public boolean removePlayer(@NotNull OfflinePlayer offlinePlayer)
 	{
+		Preconditions.checkNotNull(offlinePlayer, "OfflinePlayer cannot be null");
 		checkRegistered();
 		return this.entries.remove(offlinePlayer.getName());
 	}
@@ -329,6 +334,7 @@ public class TeamMock implements Team
 	@Override
 	public boolean removeEntry(@NotNull String entry)
 	{
+		Preconditions.checkNotNull(entry, "Entry cannot be null");
 		checkRegistered();
 		return this.entries.remove(entry);
 	}
@@ -336,12 +342,14 @@ public class TeamMock implements Team
 	@Override
 	public boolean removeEntities(@NotNull Collection<Entity> entities) throws IllegalStateException, IllegalArgumentException
 	{
+		Preconditions.checkNotNull(entities, "Entities cannot be null");
 		return removeEntries(entities.stream().map(entity -> ((EntityMock) entity).getScoreboardEntry()).toList());
 	}
 
 	@Override
 	public boolean removeEntries(@NotNull Collection<String> entries) throws IllegalStateException, IllegalArgumentException
 	{
+		Preconditions.checkNotNull(entries, "Entries cannot be null");
 		checkRegistered();
 		return this.entries.removeAll(entries);
 	}
@@ -361,27 +369,32 @@ public class TeamMock implements Team
 	@Deprecated
 	public boolean hasPlayer(@NotNull OfflinePlayer offlinePlayer)
 	{
+		Preconditions.checkNotNull(offlinePlayer, "OfflinePlayer cannot be null");
 		checkRegistered();
 		return this.entries.contains(offlinePlayer.getName());
 	}
 
 	@Override
-	public boolean hasEntry(String s)
+	public boolean hasEntry(@NotNull String entry)
 	{
+		Preconditions.checkNotNull(entry, "Entry cannot be null");
 		checkRegistered();
-		return this.entries.contains(s);
+		return this.entries.contains(entry);
 	}
 
 	@Override
-	public @NotNull OptionStatus getOption(Option option) throws IllegalStateException
+	public @NotNull OptionStatus getOption(@NotNull Option option) throws IllegalStateException
 	{
+		Preconditions.checkNotNull(option, "Option cannot be null");
 		checkRegistered();
 		return this.options.get(option);
 	}
 
 	@Override
-	public void setOption(Option option, OptionStatus optionStatus) throws IllegalStateException
+	public void setOption(@NotNull Option option, @NotNull OptionStatus optionStatus) throws IllegalStateException
 	{
+		Preconditions.checkNotNull(option, "Option cannot be null");
+		Preconditions.checkNotNull(optionStatus, "OptionStatus cannot be null");
 		checkRegistered();
 		this.options.put(option, optionStatus);
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/scoreboard/TeamMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scoreboard/TeamMock.java
@@ -98,6 +98,7 @@ public class TeamMock implements Team
 	@Override
 	public boolean hasColor()
 	{
+		checkRegistered();
 		return this.color.isColor();
 	}
 
@@ -269,6 +270,7 @@ public class TeamMock implements Team
 	@Override
 	public @NotNull Set<String> getEntries() throws IllegalStateException
 	{
+		checkRegistered();
 		return this.entries;
 	}
 
@@ -402,6 +404,7 @@ public class TeamMock implements Team
 	public boolean hasEntity(@NotNull Entity entity) throws IllegalStateException, IllegalArgumentException
 	{
 		Preconditions.checkNotNull(entity, "Entity cannot be null");
+		checkRegistered();
 		return this.entries.contains(((EntityMock) entity).getScoreboardEntry());
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/scoreboard/TeamMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scoreboard/TeamMock.java
@@ -426,10 +426,9 @@ public class TeamMock implements Team
 	 */
 	public void checkRegistered()
 	{
-		if (this.board == null)
-		{
-			throw new IllegalStateException("Team not registered");
-		}
+		if (this.board != null)
+			return;
+		throw new IllegalStateException("Team not registered");
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/scoreboard/TeamMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scoreboard/TeamMock.java
@@ -1,10 +1,12 @@
 package be.seeseemelk.mockbukkit.scoreboard;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import be.seeseemelk.mockbukkit.entity.EntityMock;
+import com.google.common.base.Preconditions;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Entity;
@@ -17,6 +19,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Level;
 
@@ -24,10 +27,10 @@ public class TeamMock implements Team
 {
 
 	private final String name;
-	private String displayName;
-	private String prefix;
-	private String suffix;
-	private ChatColor color;
+	private Component displayName;
+	private Component prefix = Component.empty();
+	private Component suffix = Component.empty();
+	private ChatColor color = ChatColor.RESET;
 	private boolean allowFriendlyFire = false;
 	private final @NotNull HashSet<String> entries;
 	private boolean canSeeFriendly = true;
@@ -37,6 +40,7 @@ public class TeamMock implements Team
 	public TeamMock(String name, ScoreboardMock board)
 	{
 		this.name = name;
+		this.displayName = Component.text(name);
 		this.board = board;
 		this.entries = new HashSet<>();
 		this.options.put(Option.NAME_TAG_VISIBILITY, OptionStatus.ALWAYS);
@@ -52,107 +56,111 @@ public class TeamMock implements Team
 	@Override
 	public @NotNull Component displayName() throws IllegalStateException
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public void displayName(@Nullable Component displayName) throws IllegalStateException, IllegalArgumentException
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public @NotNull Component prefix() throws IllegalStateException
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public void prefix(@Nullable Component prefix) throws IllegalStateException, IllegalArgumentException
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public @NotNull Component suffix() throws IllegalStateException
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public void suffix(@Nullable Component suffix) throws IllegalStateException, IllegalArgumentException
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public boolean hasColor()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public @NotNull TextColor color() throws IllegalStateException
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public void color(@Nullable NamedTextColor color)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public @NotNull String getDisplayName() throws IllegalStateException
-	{
 		checkRegistered();
 		return this.displayName;
 	}
 
 	@Override
-	public void setDisplayName(String s)
+	public void displayName(@Nullable Component displayName) throws IllegalStateException, IllegalArgumentException
 	{
 		checkRegistered();
-		this.displayName = s;
+		this.displayName = displayName == null ? Component.empty() : displayName;
 	}
 
 	@Override
-	public @NotNull String getPrefix() throws IllegalStateException
+	public @NotNull Component prefix() throws IllegalStateException
 	{
 		checkRegistered();
 		return this.prefix;
 	}
 
 	@Override
-	public void setPrefix(String s)
+	public void prefix(@Nullable Component prefix) throws IllegalStateException, IllegalArgumentException
 	{
 		checkRegistered();
-
-		this.prefix = s;
+		this.prefix = prefix == null ? Component.empty() : prefix;
 	}
 
 	@Override
-	public @NotNull String getSuffix() throws IllegalStateException
+	public @NotNull Component suffix() throws IllegalStateException
 	{
 		checkRegistered();
 		return this.suffix;
 	}
 
 	@Override
-	public void setSuffix(String s)
+	public void suffix(@Nullable Component suffix) throws IllegalStateException, IllegalArgumentException
 	{
 		checkRegistered();
-		this.suffix = s;
+		this.prefix = suffix == null ? Component.empty() : suffix;
+	}
+
+	@Override
+	public boolean hasColor()
+	{
+		return this.color.isColor();
+	}
+
+	@Override
+	public @NotNull TextColor color() throws IllegalStateException
+	{
+		if (!hasColor())
+		{
+			throw new IllegalStateException("Team colors must have hex values");
+		}
+		return TextColor.color(this.color.asBungee().getColor().getRGB());
+	}
+
+	@Override
+	public void color(@Nullable NamedTextColor color)
+	{
+		checkRegistered();
+		this.color = color == null ? ChatColor.RESET : ChatColor.valueOf(color.toString().toUpperCase(Locale.ROOT));
+	}
+
+	@Override
+	public @NotNull String getDisplayName() throws IllegalStateException
+	{
+		checkRegistered();
+		return LegacyComponentSerializer.legacySection().serialize(this.displayName);
+	}
+
+	@Override
+	public void setDisplayName(@NotNull String displayName)
+	{
+		Preconditions.checkNotNull(displayName, "Display name cannot be null");
+		checkRegistered();
+		this.displayName = LegacyComponentSerializer.legacySection().deserialize(displayName);
+	}
+
+	@Override
+	public @NotNull String getPrefix() throws IllegalStateException
+	{
+		checkRegistered();
+		return LegacyComponentSerializer.legacySection().serialize(this.prefix);
+	}
+
+	@Override
+	public void setPrefix(@NotNull String prefix)
+	{
+		Preconditions.checkNotNull(prefix, "Prefix cannot be null");
+		checkRegistered();
+		this.prefix = LegacyComponentSerializer.legacySection().deserialize(prefix);
+	}
+
+	@Override
+	public @NotNull String getSuffix() throws IllegalStateException
+	{
+		checkRegistered();
+		return LegacyComponentSerializer.legacySection().serialize(this.suffix);
+	}
+
+	@Override
+	public void setSuffix(@NotNull String suffix)
+	{
+		Preconditions.checkNotNull(suffix, "Suffix cannot be null");
+		checkRegistered();
+		this.suffix = LegacyComponentSerializer.legacySection().deserialize(suffix);
 	}
 
 	@Override
@@ -163,8 +171,9 @@ public class TeamMock implements Team
 	}
 
 	@Override
-	public void setColor(ChatColor chatColor)
+	public void setColor(@NotNull ChatColor chatColor)
 	{
+		Preconditions.checkNotNull(chatColor, "Color cannot be null");
 		checkRegistered();
 		this.color = chatColor;
 	}
@@ -285,24 +294,23 @@ public class TeamMock implements Team
 	}
 
 	@Override
-	public void addEntry(String s)
+	public void addEntry(@NotNull String entry)
 	{
 		checkRegistered();
-		this.entries.add(s);
+		this.entries.add(entry);
 	}
 
 	@Override
 	public void addEntities(@NotNull Collection<Entity> entities) throws IllegalStateException, IllegalArgumentException
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		addEntries(entities.stream().map(entity -> ((EntityMock) entity).getScoreboardEntry()).toList());
 	}
 
 	@Override
 	public void addEntries(@NotNull Collection<String> entries) throws IllegalStateException, IllegalArgumentException
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		checkRegistered();
+		this.entries.addAll(entries);
 	}
 
 	/**
@@ -317,24 +325,23 @@ public class TeamMock implements Team
 	}
 
 	@Override
-	public boolean removeEntry(String s)
+	public boolean removeEntry(@NotNull String entry)
 	{
 		checkRegistered();
-		return this.entries.remove(s);
+		return this.entries.remove(entry);
 	}
 
 	@Override
 	public boolean removeEntities(@NotNull Collection<Entity> entities) throws IllegalStateException, IllegalArgumentException
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return removeEntries(entities.stream().map(entity -> ((EntityMock) entity).getScoreboardEntry()).toList());
 	}
 
 	@Override
 	public boolean removeEntries(@NotNull Collection<String> entries) throws IllegalStateException, IllegalArgumentException
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		checkRegistered();
+		return this.entries.removeAll(entries);
 	}
 
 	@Override
@@ -380,22 +387,22 @@ public class TeamMock implements Team
 	@Override
 	public void addEntity(@NotNull Entity entity) throws IllegalStateException, IllegalArgumentException
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkNotNull(entity, "Entity cannot be null");
+		addEntry(((EntityMock) entity).getScoreboardEntry());
 	}
 
 	@Override
 	public boolean removeEntity(@NotNull Entity entity) throws IllegalStateException, IllegalArgumentException
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkNotNull(entity, "Entity cannot be null");
+		return removeEntry(((EntityMock) entity).getScoreboardEntry());
 	}
 
 	@Override
 	public boolean hasEntity(@NotNull Entity entity) throws IllegalStateException, IllegalArgumentException
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkNotNull(entity, "Entity cannot be null");
+		return this.entries.contains(((EntityMock) entity).getScoreboardEntry());
 	}
 
 	/**

--- a/src/main/java/be/seeseemelk/mockbukkit/scoreboard/TeamMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scoreboard/TeamMock.java
@@ -127,6 +127,7 @@ public class TeamMock implements Team
 	public void setDisplayName(@NotNull String displayName)
 	{
 		Preconditions.checkNotNull(displayName, "Display name cannot be null");
+		Preconditions.checkArgument(ChatColor.stripColor(displayName).length() <= 128, "Display name is longer than the limit of 128 characters");
 		checkRegistered();
 		this.displayName = LegacyComponentSerializer.legacySection().deserialize(displayName);
 	}
@@ -142,6 +143,7 @@ public class TeamMock implements Team
 	public void setPrefix(@NotNull String prefix)
 	{
 		Preconditions.checkNotNull(prefix, "Prefix cannot be null");
+		Preconditions.checkArgument(ChatColor.stripColor(prefix).length() <= 64, "Prefix is longer than the limit of 64 characters");
 		checkRegistered();
 		this.prefix = LegacyComponentSerializer.legacySection().deserialize(prefix);
 	}
@@ -157,6 +159,7 @@ public class TeamMock implements Team
 	public void setSuffix(@NotNull String suffix)
 	{
 		Preconditions.checkNotNull(suffix, "Suffix cannot be null");
+		Preconditions.checkArgument(ChatColor.stripColor(suffix).length() <= 64, "Suffix is longer than the limit of 64 characters");
 		checkRegistered();
 		this.suffix = LegacyComponentSerializer.legacySection().deserialize(suffix);
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/scoreboard/TeamMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scoreboard/TeamMock.java
@@ -105,10 +105,7 @@ public class TeamMock implements Team
 	@Override
 	public @NotNull TextColor color() throws IllegalStateException
 	{
-		if (!hasColor())
-		{
-			throw new IllegalStateException("Team colors must have hex values");
-		}
+		Preconditions.checkState(hasColor(), "Team colors must have hex values");
 		return TextColor.color(this.color.asBungee().getColor().getRGB());
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -63,6 +63,8 @@ import org.bukkit.map.MapRenderer;
 import org.bukkit.map.MapView;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.scoreboard.ScoreboardManager;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -1538,6 +1540,16 @@ class PlayerMockTest
 		{
 			player.spawnParticle(Particle.ITEM_CRACK, loc, 1, wrongObj);
 		});
+	}
+
+	@Test
+	void setScoreboard()
+	{
+		ScoreboardManager manager = server.getScoreboardManager();
+		assertSame(manager.getMainScoreboard(), player.getScoreboard());
+		Scoreboard customScoreboard = manager.getNewScoreboard();
+		player.setScoreboard(customScoreboard);
+		assertSame(customScoreboard, player.getScoreboard());
 	}
 
 	@Test


### PR DESCRIPTION
# Description
This PR completes the implementation of the `Team` interface. The display name, prefix and suffix can now be defined with components, and the color with Adventure's `NamedTextColor`. The color still uses the `ChatColor` type so that the `Team#setColor(ChatColor)` method works as before (a `ChatColor` is not necessarily a `TextColor`).

Some tests have been changed since they except to have a `null` display name by default, although the method has a `@NotNull` annotation.

The implementation of methods that accept an entity as team entry is based on the [implementation of Paper](https://github.com/PaperMC/Paper/blob/37afe987d9fff5af72ea6f16807aa271fe70fbf1/patches/server/0812-Improve-scoreboard-entries.patch).

Lastly, the `Player#setScoreboard` method has been implemented.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
