### PR TITLE
Implement Adventure's #playSound methods

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/BedMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/BedMock.java
@@ -43,6 +43,12 @@ public class BedMock extends BlockDataMock implements Bed
 	}
 
 	@Override
+	public void setOccupied(boolean occupied)
+	{
+		super.set(OCCUPIED, occupied);
+	}
+
+	@Override
 	public @NotNull BlockFace getFacing()
 	{
 		return super.get(FACING);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -1095,6 +1095,32 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	}
 
 	@Override
+	public void playSound(net.kyori.adventure.sound.@NotNull Sound sound)
+	{
+		playSound(sound, net.kyori.adventure.sound.Sound.Emitter.self()); // Not strictly equivalent since normally the sound does not follow the entity.
+	}
+
+	@Override
+	public void playSound(net.kyori.adventure.sound.@NotNull Sound sound, double x, double y, double z)
+	{
+		Preconditions.checkNotNull(sound, "Sound cannot be null");
+		heardSounds.add(new AudioExperience(sound, new Location(getWorld(), x, y, z)));
+	}
+
+	@Override
+	public void playSound(net.kyori.adventure.sound.@NotNull Sound sound, net.kyori.adventure.sound.Sound.@NotNull Emitter emitter)
+	{
+		Preconditions.checkNotNull(emitter, "Emitter cannot be null");
+		Preconditions.checkNotNull(sound, "Sound cannot be null");
+		if (emitter == net.kyori.adventure.sound.Sound.Emitter.self())
+		{
+			emitter = this;
+		}
+		Preconditions.checkArgument(emitter instanceof Entity, "Sound emitter must be an Entity or self()");
+		heardSounds.add(new AudioExperience(sound, ((Entity) emitter).getLocation()));
+	}
+
+	@Override
 	public @NotNull List<AudioExperience> getHeardSounds()
 	{
 		return heardSounds;

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -2407,6 +2407,13 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	}
 
 	@Override
