### PR TITLE
Fix compile warning in ArmorStandMockTest

### DIFF
--- a/src/test/java/be/seeseemelk/mockbukkit/entity/ArmorStandMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/ArmorStandMockTest.java
@@ -346,7 +346,7 @@ class ArmorStandMockTest
 	@Test
 	void testSetDisabledSlotsNullThrows()
 	{
-		assertThrows(NullPointerException.class, () -> armorStand.setDisabledSlots(null));
+		assertThrows(NullPointerException.class, () -> armorStand.setDisabledSlots((EquipmentSlot) null));
 	}
 
 	@Test
@@ -362,7 +362,7 @@ class ArmorStandMockTest
 	@Test
 	void testAddDisabledSlotsNullThrows()
 	{
-		assertThrows(NullPointerException.class, () -> armorStand.addDisabledSlots(null));
+		assertThrows(NullPointerException.class, () -> armorStand.addDisabledSlots((EquipmentSlot) null));
 	}
 
 	@Test
@@ -377,7 +377,7 @@ class ArmorStandMockTest
 	@Test
 	void testRemoveDisabledSlotsNullThrows()
 	{
-		assertThrows(NullPointerException.class, () -> armorStand.removeDisabledSlots(null));
+		assertThrows(NullPointerException.class, () -> armorStand.removeDisabledSlots((EquipmentSlot) null));
 	}
 
 	@Test


### PR DESCRIPTION
# Description
Fixes a pesky compile warning when compiling `ArmorStandMockTest`.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
