### PR TITLE
Fix main hand slot and nullability issues

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/adventure/LegacyComponentSerializerProviderImpl.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/adventure/LegacyComponentSerializerProviderImpl.java
@@ -31,7 +31,9 @@ public class LegacyComponentSerializerProviderImpl implements LegacyComponentSer
 	@Override
 	public @NotNull Consumer<LegacyComponentSerializer.Builder> legacy()
 	{
-		return builder -> {};
+		return builder ->
+		{
+		};
 	}
-	
+
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/AmethystClusterMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/AmethystClusterMock.java
@@ -1,7 +1,6 @@
 package be.seeseemelk.mockbukkit.block.data;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.Directional;

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -48,7 +48,6 @@ import org.spigotmc.event.entity.EntityMountEvent;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/FoxMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/FoxMock.java
@@ -62,6 +62,7 @@ public class FoxMock extends AnimalsMock implements Fox
 
 	/**
 	 * Checks if the Fox is sleeping
+	 *
 	 * @return True if he is sleeping, false if not
 	 */
 	public boolean isSleeping()

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/GoatMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/GoatMock.java
@@ -72,6 +72,7 @@ public class GoatMock extends AnimalsMock implements Goat
 
 	/**
 	 * Asserts that the goat attacked the given entity.
+	 *
 	 * @param entity The entity to assert.
 	 */
 	public void assertEntityRammed(@NotNull LivingEntity entity)

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -5,6 +5,7 @@ import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.attribute.AttributeInstanceMock;
 import be.seeseemelk.mockbukkit.attribute.AttributesMock;
+import be.seeseemelk.mockbukkit.inventory.EntityEquipmentMock;
 import be.seeseemelk.mockbukkit.potion.ActivePotionEffect;
 import com.destroystokyo.paper.block.TargetBlockInfo;
 import com.destroystokyo.paper.entity.TargetEntityInfo;

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ThrowableProjectileMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ThrowableProjectileMock.java
@@ -2,7 +2,6 @@ package be.seeseemelk.mockbukkit.entity;
 
 import be.seeseemelk.mockbukkit.ServerMock;
 import org.bukkit.entity.ThrowableProjectile;
-import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/WolfMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/WolfMock.java
@@ -55,6 +55,7 @@ public class WolfMock extends TameableAnimalMock implements Wolf
 
 	/**
 	 * Sets whether the wolf is wet or not.
+	 *
 	 * @param wet Whether the wolf is wet or not.
 	 */
 	public void setWet(boolean wet)

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/EntityEquipmentMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/EntityEquipmentMock.java
@@ -1,6 +1,6 @@
-package be.seeseemelk.mockbukkit.entity;
+package be.seeseemelk.mockbukkit.inventory;
 
-import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import be.seeseemelk.mockbukkit.entity.LivingEntityMock;
 import com.google.common.base.Preconditions;
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
@@ -28,13 +28,13 @@ public class EntityEquipmentMock implements EntityEquipment
 
 	private final Map<EquipmentSlot, Float> dropChances = new EnumMap<>(EquipmentSlot.class);
 
-	private @Nullable ItemStack itemInMainHand = new ItemStack(Material.AIR);
-	private @Nullable ItemStack itemInOffHand = new ItemStack(Material.AIR);
+	private @NotNull ItemStack itemInMainHand = new ItemStack(Material.AIR);
+	private @NotNull ItemStack itemInOffHand = new ItemStack(Material.AIR);
 
-	private @Nullable ItemStack helmet = new ItemStack(Material.AIR);
-	private @Nullable ItemStack chestPlate = new ItemStack(Material.AIR);
-	private @Nullable ItemStack leggings = new ItemStack(Material.AIR);
-	private @Nullable ItemStack boots = new ItemStack(Material.AIR);
+	private @NotNull ItemStack helmet = new ItemStack(Material.AIR);
+	private @NotNull ItemStack chestPlate = new ItemStack(Material.AIR);
+	private @NotNull ItemStack leggings = new ItemStack(Material.AIR);
+	private @NotNull ItemStack boots = new ItemStack(Material.AIR);
 
 	public EntityEquipmentMock(@NotNull LivingEntityMock holder)
 	{
@@ -94,7 +94,7 @@ public class EntityEquipmentMock implements EntityEquipment
 	@Override
 	public void setItemInMainHand(@Nullable ItemStack item, boolean silent)
 	{
-		this.itemInMainHand = item;
+		this.itemInMainHand = notNullClone(item);
 		// Sounds are not implemented here
 	}
 
@@ -113,7 +113,7 @@ public class EntityEquipmentMock implements EntityEquipment
 	@Override
 	public void setItemInOffHand(@Nullable ItemStack item, boolean silent)
 	{
-		this.itemInOffHand = item;
+		this.itemInOffHand = notNullClone(item);
 		// Sounds are not implemented here
 	}
 
@@ -132,9 +132,9 @@ public class EntityEquipmentMock implements EntityEquipment
 	}
 
 	@Override
