### PR TITLE
Fix non-standard output of Bukkit#getVersion

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -502,7 +502,7 @@ public class ServerMock extends Server.Spigot implements Server
 	@Override
 	public @NotNull String getVersion()
 	{
-		return String.format("MockBukkit (MC: %s)", getBukkitVersion());
+		return String.format("MockBukkit (MC: %s)", getMinecraftVersion());
 	}
 
 	@Override

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -182,6 +182,12 @@ class ServerMockTest
 	}
 
 	@Test
+	void getVersion_CorrectPattern()
+	{
+		assertTrue(server.getVersion().matches("MockBukkit \\(MC: (\\d)\\.(\\d+)\\.?(\\d+?)?\\)"));
+	}
+
+	@Test
 	void getBukkitVersion_NotNull()
 	{
 		assertNotNull(server.getBukkitVersion());


### PR DESCRIPTION
# Description
We were previously outputting the full version string, not just the Minecraft version as it should be.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
