### PR TITLE
Patch AsyncTask errors on BukkitSchedulerMock (v1.16)

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ gradle.ext.apiVersionFull = '1.16.5-R0.1-SNAPSHOT'
   Every new update should bump the version below according to
   the conventions.
 */
-gradle.ext.version = '1.5.2'
+gradle.ext.version = '1.5.3'
 
 /*
   This is the name of our MockBukkit artifact, it includes

--- a/src/main/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -1,10 +1,22 @@
 package be.seeseemelk.mockbukkit.scheduler;
 
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import org.apache.commons.lang.Validate;
+import org.bukkit.event.Event;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.scheduler.BukkitWorker;
+import org.jetbrains.annotations.NotNull;
+
 import java.util.ArrayList;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -15,26 +27,14 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.UnimplementedOperationException;
-
-import org.apache.commons.lang.Validate;
-import org.bukkit.event.Event;
-import org.bukkit.event.player.AsyncPlayerChatEvent;
-import org.bukkit.plugin.Plugin;
-import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.scheduler.BukkitScheduler;
-import org.bukkit.scheduler.BukkitTask;
-import org.bukkit.scheduler.BukkitWorker;
-import org.jetbrains.annotations.NotNull;
-
 public class BukkitSchedulerMock implements BukkitScheduler
 {
 	private static final String LOGGER_NAME = "BukkitSchedulerMock";
 	private final ThreadPoolExecutor pool = new ThreadPoolExecutor(0, Integer.MAX_VALUE,
-	        60L, TimeUnit.SECONDS,
-	        new SynchronousQueue<>());
+			60L, TimeUnit.SECONDS,
+			new SynchronousQueue<>());
 	private final ExecutorService asyncEventExecutor = Executors.newCachedThreadPool();
+	private final List<Future<?>> queuedAsyncEvents = new ArrayList<>();
 	private final TaskList scheduledTasks = new TaskList();
 	private final AtomicReference<Exception> asyncException = new AtomicReference<>();
 	private long currentTick = 0;
@@ -51,12 +51,15 @@ public class BukkitSchedulerMock implements BukkitScheduler
 		};
 	}
 
-
+	/**
+	 * Sets the maximum time to wait for async tasks to finish before terminating them.
+	 *
+	 * @param timeout The timeout in milliseconds.
+	 */
 	public void setShutdownTimeout(long timeout)
 	{
 		this.executorTimeout = timeout;
 	}
-
 
 	/**
 	 * Shuts the scheduler down. Note that this function will throw exception that where thrown by old asynchronous
@@ -65,18 +68,56 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	public void shutdown()
 	{
 		waitAsyncTasksFinished();
-		pool.shutdown();
+		shutdownPool(pool);
+
 		if (asyncException.get() != null)
 			throw new AsyncTaskException(asyncException.get());
-		asyncEventExecutor.shutdownNow();
+
+		waitAsyncEventsFinished();
+		shutdownPool(asyncEventExecutor);
+	}
+
+	/**
+	 * Shuts down the given executor service, waiting up to the shutdown timeout for all tasks to finish.
+	 *
+	 * @param pool The pool to shut down.
+	 * @see #setShutdownTimeout(long)
+	 */
+	private void shutdownPool(ExecutorService pool)
+	{
+		pool.shutdown();
+		try
+		{
+			if (!pool.awaitTermination(this.executorTimeout, TimeUnit.MILLISECONDS))
+			{
+				pool.shutdownNow();
+			}
+		}
+		catch (InterruptedException e)
+		{
+			pool.shutdownNow();
+			Thread.currentThread().interrupt();
+		}
 	}
 
 	public @NotNull Future<?> executeAsyncEvent(Event event)
 	{
-		Validate.notNull(event, "Cannot schedule an Event that is null!");
-		return asyncEventExecutor.submit(() -> MockBukkit.getMock().getPluginManager().callEvent(event));
+		return executeAsyncEvent(event, null);
 	}
 
