### PR TITLE
Remove removed entities from the server

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -232,6 +232,7 @@ public class ServerMock extends Server.Spigot implements Server
 	 */
 	public void registerEntity(@NotNull EntityMock entity)
 	{
+		Preconditions.checkNotNull(entity, "Entity cannot be null");
 		AsyncCatcher.catchOp("entity add");
 		entities.add(entity);
 	}
@@ -243,6 +244,8 @@ public class ServerMock extends Server.Spigot implements Server
 	 */
 	public void unregisterEntity(@NotNull EntityMock entity)
 	{
+		Preconditions.checkNotNull(entity, "Entity cannot be null");
+		Preconditions.checkArgument(!entity.isValid(), "Entity is not marked for removal");
 		AsyncCatcher.catchOp("entity remove");
 		entities.remove(entity);
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -237,6 +237,17 @@ public class ServerMock extends Server.Spigot implements Server
 	}
 
 	/**
+	 * Unregisters an entity from the server. Should only be used internally.
+	 *
+	 * @param entity The entity to unregister
+	 */
+	public void unregisterEntity(@NotNull EntityMock entity)
+	{
+		AsyncCatcher.catchOp("entity remove");
+		entities.remove(entity);
+	}
+
+	/**
 	 * Returns a set of entities that exist on the server instance.
 	 *
 	 * @return A set of entities that exist on this server instance.

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -646,6 +646,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 			new ArrayList<>(this.passengers).forEach(Entity::leaveVehicle);
 		}
 		this.removed = true;
+		this.server.unregisterEntity(this);
 	}
 
 	@Override

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
@@ -27,7 +27,6 @@ import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionAttachment;
-import org.bukkit.permissions.PermissionAttachmentInfo;
 import org.bukkit.permissions.PermissionDefault;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
@@ -38,10 +37,7 @@ import org.spigotmc.event.entity.EntityDismountEvent;
 import org.spigotmc.event.entity.EntityMountEvent;
 
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -891,6 +887,17 @@ class EntityMockTest
 		entity.remove();
 		assertNull(passenger.getVehicle());
 		assertEquals(List.of(), vehicle.getPassengers());
+	}
+
+	@Test
+	void remove()
+	{
+		EntityMock zombie = (EntityMock) world.spawnEntity(new Location(world, 10, 10, 10), EntityType.ZOMBIE);
+		assertTrue(server.getEntities().contains(zombie), "Entity should be referenced.");
+		zombie.remove();
+		assertFalse(zombie.isValid());
+		assertFalse(server.getEntities().contains(zombie), "Entity should no longer be referenced.");
+		assertNull(server.getEntity(zombie.getUniqueId()));
 	}
 
 }


### PR DESCRIPTION
# Description
~The `WorldMock` implementation was waiting for an implementation of `EntityMock#getPassengers()`. Now that is the case (#576), the vehicle and the passengers can be properly removed if the spawn event is cancelled.~ Removed in order not to conflict with #652 

Related to entity removal, the `ServerMock` class now also have an `unregisterEntity` method so that removed entities are not kept.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
