### PR TITLE
Fix Chunk#getSnapshot biome handling

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ChunkMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ChunkMock.java
@@ -110,14 +110,14 @@ public class ChunkMock implements Chunk
 				{
 					Coordinate coord = new Coordinate(x, y, z);
 					blockData.put(coord, getBlock(x, y, z).getBlockData());
-					if (includeBiome)
+					if (includeBiome || includeBiomeTempRain)
 					{
 						biomes.put(coord, world.getBiome(x << 4, y, z << 4));
 					}
 				}
 			}
 		}
-		return new ChunkSnapshotMock(x, z, world.getMinHeight(), world.getMaxHeight(), world.getName(), world.getFullTime(), blockData.build(), biomes.build());
+		return new ChunkSnapshotMock(x, z, world.getMinHeight(), world.getMaxHeight(), world.getName(), world.getFullTime(), blockData.build(), (includeBiome || includeBiomeTempRain) ? biomes.build() : null);
 	}
 
 

--- a/src/test/java/be/seeseemelk/mockbukkit/ChunkSnapshotMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ChunkSnapshotMockTest.java
@@ -3,6 +3,7 @@ package be.seeseemelk.mockbukkit;
 import be.seeseemelk.mockbukkit.block.data.AmethystClusterMock;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
+import org.bukkit.ChunkSnapshot;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Biome;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -124,6 +126,23 @@ class ChunkSnapshotMockTest
 		world.setBiome(0, 0, 0, Biome.BADLANDS);
 		assertEquals(Biome.BADLANDS, chunk.getChunkSnapshot(false, true, false).getBiome(0, 0));
 		assertEquals(Biome.BADLANDS, chunk.getChunkSnapshot(false, true, false).getBiome(0, 0, 0));
+	}
+
+	@Test
+	void getBiome_NoBiomes_ThrowsException()
+	{
+		ChunkSnapshot snapshot = chunk.getChunkSnapshot(false, false, false);
+
+		assertThrows(IllegalStateException.class, () -> snapshot.getBiome(0, 0, 0));
+	}
+
+	@Test
+	void getBiome_EitherBiome_ReturnsBiomes()
+	{
+		world.setBiome(0, 0, 0, Biome.BADLANDS);
+
+		assertEquals(Biome.BADLANDS, chunk.getChunkSnapshot(false, true, false).getBiome(0, 0, 0));
+		assertEquals(Biome.BADLANDS, chunk.getChunkSnapshot(false, false, true).getBiome(0, 0, 0));
 	}
 
 }


### PR DESCRIPTION
# Description
Previously, when `ChunkMock#getSnapshot` was called, not requesting biomes, an empty map would be passed to the snapshot leading to undefined behavior, most likely being an error if a biome was requested.

Along with this, if `includeBiome` was false but `includeBiomeTempRain` was true, biomes would not be passed to the snapshot.

This fixes both of those issues.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
