### PR TITLE
Fire teleportation events when teleporting an entity

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -214,7 +214,13 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	public void setLocation(@NotNull Location location)
 	{
 		Preconditions.checkNotNull(location, "Location cannot be null");
-		this.location = location;
+		// An entity can be teleported to a null world, i.e. the current world.
+		Location position = location.clone();
+		if (position.getWorld() == null)
+		{
+			position.setWorld(getWorld());
+		}
+		this.location = position;
 	}
 
 	@Override
@@ -266,8 +272,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	@Override
 	public boolean teleport(@NotNull Location location, @NotNull TeleportCause cause)
 	{
-		Preconditions.checkNotNull(location, "Location cannot be null");
-		Preconditions.checkNotNull(location.getWorld(), "World cannot be null");
+		Preconditions.checkNotNull(location, "Location cannot be null"); // The world can be null if it's not a player
 		location.checkFinite();
 		if (this.removed)
 		{
@@ -287,7 +292,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 
 	protected void teleportWithoutEvent(@NotNull Location location, @NotNull TeleportCause cause)
 	{
-		this.location = location.clone();
+		setLocation(location);
 		this.teleported = true;
 		this.teleportCause = cause;
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -278,7 +278,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 		{
 			return false;
 		}
-
+		//todo: Add passenger logic
 		EntityTeleportEvent event = new EntityTeleportEvent(this, getLocation(), location);
 		if (event.callEvent())
 		{

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -278,7 +278,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 		{
 			return false;
 		}
-		//todo: Add passenger logic
+		//todo: Add passenger logic: don't teleport if it's a vehicle / dismount from the current vehicle if it's a passenger
 		EntityTeleportEvent event = new EntityTeleportEvent(this, getLocation(), location);
 		if (event.callEvent())
 		{

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/HumanEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/HumanEntityMock.java
@@ -77,9 +77,15 @@ public abstract class HumanEntityMock extends LivingEntityMock implements HumanE
 	@Override
 	public void closeInventory()
 	{
+		closeInventory(InventoryCloseEvent.Reason.UNKNOWN);
+	}
+
+	@Override
+	public void closeInventory(InventoryCloseEvent.@NotNull Reason reason)
+	{
 		if (inventoryView instanceof PlayerInventoryViewMock)
 		{
-			new InventoryCloseEvent(inventoryView).callEvent();
+			new InventoryCloseEvent(inventoryView, reason).callEvent();
 
 			if (inventoryView.getTopInventory() instanceof InventoryMock inventoryMock)
 			{

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -32,6 +32,7 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityToggleSwimEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
@@ -560,6 +561,16 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	{
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public boolean teleport(@NotNull Location location, PlayerTeleportEvent.@NotNull TeleportCause cause)
+	{
+		if (isDead())
+		{
+			return false;
+		}
+		return super.teleport(location, cause);
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -2750,7 +2750,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 		{
 			return false;
 		}
-
+		//todo: Add passenger logic
 		PlayerTeleportEvent playerTeleportEvent = new PlayerTeleportEvent(this, getLocation(), location, cause);
 		Bukkit.getPluginManager().callEvent(playerTeleportEvent);
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -480,14 +480,6 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 		return MockBukkit.getMock().getBanList(BanList.Type.NAME).isBanned(getName());
 	}
 
-
-	@Override
-	public void closeInventory(InventoryCloseEvent.@NotNull Reason reason)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
 	/**
 	 * This method is an assertion for the currently open {@link InventoryView} for this {@link Player}. The
 	 * {@link Predicate} refers to the top inventory, not the {@link PlayerInventory}. It uses the method
@@ -2755,6 +2747,11 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 		if (!playerTeleportEvent.callEvent())
 		{
 			return false;
+		}
+
+		if (getOpenInventory().getType() != InventoryType.CRAFTING)
+		{
+			closeInventory(InventoryCloseEvent.Reason.TELEPORT);
 		}
 
 		World previousWorld = getWorld();

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -2742,20 +2742,24 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 		{
 			return false;
 		}
-		//todo: Add passenger logic
-		PlayerTeleportEvent playerTeleportEvent = new PlayerTeleportEvent(this, getLocation(), location, cause);
-		if (!playerTeleportEvent.callEvent())
+		//todo: Add passenger logic: don't teleport if it's a vehicle / dismount from the current vehicle if it's a passenger
+
+		PlayerTeleportEvent event = new PlayerTeleportEvent(this, getLocation(), location, cause);
+		if (!event.callEvent())
 		{
 			return false;
 		}
 
+		// Close any foreign inventory
 		if (getOpenInventory().getType() != InventoryType.CRAFTING)
 		{
 			closeInventory(InventoryCloseEvent.Reason.TELEPORT);
 		}
 
 		World previousWorld = getWorld();
-		teleportWithoutEvent(playerTeleportEvent.getTo(), cause);
+		teleportWithoutEvent(event.getTo(), cause);
+
+		// Detect player dimension change
 		if (!location.getWorld().equals(previousWorld))
 		{
 			new PlayerChangedWorldEvent(this, previousWorld).callEvent();

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -2752,9 +2752,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 		}
 		//todo: Add passenger logic
 		PlayerTeleportEvent playerTeleportEvent = new PlayerTeleportEvent(this, getLocation(), location, cause);
-		Bukkit.getPluginManager().callEvent(playerTeleportEvent);
-
-		if (playerTeleportEvent.isCancelled())
+		if (!playerTeleportEvent.callEvent())
 		{
 			return false;
 		}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -2754,7 +2754,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 		}
 
 		World previousWorld = getWorld();
-		super.teleport(playerTeleportEvent.getTo(), cause);
+		teleportWithoutEvent(playerTeleportEvent.getTo(), cause);
 		if (!location.getWorld().equals(previousWorld))
 		{
 			new PlayerChangedWorldEvent(this, previousWorld).callEvent();

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
@@ -3,6 +3,7 @@ package be.seeseemelk.mockbukkit.entity;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.MockPlugin;
 import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.TestPlugin;
 import be.seeseemelk.mockbukkit.WorldMock;
 import org.bukkit.EntityEffect;
 import org.bukkit.GameMode;
@@ -14,7 +15,10 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Mob;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityTeleportEvent;
 import org.bukkit.event.entity.EntityToggleSwimEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.metadata.FixedMetadataValue;
@@ -23,6 +27,7 @@ import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.permissions.PermissionAttachmentInfo;
 import org.bukkit.permissions.PermissionDefault;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -155,6 +160,80 @@ class EntityMockTest
 		entity2.teleport(location);
 		entity.teleport(entity2);
 		entity.assertTeleported(location, 0);
+	}
+
+	@Test
+	void teleport_RaiseEvent()
+	{
+		entity.teleport(entity.getLocation().add(10, 0, 5));
+		server.getPluginManager().assertEventFired(EntityTeleportEvent.class);
+	}
+
+	@Test
+	void teleport_Removed()
+	{
+		entity.remove();
+		Location from = entity.getLocation();
+		Location to = entity.getLocation().add(0, 5, 0);
+		assertFalse(entity.teleport(to));
+		assertEquals(from, entity.getLocation());
+	}
+
+	@Test
+	void teleport_Dead()
+	{
+		LivingEntity zombie = (LivingEntity) world.spawnEntity(new Location(world, 10, 10, 10), EntityType.ZOMBIE);
+		zombie.setHealth(0D);
+		Location from = zombie.getLocation();
+		Location to = zombie.getLocation().add(0, 5, 0);
+		assertFalse(zombie.teleport(to));
+		assertEquals(from, zombie.getLocation());
+	}
+
+	@Test
+	void teleport_CancelEvent()
+	{
+		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
+		Location from = entity.getLocation();
+		Location to = entity.getLocation().add(0, 5, 0);
+		server.getPluginManager().registerEvents(new Listener()
+		{
+			@EventHandler
+			public void onPlayerTeleport(@NotNull EntityTeleportEvent event)
+			{
+				event.setCancelled(true);
+			}
+		}, plugin);
+		assertFalse(entity.teleport(to));
+		assertEquals(from, entity.getLocation());
+	}
+
+	@Test
+	void teleport_ChangeDestinationInEvent()
+	{
+		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
+		Location changedTo = entity.getLocation().set(60, 90, -150);
+		server.getPluginManager().registerEvents(new Listener()
+		{
+			@EventHandler
+			public void onEntityTeleport(@NotNull EntityTeleportEvent event)
+			{
+				event.setTo(new Location(event.getTo().getWorld(), 60, 90, -150));
+			}
+		}, plugin);
+		assertTrue(entity.teleport(entity.getLocation().add(0, 0, 20)));
+		assertEquals(changedTo, entity.getLocation());
+	}
+
+	@Test
+	void teleport_LocationIsCloned()
+	{
+		Location to = entity.getLocation().add(40, 750, 10);
+		Location mutableTo = to.clone();
+		entity.teleport(mutableTo);
+		mutableTo.set(0, 0, 0);
+		assertNotSame(mutableTo, entity.getLocation());
+		assertEquals(to, entity.getLocation());
 	}
 
 	@Test

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
@@ -237,6 +237,17 @@ class EntityMockTest
 	}
 
 	@Test
+	void teleport_UseCurrentWorldInsteadOfNull()
+	{
+		Location to = new Location(null, 50, 200, 80);
+		assertTrue(entity.teleport(to));
+		assertEquals(world, entity.getWorld());
+		to = to.clone();
+		to.setWorld(world);
+		assertEquals(to, entity.getLocation());
+	}
+
+	@Test
 	void hasTeleport_Teleportation_CorrectStatus()
 	{
 		assertFalse(entity.hasTeleported());

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -1382,7 +1382,7 @@ class PlayerMockTest
 			@EventHandler
 			public void onChangedWorld(@NotNull PlayerChangedWorldEvent event)
 			{
-				assertSame(to, event.getPlayer().getLocation(), "The location should already have changed when the PlayerChangedWorldEvent is fired");
+				assertEquals(to, event.getPlayer().getLocation(), "The location should already have changed when the PlayerChangedWorldEvent is fired");
 			}
 		}, plugin);
 		player.teleport(to);

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -38,11 +38,13 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockDamageEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityTeleportEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerExpChangeEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerLevelChangeEvent;
@@ -1352,9 +1354,12 @@ class PlayerMockTest
 	@Test
 	void testPlayerTeleport_WithCause_EventFired()
 	{
-		player.teleport(player.getLocation().add(10, 10, 10), PlayerTeleportEvent.TeleportCause.CHORUS_FRUIT);
+		Location from = player.getLocation();
+		Location to = player.getLocation().add(10, 10, 10);
+		player.teleport(to, PlayerTeleportEvent.TeleportCause.CHORUS_FRUIT);
 
-		server.getPluginManager().assertEventFired(PlayerTeleportEvent.class);
+		server.getPluginManager().assertEventFired(PlayerTeleportEvent.class, event -> from.equals(event.getFrom()) && to.equals(event.getTo()));
+		server.getPluginManager().assertEventNotFired(EntityTeleportEvent.class);
 	}
 
 	@Test
@@ -1363,6 +1368,27 @@ class PlayerMockTest
 		player.teleport(player.getLocation().add(10, 10, 10));
 
 		server.getPluginManager().assertEventFired(PlayerTeleportEvent.class);
+		server.getPluginManager().assertEventNotFired(EntityTeleportEvent.class);
+	}
+
+	@Test
+	void testPlayerTeleport_ChangedWorldEvent()
+	{
+		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
+		World from = player.getWorld();
+		World[] playerWorldWhenEvent = new World[1];
+		server.getPluginManager().registerEvents(new Listener()
+		{
+			@EventHandler
+			public void onChangedWorld(@NotNull PlayerChangedWorldEvent event)
+			{
+				playerWorldWhenEvent[0] = event.getPlayer().getWorld();
+			}
+		}, plugin);
+		player.teleport(new Location(new WorldMock(), 0, 80, 0));
+		server.getPluginManager().assertEventFired(PlayerTeleportEvent.class);
+		server.getPluginManager().assertEventFired(PlayerChangedWorldEvent.class, event -> event.getFrom() == from);
+		assertSame(player.getWorld(), playerWorldWhenEvent[0], "The world should already have changed when the PlayerChangedWorldEvent is fired");
 	}
 
 	@Test
@@ -1394,6 +1420,23 @@ class PlayerMockTest
 		player.assertNotTeleported();
 		player.assertLocation(originalLocation, 0);
 
+	}
+
+	@Test
+	void testTeleport_ChangeDestinationInEvent()
+	{
+		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
+		Location changedTo = player.getLocation().set(60, 90, -150);
+		server.getPluginManager().registerEvents(new Listener()
+		{
+			@EventHandler
+			public void onPlayerTeleport(@NotNull PlayerTeleportEvent event)
+			{
+				event.setTo(new Location(event.getTo().getWorld(), 60, 90, -150));
+			}
+		}, plugin);
+		assertTrue(player.teleport(player.getLocation().add(0, 0, 20)));
+		assertEquals(changedTo, player.getLocation());
 	}
 
 	@Test

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -1376,19 +1376,18 @@ class PlayerMockTest
 	{
 		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
 		World from = player.getWorld();
-		World[] playerWorldWhenEvent = new World[1];
+		Location to = new Location(new WorldMock(), 0, 80, 0);
 		server.getPluginManager().registerEvents(new Listener()
 		{
 			@EventHandler
 			public void onChangedWorld(@NotNull PlayerChangedWorldEvent event)
 			{
-				playerWorldWhenEvent[0] = event.getPlayer().getWorld();
+				assertSame(to, event.getPlayer().getLocation(), "The location should already have changed when the PlayerChangedWorldEvent is fired");
 			}
 		}, plugin);
-		player.teleport(new Location(new WorldMock(), 0, 80, 0));
+		player.teleport(to);
 		server.getPluginManager().assertEventFired(PlayerTeleportEvent.class);
 		server.getPluginManager().assertEventFired(PlayerChangedWorldEvent.class, event -> event.getFrom() == from);
-		assertSame(player.getWorld(), playerWorldWhenEvent[0], "The world should already have changed when the PlayerChangedWorldEvent is fired");
 	}
 
 	@Test

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -1439,6 +1439,26 @@ class PlayerMockTest
 	}
 
 	@Test
+	void testTeleport_CloseInventory()
+	{
+		Inventory inventory = Bukkit.createInventory(null, 9);
+		player.openInventory(inventory);
+		assertTrue(player.teleport(player.getLocation().add(8, 9, 10)));
+		assertEquals(InventoryType.CRAFTING, player.getOpenInventory().getType());
+		server.getPluginManager().assertEventFired(InventoryCloseEvent.class, e -> e.getReason() == InventoryCloseEvent.Reason.TELEPORT);
+	}
+
+	@Test
+	void testTeleport_DontCloseCraftingInventory()
+	{
+		ItemStack itemStack = new ItemStack(Material.DEEPSLATE);
+		player.getOpenInventory().setCursor(itemStack);
+		assertTrue(player.teleport(player.getLocation().add(0, 10, 0)));
+		assertEquals(itemStack, player.getOpenInventory().getCursor());
+		server.getPluginManager().assertEventNotFired(InventoryCloseEvent.class);
+	}
+
+	@Test
 	void testPlayerSendSignChange_Valid()
 	{
 		assertDoesNotThrow(() ->


### PR DESCRIPTION
# Description
The `Entity#teleport` method now fires the `EntityTeleportEvent` if it's not a player. If it's a player who goes to another dimension, this method will also fire the `PlayerChangedWorldEvent` afterward.

Some preconditions have been added, namely for non-nullable arguments. Some checks prevent weird states, like if the entity is removed or dead.

The `Entity#teleport` method now also makes a defensive copy of the location to prevent external mutations. The entity is the only owner of this location.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing (local) code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
