### PR TITLE
Remove Projectile's doesBounce implementation

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/entity/AbstractProjectileMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/AbstractProjectileMock.java
@@ -13,26 +13,23 @@ import java.util.UUID;
 public abstract class AbstractProjectileMock extends EntityMock implements Projectile
 {
 
-	private boolean doesBounce;
-
 	protected AbstractProjectileMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);
-		this.doesBounce = false;
 	}
 
 	@Override
 	@Deprecated(forRemoval = true)
 	public boolean doesBounce()
 	{
-		return this.doesBounce;
+		throw new UnsupportedOperationException("Deprecated; Does not do anything");
 	}
 
 	@Override
 	@Deprecated(forRemoval = true)
 	public void setBounce(boolean doesBounce)
 	{
-		this.doesBounce = doesBounce;
+		throw new UnsupportedOperationException("Deprecated; Does not do anything");
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/AbstractProjectileMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/AbstractProjectileMockTest.java
@@ -8,8 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AbstractProjectileMockTest
 {
@@ -32,14 +31,13 @@ class AbstractProjectileMockTest
 	@Test
 	void testDoesBounceDefault()
 	{
-		assertFalse(abstractProjectile.doesBounce());
+		assertThrows(UnsupportedOperationException.class, () -> abstractProjectile.doesBounce());
 	}
 
 	@Test
 	void testSetBounce()
 	{
-		abstractProjectile.setBounce(true);
-		assertTrue(abstractProjectile.doesBounce());
+		assertThrows(UnsupportedOperationException.class, () -> abstractProjectile.setBounce(true));
 	}
 
 }


### PR DESCRIPTION
# Description
This removes the implementations of `Projectile#doesBounce`, throwing an UnsupportedOperationException when used. As the Javadoc says, this is an old feature that does not do anything anymore, and therefore should not be used. Even as far back as 1.8.8, there are no usages of it in CraftBukkit.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