-	public @Nullable ItemStack getHelmet()
+	public @NotNull ItemStack getHelmet()
 	{
-		return helmet;
+		return this.helmet.clone();
 	}
 
 	@Override
@@ -146,14 +146,14 @@ public class EntityEquipmentMock implements EntityEquipment
 	@Override
 	public void setHelmet(@Nullable ItemStack helmet, boolean silent)
 	{
-		this.helmet = helmet;
+		this.helmet = notNullClone(helmet);
 		// Sounds are not implemented here
 	}
 
 	@Override
-	public @Nullable ItemStack getChestplate()
+	public @NotNull ItemStack getChestplate()
 	{
-		return chestPlate;
+		return this.chestPlate.clone();
 	}
 
 	@Override
@@ -165,14 +165,14 @@ public class EntityEquipmentMock implements EntityEquipment
 	@Override
 	public void setChestplate(@Nullable ItemStack chestplate, boolean silent)
 	{
-		this.chestPlate = chestplate;
+		this.chestPlate = notNullClone(chestplate);
 		// Sounds are not implemented here
 	}
 
 	@Override
-	public @Nullable ItemStack getLeggings()
+	public @NotNull ItemStack getLeggings()
 	{
-		return leggings;
+		return this.leggings.clone();
 	}
 
 	@Override
@@ -184,14 +184,14 @@ public class EntityEquipmentMock implements EntityEquipment
 	@Override
 	public void setLeggings(@Nullable ItemStack leggings, boolean silent)
 	{
-		this.leggings = leggings;
+		this.leggings = notNullClone(leggings);
 		// Sounds are not implemented here
 	}
 
 	@Override
-	public @Nullable ItemStack getBoots()
+	public @NotNull ItemStack getBoots()
 	{
-		return boots;
+		return this.boots.clone();
 	}
 
 	@Override
@@ -203,7 +203,7 @@ public class EntityEquipmentMock implements EntityEquipment
 	@Override
 	public void setBoots(@Nullable ItemStack boots, boolean silent)
 	{
-		this.boots = boots;
+		this.boots = notNullClone(boots);
 		// Sounds are not implemented here
 	}
 
@@ -342,6 +342,11 @@ public class EntityEquipmentMock implements EntityEquipment
 	{
 		Preconditions.checkNotNull(slot, "Slot cannot be null");
 		return this.dropChances.get(slot);
+	}
+
+	static @NotNull ItemStack notNullClone(@Nullable ItemStack itemStack)
+	{
+		return itemStack == null ? new ItemStack(Material.AIR) : itemStack.clone();
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/EntityEquipmentMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/EntityEquipmentMock.java
@@ -94,7 +94,7 @@ public class EntityEquipmentMock implements EntityEquipment
 	@Override
 	public void setItemInMainHand(@Nullable ItemStack item, boolean silent)
 	{
-		this.itemInMainHand = notNullClone(item);
+		this.itemInMainHand = nonNullClone(item);
 		// Sounds are not implemented here
 	}
 
@@ -113,7 +113,7 @@ public class EntityEquipmentMock implements EntityEquipment
 	@Override
 	public void setItemInOffHand(@Nullable ItemStack item, boolean silent)
 	{
-		this.itemInOffHand = notNullClone(item);
+		this.itemInOffHand = nonNullClone(item);
 		// Sounds are not implemented here
 	}
 
@@ -146,7 +146,7 @@ public class EntityEquipmentMock implements EntityEquipment
 	@Override
 	public void setHelmet(@Nullable ItemStack helmet, boolean silent)
 	{
-		this.helmet = notNullClone(helmet);
+		this.helmet = nonNullClone(helmet);
 		// Sounds are not implemented here
 	}
 
@@ -165,7 +165,7 @@ public class EntityEquipmentMock implements EntityEquipment
 	@Override
 	public void setChestplate(@Nullable ItemStack chestplate, boolean silent)
 	{
-		this.chestPlate = notNullClone(chestplate);
+		this.chestPlate = nonNullClone(chestplate);
 		// Sounds are not implemented here
 	}
 
@@ -184,7 +184,7 @@ public class EntityEquipmentMock implements EntityEquipment
 	@Override
 	public void setLeggings(@Nullable ItemStack leggings, boolean silent)
 	{
-		this.leggings = notNullClone(leggings);
+		this.leggings = nonNullClone(leggings);
 		// Sounds are not implemented here
 	}
 
@@ -203,7 +203,7 @@ public class EntityEquipmentMock implements EntityEquipment
 	@Override
 	public void setBoots(@Nullable ItemStack boots, boolean silent)
 	{
-		this.boots = notNullClone(boots);
+		this.boots = nonNullClone(boots);
 		// Sounds are not implemented here
 	}
 
@@ -344,7 +344,7 @@ public class EntityEquipmentMock implements EntityEquipment
 		return this.dropChances.get(slot);
 	}
 
