### PR TITLE
Don't look up host name when adding player

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -272,7 +272,7 @@ public class ServerMock extends Server.Spigot implements Server
 			Thread.currentThread().interrupt();
 		}
 
-		PlayerLoginEvent playerLoginEvent = new PlayerLoginEvent(player, address.getHostName(), address.getAddress());
+		PlayerLoginEvent playerLoginEvent = new PlayerLoginEvent(player, address.getHostString(), address.getAddress());
 		Bukkit.getPluginManager().callEvent(playerLoginEvent);
 
 		Component joinMessage = MiniMessage.miniMessage()


### PR DESCRIPTION
# Description
Fixes the players host name being looked up every time a player is added to the server mock.
This replaced the call to `#getHostName` with `#getHostString` which returns the same thing since we're using IP addresses.

# Checklist
The following items should be checked before the pull request can be merged.
- [ ] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
