### PR TITLE
Implement server icons

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/CachedServerIconMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/CachedServerIconMock.java
@@ -1,0 +1,24 @@
+package be.seeseemelk.mockbukkit;
+
+import org.bukkit.util.CachedServerIcon;
+import org.jetbrains.annotations.Nullable;
+
+public class CachedServerIconMock implements CachedServerIcon
+{
+
+	public static final String PNG_BASE64_PREFIX = "data:image/png;base64,";
+
+	private final @Nullable String data;
+
+	protected CachedServerIconMock(@Nullable String data)
+	{
+		this.data = data;
+	}
+
+	@Override
+	public @Nullable String getData()
+	{
+		return this.data;
+	}
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -168,7 +168,7 @@ public class ServerMock extends Server.Spigot implements Server
 	private final HelpMapMock helpMap = new HelpMapMock();
 	private final StandardMessenger messenger = new StandardMessenger();
 	private final Map<Integer, MapViewMock> mapViews = new HashMap<>();
-	private CachedServerIconMock serverIcon;
+	private CachedServerIconMock serverIcon = new CachedServerIconMock(null);
 	private int nextMapId = 1;
 
 	private GameMode defaultGameMode = GameMode.SURVIVAL;
@@ -208,8 +208,6 @@ public class ServerMock extends Server.Spigot implements Server
 		{
 			logger.warning("Could not load build properties");
 		}
-
-		loadDefaultIcon();
 	}
 
 	/**
@@ -1494,6 +1492,16 @@ public class ServerMock extends Server.Spigot implements Server
 		throw new UnimplementedOperationException();
 	}
 
+	/**
+	 * Sets the return value of {@link #getServerIcon()}.
+	 *
+	 * @param serverIcon The icon to set.
+	 */
+	public void setServerIcon(CachedServerIconMock serverIcon)
+	{
+		this.serverIcon = serverIcon;
+	}
+
 	@Override
 	public CachedServerIconMock getServerIcon()
 	{
@@ -1520,25 +1528,6 @@ public class ServerMock extends Server.Spigot implements Server
 		String encoded = Base64.getEncoder().encodeToString(out.toByteArray());
 
 		return new CachedServerIconMock(CachedServerIconMock.PNG_BASE64_PREFIX + encoded);
-	}
-
-	/**
-	 * Loads the server icon from the "server-icon.png" in the servers running directory.
-	 */
-	private void loadDefaultIcon()
-	{
-		this.serverIcon = new CachedServerIconMock(null);
-		File file = new File("server-icon.png");
-		if (!file.isFile())
-			return;
-		try
-		{
-			this.serverIcon = loadServerIcon(file);
-		}
-		catch (Exception ex)
-		{
-			throw new IllegalArgumentException(ex);
-		}
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -110,16 +110,18 @@ import org.bukkit.potion.PotionBrewer;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scoreboard.Criteria;
 import org.bukkit.structure.StructureManager;
-import org.bukkit.util.CachedServerIcon;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -166,6 +168,7 @@ public class ServerMock extends Server.Spigot implements Server
 	private final HelpMapMock helpMap = new HelpMapMock();
 	private final StandardMessenger messenger = new StandardMessenger();
 	private final Map<Integer, MapViewMock> mapViews = new HashMap<>();
+	private CachedServerIconMock serverIcon;
 	private int nextMapId = 1;
 
 	private GameMode defaultGameMode = GameMode.SURVIVAL;
@@ -195,6 +198,7 @@ public class ServerMock extends Server.Spigot implements Server
 		{
 			logger.warning("Could not load file logger.properties");
 		}
+		logger.setLevel(Level.ALL);
 
 		try
 		{
@@ -205,8 +209,7 @@ public class ServerMock extends Server.Spigot implements Server
 			logger.warning("Could not load build properties");
 		}
 
-		logger.setLevel(Level.ALL);
-
+		loadDefaultIcon();
 	}
 
 	/**
@@ -1492,24 +1495,50 @@ public class ServerMock extends Server.Spigot implements Server
 	}
 
 	@Override
-	public CachedServerIcon getServerIcon()
+	public CachedServerIconMock getServerIcon()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.serverIcon;
 	}
 
 	@Override
-	public @NotNull CachedServerIcon loadServerIcon(File file)
+	public @NotNull CachedServerIconMock loadServerIcon(@NotNull File file) throws IOException
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkNotNull(file, "File cannot be null");
+		Preconditions.checkArgument(file.isFile(), file + " isn't a file");
+		return loadServerIcon(ImageIO.read(file));
 	}
 
 	@Override
-	public @NotNull CachedServerIcon loadServerIcon(BufferedImage image)
+	public @NotNull CachedServerIconMock loadServerIcon(@NotNull BufferedImage image) throws IOException
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkNotNull(image, "Image cannot be null");
+		Preconditions.checkArgument(image.getWidth() == 64, "Image must be 64 pixels wide");
+		Preconditions.checkArgument(image.getHeight() == 64, "Image must be 64 pixels high");
+
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		ImageIO.write(image, "PNG", out);
+		String encoded = Base64.getEncoder().encodeToString(out.toByteArray());
+
+		return new CachedServerIconMock(CachedServerIconMock.PNG_BASE64_PREFIX + encoded);
+	}
+
+	/**
+	 * Loads the server icon from the "server-icon.png" in the servers running directory.
+	 */
+	private void loadDefaultIcon()
+	{
+		this.serverIcon = new CachedServerIconMock(null);
+		File file = new File(new File("."), "server-icon.png");
+		if (!file.isFile())
+			return;
+		try
+		{
+			this.serverIcon = loadServerIcon(file);
+		}
+		catch (Exception ex)
+		{
+			throw new IllegalArgumentException(ex);
+		}
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -1528,7 +1528,7 @@ public class ServerMock extends Server.Spigot implements Server
 	private void loadDefaultIcon()
 	{
 		this.serverIcon = new CachedServerIconMock(null);
-		File file = new File(new File("."), "server-icon.png");
+		File file = new File("server-icon.png");
 		if (!file.isFile())
 			return;
 		try

--- a/src/test/java/be/seeseemelk/mockbukkit/CachedServerIconMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/CachedServerIconMockTest.java
@@ -1,0 +1,43 @@
+package be.seeseemelk.mockbukkit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class CachedServerIconMockTest
+{
+
+	private ServerMock mock;
+
+	@BeforeEach
+	public void setUp()
+	{
+		mock = MockBukkit.mock();
+	}
+
+	@AfterEach
+	public void teardown()
+	{
+		MockBukkit.unmock();
+	}
+
+	@Test
+	void constructor_NotNull_SetsData()
+	{
+		CachedServerIconMock icon = new CachedServerIconMock(null);
+		assertNull(icon.getData());
+	}
+
+	@Test
+	void constructor_WithData_SetsData()
+	{
+		CachedServerIconMock icon = new CachedServerIconMock("mmm yes data");
+		assertNotNull(icon.getData());
+		assertEquals("mmm yes data", icon.getData());
+	}
+
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -41,9 +41,14 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import javax.imageio.ImageIO;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -836,7 +841,7 @@ class ServerMockTest
 	{
 		server.setWhitelist(true);
 
-		PlayerMock playerMock = new PlayerMock(server,"Player", UUID.randomUUID());
+		PlayerMock playerMock = new PlayerMock(server, "Player", UUID.randomUUID());
 		playerMock.setWhitelisted(true);
 
 		server.addPlayer(playerMock);
@@ -883,6 +888,64 @@ class ServerMockTest
 	void permissionMessage_NotNull()
 	{
 		assertNotNull(server.permissionMessage());
+	}
+
+	@Test
+	void loadServerIcon_NullFile_ThrowsException()
+	{
+		assertThrows(NullPointerException.class, () -> server.loadServerIcon((File) null));
+	}
+
+	@Test
+	void loadServerIcon_NullImage_ThrowsException()
+	{
+		assertThrows(NullPointerException.class, () -> server.loadServerIcon((BufferedImage) null));
+	}
+
+	@Test
+	void loadServerIcon_WrongWidth_ThrowsException()
+	{
+		BufferedImage image63 = new BufferedImage(63, 64, BufferedImage.TYPE_INT_RGB);
+		BufferedImage image65 = new BufferedImage(65, 64, BufferedImage.TYPE_INT_RGB);
+		assertThrows(IllegalArgumentException.class, () -> server.loadServerIcon(image63));
+		assertThrows(IllegalArgumentException.class, () -> server.loadServerIcon(image65));
+	}
+
+	@Test
+	void loadServerIcon_WrongHeight_ThrowsException()
+	{
+		BufferedImage image63 = new BufferedImage(64, 63, BufferedImage.TYPE_INT_RGB);
+		BufferedImage image65 = new BufferedImage(64, 65, BufferedImage.TYPE_INT_RGB);
+		assertThrows(IllegalArgumentException.class, () -> server.loadServerIcon(image63));
+		assertThrows(IllegalArgumentException.class, () -> server.loadServerIcon(image65));
+	}
+
+	@Test
+	void loadServerIcon_CorrectSize()
+	{
+		BufferedImage image = new BufferedImage(64, 64, BufferedImage.TYPE_INT_RGB);
+		assertDoesNotThrow(() -> server.loadServerIcon(image));
+	}
+
+	@Test
+	void loadServerIcon_CorrectData() throws IOException
+	{
+		BufferedImage image = new BufferedImage(64, 64, BufferedImage.TYPE_INT_RGB);
+		Graphics2D g = image.createGraphics();
+		g.drawOval(0, 0, 64, 64);
+		g.dispose();
+
+		CachedServerIconMock icon = server.loadServerIcon(image);
+		byte[] decodedBase64 = Base64.getDecoder().decode(icon.getData().replace(CachedServerIconMock.PNG_BASE64_PREFIX, ""));
+		BufferedImage decodedImage = ImageIO.read(new ByteArrayInputStream(decodedBase64));
+
+		for (int x = 0; x < 64; x++)
+		{
+			for (int y = 0; y < 64; y++)
+			{
+				assertEquals(image.getRGB(x, y), decodedImage.getRGB(x, y));
+			}
+		}
 	}
 
 }


### PR DESCRIPTION
# Description
Implements server icons. The `CachedServerIconMock` is currently located in the root package, which I don't like, but I also couldn't think of a better place to put it. If you have a better spot for it please let me know. CraftBukkit has it in the `util` package but I don't feel like that's a great place for it.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
