### PR TITLE
Implement PluginManagerMock#removePermission(String)

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
@@ -52,6 +52,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
@@ -75,7 +76,7 @@ public class PluginManagerMock implements PluginManager
 	private final List<PluginCommand> commands = new ArrayList<>();
 	private final List<Event> events = new ArrayList<>();
 	private File parentTemporaryDirectory;
-	private final List<Permission> permissions = new ArrayList<>();
+	private final Map<String, Permission> permissions = new HashMap<>();
 	private final Map<Permissible, Set<String>> permissionSubscriptions = new HashMap<>();
 	private final Map<Boolean, Map<Permissible, Boolean>> defaultPermissionSubscriptions = new HashMap<Boolean, Map<Permissible, Boolean>>();
 	private final @NotNull Map<String, List<Listener>> listeners = new HashMap<>();
@@ -802,41 +803,34 @@ public class PluginManagerMock implements PluginManager
 	@Override
 	public Permission getPermission(@NotNull String name)
 	{
-		return permissions.stream().filter(permission -> permission.getName().equals(name)).findFirst().orElse(null);
+		return permissions.get(name.toLowerCase(Locale.ENGLISH));
 	}
 
 	@Override
 	public void addPermission(@NotNull Permission perm)
 	{
-		permissions.add(perm);
+		permissions.put(perm.getName().toLowerCase(Locale.ENGLISH), perm);
 	}
 
 	@Override
 	public void removePermission(@NotNull Permission perm)
 	{
-		permissions.remove(perm);
+		permissions.remove(perm.getName().toLowerCase(Locale.ENGLISH));
 	}
 
 	@Override
 	public void removePermission(@NotNull String name)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		permissions.remove(name.toLowerCase(Locale.ENGLISH));
 	}
 
 	@Override
 	public @NotNull Set<Permission> getDefaultPermissions(boolean op)
 	{
-		Set<Permission> perms = new HashSet<>();
-		for (Permission perm : this.permissions)
-		{
-			PermissionDefault permDefault = perm.getDefault();
-			if (permDefault == PermissionDefault.TRUE || (op && permDefault == PermissionDefault.OP))
-			{
-				perms.add(perm);
-			}
-		}
-		return perms;
+		return this.permissions.values()
+				.stream()
+				.filter(perm -> perm.getDefault() == PermissionDefault.TRUE || op && perm.getDefault() == PermissionDefault.OP)
+				.collect(Collectors.toSet());
 	}
 
 	@Override
@@ -929,7 +923,7 @@ public class PluginManagerMock implements PluginManager
 	@Override
 	public @NotNull Set<Permission> getPermissions()
 	{
-		return Set.copyOf(permissions);
+		return Set.copyOf(permissions.values());
 	}
 
 	/**

--- a/src/test/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMockTest.java
@@ -201,6 +201,17 @@ class PluginManagerMockTest
 	}
 
 	@Test
+	void removePermission_String() {
+		Permission permission = new Permission("mockbukkit.perm");
+		pluginManager.addPermission(permission);
+		assertTrue(pluginManager.getPermissions().contains(permission));
+
+		pluginManager.removePermission("mockbukkit.perm");
+
+		assertFalse(pluginManager.getPermissions().contains(permission));
+	}
+
+	@Test
 	void disablePlugin_LoadedPlugin_PluginDisabled()
 	{
 		TestPlugin plugin = MockBukkit.load(TestPlugin.class);


### PR DESCRIPTION
# Description
Implements `PluginManagerMock#removePermission(String)`.

To implement this, it refactors permission handling to store them as a map of Name->Permission. 
With that, everywhere permission names are handled, they are converted to lowercase with the English locale, to keep [Bukkit parody](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/browse/src/main/java/org/bukkit/plugin/SimplePluginManager.java#690,700,723)

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