-	static @NotNull ItemStack notNullClone(@Nullable ItemStack itemStack)
+	static @NotNull ItemStack nonNullClone(@Nullable ItemStack itemStack)
 	{
 		return itemStack == null ? new ItemStack(Material.AIR) : itemStack.clone();
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/EntityEquipmentMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/EntityEquipmentMock.java
@@ -82,7 +82,7 @@ public class EntityEquipmentMock implements EntityEquipment
 	@Override
 	public @NotNull ItemStack getItemInMainHand()
 	{
-		return itemInMainHand;
+		return this.itemInMainHand.clone();
 	}
 
 	@Override
@@ -101,7 +101,7 @@ public class EntityEquipmentMock implements EntityEquipment
 	@Override
 	public @NotNull ItemStack getItemInOffHand()
 	{
-		return itemInOffHand;
+		return this.itemInOffHand.clone();
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryMock.java
@@ -62,25 +62,25 @@ public class PlayerInventoryMock extends InventoryMock implements PlayerInventor
 	}
 
 	@Override
-	public ItemStack getHelmet()
+	public @Nullable ItemStack getHelmet()
 	{
 		return getItem(HELMET);
 	}
 
 	@Override
-	public ItemStack getChestplate()
+	public @Nullable ItemStack getChestplate()
 	{
 		return getItem(CHESTPLATE);
 	}
 
 	@Override
-	public ItemStack getLeggings()
+	public @Nullable ItemStack getLeggings()
 	{
 		return getItem(LEGGINGS);
 	}
 
 	@Override
-	public ItemStack getBoots()
+	public @Nullable ItemStack getBoots()
 	{
 		return getItem(BOOTS);
 	}
@@ -298,28 +298,17 @@ public class PlayerInventoryMock extends InventoryMock implements PlayerInventor
 		setItemInMainHand(stack);
 	}
 
-	/**
-	 * Gets the {@link ItemStack} at the given equipment slot in the inventory.
-	 *
-	 * <p>Implementation note: only the contents of the main hand
-	 * and the off hand are guaranteed not to be {@code null},
-	 * despite the annotation present in the Bukkit api.</p>
-	 *
-	 * @param slot the slot to get the {@link ItemStack}
-	 * @return the {@link ItemStack} in the given slot
-	 */
 	@Override
 	public @NotNull ItemStack getItem(@NotNull EquipmentSlot slot)
 	{
 		return switch (slot)
 				{
-					case CHEST -> getChestplate();
-					case FEET -> getBoots();
+					case CHEST -> notNull(getChestplate());
+					case FEET -> notNull(getBoots());
 					case HAND -> getItemInMainHand();
-					case HEAD -> getHelmet();
-					case LEGS -> getLeggings();
+					case HEAD -> notNull(getHelmet());
+					case LEGS -> notNull(getLeggings());
 					case OFF_HAND -> getItemInOffHand();
-					default -> new ItemStack(Material.AIR);
 				};
 	}
 
