### PR TITLE
Add an implementation for the passenger API

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -688,6 +688,11 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	@Override
 	public void remove()
 	{
+		leaveVehicle();
+		if (hasPassengers())
+		{
+			new ArrayList<>(this.passengers).forEach(Entity::leaveVehicle);
+		}
 		this.removed = true;
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -40,6 +40,8 @@ import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -61,6 +63,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	private Location location;
 	private boolean teleported;
 	private TeleportCause teleportCause;
+	private final List<Entity> passengers = new ArrayList<>(0);
 	private final MetadataTable metadataTable = new MetadataTable();
 	private final PersistentDataContainer persistentDataContainer = new PersistentDataContainerMock();
 	private boolean operator = false;
@@ -683,51 +686,58 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	@Deprecated
 	public Entity getPassenger()
 	{
-		// TODO Auto-generated constructor stub
-		throw new UnimplementedOperationException();
+		return isEmpty() ? null : this.passengers.get(0);
 	}
 
 	@Override
 	@Deprecated
 	public boolean setPassenger(@NotNull Entity passenger)
 	{
-		// TODO Auto-generated constructor stub
-		throw new UnimplementedOperationException();
+		eject(); // Make sure there is only one passenger
+		return addPassenger(passenger);
 	}
 
 	@Override
 	public @NotNull List<Entity> getPassengers()
 	{
-		// TODO Auto-generated constructor stub
-		throw new UnimplementedOperationException();
+		return Collections.unmodifiableList(this.passengers);
 	}
 
 	@Override
 	public boolean addPassenger(@NotNull Entity passenger)
 	{
-		// TODO Auto-generated constructor stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkNotNull(passenger, "Passenger cannot be null.");
+		Preconditions.checkArgument(!equals(passenger), "Entity cannot ride itself.");
+		if (this.passengers.contains(passenger))
+		{
+			return false;
+		}
+		return this.passengers.add(passenger);
 	}
 
 	@Override
 	public boolean removePassenger(@NotNull Entity passenger)
 	{
-		// TODO Auto-generated constructor stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkNotNull(passenger, "Passenger cannot be null.");
+		this.passengers.remove(passenger);
+		return true;
 	}
 
 	@Override
 	public boolean isEmpty()
 	{
-		// TODO Auto-generated constructor stub
-		throw new UnimplementedOperationException();
+		return this.passengers.isEmpty();
 	}
 
 	@Override
 	public boolean eject()
 	{
-		// TODO Auto-generated constructor stub
-		throw new UnimplementedOperationException();
+		if (isEmpty())
+		{
+			return false;
+		}
+		this.passengers.clear();
+		return true;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -744,7 +744,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	public boolean removePassenger(@NotNull Entity passenger)
 	{
 		Preconditions.checkNotNull(passenger, "Passenger cannot be null.");
-		passenger.leaveVehicle();
+		passenger.leaveVehicle(); // Only the passenger is used by the CraftBukkit implementation
 		return true;
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -299,7 +299,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 			// Don't allow teleporting between worlds while keeping passengers
 			// and if remaining on vehicle.
 			if ((ignorePassengers && hasPassengers())
-					|| (!dismount && this.vehicle != null))
+					|| (!dismount && isInsideVehicle()))
 			{
 				return false;
 			}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -877,6 +877,15 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 		return this.vehicle;
 	}
 
+	/**
+	 * Adds the entity to the passenger list.
+	 * <p>
+	 * This method only does the logic for the vehicle and could cause illegal states if
+	 * used directly. Use {@link #addPassenger(Entity)}.
+	 *
+	 * @param entity The entity that will be a passenger.
+	 * @return {@code true} if the entity has become a passenger for this vehicle, {@code false} otherwise.
+	 */
 	private boolean tryAddingPassenger(@NotNull Entity entity)
 	{
 		if (getWorld() != entity.getWorld())
@@ -900,6 +909,15 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 		return this.passengers.add(entity);
 	}
 
+	/**
+	 * Removes the entity to the passenger list.
+	 * <p>
+	 * This method only does the logic for the vehicle and could cause illegal states if
+	 * used directly. Use {@link #removePassenger(Entity)} or {@link #leaveVehicle()}.
+	 *
+	 * @param entity The entity that will leave this vehicle.
+	 * @return {@code true} if the entity is no longer a passenger for this vehicle, {@code false} otherwise.
+	 */
 	private boolean tryRemovingPassenger(@NotNull Entity entity)
 	{
 		if (this instanceof Vehicle vehicle && entity instanceof LivingEntity livingEntity)

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -910,7 +910,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	}
 
 	/**
-	 * Removes the entity to the passenger list.
+	 * Removes the entity from the passenger list.
 	 * <p>
 	 * This method only does the logic for the vehicle and could cause illegal states if
 	 * used directly. Use {@link #removePassenger(Entity)} or {@link #leaveVehicle()}.

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -566,13 +566,13 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	}
 
 	@Override
-	public boolean teleport(@NotNull Location location, PlayerTeleportEvent.@NotNull TeleportCause cause)
+	public boolean teleport(@NotNull Location location, PlayerTeleportEvent.@NotNull TeleportCause cause, boolean ignorePassengers, boolean dismount)
 	{
 		if (isDead())
 		{
 			return false;
 		}
-		return super.teleport(location, cause);
+		return super.teleport(location, cause, ignorePassengers, dismount);
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -566,13 +566,13 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	}
 
 	@Override
-	public boolean teleport(@NotNull Location location, PlayerTeleportEvent.@NotNull TeleportCause cause, boolean ignorePassengers, boolean dismount)
+	public boolean teleport(@NotNull Location location, PlayerTeleportEvent.@NotNull TeleportCause cause)
 	{
 		if (isDead())
 		{
 			return false;
 		}
-		return super.teleport(location, cause, ignorePassengers, dismount);
+		return super.teleport(location, cause);
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -2850,7 +2850,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 			// Don't allow teleporting between worlds while keeping passengers
 			// and if remaining on vehicle.
 			if ((ignorePassengers && hasPassengers())
-					|| (!dismount && getVehicle() != null))
+					|| (!dismount && isInsideVehicle()))
 			{
 				return false;
 			}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -2835,17 +2835,26 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	}
 
 	@Override
-	public boolean teleport(@NotNull Location location, @NotNull PlayerTeleportEvent.TeleportCause cause)
+	public boolean teleport(@NotNull Location location, @NotNull PlayerTeleportEvent.TeleportCause cause, boolean ignorePassengers, boolean dismount)
 	{
 		Preconditions.checkNotNull(location, "Location cannot be null");
 		Preconditions.checkNotNull(location.getWorld(), "World cannot be null");
 		Preconditions.checkNotNull(cause, "Cause cannot be null");
 		location.checkFinite();
-		if (isDead())
+		if (isDead() || (!ignorePassengers && hasPassengers()))
 		{
 			return false;
 		}
-		//todo: Add passenger logic: don't teleport if it's a vehicle / dismount from the current vehicle if it's a passenger
+		if (location.getWorld() != getWorld())
+		{
+			// Don't allow teleporting between worlds while keeping passengers
+			// and if remaining on vehicle.
+			if ((ignorePassengers && hasPassengers())
+					|| (!dismount && getVehicle() != null))
+			{
+				return false;
+			}
+		}
 
 		PlayerTeleportEvent event = new PlayerTeleportEvent(this, getLocation(), location, cause);
 		if (!event.callEvent())

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -47,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -698,6 +700,54 @@ class EntityMockTest
 		LivingEntity zombie = (LivingEntity) world.spawnEntity(new Location(world, 10, 10, 10), EntityType.ZOMBIE);
 		zombie.registerAttribute(Attribute.HORSE_JUMP_STRENGTH);
 		assertEquals(0.7, zombie.getAttribute(Attribute.HORSE_JUMP_STRENGTH).getValue());
+	}
+
+	@Test
+	void addPassenger()
+	{
+		SimpleEntityMock mock = new SimpleEntityMock(server);
+		assertTrue(entity.addPassenger(mock));
+		assertFalse(entity.addPassenger(mock));
+		assertEquals(List.of(mock), entity.getPassengers());
+		assertFalse(entity.isEmpty());
+	}
+
+	@Test
+	void addPassenger_self()
+	{
+		assertThrows(IllegalArgumentException.class, () -> entity.addPassenger(entity));
+	}
+
+	@Test
+	void getPassenger()
+	{
+		SimpleEntityMock mock = new SimpleEntityMock(server);
+		assertNull(entity.getPassenger());
+		entity.setPassenger(mock);
+		assertSame(mock, entity.getPassenger());
+	}
+
+	@Test
+	void removePassenger()
+	{
+		SimpleEntityMock mock = new SimpleEntityMock(server);
+		entity.addPassenger(mock);
+		assertTrue(entity.removePassenger(mock));
+		assertTrue(entity.removePassenger(mock));
+		assertEquals(List.of(), entity.getPassengers());
+		assertTrue(entity.isEmpty());
+	}
+
+	@Test
+	void eject()
+	{
+		assertFalse(entity.eject());
+		for (int i = 0; i < 3; i++)
+		{
+			entity.addPassenger(new SimpleEntityMock(server));
+		}
+		assertTrue(entity.eject());
+		assertTrue(entity.isEmpty());
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
@@ -34,6 +34,8 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.spigotmc.event.entity.EntityDismountEvent;
+import org.spigotmc.event.entity.EntityMountEvent;
 
 import java.util.List;
 import java.util.Optional;
@@ -707,6 +709,8 @@ class EntityMockTest
 	{
 		SimpleEntityMock mock = new SimpleEntityMock(server);
 		assertTrue(entity.addPassenger(mock));
+		server.getPluginManager().assertEventFired(EntityMountEvent.class, event -> event.getMount() == entity && event.getEntity() == mock);
+
 		assertFalse(entity.addPassenger(mock), "The passenger should not be added a second time");
 		assertEquals(List.of(mock), entity.getPassengers(), "There should be only one passenger");
 		assertSame(entity, mock.getVehicle(), "The rider should known the vehicle");
@@ -714,13 +718,25 @@ class EntityMockTest
 	}
 
 	@Test
-	void addPassenger_self()
+	void addPassenger_DifferentWorld()
+	{
+		SimpleEntityMock mock = new SimpleEntityMock(server);
+		Location loc = mock.getLocation();
+		loc.setWorld(new WorldMock());
+		mock.teleport(loc);
+
+		assertFalse(entity.addPassenger(mock));
+		assertTrue(entity.isEmpty());
+	}
+
+	@Test
+	void addPassenger_Self()
 	{
 		assertThrows(IllegalArgumentException.class, () -> entity.addPassenger(entity), "The entity should not be able to ride itself");
 	}
 
 	@Test
-	void addPassenger_stack()
+	void addPassenger_Stack()
 	{
 		EntityMock[] mocks = new EntityMock[3];
 		for (int i = 0; i < mocks.length; i++)
@@ -737,7 +753,7 @@ class EntityMockTest
 	}
 
 	@Test
-	void addPassenger_preventCircularRiding()
+	void addPassenger_PreventCircularRiding()
 	{
 		EntityMock a = new SimpleEntityMock(server);
 		EntityMock b = new SimpleEntityMock(server);
@@ -746,6 +762,23 @@ class EntityMockTest
 		// b rides a which rides entity
 		assertFalse(a.addPassenger(entity), "An entity shouldn't be the vehicle it currently rides");
 		assertFalse(b.addPassenger(entity));
+	}
+
+	@Test
+	void addPassenger_CancelMountEvent()
+	{
+		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
+		EntityMock mock = new SimpleEntityMock(server);
+		server.getPluginManager().registerEvents(new Listener()
+		{
+			@EventHandler
+			public void onMount(@NotNull EntityMountEvent event)
+			{
+				event.setCancelled(true);
+			}
+		}, plugin);
+		assertFalse(entity.addPassenger(mock));
+		assertTrue(entity.isEmpty());
 	}
 
 	@Test
@@ -763,6 +796,8 @@ class EntityMockTest
 		SimpleEntityMock mock = new SimpleEntityMock(server);
 		entity.addPassenger(mock);
 		assertTrue(entity.removePassenger(mock));
+		server.getPluginManager().assertEventFired(EntityDismountEvent.class, event -> event.getDismounted() == entity && event.getEntity() == mock);
+
 		assertTrue(entity.removePassenger(mock), "The method should always return true, even if it was not a passenger");
 		assertEquals(List.of(), entity.getPassengers());
 		assertNull(mock.getVehicle(), "The vehicle should no longer be referenced");
@@ -770,14 +805,33 @@ class EntityMockTest
 	}
 
 	@Test
-	void removePassenger_notSelf()
+	void removePassenger_NotSelf()
 	{
 		SimpleEntityMock a = new SimpleEntityMock(server);
 		SimpleEntityMock b = new SimpleEntityMock(server);
 		a.addPassenger(b);
 		entity.removePassenger(b);
+		server.getPluginManager().assertEventFired(EntityDismountEvent.class, event -> event.getDismounted() == a && event.getEntity() == b);
 		assertNull(b.getVehicle(), "b should not longer have a vehicle");
 		assertTrue(a.isEmpty(), "a should not longer have a passenger");
+	}
+
+	@Test
+	void removePassenger_CancelDismountEvent()
+	{
+		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
+		EntityMock mock = new SimpleEntityMock(server);
+		entity.addPassenger(mock);
+		server.getPluginManager().registerEvents(new Listener()
+		{
+			@EventHandler
+			public void onMount(@NotNull EntityDismountEvent event)
+			{
+				event.setCancelled(true);
+			}
+		}, plugin);
+		assertTrue(entity.removePassenger(mock));
+		assertFalse(entity.isEmpty());
 	}
 
 	@Test

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
@@ -867,4 +867,16 @@ class EntityMockTest
 		assertTrue(entity.isEmpty());
 	}
 
+	@Test
+	void eject_WhenRemoved()
+	{
+		EntityMock vehicle = new SimpleEntityMock(server);
+		EntityMock passenger = new SimpleEntityMock(server);
+		vehicle.addPassenger(entity);
+		entity.addPassenger(passenger);
+		entity.remove();
+		assertNull(passenger.getVehicle());
+		assertEquals(List.of(), vehicle.getPassengers());
+	}
+
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
@@ -198,6 +198,27 @@ class EntityMockTest
 	}
 
 	@Test
+	void teleport_Vehicle()
+	{
+		EntityMock mock = new SimpleEntityMock(server);
+		entity.addPassenger(mock);
+		Location from = entity.getLocation();
+		Location to = entity.getLocation().add(0, 1.5, 0);
+		assertFalse(entity.teleport(to));
+		assertEquals(from, entity.getLocation());
+	}
+
+	@Test
+	void teleport_Passenger()
+	{
+		EntityMock mock = new SimpleEntityMock(server);
+		mock.addPassenger(entity);
+		Location to = entity.getLocation().add(0, 1.5, 0);
+		assertTrue(entity.teleport(to));
+		assertEquals(to, entity.getLocation());
+	}
+
+	@Test
 	void teleport_CancelEvent()
 	{
 		TestPlugin plugin = MockBukkit.load(TestPlugin.class);


### PR DESCRIPTION
# Description
This PR resolves the TODOs left in #519 by implementing the passenger-related API.

An entity can now have a vehicle and have multiple passengers. This fires four new events:

- Bukkit's `VehicleEnterEvent` only when the vehicle implements `Vehicle`
- Spigot's `EntityMountEvent`
- Bukkit's `VehicleExitEvent` only when the vehicle implements `Vehicle`
- Spigot's `EntityDismountEvent`

In Vanilla/CraftBukkit, the rider always sets the reference to their vehicle first, then the vehicle updates its passenger list:
```mermaid
flowchart TB
    subgraph Passenger
    set[set vehicle]
    unset[unset vehicle]
    end
    subgraph Vehicle
    assertions
    events
    add[add passenger]
    end
    set --> assertions
    assertions --> events
    assertions -->|fail| unset
    events -->|cancelled| unset
    events --> add
```

Because of this, this sample code would dismount the sheep even if it's not the vehicle:
```java
Sheep a = world.spawn(location, Sheep.class);
Sheep b = world.spawn(location, Sheep.class);
a.addPassenger(b);
player.removePassenger(b); // The player is not the vehicle of the sheep, but can still have it dismounted from the real vehicle.
```
This behavior is replicated in this implementation.

Since #519, PaperMC/Paper@5deafd1969b3c521af9cabb46822ecb01e6ce498 has been added to Paper, allowing greater control over teleports with passengers. Teleportation methods have been updated to accept these new parameters. Note that these methods have been annotated with [`@ApiStatus.Experimental`](https://github.com/JetBrains/java-annotations/blob/d438b1132495b7fc5c272289441781d9a0275e4c/common/src/main/java/org/jetbrains/annotations/ApiStatus.java#L54).

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
