### PR TITLE
OfflinePlayerMock fixes

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/entity/OfflinePlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/OfflinePlayerMock.java
@@ -1,5 +1,6 @@
 package be.seeseemelk.mockbukkit.entity;
 
+import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import com.google.common.base.Preconditions;
@@ -91,24 +92,28 @@ public class OfflinePlayerMock implements OfflinePlayer
 	@Override
 	public boolean isBanned()
 	{
+		MockBukkit.ensureMocking();
 		return Bukkit.getBanList(BanList.Type.NAME).isBanned(getName());
 	}
 
 	@Override
 	public boolean isWhitelisted()
 	{
+		MockBukkit.ensureMocking();
 		return Bukkit.getWhitelistedPlayers().contains(this);
 	}
 
 	@Override
 	public void setWhitelisted(boolean value)
 	{
+		MockBukkit.ensureMocking();
 		Bukkit.getWhitelistedPlayers().add(this);
 	}
 
 	@Override
 	public @Nullable Player getPlayer()
 	{
+		MockBukkit.ensureMocking();
 		return Bukkit.getPlayer(this.getUniqueId());
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/OfflinePlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/OfflinePlayerMock.java
@@ -1,10 +1,10 @@
 package be.seeseemelk.mockbukkit.entity;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import com.google.common.base.Preconditions;
 import org.bukkit.BanList;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
@@ -15,7 +15,6 @@ import org.bukkit.profile.PlayerProfile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
 
@@ -54,7 +53,7 @@ public class OfflinePlayerMock implements OfflinePlayer
 	@Override
 	public boolean isOnline()
 	{
-		return false;
+		return getPlayer() != null;
 	}
 
 	@Override
@@ -86,33 +85,31 @@ public class OfflinePlayerMock implements OfflinePlayer
 	@Override
 	public @NotNull Map<String, Object> serialize()
 	{
-		Map<String, Object> result = new LinkedHashMap<>();
-		result.put("UUID", this.uuid.toString());
-		return result;
+		return Map.of("UUID", this.uuid.toString());
 	}
 
 	@Override
 	public boolean isBanned()
 	{
-		return MockBukkit.getMock().getBanList(BanList.Type.NAME).isBanned(getName());
+		return Bukkit.getBanList(BanList.Type.NAME).isBanned(getName());
 	}
 
 	@Override
 	public boolean isWhitelisted()
 	{
-		return MockBukkit.getMock().getWhitelistedPlayers().contains(this);
+		return Bukkit.getWhitelistedPlayers().contains(this);
 	}
 
 	@Override
 	public void setWhitelisted(boolean value)
 	{
-		MockBukkit.getMock().getWhitelistedPlayers().add(this);
+		Bukkit.getWhitelistedPlayers().add(this);
 	}
 
 	@Override
 	public @Nullable Player getPlayer()
 	{
-		return MockBukkit.getMock().getPlayerExact(this.name);
+		return Bukkit.getPlayer(this.getUniqueId());
 	}
 
 	@Override

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -569,7 +569,7 @@ class ServerMockTest
 
 		PlayerMock onlinePlayer = offlinePlayer.join(server);
 
-		assertFalse(offlinePlayer.isOnline());
+		assertTrue(offlinePlayer.isOnline());
 		assertTrue(onlinePlayer.isOnline());
 
 		// Assert that this is still the same Player (as far as name and uuid are concerned)

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/OfflinePlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/OfflinePlayerMockTest.java
@@ -1,7 +1,7 @@
 package be.seeseemelk.mockbukkit.entity;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
-import org.bukkit.OfflinePlayer;
+import be.seeseemelk.mockbukkit.ServerMock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -11,18 +11,22 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class OfflinePlayerMockTest
 {
 
+	private ServerMock server;
 	private UUID uuid;
-	private OfflinePlayer player;
+	private OfflinePlayerMock player;
 
 	@BeforeEach
 	void setUp()
 	{
-		MockBukkit.mock();
+		server = MockBukkit.mock();
 		uuid = UUID.randomUUID();
 		player = new OfflinePlayerMock(uuid, "player");
 	}
@@ -34,14 +38,48 @@ class OfflinePlayerMockTest
 	}
 
 	@Test
-	void testOfflinePlayerSerialization()
+	void isOnline_NotOnline_False()
+	{
+		assertFalse(player.isOnline());
+	}
+
+	@Test
+	void isOnline_IsOnline_True()
+	{
+		player.join(server);
+
+		assertTrue(player.isOnline());
+	}
+
+	@Test
+	void getName()
+	{
+		assertEquals("player", player.getName());
+	}
+
+	@Test
+	void getUniqueId()
+	{
+		assertEquals(uuid, player.getUniqueId());
+	}
+
+	@Test
+	void serialize_CorrectValues()
 	{
 		Map<String, Object> serialized = player.serialize();
+		assertEquals(1, serialized.size());
 		assertEquals(uuid.toString(), serialized.get("UUID").toString());
 	}
 
 	@Test
-	void testIsBanned()
+	void serialize_IsImmutable()
+	{
+		Map<String, Object> serialized = player.serialize();
+		assertThrows(UnsupportedOperationException.class, () -> serialized.put("key", "value"));
+	}
+
+	@Test
+	void isBanned()
 	{
 		assertFalse(player.isBanned());
 		player.banPlayer(null);
@@ -49,18 +87,24 @@ class OfflinePlayerMockTest
 	}
 
 	@Test
-	void testIsWhiteListed()
+	void setWhitelisted()
 	{
 		player.setWhitelisted(true);
-
 		assertTrue(player.isWhitelisted());
 	}
 
 	@Test
-	void setWhiteListed()
+	void getPlayer_NotOnline_Null()
 	{
-		player.setWhitelisted(true);
-		assertTrue(player.isWhitelisted());
+		assertNull(player.getPlayer());
+	}
+
+	@Test
+	void getPlayer_IsOnline_NotNull()
+	{
+		player.join(server);
+
+		assertNotNull(player.getPlayer());
 	}
 
 }


### PR DESCRIPTION
# Description
Fixes three issues with our OfflinePlayer implementation that are a little small to all be their own PRs.
- Fixes `#isOnline` always returning false, even if the player is online.
- Fixes the map returned from `#serialize` being mutable.
- Fixes `#getPlayer` doing a lookup by name, instead of UUID.

It also adds some missing tests and fixes some of the existing ones.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
