### PR TITLE
Use a PermissibleBase for handling entity permissions

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -67,7 +67,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	private boolean invulnerable;
 	private boolean glowingFlag = false;
 	private final Queue<Component> messages = new LinkedTransferQueue<>();
-	private final PermissibleBase perms = new PermissibleBase(this);
+	private final PermissibleBase perms;
 	private @NotNull Vector velocity = new Vector(0, 0, 0);
 	private float fallDistance;
 	private int fireTicks = -20;
@@ -82,6 +82,8 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 
 		this.server = server;
 		this.uuid = uuid;
+
+		this.perms = new PermissibleBase(this);
 
 		if (!Bukkit.getWorlds().isEmpty())
 			location = Bukkit.getWorlds().get(0).getSpawnLocation();

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -29,10 +29,10 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityTeleportEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.metadata.MetadataValue;
+import org.bukkit.permissions.PermissibleBase;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.permissions.PermissionAttachmentInfo;
-import org.bukkit.permissions.PermissionRemovedExecutor;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.util.BoundingBox;
@@ -40,10 +40,7 @@ import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
@@ -70,7 +67,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	private boolean invulnerable;
 	private boolean glowingFlag = false;
 	private final Queue<Component> messages = new LinkedTransferQueue<>();
-	private final Set<PermissionAttachment> permissionAttachments = new HashSet<>();
+	private final PermissibleBase perms = new PermissibleBase(this);
 	private @NotNull Vector velocity = new Vector(0, 0, 0);
 	private float fallDistance;
 	private int fireTicks = -20;
@@ -397,36 +394,28 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	public boolean isPermissionSet(@NotNull String name)
 	{
 		Preconditions.checkNotNull(name, "Name cannot be null");
-		return permissionAttachments.stream()
-				.map(PermissionAttachment::getPermissions)
-				.anyMatch(permissions -> permissions.containsKey(name) && permissions.get(name));
+		return this.perms.isPermissionSet(name);
 	}
 
 	@Override
 	public boolean isPermissionSet(@NotNull Permission perm)
 	{
 		Preconditions.checkNotNull(perm, "Permission cannot be null");
-		return isPermissionSet(perm.getName().toLowerCase(Locale.ENGLISH));
+		return this.perms.isPermissionSet(perm);
 	}
 
 	@Override
 	public boolean hasPermission(@NotNull String name)
 	{
 		Preconditions.checkNotNull(name, "Name cannot be null");
-		if (isPermissionSet(name))
-		{
-			return true;
-		}
-
-		Permission perm = server.getPluginManager().getPermission(name);
-		return perm != null ? hasPermission(perm) : Permission.DEFAULT_PERMISSION.getValue(isOp());
+		return this.perms.hasPermission(name);
 	}
 
 	@Override
 	public boolean hasPermission(@NotNull Permission perm)
 	{
 		Preconditions.checkNotNull(perm, "Permission cannot be null");
-		return isPermissionSet(perm) || perm.getDefault().getValue(isOp());
+		return this.perms.hasPermission(perm);
 	}
 
 	@Override
