### PR TITLE
Fix ZombieMock not failing on villager operations

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ZombieMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ZombieMock.java
@@ -5,6 +5,7 @@ import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Villager;
 import org.bukkit.entity.Zombie;
+import org.bukkit.entity.ZombieVillager;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
@@ -12,17 +13,15 @@ import java.util.UUID;
 public class ZombieMock extends MonsterMock implements Zombie
 {
 
+	private static final String VILLAGER_OPERATION_NOT_SUPPORTED = "Not supported. Please spawn a new Zombie Villager instead.";
+
 	private boolean baby;
-	private boolean villager;
-	private Villager.Profession profession;
 	private boolean converting;
 	private int conversionTime;
 
 	public ZombieMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);
-		setMaxHealth(20);
-		setHealth(20);
 	}
 
 	@Override
@@ -34,48 +33,38 @@ public class ZombieMock extends MonsterMock implements Zombie
 	@Override
 	public boolean isVillager()
 	{
-		return villager;
+		return this instanceof ZombieVillager;
 	}
 
-	/**
-	 * This are unimplemented because they Bukkit specifies they should always fail? (@Contract Tag)
-	 *
-	 * @param villager If the zombie is a village
-	 */
 	@Override
 	public void setVillager(boolean villager)
 	{
-		this.villager = villager;
-		throw new UnimplementedOperationException();
+		throw new UnsupportedOperationException(VILLAGER_OPERATION_NOT_SUPPORTED);
 	}
 
-	/**
-	 * This are unimplemented because they Bukkit specifies they should always fail? (@Contract Tag)
-	 *
-	 * @param profession Villager profession to use
-	 */
 	@Override
 	public void setVillagerProfession(Villager.Profession profession)
 	{
-		throw new UnimplementedOperationException();
+		throw new UnsupportedOperationException(VILLAGER_OPERATION_NOT_SUPPORTED);
 	}
 
 	@Override
 	public Villager.Profession getVillagerProfession()
 	{
-		return profession;
+		// The CraftBukkit implementation returns null here, but throwing an exception is more fitting.
+		throw new UnsupportedOperationException(VILLAGER_OPERATION_NOT_SUPPORTED);
 	}
 
 	@Override
 	public boolean isConverting()
 	{
-		return converting;
+		return this.converting;
 	}
 
 	@Override
 	public int getConversionTime()
 	{
-		return conversionTime;
+		return this.conversionTime;
 	}
 
 	@Override
@@ -181,7 +170,7 @@ public class ZombieMock extends MonsterMock implements Zombie
 	@Override
 	public boolean isBaby()
 	{
-		return baby;
+		return this.baby;
 	}
 
 	@Override


### PR DESCRIPTION
# Description
Fixes not all villager operations failing when used, as according to CraftBukkit implementations.

# Checklist
The following items should be checked before the pull request can be merged.
- [ ] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
