### PR TITLE
Fix exceptions from event handlers not failing tests

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/exception/EventHandlerException.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/exception/EventHandlerException.java
@@ -1,0 +1,14 @@
+package be.seeseemelk.mockbukkit.exception;
+
+/**
+ * Thrown when an event handler throws a non-{@link RuntimeException}
+ */
+public class EventHandlerException extends RuntimeException
+{
+
+	public EventHandlerException(Throwable cause)
+	{
+		super(cause);
+	}
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
@@ -2,6 +2,7 @@ package be.seeseemelk.mockbukkit.plugin;
 
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import be.seeseemelk.mockbukkit.exception.EventHandlerException;
 import be.seeseemelk.mockbukkit.scheduler.BukkitSchedulerMock;
 import com.destroystokyo.paper.event.server.ServerExceptionEvent;
 import com.destroystokyo.paper.exception.ServerEventException;
@@ -515,7 +516,7 @@ public class PluginManagerMock implements PluginManager
 			}
 			else
 			{
-				throw new RuntimeException(ex);
+				throw new EventHandlerException(ex);
 			}
 		}
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
@@ -17,7 +17,6 @@ import org.bukkit.event.server.PluginEnableEvent;
 import org.bukkit.permissions.Permissible;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
-import org.bukkit.plugin.AuthorNagException;
 import org.bukkit.plugin.EventExecutor;
 import org.bukkit.plugin.IllegalPluginAccessException;
 import org.bukkit.plugin.InvalidDescriptionException;
@@ -501,24 +500,16 @@ public class PluginManagerMock implements PluginManager
 		{
 			registration.callEvent(event);
 		}
-		catch (AuthorNagException ex)
-		{
-			Plugin plugin = registration.getPlugin();
-			if (plugin.isNaggable())
-			{
-				plugin.setNaggable(false);
-				server.getLogger().log(Level.SEVERE, String.format(
-						"Nag author(s): '%s' of '%s' about the following: %s",
-						plugin.getDescription().getAuthors(),
-						plugin.getDescription().getFullName(),
-						ex.getMessage()
-				));
-			}
-		}
 		catch (Throwable ex)
 		{
-			String msg = "Could not pass event " + event.getEventName() + " to " + registration.getPlugin().getDescription().getFullName();
-			server.getLogger().log(Level.SEVERE, msg, ex);
+			if (ex instanceof RuntimeException r)
+			{
+				throw r; // Rethrow same exception if possible
+			}
+			else
+			{
+				throw new RuntimeException(ex);
+			}
 		}
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
@@ -3,6 +3,8 @@ package be.seeseemelk.mockbukkit.plugin;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.scheduler.BukkitSchedulerMock;
+import com.destroystokyo.paper.event.server.ServerExceptionEvent;
+import com.destroystokyo.paper.exception.ServerEventException;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import org.bukkit.command.PluginCommand;
@@ -502,6 +504,11 @@ public class PluginManagerMock implements PluginManager
 		}
 		catch (Throwable ex)
 		{
+			if (!(event instanceof ServerExceptionEvent))
+			{ // Don't cause an endless loop
+				String msg = "Could not pass event " + event.getEventName() + " to " + registration.getPlugin().getDescription().getFullName();
+				callEvent(new ServerExceptionEvent(new ServerEventException(msg, ex, registration.getPlugin(), registration.getListener(), event)));
+			}
 			if (ex instanceof RuntimeException r)
 			{
 				throw r; // Rethrow same exception if possible

--- a/src/test/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMockTest.java
@@ -5,6 +5,8 @@ import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.TestPlugin;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.server.PluginDisableEvent;
@@ -19,12 +21,12 @@ import org.junit.jupiter.api.Test;
 import java.util.Collection;
 import java.util.Iterator;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PluginManagerMockTest
@@ -248,6 +250,34 @@ class PluginManagerMockTest
 		pluginManager.unsubscribeFromDefaultPerms(true, player);
 
 		assertFalse(pluginManager.getDefaultPermSubscriptions(true).contains(player));
+	}
+
+	@Test
+	void eventThrowsException_RuntimeException_RethrowsSame()
+	{
+		pluginManager.registerEvents(new Listener()
+		{
+			@EventHandler
+			public void event(BlockBreakEvent e)
+			{
+				throw new IllegalStateException();
+			}
+		}, MockBukkit.createMockPlugin());
+		assertThrowsExactly(IllegalStateException.class, () -> pluginManager.callEvent(new BlockBreakEvent(null, null)));
+	}
+
+	@Test
+	void eventThrowsException_NotRuntimeException_ThrowsRuntime()
+	{
+		pluginManager.registerEvents(new Listener()
+		{
+			@EventHandler
+			public void event(BlockBreakEvent e) throws Exception
+			{
+				throw new Exception();
+			}
+		}, MockBukkit.createMockPlugin());
+		assertThrowsExactly(RuntimeException.class, () -> pluginManager.callEvent(new BlockBreakEvent(null, null)));
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMockTest.java
@@ -3,6 +3,7 @@ package be.seeseemelk.mockbukkit.plugin;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.TestPlugin;
+import be.seeseemelk.mockbukkit.exception.EventHandlerException;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -267,7 +268,7 @@ class PluginManagerMockTest
 	}
 
 	@Test
-	void eventThrowsException_NotRuntimeException_ThrowsRuntime()
+	void eventThrowsException_NotRuntimeException_ThrowsEventHandlerException()
 	{
 		pluginManager.registerEvents(new Listener()
 		{
@@ -277,7 +278,7 @@ class PluginManagerMockTest
 				throw new Exception();
 			}
 		}, MockBukkit.createMockPlugin());
-		assertThrowsExactly(RuntimeException.class, () -> pluginManager.callEvent(new BlockBreakEvent(null, null)));
+		assertThrowsExactly(EventHandlerException.class, () -> pluginManager.callEvent(new BlockBreakEvent(null, null)));
 	}
 
 }


### PR DESCRIPTION
# Description
Fixes exceptions thrown from event handlers being caught and just printing a log message. RuntimeExceptions will now be rethrown, and others will be wrapped in a RuntimeException and rethrown.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.