### PR TITLE
Fix some inventories storing custom items separate from the base inventory

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/AbstractHorseInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/AbstractHorseInventoryMock.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.Nullable;
 public class AbstractHorseInventoryMock extends InventoryMock implements AbstractHorseInventory
 {
 
-	private @Nullable ItemStack saddle;
+	private static final int SADDLE_SLOT = 0;
 
 	public AbstractHorseInventoryMock(@Nullable InventoryHolder holder)
 	{
@@ -19,13 +19,13 @@ public class AbstractHorseInventoryMock extends InventoryMock implements Abstrac
 	@Override
 	public @Nullable ItemStack getSaddle()
 	{
-		return this.saddle;
+		return getItem(SADDLE_SLOT);
 	}
 
 	@Override
 	public void setSaddle(@Nullable ItemStack saddle)
 	{
-		this.saddle = saddle;
+		setItem(SADDLE_SLOT, saddle);
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/AnvilInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/AnvilInventoryMock.java
@@ -65,7 +65,7 @@ public class AnvilInventoryMock extends InventoryMock implements AnvilInventory
 	}
 
 	/**
-	 * Sets the rename Text.
+	 * Sets the result of {@link #getRenameText()}.
 	 *
 	 * @param text The text to set.
 	 */

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/BeaconInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/BeaconInventoryMock.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.Nullable;
 public class BeaconInventoryMock extends InventoryMock implements BeaconInventory
 {
 
-	private @Nullable ItemStack item;
+	private static final int ITEM_SLOT = 0;
 
 	public BeaconInventoryMock(@Nullable InventoryHolder holder)
 	{
@@ -20,13 +20,13 @@ public class BeaconInventoryMock extends InventoryMock implements BeaconInventor
 	@Override
 	public void setItem(@Nullable ItemStack item)
 	{
-		this.item = item;
+		setItem(ITEM_SLOT, item);
 	}
 
 	@Override
 	public @Nullable ItemStack getItem()
 	{
-		return this.item;
+		return getItem(ITEM_SLOT);
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/BrewerInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/BrewerInventoryMock.java
@@ -58,8 +58,8 @@ public class BrewerInventoryMock extends InventoryMock implements BrewerInventor
 	public @NotNull BrewerInventoryMock getSnapshot()
 	{
 		BrewerInventoryMock inventory = new BrewerInventoryMock(getHolder());
-		inventory.setIngredient(getFuel());
-		inventory.setFuel(getFuel());
+		inventory.setItem(INGREDIENT_SLOT, getItem(INGREDIENT_SLOT));
+		inventory.setItem(FUEL_SLOT, getItem(FUEL_SLOT));
 		return inventory;
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/BrewerInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/BrewerInventoryMock.java
@@ -12,8 +12,8 @@ import org.jetbrains.annotations.Nullable;
 public class BrewerInventoryMock extends InventoryMock implements BrewerInventory
 {
 
-	private ItemStack ingredient;
-	private ItemStack fuel;
+	private static final int INGREDIENT_SLOT = 3;
+	private static final int FUEL_SLOT = 4;
 
 	public BrewerInventoryMock(InventoryHolder holder)
 	{
@@ -24,28 +24,28 @@ public class BrewerInventoryMock extends InventoryMock implements BrewerInventor
 	public @Nullable ItemStack getIngredient()
 	{
 		checkHasIngredient();
-		return this.ingredient;
+		return getItem(INGREDIENT_SLOT);
 	}
 
 	@Override
 	public void setIngredient(@Nullable ItemStack ingredient)
 	{
 		Preconditions.checkNotNull(ingredient, "Ingredient cannot be null");
-		this.ingredient = ingredient;
+		setItem(INGREDIENT_SLOT, ingredient);
 	}
 
 	@Override
 	public @Nullable ItemStack getFuel()
 	{
 		checkHasFuel();
-		return this.fuel;
+		return getItem(FUEL_SLOT);
 	}
 
 	@Override
 	public void setFuel(@Nullable ItemStack fuel)
 	{
 		Preconditions.checkNotNull(fuel, "Fuel cannot be null");
-		this.fuel = fuel;
+		setItem(FUEL_SLOT, fuel);
 	}
 
 	@Override
@@ -58,25 +58,19 @@ public class BrewerInventoryMock extends InventoryMock implements BrewerInventor
 	public @NotNull BrewerInventoryMock getSnapshot()
 	{
 		BrewerInventoryMock inventory = new BrewerInventoryMock(getHolder());
-		if (ingredient != null)
-		{
-			inventory.setIngredient(ingredient);
-		}
-		if (fuel != null)
-		{
-			inventory.setFuel(fuel);
-		}
+		inventory.setIngredient(getFuel());
+		inventory.setFuel(getFuel());
 		return inventory;
 	}
 
 	private void checkHasFuel()
 	{
-		Preconditions.checkState(this.fuel != null, "No fuel has been set");
+		Preconditions.checkState(getItem(FUEL_SLOT) != null, "No fuel has been set");
 	}
 
 	private void checkHasIngredient()
 	{
-		Preconditions.checkState(this.ingredient != null, "No ingredient has been set");
+		Preconditions.checkState(getItem(INGREDIENT_SLOT) != null, "No ingredient has been set");
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/EnchantingInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/EnchantingInventoryMock.java
@@ -9,8 +9,8 @@ import org.jetbrains.annotations.Nullable;
 public class EnchantingInventoryMock extends InventoryMock implements EnchantingInventory
 {
 
-	private @Nullable ItemStack primaryItem = null;
-	private @Nullable ItemStack secondaryItem = null;
+	private static final int ITEM_SLOT = 0;
+	private static final int SECONDARY_SLOT = 1;
 
 	public EnchantingInventoryMock(@Nullable InventoryHolder holder)
 	{
@@ -20,25 +20,25 @@ public class EnchantingInventoryMock extends InventoryMock implements Enchanting
 	@Override
 	public void setItem(@Nullable ItemStack item)
 	{
-		this.primaryItem = item;
+		setItem(ITEM_SLOT, item);
 	}
 
 	@Override
 	public @Nullable ItemStack getItem()
 	{
-		return this.primaryItem;
+		return getItem(ITEM_SLOT);
 	}
 
 	@Override
 	public void setSecondary(@Nullable ItemStack item)
 	{
-		this.secondaryItem = item;
+		setItem(SECONDARY_SLOT, item);
 	}
 
 	@Override
 	public @Nullable ItemStack getSecondary()
 	{
-		return this.secondaryItem;
+		return getItem(SECONDARY_SLOT);
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/FurnaceInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/FurnaceInventoryMock.java
@@ -17,6 +17,10 @@ import java.util.Set;
 public class FurnaceInventoryMock extends InventoryMock implements FurnaceInventory
 {
 
+	private static final int SMELTING_SLOT = 0;
+	private static final int FUEL_SLOT = 1;
+	private static final int RESULT_SLOT = 2;
+
 	public FurnaceInventoryMock(@Nullable InventoryHolder holder)
 	{
 		super(holder, InventoryType.FURNACE);
@@ -25,37 +29,37 @@ public class FurnaceInventoryMock extends InventoryMock implements FurnaceInvent
 	@Override
 	public @Nullable ItemStack getResult()
 	{
-		return getItem(2);
+		return getItem(RESULT_SLOT);
 	}
 
 	@Override
 	public @Nullable ItemStack getFuel()
 	{
-		return getItem(1);
+		return getItem(FUEL_SLOT);
 	}
 
 	@Override
 	public @Nullable ItemStack getSmelting()
 	{
-		return getItem(0);
+		return getItem(SMELTING_SLOT);
 	}
 
 	@Override
 	public void setFuel(@Nullable ItemStack stack)
 	{
-		setItem(1, stack);
+		setItem(FUEL_SLOT, stack);
 	}
 
 	@Override
 	public void setResult(@Nullable ItemStack stack)
 	{
-		setItem(2, stack);
+		setItem(RESULT_SLOT, stack);
 	}
 
 	@Override
 	public void setSmelting(@Nullable ItemStack stack)
 	{
-		setItem(0, stack);
+		setItem(SMELTING_SLOT, stack);
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/HorseInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/HorseInventoryMock.java
@@ -8,6 +8,8 @@ import org.jetbrains.annotations.Nullable;
 public class HorseInventoryMock extends AbstractHorseInventoryMock implements HorseInventory
 {
 
+	private static final int ARMOR_SLOT = 1;
+
 	public HorseInventoryMock(InventoryHolder holder)
 	{
 		super(holder);
@@ -16,13 +18,13 @@ public class HorseInventoryMock extends AbstractHorseInventoryMock implements Ho
 	@Override
 	public ItemStack getArmor()
 	{
-		return this.getItem(1);
+		return this.getItem(ARMOR_SLOT);
 	}
 
 	@Override
 	public void setArmor(@Nullable ItemStack stack)
 	{
-		this.setItem(1, stack);
+		this.setItem(ARMOR_SLOT, stack);
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/LecternInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/LecternInventoryMock.java
@@ -14,8 +14,6 @@ import org.jetbrains.annotations.Nullable;
 public class LecternInventoryMock extends InventoryMock implements LecternInventory
 {
 
-	private @Nullable Lectern holder;
-
 	public LecternInventoryMock(InventoryHolder holder)
 	{
 		super(holder, InventoryType.LECTERN);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/LlamaInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/LlamaInventoryMock.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.Nullable;
 public class LlamaInventoryMock extends AbstractHorseInventoryMock implements LlamaInventory
 {
 
-	private @Nullable ItemStack decor;
+	private static final int DECOR_SLOT = 1;
 
 	public LlamaInventoryMock(@Nullable InventoryHolder holder)
 	{
@@ -19,13 +19,13 @@ public class LlamaInventoryMock extends AbstractHorseInventoryMock implements Ll
 	@Override
 	public @Nullable ItemStack getDecor()
 	{
-		return this.decor;
+		return getItem(DECOR_SLOT);
 	}
 
 	@Override
 	public void setDecor(@Nullable ItemStack stack)
 	{
-		this.decor = stack;
+		setItem(DECOR_SLOT, stack);
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/SmithingInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/SmithingInventoryMock.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.Nullable;
 public class SmithingInventoryMock extends InventoryMock implements SmithingInventory
 {
 
-	private @Nullable ItemStack result = null;
+	private static final int RESULT_SLOT = 0;
 
 	public SmithingInventoryMock(@Nullable InventoryHolder holder)
 	{
@@ -22,13 +22,13 @@ public class SmithingInventoryMock extends InventoryMock implements SmithingInve
 	@Override
 	public @Nullable ItemStack getResult()
 	{
-		return this.result;
+		return getItem(RESULT_SLOT);
 	}
 
 	@Override
-	public void setResult(@Nullable ItemStack newResult)
+	public void setResult(@Nullable ItemStack result)
 	{
-		this.result = newResult;
+		setItem(RESULT_SLOT, result);
 	}
 
 	@Override

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/AbstractHorseInventoryMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/AbstractHorseInventoryMockTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class AbstractHorseInventoryMockTest
+class AbstractHorseInventoryMockTest
 {
 
 	private AbstractHorseInventoryMock inventory;

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/AbstractHorseInventoryMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/AbstractHorseInventoryMockTest.java
@@ -1,0 +1,49 @@
+package be.seeseemelk.mockbukkit.inventory;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class AbstractHorseInventoryMockTest
+{
+
+	private AbstractHorseInventoryMock inventory;
+
+	@BeforeEach
+	void setUp()
+	{
+		MockBukkit.mock();
+		this.inventory = new AbstractHorseInventoryMock(null);
+	}
+
+	@AfterEach
+	void tearDown()
+	{
+		MockBukkit.unmock();
+	}
+
+	@Test
+	void setSaddle_SetsSaddle()
+	{
+		inventory.setSaddle(new ItemStack(Material.SADDLE));
+
+		assertNotNull(inventory.getSaddle());
+		assertEquals(Material.SADDLE, inventory.getSaddle().getType());
+	}
+
+	@Test
+	void setSaddle_SetsItemInSlot()
+	{
+		inventory.setSaddle(new ItemStack(Material.SADDLE));
+
+		assertNotNull(inventory.getItem(0));
+		assertEquals(Material.SADDLE, inventory.getItem(0).getType());
+	}
+
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/BeaconInventoryMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/BeaconInventoryMockTest.java
@@ -47,6 +47,17 @@ class BeaconInventoryMockTest
 	}
 
 	@Test
+	void testSetItem_SetsSlot()
+	{
+		ItemStack item = new ItemStack(Material.EMERALD);
+
+		inventory.setItem(item);
+
+		assertNotNull(inventory.getItem(0));
+		assertEquals(item, inventory.getItem(0));
+	}
+
+	@Test
 	void testSetItemNull()
 	{
 		assertDoesNotThrow(() -> inventory.setItem(null));

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/BrewerInventoryMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/BrewerInventoryMockTest.java
@@ -94,4 +94,22 @@ class BrewerInventoryMockTest
 		assertEquals(ingredient, inventory.getIngredient());
 	}
 
+	@Test
+	void testSetFuel_SetsSlot() {
+		ItemStack fuel = new ItemStack(Material.BLAZE_POWDER);
+
+		inventory.setFuel(fuel);
+
+		assertEquals(fuel, inventory.getItem(4));
+	}
+
+	@Test
+	void testSetIngredient_SetsSlot() {
+		ItemStack fuel = new ItemStack(Material.BLAZE_POWDER);
+
+		inventory.setIngredient(fuel);
+
+		assertEquals(fuel, inventory.getItem(3));
+	}
+
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/BrewerInventoryMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/BrewerInventoryMockTest.java
@@ -48,10 +48,10 @@ class BrewerInventoryMockTest
 		inventory.setFuel(fuel);
 		inventory.setIngredient(ingredient);
 
-		InventoryMock snapshot = inventory.getSnapshot();
+		BrewerInventoryMock snapshot = inventory.getSnapshot();
 
-		assertEquals(ingredient, ((BrewerInventoryMock) snapshot).getIngredient());
-		assertEquals(fuel, ((BrewerInventoryMock) snapshot).getFuel());
+		assertEquals(ingredient, snapshot.getIngredient());
+		assertEquals(fuel, snapshot.getFuel());
 	}
 
 	@Test

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/EnchantingInventoryMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/EnchantingInventoryMockTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class EnchantingInventoryMockTest
+class EnchantingInventoryMockTest
 {
 
 	private EnchantingInventoryMock inventory;

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/EnchantingInventoryMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/EnchantingInventoryMockTest.java
@@ -1,0 +1,67 @@
+package be.seeseemelk.mockbukkit.inventory;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class EnchantingInventoryMockTest
+{
+
+	private EnchantingInventoryMock inventory;
+
+	@BeforeEach
+	void setUp()
+	{
+		MockBukkit.mock();
+		this.inventory = new EnchantingInventoryMock(null);
+	}
+
+	@AfterEach
+	void tearDown()
+	{
+		MockBukkit.unmock();
+	}
+
+	@Test
+	void setItem()
+	{
+		inventory.setItem(new ItemStack(Material.DIAMOND_SWORD));
+
+		assertNotNull(inventory.getItem());
+		assertEquals(Material.DIAMOND_SWORD, inventory.getItem().getType());
+	}
+
+	@Test
+	void setItem_SetsItemInSlot()
+	{
+		inventory.setItem(new ItemStack(Material.DIAMOND_SWORD));
+
+		assertNotNull(inventory.getItem(0));
+		assertEquals(Material.DIAMOND_SWORD, inventory.getItem(0).getType());
+	}
+
+	@Test
+	void setSecondary()
+	{
+		inventory.setSecondary(new ItemStack(Material.LAPIS_LAZULI));
+
+		assertNotNull(inventory.getSecondary());
+		assertEquals(Material.LAPIS_LAZULI, inventory.getSecondary().getType());
+	}
+
+	@Test
+	void setSecondary_SetsItemInSlot()
+	{
+		inventory.setSecondary(new ItemStack(Material.LAPIS_LAZULI));
+
+		assertNotNull(inventory.getItem(1));
+		assertEquals(Material.LAPIS_LAZULI, inventory.getItem(1).getType());
+	}
+
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/FurnaceInventoryMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/FurnaceInventoryMockTest.java
@@ -22,6 +22,7 @@ class FurnaceInventoryMockTest
 	void setUp()
 	{
 		MockBukkit.mock();
+		holder = new BlastFurnaceMock(Material.BLAST_FURNACE);
 		inventory = new FurnaceInventoryMock(holder);
 	}
 
@@ -40,6 +41,14 @@ class FurnaceInventoryMockTest
 	}
 
 	@Test
+	void testSetFuel_SetsItemInSlot()
+	{
+		ItemStack fuel = new ItemStack(Material.COAL);
+		inventory.setFuel(fuel);
+		assertEquals(fuel, inventory.getItem(1));
+	}
+
+	@Test
 	void testGetResult()
 	{
 		ItemStack result = new ItemStack(Material.IRON_INGOT);
@@ -48,11 +57,27 @@ class FurnaceInventoryMockTest
 	}
 
 	@Test
+	void testSetResult_SetsItemInSlot()
+	{
+		ItemStack fuel = new ItemStack(Material.IRON_INGOT);
+		inventory.setResult(fuel);
+		assertEquals(fuel, inventory.getItem(2));
+	}
+
+	@Test
 	void testGetSmelting()
 	{
-		ItemStack smelting = new ItemStack(Material.IRON_INGOT);
+		ItemStack smelting = new ItemStack(Material.IRON_ORE);
 		inventory.setSmelting(smelting);
 		assertEquals(smelting, inventory.getSmelting());
+	}
+
+	@Test
+	void testSetSmelting_SetsItemInSlot()
+	{
+		ItemStack fuel = new ItemStack(Material.IRON_ORE);
+		inventory.setSmelting(fuel);
+		assertEquals(fuel, inventory.getItem(0));
 	}
 
 	@Test

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/LlamaInventoryMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/LlamaInventoryMockTest.java
@@ -12,12 +12,12 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-class HorseInventoryMockTest
+class LlamaInventoryMockTest
 {
 
 	private ServerMock server;
 	private WorldMock world;
-	private HorseInventoryMock inventory;
+	private LlamaInventoryMock inventory;
 
 	@BeforeEach
 	void setUp()
@@ -27,7 +27,7 @@ class HorseInventoryMockTest
 		world.setName("world");
 		server.addWorld(world);
 
-		inventory = new HorseInventoryMock(null);
+		inventory = new LlamaInventoryMock(null);
 	}
 
 	@AfterEach
@@ -43,22 +43,22 @@ class HorseInventoryMockTest
 	}
 
 	@Test
-	void setArmor()
+	void setDecor()
 	{
-		assertNull(inventory.getArmor());
+		assertNull(inventory.getDecor());
 		ItemStack item = new ItemStack(Material.IRON_HORSE_ARMOR);
 
-		inventory.setArmor(item);
+		inventory.setDecor(item);
 
-		assertEquals(item, inventory.getArmor());
+		assertEquals(item, inventory.getDecor());
 	}
 
 	@Test
-	void setArmor_SetsItemInSlot()
+	void setDecor_SetsItemInSlot()
 	{
 		ItemStack item = new ItemStack(Material.IRON_HORSE_ARMOR);
 
-		inventory.setArmor(item);
+		inventory.setDecor(item);
 
 		assertEquals(item, inventory.getItem(1));
 	}

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/SmithingInventoryMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/SmithingInventoryMockTest.java
@@ -1,14 +1,13 @@
 package be.seeseemelk.mockbukkit.inventory;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 class SmithingInventoryMockTest
@@ -39,8 +38,20 @@ class SmithingInventoryMockTest
 	void testSetResult()
 	{
 		ItemStack item = new ItemStack(Material.OAK_BOAT);
+
 		inventory.setResult(item);
-		Assertions.assertEquals(item, inventory.getResult());
+
+		assertEquals(item, inventory.getResult());
+	}
+
+	@Test
+	void testSetResult_SetsItemInSlot()
+	{
+		ItemStack item = new ItemStack(Material.OAK_BOAT);
+
+		inventory.setResult(item);
+
+		assertEquals(item, inventory.getItem(1));
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/SmithingInventoryMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/SmithingInventoryMockTest.java
@@ -51,7 +51,7 @@ class SmithingInventoryMockTest
 
 		inventory.setResult(item);
 
-		assertEquals(item, inventory.getItem(1));
+		assertEquals(item, inventory.getItem(0));
 	}
 
 }


### PR DESCRIPTION
# Description
Most current inventory implementations store custom items, like horse saddles and brewing stand fuel, in their own private fields. In CraftBukkit, these items are stored in the inventory itself at a certain index. This corrects this behavior.

The only thing that needs to be added for this to be merged is unit tests validating this behavior.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