@@ -340,9 +329,6 @@ public class PlayerInventoryMock extends InventoryMock implements PlayerInventor
 		case HEAD -> setHelmet(item);
 		case LEGS -> setLeggings(item);
 		case OFF_HAND -> setItemInOffHand(item);
-		default ->
-		{
-		}
 		}
 		// Sounds are not implemented here
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryMock.java
@@ -359,7 +359,7 @@ public class PlayerInventoryMock extends InventoryMock implements PlayerInventor
 		throw new UnsupportedOperationException("Cannot set drop chance for PlayerInventory");
 	}
 
-	private @NotNull ItemStack notNull(@Nullable ItemStack itemStack)
+	static @NotNull ItemStack notNull(@Nullable ItemStack itemStack)
 	{
 		return itemStack == null ? new ItemStack(Material.AIR) : itemStack;
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryMock.java
@@ -249,7 +249,7 @@ public class PlayerInventoryMock extends InventoryMock implements PlayerInventor
 	@Override
 	public @NotNull ItemStack getItemInMainHand()
 	{
-		return notNull(getItem(SLOT_BAR + mainHandSlot));
+		return notNull(getItem(HOTBAR + mainHandSlot));
 	}
 
 	@Override
@@ -261,7 +261,7 @@ public class PlayerInventoryMock extends InventoryMock implements PlayerInventor
 	@Override
 	public void setItemInMainHand(@Nullable ItemStack item, boolean silent)
 	{
-		setItem(SLOT_BAR + mainHandSlot, item);
+		setItem(HOTBAR + mainHandSlot, item);
 		// Sounds are not implemented here
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/WorkbenchInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/WorkbenchInventoryMock.java
@@ -10,8 +10,6 @@ import org.bukkit.inventory.Recipe;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Arrays;
-
 public class WorkbenchInventoryMock extends InventoryMock implements CraftingInventory
 {
 

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/EntityEquipmentMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/EntityEquipmentMockTest.java
@@ -1,10 +1,11 @@
-package be.seeseemelk.mockbukkit.entity;
+package be.seeseemelk.mockbukkit.inventory;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.entity.ArmorStandMock;
+import be.seeseemelk.mockbukkit.entity.ZombieMock;
 import org.bukkit.Material;
 import org.bukkit.entity.ArmorStand;
-import org.bukkit.entity.Zombie;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
@@ -20,8 +21,8 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EntityEquipmentMockTest
 {
@@ -54,6 +55,7 @@ class EntityEquipmentMockTest
 		equipment.setItemInMainHand(item);
 
 		assertEquals(item, equipment.getItemInMainHand());
+		assertNotSame(item, equipment.getItemInMainHand());
 		assertEquals(item, equipment.getItem(EquipmentSlot.HAND));
 	}
 
@@ -66,6 +68,7 @@ class EntityEquipmentMockTest
 		equipment.setItemInOffHand(item);
 
 		assertEquals(item, equipment.getItemInOffHand());
+		assertNotSame(item, equipment.getItemInOffHand());
 		assertEquals(item, equipment.getItem(EquipmentSlot.OFF_HAND));
 	}
 
@@ -78,6 +81,7 @@ class EntityEquipmentMockTest
 		equipment.setHelmet(item);
 
 		assertEquals(item, equipment.getHelmet());
+		assertNotSame(item, equipment.getHelmet());
 		assertEquals(item, equipment.getItem(EquipmentSlot.HEAD));
 	}
 
@@ -90,6 +94,7 @@ class EntityEquipmentMockTest
 		equipment.setChestplate(item);
 
 		assertEquals(item, equipment.getChestplate());
+		assertNotSame(item, equipment.getChestplate());
 		assertEquals(item, equipment.getItem(EquipmentSlot.CHEST));
 	}
 
@@ -102,6 +107,7 @@ class EntityEquipmentMockTest
 		equipment.setLeggings(item);
 
 		assertEquals(item, equipment.getLeggings());
+		assertNotSame(item, equipment.getLeggings());
 		assertEquals(item, equipment.getItem(EquipmentSlot.LEGS));
 	}
 
@@ -114,6 +120,7 @@ class EntityEquipmentMockTest
 		equipment.setBoots(item);
 
 		assertEquals(item, equipment.getBoots());
+		assertNotSame(item, equipment.getBoots());
 		assertEquals(item, equipment.getItem(EquipmentSlot.FEET));
 	}
 