+	public <T extends Event> @NotNull Future<?> executeAsyncEvent(T event, Consumer<T> func)
+	{
+		Validate.notNull(event, "Cannot call a null event!");
+		Future<?> future = asyncEventExecutor.submit(() -> {
+			MockBukkit.getMock().getPluginManager().callEvent(event);
+			if (func != null)
+			{
+				func.accept(event);
+			}
+		});
+		queuedAsyncEvents.add(future);
+		return future;
+	}
 
 	/**
 	 * Get the current tick of the server.
@@ -152,10 +193,19 @@ public class BukkitSchedulerMock implements BukkitScheduler
 
 	/**
 	 * Waits until all asynchronous tasks have finished executing. If you have an asynchronous task that runs
-	 * indefinitely, this function will never return.
+	 * indefinitely, this function will never return. Note that this will not wait for async events to finish.
 	 */
 	public void waitAsyncTasksFinished()
 	{
+		// Cancel repeating tasks so they don't run forever.
+		for (Map.Entry<Integer, ScheduledTask> entry : scheduledTasks.tasks.entrySet())
+		{
+			if (entry.getValue() instanceof RepeatingTask)
+			{
+				scheduledTasks.cancelTask(entry.getKey());
+			}
+		}
+
 		// Make sure all tasks get to execute. (except for repeating asynchronous tasks, they only will fire once)
 		while (scheduledTasks.getScheduledTaskCount() > 0)
 		{
@@ -177,9 +227,9 @@ public class BukkitSchedulerMock implements BukkitScheduler
 			}
 			if (System.currentTimeMillis() > (systemTime + executorTimeout))
 			{
-				// If a plugin has left a a runnable going and not cancelled it we could call this bad practice.
-				// we should now force interrupt all these runnables forcing them to throw Interrupted Exceptions.
-				// if they handle that
+				// If a plugin has left a runnable going and not cancelled it we could call this bad practice.
+				// We should force interrupt all these runnables, forcing them to throw Interrupted Exceptions
+				// if they handle that.
 				for (ScheduledTask task : scheduledTasks.getCurrentTaskList())
 				{
 					if (task.isRunning())
@@ -187,10 +237,37 @@ public class BukkitSchedulerMock implements BukkitScheduler
 						task.cancel();
 						cancelTask(task.getTaskId());
 						throw new RuntimeException("Forced Cancellation of task owned by "
-						                           + task.getOwner().getName());
+														   + task.getOwner().getName());
 					}
 				}
 				pool.shutdownNow();
+			}
+		}
+	}
+
+	public void waitAsyncEventsFinished()
+	{
+		for (Future<?> futureEvent : new ArrayList<>(queuedAsyncEvents))
+		{
+			if (futureEvent.isDone())
+			{
+				queuedAsyncEvents.remove(futureEvent);
+			}
+			else
+			{
+				try
+				{
+					queuedAsyncEvents.remove(futureEvent);
+					futureEvent.get();
+				}
+				catch (InterruptedException e)
+				{
+					Thread.currentThread().interrupt();
+				}
+				catch (ExecutionException e)
+				{
+					throw new RuntimeException(e);
+				}
 			}
 		}
 	}
@@ -202,6 +279,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	}
 
 	@Override
+	@Deprecated
 	public @NotNull BukkitTask runTask(@NotNull Plugin plugin, @NotNull BukkitRunnable task)
 	{
 		return runTask(plugin, (Runnable) task);
@@ -226,6 +304,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	}
 
 	@Override
+	@Deprecated
 	public @NotNull BukkitTask runTaskTimer(@NotNull Plugin plugin, @NotNull BukkitRunnable task, long delay, long period)
 	{
 		return runTaskTimer(plugin, (Runnable) task, delay, period);
@@ -239,6 +318,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	}
 
 	@Override
+	@Deprecated
 	public int scheduleSyncDelayedTask(@NotNull Plugin plugin, @NotNull BukkitRunnable task, long delay)
 	{
 		Logger.getLogger(LOGGER_NAME).warning("Consider using runTaskLater instead of scheduleSyncDelayTask");
@@ -253,6 +333,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	}
 
 	@Override
+	@Deprecated
 	public int scheduleSyncDelayedTask(@NotNull Plugin plugin, @NotNull BukkitRunnable task)
 	{
 		Logger.getLogger(LOGGER_NAME).warning("Consider using runTask instead of scheduleSyncDelayTask");
@@ -267,6 +348,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	}
 
 	@Override