+	public void showElderGuardian(boolean silent)
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
 	public void attack(@NotNull Entity target)
 	{
 		// TODO Auto-generated method stub

--- a/src/main/java/be/seeseemelk/mockbukkit/sound/AudioExperience.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/sound/AudioExperience.java
@@ -88,19 +88,7 @@ public final class AudioExperience
 	 */
 	public net.kyori.adventure.sound.Sound.@NotNull Source getSource()
 	{
-		return switch (category)
-				{
-					case MASTER -> net.kyori.adventure.sound.Sound.Source.MASTER;
-					case MUSIC -> net.kyori.adventure.sound.Sound.Source.MUSIC;
-					case RECORDS -> net.kyori.adventure.sound.Sound.Source.RECORD;
-					case WEATHER -> net.kyori.adventure.sound.Sound.Source.WEATHER;
-					case BLOCKS -> net.kyori.adventure.sound.Sound.Source.BLOCK;
-					case HOSTILE -> net.kyori.adventure.sound.Sound.Source.HOSTILE;
-					case NEUTRAL -> net.kyori.adventure.sound.Sound.Source.NEUTRAL;
-					case PLAYERS -> net.kyori.adventure.sound.Sound.Source.PLAYER;
-					case AMBIENT -> net.kyori.adventure.sound.Sound.Source.AMBIENT;
-					case VOICE -> net.kyori.adventure.sound.Sound.Source.VOICE;
-				};
+		return category.soundSource();
 	}
 
 	/**

--- a/src/main/java/be/seeseemelk/mockbukkit/sound/AudioExperience.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/sound/AudioExperience.java
@@ -41,6 +41,23 @@ public final class AudioExperience
 		this(sound.getKey().getKey(), category, loc, volume, pitch);
 	}
 
+	public AudioExperience(@NotNull net.kyori.adventure.sound.Sound sound, @NotNull Location loc)
+	{
+		this(sound.name().asString(), switch (sound.source())
+				{
+					case MASTER -> SoundCategory.MASTER;
+					case MUSIC -> SoundCategory.MUSIC;
+					case RECORD -> SoundCategory.RECORDS;
+					case WEATHER -> SoundCategory.WEATHER;
+					case BLOCK -> SoundCategory.BLOCKS;
+					case HOSTILE -> SoundCategory.HOSTILE;
+					case NEUTRAL -> SoundCategory.NEUTRAL;
+					case PLAYER -> SoundCategory.PLAYERS;
+					case AMBIENT -> SoundCategory.AMBIENT;
+					case VOICE -> SoundCategory.VOICE;
+				}, loc, sound.volume(), sound.pitch());
+	}
+
 	/**
 	 * This returns the {@link Sound} that was played. We return the {@link String} representation of the actual sound,
 	 * not the sound itself.
@@ -62,6 +79,29 @@ public final class AudioExperience
 	public SoundCategory getCategory()
 	{
 		return category;
+	}
+
+	/**
+	 * This method returns the {@link net.kyori.adventure.sound.Sound.Source} with which the {@link Sound} was played.
+	 *
+	 * @return The {@link net.kyori.adventure.sound.Sound.Source}
+	 */
+	@NotNull
+	public net.kyori.adventure.sound.Sound.Source getSource()
+	{
+		return switch (category)
+				{
+					case MASTER -> net.kyori.adventure.sound.Sound.Source.MASTER;
+					case MUSIC -> net.kyori.adventure.sound.Sound.Source.MUSIC;
+					case RECORDS -> net.kyori.adventure.sound.Sound.Source.RECORD;
+					case WEATHER -> net.kyori.adventure.sound.Sound.Source.WEATHER;
+					case BLOCKS -> net.kyori.adventure.sound.Sound.Source.BLOCK;
+					case HOSTILE -> net.kyori.adventure.sound.Sound.Source.HOSTILE;
+					case NEUTRAL -> net.kyori.adventure.sound.Sound.Source.NEUTRAL;
+					case PLAYERS -> net.kyori.adventure.sound.Sound.Source.PLAYER;
+					case AMBIENT -> net.kyori.adventure.sound.Sound.Source.AMBIENT;
+					case VOICE -> net.kyori.adventure.sound.Sound.Source.VOICE;
+				};
 	}
 
 	/**

--- a/src/main/java/be/seeseemelk/mockbukkit/sound/AudioExperience.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/sound/AudioExperience.java
@@ -41,7 +41,7 @@ public final class AudioExperience
 		this(sound.getKey().getKey(), category, loc, volume, pitch);
 	}
 
-	public AudioExperience(@NotNull net.kyori.adventure.sound.Sound sound, @NotNull Location loc)
+	public AudioExperience(net.kyori.adventure.sound.@NotNull Sound sound, @NotNull Location loc)
 	{
 		this(sound.name().asString(), switch (sound.source())
 				{
@@ -86,8 +86,7 @@ public final class AudioExperience
 	 *
 	 * @return The {@link net.kyori.adventure.sound.Sound.Source}
 	 */
-	@NotNull
-	public net.kyori.adventure.sound.Sound.Source getSource()
+	public net.kyori.adventure.sound.Sound.@NotNull Source getSource()
 	{
 		return switch (category)
 				{

--- a/src/main/java/be/seeseemelk/mockbukkit/sound/SoundReceiver.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/sound/SoundReceiver.java
@@ -79,7 +79,7 @@ public interface SoundReceiver
 		assertSoundHeard("Sound Heard Assertion failed", sound, predicate);
 	}
 
-	default void assertSoundHeard(@NotNull net.kyori.adventure.sound.Sound sound, @NotNull Predicate<AudioExperience> predicate)
+	default void assertSoundHeard(net.kyori.adventure.sound.@NotNull Sound sound, @NotNull Predicate<AudioExperience> predicate)
 	{
 		assertSoundHeard("Sound Heard Assertion failed", sound, predicate);
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/sound/SoundReceiver.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/sound/SoundReceiver.java
@@ -2,6 +2,7 @@ package be.seeseemelk.mockbukkit.sound;
 
 import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import com.google.common.base.Preconditions;
+import net.kyori.adventure.util.ShadyPines;
 import org.bukkit.Sound;
 import org.jetbrains.annotations.NotNull;
 
@@ -39,17 +40,46 @@ public interface SoundReceiver
 		getHeardSounds().clear();
 	}
 
+	/**
+	 * Assert that a sound type has been played for this sound receiver.
+	 * <p>
+	 * The {@link #assertSoundHeard(net.kyori.adventure.sound.Sound) adventure method} also checks the source of the sound, the volume and the pitch.
+	 *
+	 * @param sound The sound type to check.
+	 */
 	default void assertSoundHeard(@NotNull Sound sound)
 	{
 		assertSoundHeard("Sound Heard Assertion failed", sound);
 	}
 
+	/**
+	 * Assert that a sound with a given source, volume and pitch have been played for this sound receiver.
+	 *
+	 * @param sound The sound to check.
+	 */
+	default void assertSoundHeard(net.kyori.adventure.sound.@NotNull Sound sound)
+	{
+		assertSoundHeard("Sound Heard Assertion failed", sound);
+	}
+
+	/**
+	 * Assert that a sound key has been played for this sound receiver.
+	 * <p>
+	 * The {@link #assertSoundHeard(net.kyori.adventure.sound.Sound) adventure method} also checks the source of the sound, the volume and the pitch.
+	 *
+	 * @param sound The sound key to check.
+	 */
 	default void assertSoundHeard(@NotNull String sound)
 	{
 		assertSoundHeard("Sound Heard Assertion failed", sound);
 	}
 
 	default void assertSoundHeard(@NotNull Sound sound, @NotNull Predicate<AudioExperience> predicate)
+	{
+		assertSoundHeard("Sound Heard Assertion failed", sound, predicate);
+	}
+
+	default void assertSoundHeard(@NotNull net.kyori.adventure.sound.Sound sound, @NotNull Predicate<AudioExperience> predicate)
 	{
 		assertSoundHeard("Sound Heard Assertion failed", sound, predicate);
 	}
@@ -64,6 +94,11 @@ public interface SoundReceiver
 		assertSoundHeard(message, sound, e -> true);
 	}
 
+	default void assertSoundHeard(@NotNull String message, net.kyori.adventure.sound.@NotNull Sound sound)
+	{
+		assertSoundHeard(message, sound, e -> true);
+	}
+
 	default void assertSoundHeard(@NotNull String message, @NotNull String sound)
 	{
 		assertSoundHeard(message, sound, e -> true);
@@ -73,6 +108,15 @@ public interface SoundReceiver
 								  @NotNull Predicate<AudioExperience> predicate)
 	{
 		assertSoundHeard(message, sound.getKey().getKey(), predicate);
+	}
+
+	default void assertSoundHeard(@NotNull String message, net.kyori.adventure.sound.@NotNull Sound sound,
+								  @NotNull Predicate<AudioExperience> predicate)
+	{
+		Predicate<AudioExperience> test = e -> e.getSource() == sound.source()
+				&& ShadyPines.equals(sound.volume(), e.getVolume())
+				&& ShadyPines.equals(sound.pitch(), e.getPitch());
+		assertSoundHeard(message, sound.name().asString(), test.and(predicate));
 	}
 
 	default void assertSoundHeard(@NotNull String message, @NotNull String sound,

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -1005,6 +1005,66 @@ class PlayerMockTest
 	}
 
 	@Test
+	void testPlaySound_Adventure()
+	{
+		net.kyori.adventure.sound.Sound sound = net.kyori.adventure.sound.Sound.sound(
+				Sound.BLOCK_ANVIL_FALL,
+				net.kyori.adventure.sound.Sound.Source.BLOCK,
+				0.9f,
+				0.8f
+		);
+		player.playSound(sound);
+		player.assertSoundHeard(sound, audio -> player.getLocation().equals(audio.getLocation()));
+	}
+
+	@Test
+	void testPlaySoundSelfEmitter_Adventure()
+	{
+		net.kyori.adventure.sound.Sound sound = net.kyori.adventure.sound.Sound.sound(
+				Sound.ENTITY_CREEPER_PRIMED,
+				net.kyori.adventure.sound.Sound.Source.HOSTILE,
+				0.9f,
+				0.8f
+		);
+		player.playSound(sound, net.kyori.adventure.sound.Sound.Emitter.self());
+		player.assertSoundHeard(sound, audio -> player.getLocation().equals(audio.getLocation()));
+	}
+
+	@Test
+	void testPlaySoundLocation_Adventure()
+	{
+		net.kyori.adventure.sound.Sound sound = net.kyori.adventure.sound.Sound.sound(
+				Sound.AMBIENT_CAVE,
+				net.kyori.adventure.sound.Sound.Source.AMBIENT,
+				0.5f,
+				1f
+		);
+		Location loc = new Location(player.getWorld(), 80D, 30D, 50D);
+		player.playSound(sound, loc.getX(), loc.getY(), loc.getZ());
+		player.assertSoundHeard(sound, audio -> loc.equals(audio.getLocation()));
+	}
+
+	@Test
+	void testAssertSoundHeard_Adventure()
+	{
+		net.kyori.adventure.sound.Sound soundA = net.kyori.adventure.sound.Sound.sound(
+				Sound.BLOCK_DEEPSLATE_FALL,
+				net.kyori.adventure.sound.Sound.Source.BLOCK,
+				1f,
+				1f
+		);
+		net.kyori.adventure.sound.Sound soundB = net.kyori.adventure.sound.Sound.sound(
+				soundA.name(),
+				net.kyori.adventure.sound.Sound.Source.MASTER,
+				soundA.volume(),
+				soundA.pitch()
+		);
+		player.playSound(soundA);
+		player.assertSoundHeard(soundA);
+		assertThrows(AssertionFailedError.class, () -> player.assertSoundHeard(soundB));
+	}
+
+	@Test
 	void testPlayNote_NewMethod()
 	{
 		int note = 10;


### PR DESCRIPTION
# Description
Adventure's `#playSound` methods are now overridden. The `AudioExperience` type is reused, and Adventure's `Sound.Source` is converted to Bukkit's `SoundCategory`. For now, in MockBukkit, sounds cannot follow entities and are bound to a location: emitters are assumed to be immobile.

Some `assertSoundHeard` methods have been added to check with the Adventure's `Sound` type, as well as the volume, the pitch and the source.

Two stubs have been added in order to compile, but are not related to this PR. `BedMock#setOccupied` has been implemented because the necessary parts were already present.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing (local) code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.