### PR TITLE
Fix WorldMock#getEmptyChunkSnapshot returning an incorrect snapshot

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
@@ -1,6 +1,7 @@
 package be.seeseemelk.mockbukkit;
 
 import be.seeseemelk.mockbukkit.block.BlockMock;
+import be.seeseemelk.mockbukkit.block.data.BlockDataMock;
 import be.seeseemelk.mockbukkit.entity.AllayMock;
 import be.seeseemelk.mockbukkit.entity.ArmorStandMock;
 import be.seeseemelk.mockbukkit.entity.AxolotlMock;
@@ -51,6 +52,7 @@ import be.seeseemelk.mockbukkit.metadata.MetadataTable;
 import be.seeseemelk.mockbukkit.persistence.PersistentDataContainerMock;
 import com.destroystokyo.paper.HeightmapType;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import io.papermc.paper.world.MoonPhase;
 import org.bukkit.BlockChangeDelegate;
 import org.bukkit.Bukkit;
@@ -1548,9 +1550,29 @@ public class WorldMock implements World
 	}
 
 	@Override
-	public @NotNull ChunkSnapshot getEmptyChunkSnapshot(int x, int z, boolean includeBiome, boolean includeBiomeTempRain)
+	@SuppressWarnings("UnstableApiUsage")
+	public @NotNull ChunkSnapshotMock getEmptyChunkSnapshot(int chunkX, int chunkZ, boolean includeBiome, boolean includeBiomeTempRain)
 	{
-		return new ChunkSnapshotMock(x, z, getMinHeight(), getMaxHeight(), getName(), getFullTime(), Map.of(), (includeBiome || includeBiomeTempRain) ? Map.of() : null);
+		// Cubic size of the chunk (w * w * h).
+		int size = (16 * 16) * Math.abs((getMaxHeight() - getMinHeight()));
+		ImmutableMap.Builder<Coordinate, BlockData> chunkBlockData = ImmutableMap.builderWithExpectedSize(size);
+		ImmutableMap.Builder<Coordinate, Biome> chunkBiomes = ImmutableMap.builderWithExpectedSize(size);
+		for (int x = 0; x < 15; x++)
+		{
+			for (int y = getMinHeight(); y < getMaxHeight(); y++)
+			{
+				for (int z = 0; z < 15; z++)
+				{
+					Coordinate coord = new Coordinate(x, y, z);
+					chunkBlockData.put(coord, new BlockDataMock(Material.AIR));
+					if (includeBiome || includeBiomeTempRain)
+					{
+						chunkBiomes.put(coord, Biome.PLAINS);
+					}
+				}
+			}
+		}
+		return new ChunkSnapshotMock(chunkX, chunkZ, getMinHeight(), getMaxHeight(), getName(), getFullTime(), chunkBlockData.build(), (includeBiome || includeBiomeTempRain) ? chunkBiomes.build() : null);
 	}
 
 	@Override

--- a/src/test/java/be/seeseemelk/mockbukkit/WorldMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/WorldMockTest.java
@@ -1360,7 +1360,7 @@ class WorldMockTest
 		WorldMock world = new WorldMock(Material.GRASS_BLOCK, -64, 319, 3);
 		ChunkSnapshot snapshot = world.getEmptyChunkSnapshot(0, 0, false, false);
 
-		assertEquals("world", snapshot.getWorldName());
+		assertEquals("World", snapshot.getWorldName());
 	}
 
 	@Test

--- a/src/test/java/be/seeseemelk/mockbukkit/WorldMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/WorldMockTest.java
@@ -22,8 +22,8 @@ import be.seeseemelk.mockbukkit.entity.ExperienceOrbMock;
 import be.seeseemelk.mockbukkit.entity.FireworkMock;
 import be.seeseemelk.mockbukkit.entity.FoxMock;
 import be.seeseemelk.mockbukkit.entity.FrogMock;
-import be.seeseemelk.mockbukkit.entity.GiantMock;
 import be.seeseemelk.mockbukkit.entity.GhastMock;
+import be.seeseemelk.mockbukkit.entity.GiantMock;
 import be.seeseemelk.mockbukkit.entity.GoatMock;
 import be.seeseemelk.mockbukkit.entity.ItemEntityMock;
 import be.seeseemelk.mockbukkit.entity.LlamaMock;