@@ -434,77 +423,45 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	{
 		Preconditions.checkNotNull(plugin, "Plugin cannot be null");
 		Preconditions.checkNotNull(name, "Name cannot be null");
-		PermissionAttachment attachment = addAttachment(plugin);
-		attachment.setPermission(name, value);
-		return attachment;
+		return this.perms.addAttachment(plugin, name, value);
 	}
 
 	@Override
 	public @NotNull PermissionAttachment addAttachment(@NotNull Plugin plugin)
 	{
 		Preconditions.checkNotNull(plugin, "Plugin cannot be null");
-		PermissionAttachment attachment = new PermissionAttachment(plugin, this);
-		permissionAttachments.add(attachment);
-		return attachment;
+		return this.perms.addAttachment(plugin);
 	}
 
 	@Override
 	public PermissionAttachment addAttachment(@NotNull Plugin plugin, @NotNull String name, boolean value, int ticks)
 	{
-		// TODO Auto-generated constructor stub
-		throw new UnimplementedOperationException();
+		return this.perms.addAttachment(plugin, name, value, ticks);
 	}
 
 	@Override
 	public PermissionAttachment addAttachment(@NotNull Plugin plugin, int ticks)
 	{
-		// TODO Auto-generated constructor stub
-		throw new UnimplementedOperationException();
+		return this.perms.addAttachment(plugin, ticks);
 	}
 
 	@Override
 	public void removeAttachment(@NotNull PermissionAttachment attachment)
 	{
 		Preconditions.checkNotNull(attachment, "Attachment cannot be null");
-
-		if (permissionAttachments.contains(attachment))
-		{
-			permissionAttachments.remove(attachment);
-			PermissionRemovedExecutor ex = attachment.getRemovalCallback();
-
-			if (ex != null)
-			{
-				ex.attachmentRemoved(attachment);
-			}
-
-			recalculatePermissions();
-		}
-		else
-		{
-			throw new IllegalArgumentException("Given attachment is not part of Permissible object " + this);
-		}
+		this.perms.removeAttachment(attachment);
 	}
 
 	@Override
 	public void recalculatePermissions()
 	{
-
+		this.perms.recalculatePermissions();
 	}
 
 	@Override
 	public @NotNull Set<PermissionAttachmentInfo> getEffectivePermissions()
 	{
-		HashSet<PermissionAttachmentInfo> permissionAttachmentInfos = new HashSet<>();
-
-		for (PermissionAttachment permissionAttachment : permissionAttachments)
-		{
-			for (Map.Entry<String, Boolean> entry : permissionAttachment.getPermissions().entrySet())
-			{
-				permissionAttachmentInfos.add(new PermissionAttachmentInfo(this, entry.getKey(), permissionAttachment, entry.getValue()));
-			}
-		}
-
-		return permissionAttachmentInfos;
+		return this.perms.getEffectivePermissions();
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -395,43 +395,36 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	@Override
 	public boolean isPermissionSet(@NotNull String name)
 	{
-		Preconditions.checkNotNull(name, "Name cannot be null");
 		return this.perms.isPermissionSet(name);
 	}
 
 	@Override
 	public boolean isPermissionSet(@NotNull Permission perm)
 	{
-		Preconditions.checkNotNull(perm, "Permission cannot be null");
 		return this.perms.isPermissionSet(perm);
 	}
 
 	@Override
 	public boolean hasPermission(@NotNull String name)
 	{
-		Preconditions.checkNotNull(name, "Name cannot be null");
 		return this.perms.hasPermission(name);
 	}
 
 	@Override
 	public boolean hasPermission(@NotNull Permission perm)
 	{
-		Preconditions.checkNotNull(perm, "Permission cannot be null");
 		return this.perms.hasPermission(perm);
 	}
 
 	@Override
 	public @NotNull PermissionAttachment addAttachment(@NotNull Plugin plugin, @NotNull String name, boolean value)
 	{
-		Preconditions.checkNotNull(plugin, "Plugin cannot be null");
-		Preconditions.checkNotNull(name, "Name cannot be null");
 		return this.perms.addAttachment(plugin, name, value);
 	}
 
 	@Override
 	public @NotNull PermissionAttachment addAttachment(@NotNull Plugin plugin)
 	{
-		Preconditions.checkNotNull(plugin, "Plugin cannot be null");
 		return this.perms.addAttachment(plugin);
 	}
 
@@ -450,7 +443,6 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	@Override
 	public void removeAttachment(@NotNull PermissionAttachment attachment)
 	{
-		Preconditions.checkNotNull(attachment, "Attachment cannot be null");
 		this.perms.removeAttachment(attachment);
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
@@ -370,89 +370,103 @@ class EntityMockTest
 	}
 
 	@Test
-	void hasPermission_NotAddedNotDefault_DoesNotHavePermission()
+	void addAttachment_True_Has()
 	{
-		Permission permission = new Permission("mockbukkit.perm", PermissionDefault.FALSE);
-		server.getPluginManager().addPermission(permission);
-		assertFalse(entity.hasPermission("mockbukkit.perm"));
+		entity.addAttachment(MockBukkit.createMockPlugin(), "test.permission", true);
+		assertTrue(entity.hasPermission("test.permission"));
 	}
 
 	@Test
-	void hasPermission_NotAddedButDefault_DoesPermission()
+	void addAttachment_False_DoesntHave()
 	{
-		MockPlugin plugin = MockBukkit.createMockPlugin();
-		Permission permission = new Permission("mockbukkit.perm", PermissionDefault.TRUE);
-		server.getPluginManager().addPermission(permission);
-		entity.addAttachment(plugin, "mockbukkit.perm", true);
-		assertTrue(entity.hasPermission("mockbukkit.perm"));
+		entity.addAttachment(MockBukkit.createMockPlugin(), "test.permission", false);
+		assertFalse(entity.hasPermission("test.permission"));
 	}
 
 	@Test
-	void addAttachment_PermissionObject_PermissionAdded()
+	void addAttachment_RemovedAfterTicks()
 	{
-		MockPlugin plugin = MockBukkit.createMockPlugin();
-		Permission permission = new Permission("mockbukkit.perm", PermissionDefault.FALSE);
-		server.getPluginManager().addPermission(permission);
-		PermissionAttachment attachment = entity.addAttachment(plugin);
-		attachment.setPermission(permission, true);
-		assertTrue(entity.hasPermission("mockbukkit.perm"));
+		entity.addAttachment(MockBukkit.createMockPlugin(), "test.permission", true, 10);
+		assertTrue(entity.isPermissionSet("test.permission"));
+		server.getScheduler().performTicks(9);
+		assertTrue(entity.isPermissionSet("test.permission"));
+		server.getScheduler().performTicks(10);
+		assertFalse(entity.isPermissionSet("test.permission"));
 	}
 
 	@Test
-	void addAttachment_PermissionName_PermissionAdded()
+	void removeAttachment_RemovesAttachment()
 	{
-		MockPlugin plugin = MockBukkit.createMockPlugin();
-		Permission permission = new Permission("mockbukkit.perm", PermissionDefault.TRUE);
-		server.getPluginManager().addPermission(permission);
-		PermissionAttachment attachment = entity.addAttachment(plugin);
-		attachment.setPermission(permission.getName(), true);
-		assertTrue(entity.hasPermission("mockbukkit.perm"));
+		PermissionAttachment att = entity.addAttachment(MockBukkit.createMockPlugin(), "test.permission", false);
+		assertFalse(entity.hasPermission("test.permission"));
+		entity.removeAttachment(att);
+		assertTrue(entity.hasPermission("test.permission"));
 	}
 
 	@Test
-	void addPermission_String_PermissionAdded()
+	void isPermissionSet_String_IsSet_True()
 	{
-		MockPlugin plugin = MockBukkit.createMockPlugin();
-		Permission permission = new Permission("mockbukkit.perm", PermissionDefault.TRUE);
-		server.getPluginManager().addPermission(permission);
-		PermissionAttachment attachment = entity.addAttachment(plugin);
-		attachment.setPermission(permission.getName(), true);
-		assertTrue(entity.hasPermission("mockbukkit.perm"));
+		entity.addAttachment(MockBukkit.createMockPlugin(), "test.permission", true);
+		assertTrue(entity.isPermissionSet("test.permission"));
 	}
 
 	@Test
-	void getEffectivePermissions_GetPermissionsList()
+	void isPermissionSet_String_IsntSet_False()
 	{
-		MockPlugin plugin = MockBukkit.createMockPlugin();
-		entity.addAttachment(plugin, "mockbukkit.perm", true);
-		entity.addAttachment(plugin, "mockbukkit.perm2", true);
-		entity.addAttachment(plugin, "mockbukkit.perm3", false);
-
-		Set<PermissionAttachmentInfo> effectivePermissions = entity.getEffectivePermissions();
-		assertEquals(3, effectivePermissions.size());
-
-		Set<String> permissions = effectivePermissions.stream().map(PermissionAttachmentInfo::getPermission).collect(Collectors.toSet());
-		assertTrue(permissions.contains("mockbukkit.perm"));
-		assertTrue(permissions.contains("mockbukkit.perm2"));
-		assertTrue(permissions.contains("mockbukkit.perm3"));
-
-		Optional<PermissionAttachmentInfo> first = effectivePermissions.stream().filter(permissionAttachmentInfo -> permissionAttachmentInfo.getPermission().equals("mockbukkit.perm3")).findFirst();
-		assertTrue(first.isPresent());
-		assertFalse(first.get().getValue());
+		assertFalse(entity.isPermissionSet("test.permission"));
 	}
 
 	@Test
-	void removeAttachment_RemovesPermission()
+	void isPermissionSet_Permission_IsSet_True()
 	{
-		MockPlugin plugin = MockBukkit.createMockPlugin();
-		Permission permission = new Permission("mockbukkit.perm");
-		server.getPluginManager().addPermission(permission);
-		PermissionAttachment attachment = entity.addAttachment(plugin);
-		attachment.setPermission(permission.getName(), true);
-		assertTrue(entity.hasPermission("mockbukkit.perm"));
+		entity.addAttachment(MockBukkit.createMockPlugin(), "test.permission", true);
+		assertTrue(entity.isPermissionSet(new Permission("test.permission")));
+	}
 
-		entity.removeAttachment(attachment);
-		assertFalse(entity.hasPermission("mockbukkit.perm"));
+	@Test
+	void isPermissionSet_Permission_IsntSet_False()
+	{
+		assertFalse(entity.isPermissionSet(new Permission("test.permission")));
+	}
+
+	@Test
+	void hasPermission_String_SetTrue_True()
+	{
+		entity.addAttachment(MockBukkit.createMockPlugin(), "test.permission", true);
+		assertTrue(entity.hasPermission("test.permission"));
+	}
+
+	@Test
+	void hasPermission_String_SetFalse_True()
+	{
+		entity.addAttachment(MockBukkit.createMockPlugin(), "test.permission", false);
+		assertFalse(entity.hasPermission("test.permission"));
+	}
+
+	@Test
+	void hasPermission_String_NotSet_True()
+	{
+		assertTrue(entity.hasPermission("test.permission"));
+	}
+
+	@Test
+	void hasPermission_Permission_SetTrue_True()
+	{
+		entity.addAttachment(MockBukkit.createMockPlugin(), "test.permission", true);
+		assertTrue(entity.hasPermission(new Permission("test.permission")));
+	}
+
+	@Test
+	void hasPermission_Permission_SetFalse_True()
+	{
+		entity.addAttachment(MockBukkit.createMockPlugin(), "test.permission", false);
+		assertFalse(entity.hasPermission(new Permission("test.permission")));
+	}
+
+	@Test
+	void hasPermission_Permission_NotSet_True()
+	{
+		assertTrue(entity.hasPermission(new Permission("test.permission")));
 	}
 
 	@Test

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
@@ -397,10 +397,10 @@ class EntityMockTest
 	@Test
 	void removeAttachment_RemovesAttachment()
 	{
-		PermissionAttachment att = entity.addAttachment(MockBukkit.createMockPlugin(), "test.permission", false);
-		assertFalse(entity.hasPermission("test.permission"));
-		entity.removeAttachment(att);
+		PermissionAttachment att = entity.addAttachment(MockBukkit.createMockPlugin(), "test.permission", true);
 		assertTrue(entity.hasPermission("test.permission"));
+		entity.removeAttachment(att);
+		assertFalse(entity.hasPermission("test.permission"));
 	}
 
 	@Test
@@ -446,7 +446,7 @@ class EntityMockTest
 	@Test
 	void hasPermission_String_NotSet_True()
 	{
-		assertTrue(entity.hasPermission("test.permission"));
+		assertFalse(entity.hasPermission("test.permission"));
 	}
 
 	@Test
@@ -466,7 +466,7 @@ class EntityMockTest
 	@Test
 	void hasPermission_Permission_NotSet_True()
 	{
-		assertTrue(entity.hasPermission(new Permission("test.permission")));
+		assertTrue(entity.hasPermission(new Permission("test.permission", PermissionDefault.TRUE)));
 	}
 
 	@Test


### PR DESCRIPTION
# Description
Switches the EntityMock to use a PermissibleBase for storing permissions instead of doing everything ourselves.

Closes #444.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
