### PR TITLE
Fix inconsistent BlockState constructor visibility

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BrewingStandMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BrewingStandMock.java
@@ -15,7 +15,7 @@ public class BrewingStandMock extends ContainerMock implements BrewingStand
 	private int brewingTime;
 	private int fuelLevel;
 
-	protected BrewingStandMock(@NotNull Material material)
+	public BrewingStandMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.BREWING_STAND);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/CommandBlockMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/CommandBlockMock.java
@@ -15,7 +15,7 @@ public class CommandBlockMock extends TileStateMock implements CommandBlock, Com
 	private Component name;
 	private String command;
 
-	protected CommandBlockMock(@NotNull Material material)
+	public CommandBlockMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.COMMAND_BLOCK, Material.REPEATING_COMMAND_BLOCK, Material.CHAIN_COMMAND_BLOCK);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ComparatorMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ComparatorMock.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
 public class ComparatorMock extends TileStateMock implements Comparator
 {
 
-	protected ComparatorMock(@NotNull Material material)
+	public ComparatorMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.COMPARATOR);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ConduitMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ConduitMock.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
 public class ConduitMock extends TileStateMock implements Conduit
 {
 
-	protected ConduitMock(@NotNull Material material)
+	public ConduitMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.CONDUIT);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/CreatureSpawnerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/CreatureSpawnerMock.java
@@ -23,7 +23,7 @@ public class CreatureSpawnerMock extends TileStateMock implements CreatureSpawne
 	private int requiredPlayerRange = 16;
 	private int spawnRange = 4;
 
-	protected CreatureSpawnerMock(@NotNull Material material)
+	public CreatureSpawnerMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.SPAWNER);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/DaylightDetectorMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/DaylightDetectorMock.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
 public class DaylightDetectorMock extends TileStateMock implements DaylightDetector
 {
 
-	protected DaylightDetectorMock(@NotNull Material material)
+	public DaylightDetectorMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.DAYLIGHT_DETECTOR);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/EnchantingTableMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/EnchantingTableMock.java
@@ -14,7 +14,7 @@ public class EnchantingTableMock extends TileStateMock implements EnchantingTabl
 
 	private Component customName;
 
-	protected EnchantingTableMock(@NotNull Material material)
+	public EnchantingTableMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.ENCHANTING_TABLE);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/JigsawMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/JigsawMock.java
@@ -15,13 +15,13 @@ public class JigsawMock extends TileStateMock implements Jigsaw
 		checkType(material, Material.JIGSAW);
 	}
 
-	public JigsawMock(@NotNull Block block)
+	protected JigsawMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.JIGSAW);
 	}
 
-	public JigsawMock(@NotNull TileStateMock state)
+	protected JigsawMock(@NotNull JigsawMock state)
 	{
 		super(state);
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/JukeboxMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/JukeboxMock.java
@@ -21,14 +21,14 @@ public class JukeboxMock extends TileStateMock implements Jukebox
 		setRecord(null);
 	}
 
-	public JukeboxMock(@NotNull Block block)
+	protected JukeboxMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.JUKEBOX);
 		setRecord(null);
 	}
 
-	public JukeboxMock(@NotNull JukeboxMock state)
+	protected JukeboxMock(@NotNull JukeboxMock state)
 	{
 		super(state);
 		this.recordItem = state.recordItem;


### PR DESCRIPTION
# Description
Fixes some BlockState mocks having all public or all protected constructors and sets them all to the proper visibility.

# Checklist
The following items should be checked before the pull request can be merged.
- [ ] Unit tests added.
- [x] Code follows existing code format.