@@ -215,13 +222,17 @@ class EntityEquipmentMockTest
 		contents[3] = new ItemStack(Material.DIAMOND);
 		equipment.setArmorContents(contents);
 		equipment.clear();
-		assertArrayEquals(new ItemStack[4], equipment.getArmorContents());
+		ItemStack[] excepted = new ItemStack[4];
+		Arrays.fill(excepted, new ItemStack(Material.AIR));
+		assertArrayEquals(excepted, equipment.getArmorContents());
 	}
 
 	@ParameterizedTest
 	@EnumSource(EquipmentSlot.class)
 	void testGetItem(EquipmentSlot slot)
 	{
+		equipment.setItem(slot, null);
+		assertEquals(new ItemStack(Material.AIR), equipment.getItem(slot));
 		ItemStack item = new ItemStack(Material.DIAMOND);
 		equipment.setItem(slot, item);
 		assertEquals(item, equipment.getItem(slot));

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryMockTest.java
@@ -59,7 +59,7 @@ class PlayerInventoryMockTest
 		inventory.setItemInMainHand(item);
 		assertEquals(item, inventory.getItemInMainHand());
 		assertEquals(item, inventory.getItemInHand());
-		assertEquals(item, inventory.getContents()[PlayerInventoryMock.SLOT_BAR]);
+		assertEquals(item, inventory.getContents()[inventory.getHeldItemSlot()]);
 	}
 
 	@SuppressWarnings("deprecation")
@@ -82,7 +82,7 @@ class PlayerInventoryMockTest
 		item.setAmount(25);
 		inventory.setItemInMainHand(item);
 		assertEquals(item, inventory.getItemInMainHand());
-		assertEquals(item, inventory.getItem(PlayerInventoryMock.SLOT_BAR + 1));
+		assertEquals(item, inventory.getItem(PlayerInventoryMock.HOTBAR + 1));
 	}
 
 	@Test

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryMockTest.java
@@ -9,11 +9,12 @@ import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -261,18 +262,15 @@ class PlayerInventoryMockTest
 		assertThrows(IllegalArgumentException.class, () -> inventory.setExtraContents(new ItemStack[2]));
 	}
 
-	@Test
-	void getItem_Nullability()
+	@ParameterizedTest
+	@EnumSource(EquipmentSlot.class)
+	void getItem_Mirror(EquipmentSlot slot)
 	{
-		inventory.setItemInMainHand(null);
-		inventory.setItemInOffHand(null);
-		inventory.setChestplate(null);
-		assertNotNull(inventory.getItem(EquipmentSlot.HAND));
-		assertNotNull(inventory.getItemInMainHand());
-		assertNotNull(inventory.getItem(EquipmentSlot.OFF_HAND));
-		assertNotNull(inventory.getItemInOffHand());
-		assertNotNull(inventory.getItem(EquipmentSlot.CHEST));
-		assertNull(inventory.getChestplate());
+		ItemStack apiItemStack = new ItemStack(Material.SCULK);
+		inventory.setItem(slot, apiItemStack);
+		ItemStack mirrorItemStack = inventory.getItem(slot);
+		assertNotSame(apiItemStack, mirrorItemStack);
+		assertSame(mirrorItemStack, inventory.getItem(slot));
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryMockTest.java
@@ -271,7 +271,7 @@ class PlayerInventoryMockTest
 		assertNotNull(inventory.getItemInMainHand());
 		assertNotNull(inventory.getItem(EquipmentSlot.OFF_HAND));
 		assertNotNull(inventory.getItemInOffHand());
-		assertNull(inventory.getItem(EquipmentSlot.CHEST));
+		assertNotNull(inventory.getItem(EquipmentSlot.CHEST));
 		assertNull(inventory.getChestplate());
 	}
 


### PR DESCRIPTION
# Description
Fixes #616 by using the correct slot offset for `#getItemInMainHand()`. This also updates the `PlayerInventory#getItem(EquipmentSlot)` method, Paper [has fixed the annotation issue](https://github.com/PaperMC/Paper/blob/09904fd780175821a43adf74cc5a00d363e4a83d/patches/server/0865-Make-some-itemstacks-nonnull.patch).

In the nullable territory, this PR also fixes the non-null contract for `EntityEquipment#getHelmet()` (and other equipments, only for non-players inventories). 

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
