### PR TITLE
Fix #assertSaid working with strings instead of components

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/command/ConsoleCommandSenderMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/command/ConsoleCommandSenderMock.java
@@ -23,7 +23,7 @@ import java.util.UUID;
 public class ConsoleCommandSenderMock implements ConsoleCommandSender, MessageTarget
 {
 
-	private final Queue<String> messages = new LinkedList<>();
+	private final Queue<Component> messages = new LinkedList<>();
 
 	@Override
 	public void sendMessage(@NotNull String message)
@@ -55,15 +55,11 @@ public class ConsoleCommandSenderMock implements ConsoleCommandSender, MessageTa
 	@Override
 	public @Nullable Component nextComponentMessage()
 	{
-		if (messages.peek() == null)
-		{
-			return null;
-		}
-		return LegacyComponentSerializer.legacySection().deserialize(messages.poll());
+		return messages.poll();
 	}
 
 	@Override
-	public boolean isPermissionSet(String name)
+	public boolean isPermissionSet(@NotNull String name)
 	{
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
@@ -209,7 +205,7 @@ public class ConsoleCommandSenderMock implements ConsoleCommandSender, MessageTa
 	public void sendRawMessage(@Nullable UUID sender, @NotNull String message)
 	{
 		Preconditions.checkNotNull(message, "Message cannot be null");
-		messages.add(message);
+		messages.add(LegacyComponentSerializer.legacySection().deserialize(message));
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/command/ConsoleCommandSenderMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/command/ConsoleCommandSenderMock.java
@@ -3,6 +3,7 @@ package be.seeseemelk.mockbukkit.command;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import com.google.common.base.Preconditions;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Server;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.conversations.Conversation;
@@ -27,24 +28,11 @@ public class ConsoleCommandSenderMock implements ConsoleCommandSender, MessageTa
 	@Override
 	public void sendMessage(@NotNull String message)
 	{
-		sendMessage(null, message);
+		sendRawMessage(message);
 	}
 
 	@Override
 	public void sendMessage(String... messages)
-	{
-		sendMessage(null, messages);
-	}
-
-	@Override
-	public void sendMessage(UUID sender, @NotNull String message)
-	{
-		Preconditions.checkNotNull(message, "Message cannot be null");
-		messages.add(message);
-	}
-
-	@Override
-	public void sendMessage(UUID sender, String @NotNull ... messages)
 	{
 		for (String message : messages)
 		{
@@ -53,9 +41,25 @@ public class ConsoleCommandSenderMock implements ConsoleCommandSender, MessageTa
 	}
 
 	@Override
-	public @Nullable String nextMessage()
+	public void sendMessage(UUID sender, @NotNull String message)
 	{
-		return messages.poll();
+		sendRawMessage(message);
+	}
+
+	@Override
+	public void sendMessage(UUID sender, String @NotNull ... messages)
+	{
+		sendMessage(messages);
+	}
+
+	@Override
+	public @Nullable Component nextComponentMessage()
+	{
+		if (messages.peek() == null)
+		{
+			return null;
+		}
+		return LegacyComponentSerializer.legacySection().deserialize(messages.poll());
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/command/MessageTarget.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/command/MessageTarget.java
@@ -1,5 +1,7 @@
 package be.seeseemelk.mockbukkit.command;
 
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -15,7 +17,40 @@ public interface MessageTarget
 	 *
 	 * @return The next message sent to the target.
 	 */
-	@Nullable String nextMessage();
+	@Nullable Component nextComponentMessage();
+
+	/**
+	 * Returns the next message that was sent to the target.
+	 *
+	 * @return The next message sent to the target.
+	 */
+	default String nextMessage()
+	{
+		Component comp = nextComponentMessage();
+		if (comp == null)
+		{
+			return null;
+		}
+		return LegacyComponentSerializer.legacySection().serialize(comp);
+	}
+
+	/**
+	 * Asserts that a specific message was not received next by the message target.
+	 *
+	 * @param expected The message that should have been received by the target.
+	 */
+	default void assertSaid(@NotNull Component expected)
+	{
+		Component comp = nextComponentMessage();
+		if (comp == null)
+		{
+			fail("No more messages were sent");
+		}
+		else
+		{
+			assertEquals(expected, comp);
+		}
+	}
 
 	/**
 	 * Asserts that a specific message was not received next by the message target.
@@ -24,15 +59,7 @@ public interface MessageTarget
 	 */
 	default void assertSaid(@NotNull String expected)
 	{
-		String message = nextMessage();
-		if (message == null)
-		{
-			fail("No more messages were sent");
-		}
-		else
-		{
-			assertEquals(expected, message);
-		}
+		assertSaid(LegacyComponentSerializer.legacySection().deserialize(expected));
 	}
 
 	/**
@@ -40,7 +67,7 @@ public interface MessageTarget
 	 */
 	default void assertNoMoreSaid()
 	{
-		if (nextMessage() != null)
+		if (nextComponentMessage() != null)
 		{
 			fail("More messages were available");
 		}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -364,13 +364,6 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	}
 
 	@Override
-	public @Nullable String nextMessage()
-	{
-		if (messages.peek() == null)
-			return null;
-		return LegacyComponentSerializer.legacySection().serialize(messages.poll());
-	}
-
 	public @Nullable Component nextComponentMessage()
 	{
 		return messages.poll();

--- a/src/test/java/be/seeseemelk/mockbukkit/command/ConsoleCommandSenderMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/command/ConsoleCommandSenderMockTest.java
@@ -1,5 +1,9 @@
 package be.seeseemelk.mockbukkit.command;
 
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -85,6 +89,14 @@ class ConsoleCommandSenderMockTest
 	{
 		sender.sendMessage("Some message");
 		assertThrows(AssertionError.class, () -> sender.assertNoMoreSaid());
+	}
+
+	@Test
+	void sendMessage_StoredAsComponent()
+	{
+		TextComponent comp = Component.text().content("hi").color(TextColor.color(11141120)).build();
+		sender.sendMessage(comp);
+		sender.assertSaid(comp);
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
@@ -4,6 +4,12 @@ import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.MockPlugin;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.WorldMock;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.ChatColor;
 import org.bukkit.EntityEffect;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
@@ -215,6 +221,14 @@ class EntityMockTest
 		assertEquals("hello", entity.nextMessage());
 		assertEquals("my", entity.nextMessage());
 		assertEquals("world", entity.nextMessage());
+	}
+
+	@Test
+	void sendMessage_StoredAsComponent()
+	{
+		TextComponent comp = Component.text().content("hi").clickEvent(ClickEvent.openUrl("https://www.youtube.com/watch?v=dQw4w9WgXcQ")).build();
+		entity.sendMessage(comp);
+		entity.assertSaid(comp);
 	}
 
 	@Test


### PR DESCRIPTION
# Description
Fixes `MessageTarget#assertSaid` working mainly with Strings instead of Components possibly leading to unexpected behavior.

Closes #520.

# Checklist
The following items should be checked before the pull request can be merged.
- [ ] Unit tests added.
- [x] Code follows existing code format.