### PR TITLE
Use BlockDataMock.mock() for internal BlockDataMock construction

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/MockChunkData.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockChunkData.java
@@ -63,14 +63,16 @@ public class MockChunkData implements ChunkGenerator.ChunkData
 	@Override
 	public void setBlock(int x, int y, int z, @NotNull Material material)
 	{
-		this.setBlock(x, y, z, new BlockDataMock(material));
+		Preconditions.checkNotNull(material, "Material cannot be null");
+		this.setBlock(x, y, z, BlockDataMock.mock(material));
 	}
 
 	@Override
 	@Deprecated
 	public void setBlock(int x, int y, int z, @NotNull MaterialData material)
 	{
-		this.setBlock(x, y, z, new BlockDataMock(material.getItemType()));
+		Preconditions.checkNotNull(material, "MaterialData cannot be null");
+		this.setBlock(x, y, z, BlockDataMock.mock(material.getItemType()));
 	}
 
 	@Override
@@ -83,14 +85,16 @@ public class MockChunkData implements ChunkGenerator.ChunkData
 	@Override
 	public void setRegion(int xMin, int yMin, int zMin, int xMax, int yMax, int zMax, @NotNull Material material)
 	{
-		this.setRegion(xMin, yMin, zMin, xMax, yMax, zMax, new BlockDataMock(material));
+		Preconditions.checkNotNull(material, "Material cannot be null");
+		this.setRegion(xMin, yMin, zMin, xMax, yMax, zMax, BlockDataMock.mock(material));
 	}
 
 	@Override
 	@Deprecated
 	public void setRegion(int xMin, int yMin, int zMin, int xMax, int yMax, int zMax, @NotNull MaterialData material)
 	{
-		this.setRegion(xMin, yMin, zMin, xMax, yMax, zMax, new BlockDataMock(material.getItemType()));
+		Preconditions.checkNotNull(material, "MaterialData cannot be null");
+		this.setRegion(xMin, yMin, zMin, xMax, yMax, zMax, BlockDataMock.mock(material.getItemType()));
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/block/BlockMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/BlockMock.java
@@ -87,7 +87,7 @@ public class BlockMock implements Block
 		this.material = material;
 		this.location = location;
 		this.state = BlockStateMock.mockState(this);
-		this.blockData = new BlockDataMock(material);
+		this.blockData = BlockDataMock.mock(material);
 	}
 
 	@Override
@@ -250,7 +250,7 @@ public class BlockMock implements Block
 		Preconditions.checkNotNull(type, "Type cannot be null");
 		material = type;
 		state = BlockStateMock.mockState(this);
-		blockData = new BlockDataMock(type);
+		blockData = BlockDataMock.mock(type);
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/BlockDataMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/BlockDataMock.java
@@ -195,7 +195,7 @@ public class BlockDataMock implements BlockData
 		}
 		catch (CloneNotSupportedException e)
 		{
-			return new BlockDataMock(type);
+			return BlockDataMock.mock(type);
 		}
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -969,4 +969,11 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		throw new UnimplementedOperationException();
 	}
 
+	@Override
+	public void knockback(double strength, double directionX, double directionZ)
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/MockChunkDataTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/MockChunkDataTest.java
@@ -9,7 +9,6 @@ import org.bukkit.block.data.type.TrapDoor;
 import org.bukkit.generator.ChunkGenerator;
 import org.bukkit.material.MaterialData;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +23,6 @@ class MockChunkDataTest
 	private ServerMock server;
 	private WorldMock world;
 	private ChunkGenerator.ChunkData chunkData;
-
 
 	@BeforeEach
 	void setUp()
@@ -45,7 +43,7 @@ class MockChunkDataTest
 		ChunkGenerator.ChunkData data = server.createChunkData(dummy);
 
 		data.setBlock(0, 0, 0, Material.STONE);
-		Assertions.assertEquals(Material.STONE, data.getType(0, 0, 0));
+		assertEquals(Material.STONE, data.getType(0, 0, 0));
 	}
 
 	@Test
@@ -98,7 +96,7 @@ class MockChunkDataTest
 		chunkData = server.createChunkData(world);
 
 		chunkData.setBlock(0, -40, 0, Material.OBSIDIAN);
-		Assertions.assertEquals(Material.OBSIDIAN, chunkData.getType(0, -40, 0));
+		assertEquals(Material.OBSIDIAN, chunkData.getType(0, -40, 0));
 	}
 
 	@Test
@@ -108,7 +106,7 @@ class MockChunkDataTest
 		chunkData = server.createChunkData(world);
 
 		chunkData.setBlock(0, 80, 0, Material.OBSIDIAN);
-		Assertions.assertEquals(Material.OBSIDIAN, chunkData.getType(0, 80, 0));
+		assertEquals(Material.OBSIDIAN, chunkData.getType(0, 80, 0));
 	}
 
 	@Test

