### PR TITLE
Fix ServerMock#getBukkitVersion not returning the full version

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -485,18 +485,16 @@ public class ServerMock extends Server.Spigot implements Server
 	@Override
 	public @NotNull String getBukkitVersion()
 	{
-		return getMinecraftVersion();
+		Preconditions.checkNotNull(this.buildProperties, "Failed to load build properties!");
+		String apiVersion = buildProperties.getProperty("full-api-version");
+		Preconditions.checkNotNull(apiVersion, "Failed to get full-api-version from the build properties!");
+		return apiVersion;
 	}
 
 	@Override
 	public @NotNull String getMinecraftVersion()
 	{
-		String apiVersion;
-		if (buildProperties == null || (apiVersion = buildProperties.getProperty("full-api-version")) == null)
-		{
-			throw new IllegalStateException("Minecraft version could not be determined");
-		}
-		return apiVersion.split("-")[0];
+		return this.getBukkitVersion().split("-")[0];
 	}
 
 	@Override

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -186,7 +186,7 @@ class ServerMockTest
 	@Test
 	void getBukkitVersion_CorrectPattern()
 	{
-		assertTrue(server.getBukkitVersion().matches("1\\.[0-9]+(\\.[0-9]+)?-R[0-9].[0-9]-SNAPSHOT"));
+		assertTrue(server.getBukkitVersion().matches("1\\.[0-9]+(\\.[0-9]+)?-.*SNAPSHOT.*"));
 	}
 
 	@Test

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -184,6 +184,24 @@ class ServerMockTest
 	}
 
 	@Test
+	void getBukkitVersion_CorrectPattern()
+	{
+		assertTrue(server.getBukkitVersion().matches("1\\.[0-9]+(\\.[0-9]+)?-R[0-9].[0-9]-SNAPSHOT"));
+	}
+
+	@Test
+	void getMinecraftVersion_NotNull()
+	{
+		assertNotNull(server.getMinecraftVersion());
+	}
+
+	@Test
+	void getMinecraftVersion_CorrectPattern()
+	{
+		assertTrue(server.getMinecraftVersion().matches("1\\.[0-9]+(\\.[0-9]+)?"));
+	}
+
+	@Test
 	void getName_NotNull()
 	{
 		assertNotNull(server.getName());

--- a/src/test/java/be/seeseemelk/mockbukkit/UnsafeValuesTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/UnsafeValuesTest.java
@@ -51,9 +51,9 @@ class UnsafeValuesTest
 	}
 
 	@Test
-	void checkSupported_currentServerVersion() throws InvalidPluginException
+	void checkSupported_currentServerVersion()
 	{
-		String currentVersion = server.getBukkitVersion();
+		String currentVersion = server.getMinecraftVersion();
 		// if version is in pattern MAJOR.MINOR.FIX, transform to MAJOR.MINOR
 		if (Pattern.matches(".{1,3}\\..{1,3}\\..*", currentVersion))
 		{


### PR DESCRIPTION
# Description
Fixes the non-standard output of `ServerMock#getBukkitVersion`.
Also added tests to ensure this, and `ServerMock#getMinecraftVersion` return something matching the correct pattern.

Closes #543.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
