### PR TITLE
Fix publishing to maven local not working

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ artifacts {
 def isFork = isFork()
 
 signing {
-    required { !isFork && System.getenv('JITPACK') == null }
+    required { !isFork && System.getenv('CI') != null }
     sign publishing.publications
 }
 
@@ -97,7 +97,7 @@ jacoco {
 }
 
 group = 'com.github.seeseemelk'
-version = property('mockbukkit.version')
+version = this.getVersion()
 
 nexusPublishing {
     repositories {
@@ -116,7 +116,6 @@ publishing {
 
             artifact sourcesJar
             artifact javadocJar
-            version = property('mockbukkit.version')
             pom {
                 name = "MockBukkit-v${gradle.ext.apiVersion}"
                 packaging = 'jar'
@@ -145,6 +144,12 @@ publishing {
     }
 }
 
+publishToMavenLocal {
+    doLast {
+        println("Published to Maven local with version '${this.getVersion()}'")
+    }
+}
+
 test {
     useJUnitPlatform()
 }
@@ -163,4 +168,12 @@ def isFork() {
     } catch (e) {
     }
     return true
+}
+
+def getVersion() {
+    if (System.getenv('CI') == null) {
+        return 'dev-' + 'git rev-parse --verify --short HEAD'.execute().text.trim()
+    } else {
+        return property('mockbukkit.version')
+    }
 }


### PR DESCRIPTION
# Description
Fixes Gradle trying to sign jars locally by checking if the `CI` env var exists, rather than `JITPACK`. ([source](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables))

This also makes it so the version is the git revision prefixed with `dev-` when built locally, since the `mockbukkit.version` property only exists when running in the GitHub action.

# Checklist
The following items should be checked before the pull request can be merged.
- [ ] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