+	@Deprecated
 	public int scheduleSyncRepeatingTask(@NotNull Plugin plugin, @NotNull BukkitRunnable task, long delay, long period)
 	{
 		Logger.getLogger(LOGGER_NAME).warning("Consider using runTaskTimer instead of scheduleSyncRepeatingTask");
@@ -274,26 +356,29 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	}
 
 	@Override
+	@Deprecated
 	public int scheduleAsyncDelayedTask(@NotNull Plugin plugin, @NotNull Runnable task, long delay)
 	{
 		Logger.getLogger(LOGGER_NAME)
-		.warning("Consider using runTaskLaterAsynchronously instead of scheduleAsyncDelayedTask");
+				.warning("Consider using runTaskLaterAsynchronously instead of scheduleAsyncDelayedTask");
 		return runTaskLaterAsynchronously(plugin, task, delay).getTaskId();
 	}
 
 	@Override
+	@Deprecated
 	public int scheduleAsyncDelayedTask(@NotNull Plugin plugin, @NotNull Runnable task)
 	{
 		Logger.getLogger(LOGGER_NAME)
-		.warning("Consider using runTaskAsynchronously instead of scheduleAsyncDelayedTask");
+				.warning("Consider using runTaskAsynchronously instead of scheduleAsyncDelayedTask");
 		return runTaskAsynchronously(plugin, task).getTaskId();
 	}
 
 	@Override
+	@Deprecated
 	public int scheduleAsyncRepeatingTask(@NotNull Plugin plugin, @NotNull Runnable task, long delay, long period)
 	{
 		Logger.getLogger(LOGGER_NAME)
-		.warning("Consider using runTaskTimerAsynchronously instead of scheduleAsyncRepeatingTask");
+				.warning("Consider using runTaskTimerAsynchronously instead of scheduleAsyncRepeatingTask");
 		return runTaskTimerAsynchronously(plugin, task, delay, period).getTaskId();
 	}
 
@@ -381,7 +466,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	public @NotNull BukkitTask runTaskLaterAsynchronously(@NotNull Plugin plugin, @NotNull Runnable task, long delay)
 	{
 		ScheduledTask scheduledTask = new ScheduledTask(id++, plugin, false, currentTick + delay,
-		        new AsyncRunnable(task));
+				new AsyncRunnable(task));
 		scheduledTasks.addTask(scheduledTask);
 		return scheduledTask;
 	}
@@ -396,7 +481,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	public @NotNull BukkitTask runTaskTimerAsynchronously(@NotNull Plugin plugin, @NotNull Runnable task, long delay, long period)
 	{
 		RepeatingTask scheduledTask = new RepeatingTask(id++, plugin, false, currentTick + delay, period,
-		        new AsyncRunnable(task));
+				new AsyncRunnable(task));
 		scheduledTasks.addTask(scheduledTask);
 		return scheduledTask;
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -73,7 +73,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 		if (asyncException.get() != null)
 		{
 			throw new AsyncTaskException(asyncException.get());
-        }
+		}
 
 		waitAsyncEventsFinished();
 		shutdownPool(asyncEventExecutor);

--- a/src/main/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -71,7 +71,9 @@ public class BukkitSchedulerMock implements BukkitScheduler
 		shutdownPool(pool);
 
 		if (asyncException.get() != null)
+		{
 			throw new AsyncTaskException(asyncException.get());
+        }
 
 		waitAsyncEventsFinished();
 		shutdownPool(asyncEventExecutor);

--- a/src/main/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -31,8 +31,8 @@ public class BukkitSchedulerMock implements BukkitScheduler
 {
 	private static final String LOGGER_NAME = "BukkitSchedulerMock";
 	private final ThreadPoolExecutor pool = new ThreadPoolExecutor(0, Integer.MAX_VALUE,
-			60L, TimeUnit.SECONDS,
-			new SynchronousQueue<>());
+	        60L, TimeUnit.SECONDS,
+	        new SynchronousQueue<>());
 	private final ExecutorService asyncEventExecutor = Executors.newCachedThreadPool();
 	private final List<Future<?>> queuedAsyncEvents = new ArrayList<>();
 	private final TaskList scheduledTasks = new TaskList();
