### PR TITLE
Properly link external Javadocs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,14 +49,15 @@ jar {
     }
 }
 
-task javadocJar(type: Jar) {
-    classifier('javadoc')
-    from javadoc
+java {
+    withSourcesJar()
+    withJavadocJar()
 }
 
-task sourcesJar(type: Jar) {
-    classifier('sources')
-    from sourceSets.main.allSource
+javadoc {
+    options {
+        links "https://jd.papermc.io/paper/${gradle.ext.apiVersion}/"
+    }
 }
 
 processResources {
@@ -73,10 +74,6 @@ sourceCompatibility = gradle.ext.javaVersion
 targetCompatibility = gradle.ext.javaVersion
 tasks.withType(JavaCompile) {
     options.release.set(gradle.ext.javaVersion)
-}
-
-artifacts {
-    archives javadocJar, sourcesJar
 }
 
 def isFork = isFork()
@@ -114,8 +111,6 @@ publishing {
             artifactId = "MockBukkit-v${gradle.ext.apiVersion}"
             from components.java
 
-            artifact sourcesJar
-            artifact javadocJar
             version = property('mockbukkit.version')
             pom {
                 name = "MockBukkit-v${gradle.ext.apiVersion}"


### PR DESCRIPTION
# Description
Ensures that our Javadocs properly link to Papers.

It also cleans up the legacy way of generating Javadoc and sources jars.

# Checklist
The following items should be checked before the pull request can be merged.
- [ ] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
