### PR TITLE
Fix MetadataTable#getMetadata NPE

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/metadata/MetadataTable.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/metadata/MetadataTable.java
@@ -5,7 +5,6 @@ import org.bukkit.metadata.Metadatable;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,26 +25,27 @@ public class MetadataTable implements Metadatable
 	}
 
 	@Override
-	public void setMetadata(String metadataKey, @NotNull MetadataValue newMetadataValue)
+	public void setMetadata(@NotNull String metadataKey, @NotNull MetadataValue newMetadataValue)
 	{
 		Map<Plugin, MetadataValue> values = metadata.computeIfAbsent(metadataKey, key -> new HashMap<>());
 		values.put(newMetadataValue.getOwningPlugin(), newMetadataValue);
 	}
 
 	@Override
-	public @NotNull List<MetadataValue> getMetadata(String metadataKey)
+	public @NotNull List<MetadataValue> getMetadata(@NotNull String metadataKey)
 	{
-		return new ArrayList<>(metadata.get(metadataKey).values());
+		Map<Plugin, MetadataValue> values = this.metadata.get(metadataKey);
+		return values == null ? List.of() : List.copyOf(values.values());
 	}
 
 	@Override
-	public boolean hasMetadata(String metadataKey)
+	public boolean hasMetadata(@NotNull String metadataKey)
 	{
 		return metadata.containsKey(metadataKey) && metadata.get(metadataKey).size() > 0;
 	}
 
 	@Override
-	public void removeMetadata(String metadataKey, Plugin owningPlugin)
+	public void removeMetadata(@NotNull String metadataKey, @NotNull Plugin owningPlugin)
 	{
 		if (metadata.containsKey(metadataKey))
 		{


### PR DESCRIPTION
# Description
When calling `MetadataTable#getMetadata` with data that isn't set, an NPE is thrown.
This changes the implementation to [align with Bukkit](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/browse/src/main/java/org/bukkit/metadata/MetadataStoreBase.java#63-71), and not throw an exception.

This also inadvertently changes the returned list to be immutable, which improves Bukkit parody.

# Checklist
The following items should be checked before the pull request can be merged.
- [ ] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