@@ -108,7 +108,8 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	public <T extends Event> @NotNull Future<?> executeAsyncEvent(T event, Consumer<T> func)
 	{
 		Validate.notNull(event, "Cannot call a null event!");
-		Future<?> future = asyncEventExecutor.submit(() -> {
+		Future<?> future = asyncEventExecutor.submit(() ->
+		{
 			MockBukkit.getMock().getPluginManager().callEvent(event);
 			if (func != null)
 			{
@@ -237,7 +238,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 						task.cancel();
 						cancelTask(task.getTaskId());
 						throw new RuntimeException("Forced Cancellation of task owned by "
-														   + task.getOwner().getName());
+						                           + task.getOwner().getName());
 					}
 				}
 				pool.shutdownNow();
@@ -360,7 +361,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	public int scheduleAsyncDelayedTask(@NotNull Plugin plugin, @NotNull Runnable task, long delay)
 	{
 		Logger.getLogger(LOGGER_NAME)
-				.warning("Consider using runTaskLaterAsynchronously instead of scheduleAsyncDelayedTask");
+		.warning("Consider using runTaskLaterAsynchronously instead of scheduleAsyncDelayedTask");
 		return runTaskLaterAsynchronously(plugin, task, delay).getTaskId();
 	}
 
@@ -369,7 +370,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	public int scheduleAsyncDelayedTask(@NotNull Plugin plugin, @NotNull Runnable task)
 	{
 		Logger.getLogger(LOGGER_NAME)
-				.warning("Consider using runTaskAsynchronously instead of scheduleAsyncDelayedTask");
+		.warning("Consider using runTaskAsynchronously instead of scheduleAsyncDelayedTask");
 		return runTaskAsynchronously(plugin, task).getTaskId();
 	}
 
@@ -378,7 +379,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	public int scheduleAsyncRepeatingTask(@NotNull Plugin plugin, @NotNull Runnable task, long delay, long period)
 	{
 		Logger.getLogger(LOGGER_NAME)
-				.warning("Consider using runTaskTimerAsynchronously instead of scheduleAsyncRepeatingTask");
+		.warning("Consider using runTaskTimerAsynchronously instead of scheduleAsyncRepeatingTask");
 		return runTaskTimerAsynchronously(plugin, task, delay, period).getTaskId();
 	}
 
@@ -466,7 +467,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	public @NotNull BukkitTask runTaskLaterAsynchronously(@NotNull Plugin plugin, @NotNull Runnable task, long delay)
 	{
 		ScheduledTask scheduledTask = new ScheduledTask(id++, plugin, false, currentTick + delay,
-				new AsyncRunnable(task));
+		        new AsyncRunnable(task));
 		scheduledTasks.addTask(scheduledTask);
 		return scheduledTask;
 	}
@@ -481,7 +482,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	public @NotNull BukkitTask runTaskTimerAsynchronously(@NotNull Plugin plugin, @NotNull Runnable task, long delay, long period)
 	{
 		RepeatingTask scheduledTask = new RepeatingTask(id++, plugin, false, currentTick + delay, period,
-				new AsyncRunnable(task));
+		        new AsyncRunnable(task));
 		scheduledTasks.addTask(scheduledTask);
 		return scheduledTask;
 	}

--- a/src/test/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMockTest.java
@@ -301,10 +301,10 @@ class BukkitSchedulerMockTest
 		scheduler.performTicks(10);
 		scheduler.setShutdownTimeout(10);
 		assertThrows(RuntimeException.class,
-				() ->
-				{
-					scheduler.shutdown();
-				});
+		             () ->
+		{
+			scheduler.shutdown();
+		});
 	}
 
 	@Test


### PR DESCRIPTION
# Description
This PR adds patches applied on v1.18 branch to v1.16 branch concerning BukkitSchedulerMock and its failures about AsyncTasks' stopping

# Checklist
The following items should be checked before the pull request can be merged.
- [x] No unit tests added but updated older one
- [x] Code follows existing code format.