### PR TITLE
Add Eclipse classpath and project files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,8 @@ local.properties
 .settings/
 .loadpath
 .recommenders
+.classpath
+.project
 
 # External tool builders
 .externalToolBuilders/


### PR DESCRIPTION
# Description
Eclipse's `.classpath` and `.project` files weren't added to the new `.gitignore`.
Given that Eclipse can generate these from the Gradle file, they shouldn't be commited to the repo.