--- a/src/test/java/be/seeseemelk/mockbukkit/MockChunkDataTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/MockChunkDataTest.java
@@ -2,13 +2,19 @@ package be.seeseemelk.mockbukkit;
 
 import org.bukkit.Material;
 import org.bukkit.block.Biome;
+import org.bukkit.block.data.type.AmethystCluster;
+import org.bukkit.block.data.type.Bed;
+import org.bukkit.block.data.type.Stairs;
+import org.bukkit.block.data.type.TrapDoor;
 import org.bukkit.generator.ChunkGenerator;
+import org.bukkit.material.MaterialData;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
@@ -16,6 +22,9 @@ class MockChunkDataTest
 {
 
 	private ServerMock server;
+	private WorldMock world;
+	private ChunkGenerator.ChunkData chunkData;
+
 
 	@BeforeEach
 	void setUp()
@@ -40,56 +49,136 @@ class MockChunkDataTest
 	}
 
 	@Test
+	void setBlock_NullMaterial_ThrowsException()
+	{
+		assertThrowsExactly(NullPointerException.class, () -> chunkData.setBlock(0, 0, 0, (Material) null));
+	}
+
+	@Test
+	void setBlock_MaterialWithBlockDataMockSubclass()
+	{
+		setUpDummyWorldAndChunkData();
+		chunkData.setBlock(0, 0, 0, Material.BLUE_BED);
+		assertInstanceOf(Bed.class, chunkData.getBlockData(0, 0, 0));
+	}
+
+	@Test
+	void setBlock_NullMaterialData_ThrowsException()
+	{
+		assertThrowsExactly(NullPointerException.class, () -> chunkData.setBlock(0, 0, 0, (MaterialData) null));
+	}
+
+	@Test
+	void setBlock_MaterialDataWithBlockDataMockSubclass()
+	{
+		setUpDummyWorldAndChunkData();
+		MaterialData materialData = new MaterialData(Material.AMETHYST_CLUSTER);
+		chunkData.setBlock(0, 0, 0, materialData);
+		assertInstanceOf(AmethystCluster.class, chunkData.getBlockData(0, 0, 0));
+	}
+
+	@Test
 	void test_set_out_of_bounds()
 	{
-		WorldMock dummy = server.addSimpleWorld("dummy");
-		ChunkGenerator.ChunkData data = server.createChunkData(dummy);
-
-		assertThrowsExactly(IllegalArgumentException.class, () -> data.setBlock(33, 1000, 33, Material.STONE));
+		setUpDummyWorldAndChunkData();
+		assertThrowsExactly(IllegalArgumentException.class, () -> chunkData.setBlock(33, 1000, 33, Material.STONE));
 	}
 
 	@Test
 	void test_get_out_of_bounds()
 	{
-		WorldMock dummy = server.addSimpleWorld("dummy");
-		ChunkGenerator.ChunkData data = server.createChunkData(dummy);
-
-		assertThrowsExactly(IllegalArgumentException.class, () -> data.getType(33, 1000, 33));
+		setUpDummyWorldAndChunkData();
+		assertThrowsExactly(IllegalArgumentException.class, () -> chunkData.getType(33, 1000, 33));
 	}
 
 	@Test
 	void test_neg_min_height()
 	{
-		WorldMock dummy = new WorldMock(Material.GRASS, -60, 256, 70);
-		ChunkGenerator.ChunkData data = server.createChunkData(dummy);
+		world = new WorldMock(Material.GRASS, -60, 256, 70);
+		chunkData = server.createChunkData(world);
 
-		data.setBlock(0, -40, 0, Material.OBSIDIAN);
-		Assertions.assertEquals(Material.OBSIDIAN, data.getType(0, -40, 0));
+		chunkData.setBlock(0, -40, 0, Material.OBSIDIAN);
+		Assertions.assertEquals(Material.OBSIDIAN, chunkData.getType(0, -40, 0));
 	}
 
 	@Test
 	void test_pos_min_height()
 	{
-		WorldMock dummy = new WorldMock(Material.GRASS, 60, 256, 70);
-		ChunkGenerator.ChunkData data = server.createChunkData(dummy);
+		world = new WorldMock(Material.GRASS, 60, 256, 70);
+		chunkData = server.createChunkData(world);
 
-		data.setBlock(0, 80, 0, Material.OBSIDIAN);
-		Assertions.assertEquals(Material.OBSIDIAN, data.getType(0, 80, 0));
+		chunkData.setBlock(0, 80, 0, Material.OBSIDIAN);
+		Assertions.assertEquals(Material.OBSIDIAN, chunkData.getType(0, 80, 0));
 	}
 
 	@Test
 	void getBiome()
 	{
-		WorldMock dummy = new WorldMock(Material.GRASS, 60, 256, 70);
-		ChunkGenerator.ChunkData data = server.createChunkData(dummy);
+		world = new WorldMock(Material.GRASS, 60, 256, 70);
+		chunkData = server.createChunkData(world);
 
-		Biome worldBiome = dummy.getBiome(0, 0, 0);
+		Biome worldBiome = world.getBiome(0, 0, 0);
 		assertNotNull(worldBiome);
 
-		Biome chunkBiome = data.getBiome(0, 0, 0);
+		Biome chunkBiome = chunkData.getBiome(0, 0, 0);
 		assertNotNull(chunkBiome);
 
 		assertEquals(worldBiome, chunkBiome);
+	}
+
+	@Test
+	void setRegion_NullMaterial_ThrowsException()
+	{
+		assertThrowsExactly(NullPointerException.class,
+				() -> chunkData.setRegion(0, 0, 0, 1, 1, 1, (Material) null));
+	}
+
+	@Test
+	void setRegion_MaterialWithBlockDataMockSubclass()
+	{
+		setUpDummyWorldAndChunkData();
+		int min = 0;
+		int max = 2;
+		chunkData.setRegion(min, min, min, max, max, max, Material.BIRCH_STAIRS);
+		assertInstanceOfForVolume(Stairs.class, min, max);
+	}
+
+	@Test
+	void setRegion_NullMaterialData_ThrowsException()
+	{
+		assertThrowsExactly(NullPointerException.class,
+				() -> chunkData.setRegion(0, 0, 0, 1, 1, 1, (MaterialData) null));
+	}
+
+	@Test
+	void setRegion_MaterialDataWithBlockDataMockSubclass()
+	{
+		setUpDummyWorldAndChunkData();
+		int min = 0;
+		int max = 2;
+		MaterialData materialData = new MaterialData(Material.WARPED_TRAPDOOR);
+		chunkData.setRegion(min, min, min, max, max, max, materialData);
+		assertInstanceOfForVolume(TrapDoor.class, min, max);
+	}
+
+	private void setUpDummyWorldAndChunkData()
+	{
+		world = server.addSimpleWorld("dummy");
+		chunkData = server.createChunkData(world);
+	}
+
+	private <T> void assertInstanceOfForVolume(Class<T> clazz, int min, int max)
+	{
+		for (int x = min; x < max; x++)
+		{
+			for (int y = min; y < max; y++)
+			{
+				for (int z = min; z < max; z++)
+				{
+					assertInstanceOf(clazz, chunkData.getBlockData(x, y, z));
+				}
+			}
+		}
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/MockChunkDataTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/MockChunkDataTest.java
@@ -28,6 +28,8 @@ class MockChunkDataTest
 	void setUp()
 	{
 		server = MockBukkit.mock();
+		world = server.addSimpleWorld("dummy");
+		chunkData = server.createChunkData(world);
 	}
 
 	@AfterEach
@@ -55,7 +57,6 @@ class MockChunkDataTest
 	@Test
 	void setBlock_MaterialWithBlockDataMockSubclass()
 	{
-		setUpDummyWorldAndChunkData();
 		chunkData.setBlock(0, 0, 0, Material.BLUE_BED);
 		assertInstanceOf(Bed.class, chunkData.getBlockData(0, 0, 0));
 	}
@@ -69,7 +70,6 @@ class MockChunkDataTest
 	@Test
 	void setBlock_MaterialDataWithBlockDataMockSubclass()
 	{
-		setUpDummyWorldAndChunkData();
 		MaterialData materialData = new MaterialData(Material.AMETHYST_CLUSTER);
 		chunkData.setBlock(0, 0, 0, materialData);
 		assertInstanceOf(AmethystCluster.class, chunkData.getBlockData(0, 0, 0));
@@ -78,14 +78,12 @@ class MockChunkDataTest
 	@Test
 	void test_set_out_of_bounds()
 	{
-		setUpDummyWorldAndChunkData();
 		assertThrowsExactly(IllegalArgumentException.class, () -> chunkData.setBlock(33, 1000, 33, Material.STONE));
 	}
 
 	@Test
 	void test_get_out_of_bounds()
 	{
-		setUpDummyWorldAndChunkData();
 		assertThrowsExactly(IllegalArgumentException.class, () -> chunkData.getType(33, 1000, 33));
 	}
 
@@ -134,7 +132,6 @@ class MockChunkDataTest
 	@Test
 	void setRegion_MaterialWithBlockDataMockSubclass()
 	{
-		setUpDummyWorldAndChunkData();
 		int min = 0;
 		int max = 2;
 		chunkData.setRegion(min, min, min, max, max, max, Material.BIRCH_STAIRS);
@@ -151,18 +148,11 @@ class MockChunkDataTest
 	@Test
 	void setRegion_MaterialDataWithBlockDataMockSubclass()
 	{
-		setUpDummyWorldAndChunkData();
 		int min = 0;
 		int max = 2;
 		MaterialData materialData = new MaterialData(Material.WARPED_TRAPDOOR);
 		chunkData.setRegion(min, min, min, max, max, max, materialData);
 		assertInstanceOfForVolume(TrapDoor.class, min, max);
-	}
-
-	private void setUpDummyWorldAndChunkData()
-	{
-		world = server.addSimpleWorld("dummy");
-		chunkData = server.createChunkData(world);
 	}
 
 	private <T> void assertInstanceOfForVolume(Class<T> clazz, int min, int max)

--- a/src/test/java/be/seeseemelk/mockbukkit/block/BlockMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/BlockMockTest.java
@@ -3,6 +3,7 @@ package be.seeseemelk.mockbukkit.block;
 import be.seeseemelk.mockbukkit.ChunkCoordinate;
 import be.seeseemelk.mockbukkit.ChunkMock;
 import be.seeseemelk.mockbukkit.Coordinate;
+import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.WorldMock;
 import be.seeseemelk.mockbukkit.block.data.BlockDataMock;
 import org.bukkit.Location;
@@ -11,26 +12,61 @@ import org.bukkit.World;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.type.Slab;
+import org.bukkit.block.data.type.TrapDoor;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class BlockMockTest
 {
 
 	private BlockMock block;
+	private Location location;
 
 	@BeforeEach
 	void setUp()
 	{
+		MockBukkit.mock();
 		World world = new WorldMock();
-		block = new BlockMock(new Location(world, 120, 60, 120));
+		location = new Location(world, 120, 60, 120);
+		block = new BlockMock(location);
+	}
+
+	@AfterEach
+	void teardown()
+	{
+		MockBukkit.unmock();
+	}
+
+	@Test
+	void constructor_NullMaterial_ThrowsException()
+	{
+		assertThrowsExactly(NullPointerException.class, () -> new BlockMock((Material) null));
+	}
+
+	@Test
+	void constructorWithLocation_NullMaterial_ThrowsException()
+	{
+		assertThrowsExactly(NullPointerException.class, () -> new BlockMock(null, null));
+	}
+
+	@Test
+	void constructor_MaterialWithBlockDataMockSubclass_CorrectBlockDataType()
+	{
+		BlockMock slabBlock = new BlockMock(Material.ACACIA_SLAB, location);
+		BlockData blockData = slabBlock.getBlockData();
+		assertInstanceOf(Slab.class, blockData);
 	}
 
 	@Test
@@ -40,10 +76,23 @@ class BlockMockTest
 	}
 
 	@Test
+	void setType_NullParameter_ThrowsException()
+	{
+		assertThrowsExactly(NullPointerException.class, () -> block.setType(null));
+	}
+
+	@Test
 	void setType_Stone_Set()
 	{
 		block.setType(Material.STONE);
 		assertEquals(Material.STONE, block.getType());
+	}
+
+	@Test
+	void setType_SetToMaterialWithBlockDataMockSubclass()
+	{
+		block.setType(Material.JUNGLE_TRAPDOOR);
+		assertInstanceOf(TrapDoor.class, block.getBlockData());
 	}
 
 	@Test
@@ -145,7 +194,7 @@ class BlockMockTest
 	}
 
 	@Test
-	void testGetRelativeCordinates()
+	void testGetRelativeCoordinates()
 	{
 		Block relative = block.getRelative(2, 6, 0);
 		assertEquals(block.getX() + 2, relative.getX());
@@ -242,7 +291,7 @@ class BlockMockTest
 	void testGetFace_Valid()
 	{
 		Block b = block.getRelative(BlockFace.NORTH);
-		assertEquals(block.getFace(b), BlockFace.NORTH);
+		assertEquals(BlockFace.NORTH, block.getFace(b));
 	}
 
 	@Test


### PR DESCRIPTION
# Description
If you previously tried to create a `BlockData` indirectly, it would always create an instance of `BlockDataMock`, even if the given `Material` had a special subclass implementation. For example, if you did:

```
BlockMock block = new BlockMock(Material.OAK_SLAB);
BlockDataMock blockData = block.getBlockData();

assertInstanceOf(Slab.class, blockData);
```

Then the assertion would fail. `blockData` would _not_ be an instance of `Slab` or `SlabMock`, but would only be an instance of `BlockDataMock`. This is because the `BlockMock` constructor (and a couple of other places) were using the `BlockDataMock` constructor rather than the static factory method `BlockDataMock.mock()`.

I left all references to the `BlockDataMock` constructor that were just constructing with `Material.AIR`.

# Checklist
The following items should be checked before the pull request can be merged.
- [ ] Unit tests added.
- [ ] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