@@ -47,6 +47,7 @@ import be.seeseemelk.mockbukkit.entity.ZombieMock;
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
 import org.bukkit.Chunk;
+import org.bukkit.ChunkSnapshot;
 import org.bukkit.Difficulty;
 import org.bukkit.Effect;
 import org.bukkit.GameRule;
@@ -77,6 +78,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -1283,6 +1285,93 @@ class WorldMockTest
 		Entity entity = world.spawnEntity(new Location(world, 0, 0, 0), EntityType.PIG);
 		assertInstanceOf(PigMock.class, entity);
 		assertTrue(entity.isValid());
+	}
+
+	@Test
+	void getEmptyChunkSnapshot_AllBlocksAir()
+	{
+		WorldMock world = new WorldMock(Material.DIRT, 3);
+		ChunkSnapshot snapshot = world.getEmptyChunkSnapshot(0, 0, true, true);
+
+		for (int x = 0; x < 15; x++)
+		{
+			for (int y = world.getMinHeight(); y < world.getMaxHeight(); y++)
+			{
+				for (int z = 0; z < 15; z++)
+				{
+					assertEquals(Material.AIR, snapshot.getBlockData(x, y, z).getMaterial());
+				}
+			}
+		}
+	}
+
+	@Test
+	void getEmptyChunkSnapshot_AllBiomesPlains()
+	{
+		WorldMock world = new WorldMock(Material.DIRT, 3);
+		ChunkSnapshot snapshot = world.getEmptyChunkSnapshot(0, 0, true, true);
+
+		for (int x = 0; x < 15; x++)
+		{
+			for (int y = world.getMinHeight(); y < world.getMaxHeight(); y++)
+			{
+				for (int z = 0; z < 15; z++)
+				{
+					assertEquals(Biome.PLAINS, snapshot.getBiome(x, y, z));
+				}
+			}
+		}
+	}
+
+	@Test
+	void getEmptyChunkSnapshot_NoBiome_Error()
+	{
+		WorldMock world = new WorldMock(Material.DIRT, 3);
+		ChunkSnapshot snapshot = world.getEmptyChunkSnapshot(0, 0, false, false);
+
+		assertThrowsExactly(IllegalStateException.class, () -> snapshot.getBiome(0, 0, 0));
+	}
+
+	@Test
+	void getEmptyChunkSnapshot_EitherBiome_ReturnsBiome()
+	{
+		WorldMock world = new WorldMock(Material.DIRT, 3);
+
+		ChunkSnapshot snapshot = world.getEmptyChunkSnapshot(0, 0, true, false);
+		assertEquals(Biome.PLAINS, snapshot.getBiome(0, 0, 0));
+
+		snapshot = world.getEmptyChunkSnapshot(0, 0, false, true);
+		assertEquals(Biome.PLAINS, snapshot.getBiome(0, 0, 0));
+	}
+
+	@Test
+	void getEmptyChunkSnapshot_CorrectCoords()
+	{
+		WorldMock world = new WorldMock(Material.DIRT, 3);
+		ChunkSnapshot snapshot = world.getEmptyChunkSnapshot(69, 420, false, false);
+
+		assertEquals(69, snapshot.getX());
+		assertEquals(420, snapshot.getZ());
+	}
+
+	@Test
+	void getEmptyChunkSnapshot_CorrectName()
+	{
+		WorldMock world = new WorldMock(Material.GRASS_BLOCK, -64, 319, 3);
+		ChunkSnapshot snapshot = world.getEmptyChunkSnapshot(0, 0, false, false);
+
+		assertEquals("world", snapshot.getWorldName());
+	}
+
+	@Test
+	void getEmptyChunkSnapshot_CorrectTime()
+	{
+		WorldMock world = new WorldMock(Material.GRASS_BLOCK, -64, 319, 3);
+		world.setFullTime(69);
+
+		ChunkSnapshot snapshot = world.getEmptyChunkSnapshot(0, 0, false, false);
+
+		assertEquals(69, snapshot.getCaptureFullTime());
 	}
 
 }


### PR DESCRIPTION
# Description
Previously, `WorldMock#getEmptyChunkSnapshot` would always return a ChunkSnapshot with no blocks and no biomes. This deviates from CraftBukkit which returns a snapshot that's all air and all the plains biome.

This corrects this behavior and adds some missed tests.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
