### PR TITLE
Provide component serializers with service providers

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
@@ -38,54 +38,44 @@ public class MockUnsafeValues implements UnsafeValues
 {
 
 	private static final List<String> COMPATIBLE_API_VERSIONS = Arrays.asList("1.13", "1.14", "1.15", "1.16", "1.17", "1.18", "1.19");
-	public static final ComponentFlattener FLATTENER = ComponentFlattener.basic().toBuilder()
-			.build();
-	public static final LegacyComponentSerializer LEGACY_SECTION_UXRC = LegacyComponentSerializer.builder().flattener(FLATTENER).hexColors().useUnusualXRepeatedCharacterHexFormat().build();
-	public static final PlainComponentSerializer PLAIN = PlainComponentSerializer.builder().flattener(FLATTENER).build();
-	public static final PlainTextComponentSerializer PLAIN_TEXT = PlainTextComponentSerializer.builder().flattener(FLATTENER).build();
-	public static final GsonComponentSerializer GSON = GsonComponentSerializer.builder()
-			.build();
-	public static final GsonComponentSerializer COLOR_DOWNSAMPLING_GSON = GsonComponentSerializer.builder()
-			.downsampleColors()
-			.build();
 
 	private String minimumApiVersion = "none";
 
 	@Override
 	public @NotNull ComponentFlattener componentFlattener()
 	{
-		return FLATTENER;
+		return ComponentFlattener.basic();
 	}
 
 	@Override
 	@Deprecated(forRemoval = true)
 	public @NotNull PlainComponentSerializer plainComponentSerializer()
 	{
-		return PLAIN;
+		return PlainComponentSerializer.plain();
 	}
 
 	@Override
 	public @NotNull PlainTextComponentSerializer plainTextSerializer()
 	{
-		return PLAIN_TEXT;
+		return PlainTextComponentSerializer.plainText();
 	}
 
 	@Override
 	public @NotNull GsonComponentSerializer gsonComponentSerializer()
 	{
-		return GSON;
+		return GsonComponentSerializer.gson();
 	}
 
 	@Override
 	public @NotNull GsonComponentSerializer colorDownsamplingGsonComponentSerializer()
 	{
-		return COLOR_DOWNSAMPLING_GSON;
+		return GsonComponentSerializer.colorDownsamplingGson();
 	}
 
 	@Override
 	public @NotNull LegacyComponentSerializer legacyComponentSerializer()
 	{
-		return LEGACY_SECTION_UXRC;
+		return LegacyComponentSerializer.legacySection();
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/adventure/LegacyComponentSerializerProviderImpl.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/adventure/LegacyComponentSerializerProviderImpl.java
@@ -33,4 +33,5 @@ public class LegacyComponentSerializerProviderImpl implements LegacyComponentSer
 	{
 		return builder -> {};
 	}
+	
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/adventure/LegacyComponentSerializerProviderImpl.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/adventure/LegacyComponentSerializerProviderImpl.java
@@ -1,0 +1,36 @@
+package be.seeseemelk.mockbukkit.adventure;
+
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Consumer;
+
+public class LegacyComponentSerializerProviderImpl implements LegacyComponentSerializer.Provider
+{
+
+	@Override
+	public @NotNull LegacyComponentSerializer legacyAmpersand()
+	{
+		return LegacyComponentSerializer.builder()
+				.character(LegacyComponentSerializer.AMPERSAND_CHAR)
+				.hexColors()
+				.useUnusualXRepeatedCharacterHexFormat()
+				.build();
+	}
+
+	@Override
+	public @NotNull LegacyComponentSerializer legacySection()
+	{
+		return LegacyComponentSerializer.builder()
+				.character(LegacyComponentSerializer.SECTION_CHAR)
+				.hexColors()
+				.useUnusualXRepeatedCharacterHexFormat()
+				.build();
+	}
+
+	@Override
+	public @NotNull Consumer<LegacyComponentSerializer.Builder> legacy()
+	{
+		return builder -> {};
+	}
+}

--- a/src/main/resources/META-INF/services/net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer$Provider
+++ b/src/main/resources/META-INF/services/net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer$Provider
@@ -1,0 +1,1 @@
+be.seeseemelk.mockbukkit.adventure.LegacyComponentSerializerProviderImpl

--- a/src/test/java/be/seeseemelk/mockbukkit/adventure/LegacyComponentSerializerTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/adventure/LegacyComponentSerializerTest.java
@@ -19,4 +19,5 @@ class LegacyComponentSerializerTest
 		String exceptedOutput = ChatColor.of("#9f392b") + "colored text";
 		assertEquals(exceptedOutput, legacySection().serialize(input));
 	}
+	
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/adventure/LegacyComponentSerializerTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/adventure/LegacyComponentSerializerTest.java
@@ -1,0 +1,22 @@
+package be.seeseemelk.mockbukkit.adventure;
+
+import net.kyori.adventure.text.Component;
+import net.md_5.bungee.api.ChatColor;
+import org.junit.jupiter.api.Test;
+
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.format.TextColor.color;
+import static net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LegacyComponentSerializerTest
+{
+
+	@Test
+	void deserialize_UseBungeeColorFormat()
+	{
+		Component input = text("colored text", color(0x9f392b));
+		String exceptedOutput = ChatColor.of("#9f392b") + "colored text";
+		assertEquals(exceptedOutput, legacySection().serialize(input));
+	}
+}


### PR DESCRIPTION
# Description
The main reason for this change is to get the bungee format for hex colors when converting a `Component` to a legacy string. Hex colors are down sampled by default because there is no official format for this. This leads to the failure of this type of tests:
```java
class Test {
  @Test
  void hexColorRoundTrip() {
    MockBukkit.mock();
    String itemName = ChatColor.of("#1c3339") + "The Trident";
    ItemStack itemStack = new ItemStack(Material.TRIDENT);
    ItemMeta meta = itemStack.getItemMeta();
    meta.setDisplayName(itemName);
    itemStack.setItemMeta(meta);
    assertEquals(itemName, itemStack.getItemMeta().getDisplayName());
    // Expected :§x§1§c§3§3§3§9The Trident
    // Actual   :§3The Trident
  }
}
```

These methods use `LegacyComponentSerializer.legacySection()`, which creates a static component serializer with a default config if no service is registered for `LegacyComponentSerializer.Provider`.

Note that the legacy serializer can, even by default, deserialize bungee color format.

For the other serializers, their defaults should work exactly the same as before.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
