### PR TITLE
Add many missing Javadocs and improve existing ones

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/AsyncCatcher.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/AsyncCatcher.java
@@ -1,19 +1,27 @@
 package be.seeseemelk.mockbukkit;
 
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 
+/**
+ * A class used to prevent synchronous-only methods from being run asynchronously.
+ */
 public class AsyncCatcher
 {
 
 	private AsyncCatcher()
 	{
+		throw new UnsupportedOperationException("Utility class");
 	}
 
+	/**
+	 * Throws an {@link IllegalStateException} if not called from the primary thread.
+	 *
+	 * @param reason The reason for the exception.
+	 */
 	public static void catchOp(String reason)
 	{
-		if (Bukkit.getServer().isPrimaryThread())
-			return;
-		throw new IllegalStateException("Asynchronous " + reason + "!");
+		Preconditions.checkState(Bukkit.getServer().isPrimaryThread(), "Asynchronous " + reason + "!");
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/CachedServerIconMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/CachedServerIconMock.java
@@ -3,6 +3,9 @@ package be.seeseemelk.mockbukkit;
 import org.bukkit.util.CachedServerIcon;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Mock implementation of a {@link CachedServerIcon}.
+ */
 public class CachedServerIconMock implements CachedServerIcon
 {
 
@@ -10,6 +13,11 @@ public class CachedServerIconMock implements CachedServerIcon
 
 	private final @Nullable String data;
 
+	/**
+	 * Constructs a new {@link CachedServerIconMock} with the provided data.
+	 *
+	 * @param data The data to be later retrieved in {@link #getData()}.
+	 */
 	protected CachedServerIconMock(@Nullable String data)
 	{
 		this.data = data;

--- a/src/main/java/be/seeseemelk/mockbukkit/CachedServerIconMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/CachedServerIconMock.java
@@ -9,6 +9,9 @@ import org.jetbrains.annotations.Nullable;
 public class CachedServerIconMock implements CachedServerIcon
 {
 
+	/**
+	 * The prefix used for base 64 images.
+	 */
 	public static final String PNG_BASE64_PREFIX = "data:image/png;base64,";
 
 	private final @Nullable String data;

--- a/src/main/java/be/seeseemelk/mockbukkit/ChunkCoordinate.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ChunkCoordinate.java
@@ -10,14 +10,21 @@ import java.util.Objects;
 public class ChunkCoordinate
 {
 
+	/**
+	 * The X coordinate.
+	 */
 	public final int x;
+
+	/**
+	 * The Z coordinate.
+	 */
 	public final int z;
 
 	/**
 	 * Constructs a new {@link ChunkCoordinate}.
 	 *
 	 * @param x The X coordinate.
-	 * @param z The Y coordinate.
+	 * @param z The Z coordinate.
 	 */
 	public ChunkCoordinate(int x, int z)
 	{
@@ -25,11 +32,17 @@ public class ChunkCoordinate
 		this.z = z;
 	}
 
+	/**
+	 * @return The X coordinate.
+	 */
 	public int getX()
 	{
 		return x;
 	}
 
+	/**
+	 * @return The Z coordinate.
+	 */
 	public int getZ()
 	{
 		return z;

--- a/src/main/java/be/seeseemelk/mockbukkit/ChunkCoordinate.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ChunkCoordinate.java
@@ -13,6 +13,12 @@ public class ChunkCoordinate
 	public final int x;
 	public final int z;
 
+	/**
+	 * Constructs a new {@link ChunkCoordinate}.
+	 *
+	 * @param x The X coordinate.
+	 * @param z The Y coordinate.
+	 */
 	public ChunkCoordinate(int x, int z)
 	{
 		this.x = x;

--- a/src/main/java/be/seeseemelk/mockbukkit/ChunkMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ChunkMock.java
@@ -19,6 +19,9 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Collection;
 import java.util.function.Predicate;
 
+/**
+ * Mock implementation of a {@link Chunk}.
+ */
 public class ChunkMock implements Chunk
 {
 
@@ -28,6 +31,13 @@ public class ChunkMock implements Chunk
 	private boolean loaded = true;
 	private final PersistentDataContainer persistentDataContainer = new PersistentDataContainerMock();
 
+	/**
+	 * Constructs a new {@link ChunkMock} for the provided world, at the specified coordinates.
+	 *
+	 * @param world The world the chunk is in.
+	 * @param x     The X coordinate of the chunk.
+	 * @param z     The Y coordinate of the chunk.
+	 */
 	protected ChunkMock(final World world, final int x, final int z)
 	{
 		this.world = world;

--- a/src/main/java/be/seeseemelk/mockbukkit/ChunkMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ChunkMock.java
@@ -86,6 +86,12 @@ public class ChunkMock implements Chunk
 		return world.getBlockAt((this.x << 4) + x, y, (this.z << 4) + z);
 	}
 
+	/**
+	 * Gets a block at a {@link Coordinate}.
+	 *
+	 * @param coordinate The coordinate at which to get the block.
+	 * @return The block at the provided coordinate.
+	 */
 	public @NotNull Block getBlock(@NotNull Coordinate coordinate)
 	{
 		return getBlock(coordinate.x, coordinate.y, coordinate.z);

--- a/src/main/java/be/seeseemelk/mockbukkit/ChunkSnapshotMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ChunkSnapshotMock.java
@@ -9,6 +9,9 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
 
+/**
+ * Mock implementation of a {@link ChunkSnapshot}.
+ */
 public class ChunkSnapshotMock implements ChunkSnapshot
 {
 
@@ -21,6 +24,18 @@ public class ChunkSnapshotMock implements ChunkSnapshot
 	private final Map<Coordinate, BlockData> blockData;
 	private final Map<Coordinate, Biome> biomes;
 
+	/**
+	 * Constructs a new {@link ChunkSnapshotMock} with the provided parameters.
+	 *
+	 * @param x         The X coordinate of the chunk.
+	 * @param z         The Y coordinate of the chunk.
+	 * @param minY      The minimum Y level of the world.
+	 * @param maxY      The maximum Y level of the world.
+	 * @param worldName The name of the world.
+	 * @param worldTime The time of the world at snapshot creation.
+	 * @param blockData A map of all {@link BlockData} in this chunk.
+	 * @param biomes    A map of all {@link Biome}s in this chunk.
+	 */
 	ChunkSnapshotMock(int x, int z, int minY, int maxY, String worldName, long worldTime, Map<Coordinate, BlockData> blockData, Map<Coordinate, Biome> biomes)
 	{
 		this.x = x;
@@ -171,6 +186,17 @@ public class ChunkSnapshotMock implements ChunkSnapshot
 		return this.blockData.containsValue(block);
 	}
 
+	/**
+	 * Validates that the chunk coordinates are within the proper range.
+	 * <p>
+	 * X: 0-15 (inclusive)<p>
+	 * Y: {@link #minY}-{@link #maxY} (inclusive)<p>
+	 * Z: 0-15 (inclusive)
+	 *
+	 * @param x The X coordinate.
+	 * @param y The Y coordinate.
+	 * @param z The Z coordinate.
+	 */
 	private void validateChunkCoordinates(int x, int y, int z)
 	{
 		Preconditions.checkArgument(0 <= x && x <= 15, "x out of range (expected 0-15, got %s)", x);

--- a/src/main/java/be/seeseemelk/mockbukkit/Coordinate.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/Coordinate.java
@@ -8,16 +8,27 @@ import org.jetbrains.annotations.NotNull;
 public class Coordinate
 {
 
+	/**
+	 * The X coordinate.
+	 */
 	public final int x;
+
+	/**
+	 * The Y coordinate.
+	 */
 	public final int y;
+
+	/**
+	 * The Z coordinate.
+	 */
 	public final int z;
 
 	/**
 	 * Creates a new coordinate object with a specified (x, y, z).
 	 *
-	 * @param x The x coordinate to set.
-	 * @param y The y coordinate to set.
-	 * @param z The z coordinate to set.
+	 * @param x The X coordinate to set.
+	 * @param y The Y coordinate to set.
+	 * @param z The Z coordinate to set.
 	 */
 	public Coordinate(int x, int y, int z)
 	{

--- a/src/main/java/be/seeseemelk/mockbukkit/MockBanList.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockBanList.java
@@ -10,6 +10,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Mock implementation of a {@link BanList}.
+ */
 public class MockBanList implements BanList
 {
 
@@ -47,6 +50,9 @@ public class MockBanList implements BanList
 		this.bans.remove(target);
 	}
 
+	/**
+	 * Mock implementation of a {@link BanEntry}.
+	 */
 	public static final class MockBanEntry implements BanEntry
 	{
 
@@ -56,6 +62,14 @@ public class MockBanList implements BanList
 		private Date created;
 		private Date expires;
 
+		/**
+		 * Constructs a new {@link MockBanEntry}.
+		 *
+		 * @param target  The target of the ban.
+		 * @param expires When the ban expires, or null for a permanent ban.
+		 * @param reason  The reason for the ban.
+		 * @param source  The source of the ban.
+		 */
 		public MockBanEntry(final String target, final Date expires, final String reason, final String source)
 		{
 			this.target = target;

--- a/src/main/java/be/seeseemelk/mockbukkit/MockBukkit.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockBukkit.java
@@ -17,6 +17,9 @@ import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.util.logging.Level;
 
+/**
+ * Handles mocking the {@link Bukkit} server, along with containing some handy utility methods.
+ */
 public class MockBukkit
 {
 
@@ -24,7 +27,7 @@ public class MockBukkit
 
 	private MockBukkit()
 	{
-		// This class should never be instantiated.
+		throw new UnsupportedOperationException("Utility class");
 	}
 
 	/**

--- a/src/main/java/be/seeseemelk/mockbukkit/MockChunkData.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockChunkData.java
@@ -13,6 +13,9 @@ import org.jetbrains.annotations.NotNull;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Mock implementation of a {@link ChunkGenerator.ChunkData}.
+ */
 public class MockChunkData implements ChunkGenerator.ChunkData
 {
 
@@ -24,6 +27,11 @@ public class MockChunkData implements ChunkGenerator.ChunkData
 	private final int minHeight;
 	private final int maxHeight;
 
+	/**
+	 * Constructs a new {@link MockChunkData} for the provided {@link World}.
+	 *
+	 * @param world The world the chunk is in.
+	 */
 	public MockChunkData(@NotNull World world)
 	{
 		this.minHeight = world.getMinHeight();

--- a/src/main/java/be/seeseemelk/mockbukkit/MockPlayerList.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockPlayerList.java
@@ -24,9 +24,6 @@ import java.util.stream.Stream;
 
 /**
  * Replica of the Bukkit internal PlayerList and CraftPlayerList implementation
- *
- * @author seeseemelk
- * @author TheBusyBiscuit
  */
 public class MockPlayerList
 {

--- a/src/main/java/be/seeseemelk/mockbukkit/MockPlayerList.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockPlayerList.java
@@ -229,7 +229,7 @@ public class MockPlayerList
 	}
 
 	/**
-	 * @return All offline & online players.
+	 * @return All offline and online players.
 	 */
 	@NotNull
 	public OfflinePlayer @NotNull [] getOfflinePlayers()

--- a/src/main/java/be/seeseemelk/mockbukkit/MockPlayerList.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockPlayerList.java
@@ -6,6 +6,7 @@ import com.google.common.base.Preconditions;
 import org.bukkit.BanList;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -40,29 +41,50 @@ public class MockPlayerList
 	private final @NotNull BanList ipBans = new MockBanList();
 	private final @NotNull BanList profileBans = new MockBanList();
 
+	/**
+	 * Sets the maximum number of online players.
+	 * <b>This is not currently enforced.</b>
+	 *
+	 * @param maxPlayers The maximum amount of players.
+	 */
 	public void setMaxPlayers(int maxPlayers)
 	{
 		// TODO: The maxPlayers setting is currently not enforced.
 		this.maxPlayers = maxPlayers;
 	}
 
+	/**
+	 * @return The maximum number of online players.
+	 */
 	public int getMaxPlayers()
 	{
 		return this.maxPlayers;
 	}
 
+	/**
+	 * @return All IP bans.
+	 */
 	@NotNull
 	public BanList getIPBans()
 	{
 		return this.ipBans;
 	}
 
+	/**
+	 * @return All profile bans.
+	 */
 	@NotNull
 	public BanList getProfileBans()
 	{
 		return this.profileBans;
 	}
 
+	/**
+	 * Marks a player as on the server, and sets related data like hasPlayedBefore and lastLogin.
+	 *
+	 * @param player The player to add.
+	 */
+	@ApiStatus.Internal
 	public void addPlayer(@NotNull PlayerMock player)
 	{
 		this.firstPlayed.putIfAbsent(player.getUniqueId(), System.currentTimeMillis());
@@ -72,6 +94,12 @@ public class MockPlayerList
 		this.hasPlayedBefore.put(player.getUniqueId(), this.hasPlayedBefore.containsKey(player.getUniqueId()));
 	}
 
+	/**
+	 * Marks a player as disconnected, and sets related data like lastSeen.
+	 *
+	 * @param player The player to disconnect.
+	 */
+	@ApiStatus.Internal
 	public void disconnectPlayer(@NotNull PlayerMock player)
 	{
 		this.lastSeen.put(player.getUniqueId(), System.currentTimeMillis());
@@ -91,6 +119,12 @@ public class MockPlayerList
 		return this.hasPlayedBefore.getOrDefault(uuid, false);
 	}
 
+	/**
+	 * Adds an offline player to the offline players set.
+	 *
+	 * @param player The player.
+	 */
+	@ApiStatus.Internal
 	public void addOfflinePlayer(@NotNull OfflinePlayer player)
 	{
 		this.offlinePlayers.add(player);
@@ -174,6 +208,9 @@ public class MockPlayerList
 		this.lastLogins.put(uuid, lastLogin);
 	}
 
+	/**
+	 * @return All server operators.
+	 */
 	@NotNull
 	public Set<OfflinePlayer> getOperators()
 	{
@@ -182,23 +219,38 @@ public class MockPlayerList
 				.collect(Collectors.toSet());
 	}
 
+	/**
+	 * @return All online players.
+	 */
 	@NotNull
 	public Collection<PlayerMock> getOnlinePlayers()
 	{
 		return Collections.unmodifiableSet(this.onlinePlayers);
 	}
 
+	/**
+	 * @return All offline & online players.
+	 */
 	@NotNull
 	public OfflinePlayer @NotNull [] getOfflinePlayers()
 	{
 		return this.offlinePlayers.toArray(new OfflinePlayer[0]);
 	}
 
+	/**
+	 * @return Whether anyone is online.
+	 */
 	public boolean isSomeoneOnline()
 	{
 		return !this.onlinePlayers.isEmpty();
 	}
 
+	/**
+	 * Matches a player by partial name.
+	 *
+	 * @param name The name to match by.
+	 * @return All online players whose names start with the provided name.
+	 */
 	@NotNull
 	public List<Player> matchPlayer(@NotNull String name)
 	{
@@ -208,6 +260,12 @@ public class MockPlayerList
 				.collect(Collectors.toList());
 	}
 
+	/**
+	 * Matches a player by their exact name.
+	 *
+	 * @param name The name to match by.
+	 * @return The player with the exact name provided, or null.
+	 */
 	@Nullable
 	public Player getPlayerExact(@NotNull String name)
 	{
@@ -217,6 +275,12 @@ public class MockPlayerList
 				.findFirst().orElse(null);
 	}
 
+	/**
+	 * Finds the player with the closest matching name.
+	 *
+	 * @param name The name to search with.
+	 * @return The closest matching player.
+	 */
 	@Nullable
 	public Player getPlayer(@NotNull String name)
 	{
@@ -247,6 +311,10 @@ public class MockPlayerList
 		return player;
 	}
 
+	/**
+	 * @param id The UUID of the player.
+	 * @return The player with the provided UUID, or null.
+	 */
 	@Nullable
 	public Player getPlayer(@NotNull UUID id)
 	{
@@ -261,12 +329,25 @@ public class MockPlayerList
 		return null;
 	}
 
+	/**
+	 * Gets a player at the provided index. Note player indexes will change whenever they join/leave.
+	 *
+	 * @param index The index.
+	 * @return The player at the provided index.
+	 */
 	@NotNull
-	public PlayerMock getPlayer(int num)
+	public PlayerMock getPlayer(int index)
 	{
-		return List.copyOf(this.onlinePlayers).get(num);
+		return List.copyOf(this.onlinePlayers).get(index);
 	}
 
+	/**
+	 * Gets an offline, or online player by name.
+	 *
+	 * @param name The name to match.
+	 * @return The player, or offline player with the provided name.
+	 * @see #getPlayer(String)
+	 */
 	@NotNull
 	public OfflinePlayer getOfflinePlayer(@NotNull String name)
 	{
@@ -288,6 +369,13 @@ public class MockPlayerList
 		return new OfflinePlayerMock(name);
 	}
 
+	/**
+	 * Gets an offline, or online player by UUID.
+	 *
+	 * @param id The UUID to match.
+	 * @return The player, or offline player with the provided UUID.
+	 * @see #getPlayer(UUID)
+	 */
 	@Nullable
 	public OfflinePlayer getOfflinePlayer(@NotNull UUID id)
 	{
@@ -309,11 +397,17 @@ public class MockPlayerList
 		return null;
 	}
 
+	/**
+	 * Clears all online players.
+	 */
 	public void clearOnlinePlayers()
 	{
 		this.onlinePlayers.clear();
 	}
 
+	/**
+	 * Clears all offline players.
+	 */
 	public void clearOfflinePlayers()
 	{
 		this.offlinePlayers.clear();

--- a/src/main/java/be/seeseemelk/mockbukkit/MockPlugin.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockPlugin.java
@@ -7,6 +7,9 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 
+/**
+ * A simple plugin that does nothing.
+ */
 public class MockPlugin extends JavaPlugin
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/MockPlugin.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockPlugin.java
@@ -13,10 +13,21 @@ import java.io.File;
 public class MockPlugin extends JavaPlugin
 {
 
+	/**
+	 * CraftBukkit constructor.
+	 */
 	public MockPlugin()
 	{
 	}
 
+	/**
+	 * MockBukkit constructor.
+	 *
+	 * @param loader      The plugin loader.
+	 * @param description The plugin description file.
+	 * @param dataFolder  The plugins data folder.
+	 * @param file        The plugins file.
+	 */
 	protected MockPlugin(@NotNull JavaPluginLoader loader, @NotNull PluginDescriptionFile description, @NotNull File dataFolder, @NotNull File file)
 	{
 		super(loader, description, dataFolder, file);

--- a/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
@@ -34,6 +34,9 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * Mock implementation of an {@link UnsafeValues}.
+ */
 @Deprecated
 public class MockUnsafeValues implements UnsafeValues
 {

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -642,14 +642,22 @@ public class ServerMock extends Server.Spigot implements Server
 		throw new UnimplementedOperationException();
 	}
 
+	/**
+	 * Creates an inventory with the provided parameters.
+	 *
+	 * @param owner The holder of the inventory.
+	 * @param type  The type of the inventory.
+	 * @param title The title of the inventory view.
+	 * @param size  The size of the inventory.
+	 * @return The created inventory.
+	 * @throws IllegalArgumentException If the InventoryType is not creatable.
+	 * @see InventoryType#isCreatable()
+	 */
 	@NotNull
 	@Deprecated
 	public InventoryMock createInventory(InventoryHolder owner, @NotNull InventoryType type, String title, int size)
 	{
-		if (!type.isCreatable())
-		{
-			throw new IllegalArgumentException("Inventory Type is not creatable!");
-		}
+		Preconditions.checkArgument(type.isCreatable(), "Inventory Type '" + type + "' is not creatable!");
 
 		switch (type)
 		{
@@ -660,9 +668,9 @@ public class ServerMock extends Server.Spigot implements Server
 		case DROPPER:
 			return new DropperInventoryMock(owner);
 		case PLAYER:
-			if (owner instanceof HumanEntity)
+			if (owner instanceof HumanEntity he)
 			{
-				return new PlayerInventoryMock((HumanEntity) owner);
+				return new PlayerInventoryMock(he);
 			}
 			else
 			{
@@ -1033,6 +1041,13 @@ public class ServerMock extends Server.Spigot implements Server
 		}
 	}
 
+	/**
+	 * Gets the tab completion result for a command.
+	 *
+	 * @param sender      The command sender.
+	 * @param commandLine The command string, without a leading slash.
+	 * @return The tab completion result, or an empty list.
+	 */
 	public @NotNull List<String> getCommandTabComplete(@NotNull CommandSender sender, @NotNull String commandLine)
 	{
 		AsyncCatcher.catchOp("command tabcomplete");
@@ -1845,6 +1860,11 @@ public class ServerMock extends Server.Spigot implements Server
 		return tag;
 	}
 
+	/**
+	 * Adds a tag registry.
+	 *
+	 * @param registry The registry to add.
+	 */
 	public void addTagRegistry(@NotNull TagRegistry registry)
 	{
 		materialTags.put(registry.getRegistry(), registry);

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -146,6 +146,9 @@ import java.util.logging.LogManager;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+/**
+ * Mock implementation of a {@link Server} and {@link Server.Spigot}.
+ */
 public class ServerMock extends Server.Spigot implements Server
 {
 
@@ -187,6 +190,10 @@ public class ServerMock extends Server.Spigot implements Server
 
 	private final @NotNull ServerConfiguration serverConfiguration = new ServerConfiguration();
 
+	/**
+	 * Constructs a new ServerMock and sets it up.
+	 * Does <b>NOT</b> set the server returned from {@link Bukkit#getServer()}.
+	 */
 	public ServerMock()
 	{
 		ServerMock.registerSerializables();

--- a/src/main/java/be/seeseemelk/mockbukkit/ThreadAccessException.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ThreadAccessException.java
@@ -1,5 +1,6 @@
 package be.seeseemelk.mockbukkit;
 
+@Deprecated(forRemoval = true)
 public class ThreadAccessException extends RuntimeException
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/ThreadAccessException.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ThreadAccessException.java
@@ -1,16 +1,32 @@
 package be.seeseemelk.mockbukkit;
 
+import java.io.Serial;
+
+/**
+ * Unused.
+ */
 @Deprecated(forRemoval = true)
 public class ThreadAccessException extends RuntimeException
 {
 
+	@Serial
 	private static final long serialVersionUID = 4506968718169636022L;
 
+	/**
+	 * Constructs a new .
+	 */
+	@Deprecated(forRemoval = true)
 	public ThreadAccessException()
 	{
 		super();
 	}
 
+	/**
+	 * Constructs a new with the provided message.
+	 *
+	 * @param message The message.
+	 */
+	@Deprecated(forRemoval = true)
 	public ThreadAccessException(String message)
 	{
 		super(message);

--- a/src/main/java/be/seeseemelk/mockbukkit/UnimplementedOperationException.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/UnimplementedOperationException.java
@@ -5,7 +5,7 @@ import org.opentest4j.TestAbortedException;
 
 /**
  * Sometimes your code may use a method that is not yet implemented in MockBukkit. When this happens {@link MockBukkit}
- * will, instead of returning placeholder values, throw an {@link UnimplementedOperationException}.
+ * will, instead of returning placeholder values or failing your test, throw an {@link UnimplementedOperationException}.
  * <p>
  * This is a {@link TestAbortedException} and causes your Test to be skipped instead of just failing.
  *

--- a/src/main/java/be/seeseemelk/mockbukkit/UnimplementedOperationException.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/UnimplementedOperationException.java
@@ -1,7 +1,10 @@
 package be.seeseemelk.mockbukkit;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.opentest4j.TestAbortedException;
+
+import java.io.Serial;
 
 /**
  * Sometimes your code may use a method that is not yet implemented in MockBukkit. When this happens {@link MockBukkit}
@@ -14,13 +17,24 @@ import org.opentest4j.TestAbortedException;
 public class UnimplementedOperationException extends TestAbortedException
 {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
+	/**
+	 * Constructs a new  with a default message.
+	 */
+	@ApiStatus.Internal
 	public UnimplementedOperationException()
 	{
 		this("Not implemented");
 	}
 
+	/**
+	 * Constructs a new  with the provided message.
+	 *
+	 * @param message The message.
+	 */
+	@ApiStatus.Internal
 	public UnimplementedOperationException(@NotNull String message)
 	{
 		super(message);

--- a/src/main/java/be/seeseemelk/mockbukkit/WorldBorderMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/WorldBorderMock.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.concurrent.TimeUnit;
 
 /**
- * A mock world border object.
+ * Mock implementation of a {@link WorldBorder}.
  */
 public class WorldBorderMock implements WorldBorder
 {

--- a/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
@@ -58,7 +58,6 @@ import io.papermc.paper.world.MoonPhase;
 import org.bukkit.BlockChangeDelegate;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
-import org.bukkit.ChunkSnapshot;
 import org.bukkit.Difficulty;
 import org.bukkit.Effect;
 import org.bukkit.FluidCollisionMode;
@@ -185,7 +184,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
- * A mock world object. Note that it is made to be as simple as possible. It is by no means an efficient implementation.
+ * Mock implementation of a {@link World}.
  */
 public class WorldMock implements World
 {

--- a/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
@@ -282,6 +282,11 @@ public class WorldMock implements World
 		gameRules.put(GameRule.SPECTATORS_GENERATE_CHUNKS, true);
 	}
 
+	/**
+	 * Creates a new mock world.
+	 *
+	 * @param creator The {@link WorldCreator} to use to create the world.
+	 */
 	public WorldMock(@NotNull WorldCreator creator)
 	{
 		this();
@@ -433,6 +438,12 @@ public class WorldMock implements World
 		return getBlockAt(new Coordinate(x, y, z));
 	}
 
+	/**
+	 * Gets the block at a coordinate.
+	 *
+	 * @param coordinate The coordinate at which to get the block.
+	 * @return The block.
+	 */
 	public @NotNull BlockMock getBlockAt(@NotNull Coordinate coordinate)
 	{
 		if (blocks.containsKey(coordinate))
@@ -841,18 +852,29 @@ public class WorldMock implements World
 		return this.spawn(location, clazz, function, CreatureSpawnEvent.SpawnReason.CUSTOM, randomizeData);
 	}
 
+	@Override
 	public <T extends Entity> @NotNull T spawn(@NotNull Location location, @NotNull Class<T> clazz, Consumer<T> function, CreatureSpawnEvent.@NotNull SpawnReason reason) throws IllegalArgumentException
 	{
 		return this.spawn(location, clazz, function, reason, true);
 	}
 
+	/**
+	 * Spawns an entity.
+	 *
+	 * @param location      The location to spawn the entity at.
+	 * @param clazz         The class of entity to spawn. This should be the class of the Bukkit interface, not the mock.
+	 * @param function      A function to call once the entity has been spawned.
+	 * @param reason        The reason for spawning the entity.
+	 * @param randomizeData Whether data should be randomized. Currently, does nothing.
+	 * @param <T>           The entity type.
+	 * @return The spawned entity.
+	 */
 	@SuppressWarnings("unchecked")
-	public <T extends Entity> @NotNull T spawn(@Nullable Location location, @Nullable Class<T> clazz, @Nullable Consumer<T> function, CreatureSpawnEvent.@NotNull SpawnReason reason, boolean randomizeData) throws IllegalArgumentException
+	public <T extends Entity> @NotNull T spawn(@Nullable Location location, @Nullable Class<T> clazz, @Nullable Consumer<T> function, CreatureSpawnEvent.@NotNull SpawnReason reason, boolean randomizeData)
 	{
-		if (location == null || clazz == null)
-		{
-			throw new IllegalArgumentException("Location or entity class cannot be null");
-		}
+		Preconditions.checkNotNull(location, "Location cannot be null");
+		Preconditions.checkNotNull(clazz, "Class cannot be null");
+		Preconditions.checkNotNull(reason, "Reason cannot be null");
 
 		EntityMock entity = this.mockEntity(location, clazz, randomizeData);
 
@@ -2454,6 +2476,11 @@ public class WorldMock implements World
 		biomes.put(new Coordinate(x, y, z), bio);
 	}
 
+	/**
+	 * Gets a map of what biome is at each coordinate.
+	 *
+	 * @return A clone of the internal biome map.
+	 */
 	protected @NotNull Map<Coordinate, Biome> getBiomeMap()
 	{
 		return new HashMap<>(biomes);

--- a/src/main/java/be/seeseemelk/mockbukkit/adventure/LegacyComponentSerializerProviderImpl.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/adventure/LegacyComponentSerializerProviderImpl.java
@@ -5,6 +5,10 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Consumer;
 
+/**
+ * Mock implementation of {@link LegacyComponentSerializer.Provider} based on {@code io.papermc.paper.adventure.providers.LegacyComponentSerializerProviderImpl}.
+ */
+@SuppressWarnings("UnstableApiUsage") // We are the internal
 public class LegacyComponentSerializerProviderImpl implements LegacyComponentSerializer.Provider
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/attribute/AttributeInstanceMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/attribute/AttributeInstanceMock.java
@@ -10,6 +10,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+/**
+ * Mock implementation of {@link AttributeInstance}.
+ */
 public class AttributeInstanceMock implements AttributeInstance
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/attribute/AttributeInstanceMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/attribute/AttributeInstanceMock.java
@@ -21,6 +21,12 @@ public class AttributeInstanceMock implements AttributeInstance
 	private double value;
 	private final @NotNull List<AttributeModifier> modifiers;
 
+	/**
+	 * Constructs a new {@link AttributeInstanceMock} for the provided {@link Attribute} and with the specified value.
+	 *
+	 * @param attribute The Attribute this is an instance of.
+	 * @param value     The value of the attribute.
+	 */
 	public AttributeInstanceMock(@NotNull Attribute attribute, double value)
 	{
 		Preconditions.checkNotNull(attribute, "Attribute cannot be null");

--- a/src/main/java/be/seeseemelk/mockbukkit/attribute/AttributesMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/attribute/AttributesMock.java
@@ -13,10 +13,6 @@ import java.util.Map;
 public class AttributesMock
 {
 
-	private AttributesMock()
-	{
-	}
-
 	private static final Map<Attribute, Double> DEFAULT_ATTRIBUTE_VALUES = ImmutableMap.ofEntries(
 			Map.entry(Attribute.GENERIC_MAX_HEALTH, 20.0),
 			Map.entry(Attribute.GENERIC_FOLLOW_RANGE, 32.0),
@@ -37,6 +33,11 @@ public class AttributesMock
 	{
 		Preconditions.checkNotNull(attribute, "Attribute cannot be null");
 		return DEFAULT_ATTRIBUTE_VALUES.get(attribute);
+	}
+
+	private AttributesMock()
+	{
+		throw new UnsupportedOperationException("Utility class");
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/attribute/AttributesMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/attribute/AttributesMock.java
@@ -29,6 +29,12 @@ public class AttributesMock
 			Map.entry(Attribute.ZOMBIE_SPAWN_REINFORCEMENTS, 0.0)
 	);
 
+	/**
+	 * Gets the default value of an {@link Attribute}.
+	 *
+	 * @param attribute The attribute to get.
+	 * @return The default value of the attribute.
+	 */
 	public static double getDefaultValue(@NotNull Attribute attribute)
 	{
 		Preconditions.checkNotNull(attribute, "Attribute cannot be null");

--- a/src/main/java/be/seeseemelk/mockbukkit/block/BlockMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/BlockMock.java
@@ -35,6 +35,9 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+/**
+ * Mock implementation of a {@link Block}.
+ */
 public class BlockMock implements Block
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/AmethystClusterMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/AmethystClusterMock.java
@@ -17,6 +17,12 @@ import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.WATERLOGGED;
 public class AmethystClusterMock extends BlockDataMock implements AmethystCluster
 {
 
+	/**
+	 * Constructs a new {@link BedMock} for the provided {@link Material}.
+	 * Only supports {@link Material#AMETHYST_CLUSTER}
+	 *
+	 * @param type The material this data is for.
+	 */
 	public AmethystClusterMock(@NotNull Material type)
 	{
 		super(type);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/AmethystClusterMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/AmethystClusterMock.java
@@ -3,8 +3,6 @@ package be.seeseemelk.mockbukkit.block.data;
 import com.google.common.base.Preconditions;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
-import org.bukkit.block.data.Directional;
-import org.bukkit.block.data.Waterlogged;
 import org.bukkit.block.data.type.AmethystCluster;
 import org.jetbrains.annotations.NotNull;
 
@@ -13,7 +11,10 @@ import java.util.Set;
 import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.FACING;
 import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.WATERLOGGED;
 
-public class AmethystClusterMock extends BlockDataMock implements AmethystCluster, Directional, Waterlogged
+/**
+ * Mock implementation of {@link AmethystCluster}.
+ */
+public class AmethystClusterMock extends BlockDataMock implements AmethystCluster
 {
 
 	public AmethystClusterMock(@NotNull Material type)

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/BedMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/BedMock.java
@@ -12,6 +12,9 @@ import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.FACING;
 import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.OCCUPIED;
 import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.PART;
 
+/**
+ * Mock implementation of {@link Bed}.
+ */
 public class BedMock extends BlockDataMock implements Bed
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/BedMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/BedMock.java
@@ -1,7 +1,7 @@
 package be.seeseemelk.mockbukkit.block.data;
 
-import com.destroystokyo.paper.MaterialTags;
 import org.bukkit.Material;
+import org.bukkit.Tag;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.type.Bed;
 import org.jetbrains.annotations.NotNull;
@@ -18,10 +18,16 @@ import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.PART;
 public class BedMock extends BlockDataMock implements Bed
 {
 
+	/**
+	 * Constructs a new {@link BedMock} for the provided {@link Material}.
+	 * Only supports materials in {@link Tag#BEDS}
+	 *
+	 * @param type The material this data is for.
+	 */
 	public BedMock(@NotNull Material type)
 	{
 		super(type);
-		checkType(type, MaterialTags.BEDS);
+		checkType(type, Tag.BEDS);
 		this.setFacing(BlockFace.NORTH);
 		super.set(OCCUPIED, false);
 		this.setPart(Part.FOOT);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/BlockDataKey.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/BlockDataKey.java
@@ -1,22 +1,72 @@
 package be.seeseemelk.mockbukkit.block.data;
 
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.Bisected;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Directional;
+import org.bukkit.block.data.Lightable;
+import org.bukkit.block.data.Openable;
+import org.bukkit.block.data.Powerable;
+import org.bukkit.block.data.Waterlogged;
+import org.bukkit.block.data.type.Bed;
+import org.bukkit.block.data.type.Campfire;
+import org.bukkit.block.data.type.Slab;
+import org.bukkit.block.data.type.Stairs;
+
+/**
+ * Stores all {@link BlockData} keys.
+ */
 final class BlockDataKey
 {
 
+	/**
+	 * Stores the {@link BlockFace} a {@link Directional} block is facing towards.
+	 */
 	static final String FACING = "facing";
+	/**
+	 * Stores whether a {@link Campfire} is a signal fire (hay block underneath).
+	 */
 	static final String SIGNAL_FIRE = "signal_fire";
+	/**
+	 * Stores what {@link Bisected.Half} a {@link Bisected} block is placed in.
+	 */
 	static final String HALF = "half";
+	/**
+	 * Stores whether a {@link Lightable} is list.
+	 */
 	static final String LIT = "lit";
+	/**
+	 * Stores whether a {@link Bed} is occupied.
+	 */
 	static final String OCCUPIED = "occupied";
+	/**
+	 * Stores whether a {@link Openable} is open.
+	 */
 	static final String OPEN = "open";
+	/**
+	 * Stores what {@link Bed.Part} of a {@link Bed} this block is.
+	 */
 	static final String PART = "part";
+	/**
+	 * Stores whether a {@link Powerable} is powered.
+	 */
 	static final String POWERED = "powered";
+	/**
+	 * Stores what {@link Stairs.Shape} a {@link Stairs} block is.
+	 */
 	static final String SHAPE = "shape";
+	/**
+	 * Store what {@link Slab.Type} a {@link Slab} is.
+	 */
 	static final String TYPE = "type";
+	/**
+	 * Stores whether a {@link Waterlogged} block is waterlogged.
+	 */
 	static final String WATERLOGGED = "waterlogged";
 
 	private BlockDataKey()
 	{
+		throw new UnsupportedOperationException("Utility class");
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/BlockDataMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/BlockDataMock.java
@@ -32,6 +32,11 @@ public class BlockDataMock implements BlockData
 	private final @NotNull Material type;
 	private final @NotNull Map<String, Object> data;
 
+	/**
+	 * Constructs a new {@link BlockDataMock} for the provided {@link Material}.
+	 *
+	 * @param type The material this data is for.
+	 */
 	public BlockDataMock(@NotNull Material type)
 	{
 		Preconditions.checkNotNull(type, "Type cannot be null");

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/BlockDataMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/BlockDataMock.java
@@ -45,27 +45,60 @@ public class BlockDataMock implements BlockData
 	}
 
 	// region Type Checking
+
+	/**
+	 * Ensures the provided material is one of the expected materials provided.
+	 *
+	 * @param material The material to test.
+	 * @param expected The expected materials.
+	 */
 	protected void checkType(@NotNull Material material, @NotNull Material... expected)
 	{
 		Preconditions.checkArgument(Arrays.stream(expected).anyMatch(m -> material == m), "Cannot create a " + getClass().getSimpleName() + " from " + material);
 	}
 
+	/**
+	 * Ensures the provided block type is one of the expected materials provided.
+	 *
+	 * @param block    The block to test.
+	 * @param expected The expected materials.
+	 */
 	protected void checkType(@NotNull Block block, @NotNull Material... expected)
 	{
 		checkType(block.getType(), expected);
 	}
 
-	protected void checkType(@NotNull Material material, @NotNull Tag<Material> tag)
+	/**
+	 * Ensures the provided material is contained in the {@link Tag}.
+	 *
+	 * @param material The material to test.
+	 * @param expected The expected tag.
+	 */
+	protected void checkType(@NotNull Material material, @NotNull Tag<Material> expected)
 	{
-		Preconditions.checkArgument(tag.isTagged(material), "Cannot create a " + getClass().getSimpleName() + " from " + material);
+		Preconditions.checkArgument(expected.isTagged(material), "Cannot create a " + getClass().getSimpleName() + " from " + material);
 	}
 
+	/**
+	 * Ensures the provided block type is contained in the {@link Tag}.
+	 *
+	 * @param block    The material to test.
+	 * @param expected The expected tag.
+	 */
 	protected void checkType(@NotNull Block block, @NotNull Tag<Material> expected)
 	{
 		checkType(block.getType(), expected);
 	}
 	// endregion
 
+	/**
+	 * Sets a data value.
+	 *
+	 * @param key   The data key.
+	 * @param value The data value.
+	 * @param <T>   The type of the data.
+	 * @see BlockDataKey
+	 */
 	protected <T> void set(@NotNull String key, @NotNull T value)
 	{
 		Preconditions.checkNotNull(key, "Key cannot be null");
@@ -73,6 +106,15 @@ public class BlockDataMock implements BlockData
 		this.data.put(key, value);
 	}
 
+	/**
+	 * Gets a data value.
+	 * Will throw an {@link IllegalArgumentException} if no data is set for the provided key.
+	 *
+	 * @param key The data key.
+	 * @param <T> The type of the data.
+	 * @return The data attached to the key.
+	 * @see BlockDataKey
+	 */
 	@SuppressWarnings("unchecked")
 	protected <T> @NotNull T get(@NotNull String key)
 	{
@@ -208,6 +250,13 @@ public class BlockDataMock implements BlockData
 		}
 	}
 
+	/**
+	 * Attempts to construct a BlockDataMock by the provided material.
+	 * Will return a basic {@link BlockDataMock} if no implementation is found.
+	 *
+	 * @param material The material to create the BlockData from.
+	 * @return The BlockData.
+	 */
 	public static @NotNull BlockDataMock mock(@NotNull Material material)
 	{
 		Preconditions.checkNotNull(material, NULL_MATERIAL_EXCEPTION_MESSAGE);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/BlockDataMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/BlockDataMock.java
@@ -20,6 +20,10 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * Mock implementation of {@link BlockData}.
+ * Also manages the creation of new BlockData with the appropriate mock class.
+ */
 public class BlockDataMock implements BlockData
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/CampfireMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/CampfireMock.java
@@ -20,6 +20,12 @@ import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.WATERLOGGED;
 public class CampfireMock extends BlockDataMock implements Campfire
 {
 
+	/**
+	 * Constructs a new {@link BedMock} for the provided {@link Material}.
+	 * Only supports materials in {@link Tag#CAMPFIRES}
+	 *
+	 * @param type The material this data is for.
+	 */
 	public CampfireMock(@NotNull Material type)
 	{
 		super(type);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/CampfireMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/CampfireMock.java
@@ -14,6 +14,9 @@ import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.LIT;
 import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.SIGNAL_FIRE;
 import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.WATERLOGGED;
 
+/**
+ * Mock implementation of {@link Campfire}.
+ */
 public class CampfireMock extends BlockDataMock implements Campfire
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/SlabMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/SlabMock.java
@@ -15,6 +15,12 @@ import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.WATERLOGGED;
 public class SlabMock extends BlockDataMock implements Slab
 {
 
+	/**
+	 * Constructs a new {@link BedMock} for the provided {@link Material}.
+	 * Only supports materials in {@link Tag#SLABS}
+	 *
+	 * @param type The material this data is for.
+	 */
 	public SlabMock(@NotNull Material type)
 	{
 		super(type);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/SlabMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/SlabMock.java
@@ -9,6 +9,9 @@ import org.jetbrains.annotations.NotNull;
 import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.TYPE;
 import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.WATERLOGGED;
 
+/**
+ * Mock implementation of {@link Slab}.
+ */
 public class SlabMock extends BlockDataMock implements Slab
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/StairsMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/StairsMock.java
@@ -20,6 +20,12 @@ import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.WATERLOGGED;
 public class StairsMock extends BlockDataMock implements Stairs
 {
 
+	/**
+	 * Constructs a new {@link BedMock} for the provided {@link Material}.
+	 * Only supports materials in {@link Tag#STAIRS}
+	 *
+	 * @param type The material this data is for.
+	 */
 	public StairsMock(@NotNull Material type)
 	{
 		super(type);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/StairsMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/StairsMock.java
@@ -14,6 +14,9 @@ import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.HALF;
 import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.SHAPE;
 import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.WATERLOGGED;
 
+/**
+ * Mock implementation of {@link Stairs}.
+ */
 public class StairsMock extends BlockDataMock implements Stairs
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/TrapDoorMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/TrapDoorMock.java
@@ -21,6 +21,12 @@ import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.WATERLOGGED;
 public class TrapDoorMock extends BlockDataMock implements TrapDoor
 {
 
+	/**
+	 * Constructs a new {@link BedMock} for the provided {@link Material}.
+	 * Only supports materials in {@link Tag#TRAPDOORS}
+	 *
+	 * @param type The material this data is for.
+	 */
 	public TrapDoorMock(@NotNull Material type)
 	{
 		super(type);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/TrapDoorMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/TrapDoorMock.java
@@ -15,6 +15,9 @@ import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.OPEN;
 import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.POWERED;
 import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.WATERLOGGED;
 
+/**
+ * Mock implementation of {@link TrapDoor}.
+ */
 public class TrapDoorMock extends BlockDataMock implements TrapDoor
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/AbstractFurnaceMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/AbstractFurnaceMock.java
@@ -14,7 +14,9 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Map;
 
 /**
- * Mock implementation of {@link Furnace}.
+ * Mock implementation of a {@link Furnace}.
+ *
+ * @see ContainerMock
  */
 public abstract class AbstractFurnaceMock extends ContainerMock implements Furnace
 {
@@ -24,18 +26,35 @@ public abstract class AbstractFurnaceMock extends ContainerMock implements Furna
 	private int cookTimeTotal;
 	private double cookSpeedMultiplier = 1.0;
 
+	/**
+	 * Constructs a new {@link AbstractFurnaceMock} for the provided {@link Material}.
+	 * Only supports {@link Material#SMOKER}, {@link Material#FURNACE}, and {@link Material#BLAST_FURNACE}.
+	 *
+	 * @param material The material this state is for.
+	 */
 	protected AbstractFurnaceMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.SMOKER, Material.FURNACE, Material.BLAST_FURNACE);
 	}
 
+	/**
+	 * Constructs a new {@link AbstractFurnaceMock} for the provided {@link Block}.
+	 * Only supports {@link Material#SMOKER}, {@link Material#FURNACE}, and {@link Material#BLAST_FURNACE}.
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected AbstractFurnaceMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.SMOKER, Material.FURNACE, Material.BLAST_FURNACE);
 	}
 
+	/**
+	 * Constructs a new {@link AbstractFurnaceMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected AbstractFurnaceMock(@NotNull AbstractFurnaceMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/AbstractFurnaceMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/AbstractFurnaceMock.java
@@ -13,6 +13,9 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
 
+/**
+ * Mock implementation of {@link Furnace}.
+ */
 public abstract class AbstractFurnaceMock extends ContainerMock implements Furnace
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BannerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BannerMock.java
@@ -16,7 +16,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Mock implementation of {@link Banner}.
+ * Mock implementation of a {@link Banner}.
+ *
+ * @see TileStateMock
  */
 public class BannerMock extends TileStateMock implements Banner
 {
@@ -25,18 +27,35 @@ public class BannerMock extends TileStateMock implements Banner
 	private @NotNull List<Pattern> patterns = new ArrayList<>();
 	private @Nullable Component customName;
 
+	/**
+	 * Constructs a new {@link BannerMock} for the provided {@link Material}.
+	 * Only supports materials in {@link Tag#BANNERS}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public BannerMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Tag.BANNERS);
 	}
 
+	/**
+	 * Constructs a new {@link BannerMock} for the provided {@link Block}.
+	 * Only supports materials in {@link Tag#BANNERS}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected BannerMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Tag.BANNERS);
 	}
 
+	/**
+	 * Constructs a new {@link BannerMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected BannerMock(@NotNull BannerMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BannerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BannerMock.java
@@ -15,6 +15,9 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Mock implementation of {@link Banner}.
+ */
 public class BannerMock extends TileStateMock implements Banner
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BarrelMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BarrelMock.java
@@ -11,25 +11,44 @@ import org.bukkit.loot.LootTable;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Mock implementation of {@link Barrel}.
+ * Mock implementation of a {@link Barrel}.
+ *
+ * @see ContainerMock
  */
 public class BarrelMock extends ContainerMock implements Barrel
 {
 
 	private boolean isOpen = false;
 
+	/**
+	 * Constructs a new {@link BarrelMock} for the provided {@link Material}.
+	 * Only supports {@link Material#BARREL}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public BarrelMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.BARREL);
 	}
 
+	/**
+	 * Constructs a new {@link BarrelMock} for the provided {@link Block}.
+	 * Only supports {@link Material#BARREL}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected BarrelMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.BARREL);
 	}
 
+	/**
+	 * Constructs a new {@link BarrelMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected BarrelMock(@NotNull BarrelMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BarrelMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BarrelMock.java
@@ -11,10 +11,7 @@ import org.bukkit.loot.LootTable;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * This {@link ContainerMock} represents a {@link Barrel}
- *
- * @author TheBusyBiscuit
- * @see ChestMock
+ * Mock implementation of {@link Barrel}.
  */
 public class BarrelMock extends ContainerMock implements Barrel
 {

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BeaconMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BeaconMock.java
@@ -19,6 +19,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 
+/**
+ * Mock implementation of {@link Beacon}.
+ */
 public class BeaconMock extends TileStateMock implements Beacon
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BeaconMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BeaconMock.java
@@ -20,7 +20,9 @@ import org.junit.jupiter.api.Test;
 import java.util.Collection;
 
 /**
- * Mock implementation of {@link Beacon}.
+ * Mock implementation of a {@link Beacon}.
+ *
+ * @see TileStateMock
  */
 public class BeaconMock extends TileStateMock implements Beacon
 {
@@ -32,18 +34,35 @@ public class BeaconMock extends TileStateMock implements Beacon
 	private @Nullable PotionEffectType secondaryEffect;
 	private double effectRange = -1;
 
+	/**
+	 * Constructs a new {@link BeaconMock} for the provided {@link Material}.
+	 * Only supports {@link Material#BARREL}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public BeaconMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.BEACON);
 	}
 
+	/**
+	 * Constructs a new {@link BeaconMock} for the provided {@link Block}.
+	 * Only supports {@link Material#BEACON}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected BeaconMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.BEACON);
 	}
 
+	/**
+	 * Constructs a new {@link BeaconMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected BeaconMock(@NotNull BeaconMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BedMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BedMock.java
@@ -9,6 +9,9 @@ import org.bukkit.block.BlockState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Mock implementation of {@link Bed}.
+ */
 public class BedMock extends TileStateMock implements Bed
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BedMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BedMock.java
@@ -10,23 +10,42 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Mock implementation of {@link Bed}.
+ * Mock implementation of a {@link Bed}.
+ *
+ * @see TileStateMock
  */
 public class BedMock extends TileStateMock implements Bed
 {
 
+	/**
+	 * Constructs a new {@link BedMock} for the provided {@link Material}.
+	 * Only supports materials in {@link MaterialTags#BEDS}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public BedMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, MaterialTags.BEDS);
 	}
 
+	/**
+	 * Constructs a new {@link BedMock} for the provided {@link Block}.
+	 * Only supports materials in {@link MaterialTags#BEDS}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected BedMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, MaterialTags.BEDS);
 	}
 
+	/**
+	 * Constructs a new {@link BedMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected BedMock(@NotNull BedMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BeehiveMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BeehiveMock.java
@@ -15,6 +15,9 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Mock implementation of {@link Beehive}.
+ */
 public class BeehiveMock extends TileStateMock implements Beehive
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BeehiveMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BeehiveMock.java
@@ -16,7 +16,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Mock implementation of {@link Beehive}.
+ * Mock implementation of a {@link Beehive}.
+ *
+ * @see TileStateMock
  */
 public class BeehiveMock extends TileStateMock implements Beehive
 {
@@ -26,18 +28,35 @@ public class BeehiveMock extends TileStateMock implements Beehive
 	private boolean sedated;
 	private final List<Bee> bees = new ArrayList<>();
 
+	/**
+	 * Constructs a new {@link BeehiveMock} for the provided {@link Material}.
+	 * Only supports {@link Material#BEEHIVE}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public BeehiveMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.BEEHIVE);
 	}
 
+	/**
+	 * Constructs a new {@link BeehiveMock} for the provided {@link Block}.
+	 * Only supports {@link Material#BEEHIVE}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected BeehiveMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.BEEHIVE);
 	}
 
+	/**
+	 * Constructs a new {@link BeehiveMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected BeehiveMock(@NotNull BeehiveMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BellMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BellMock.java
@@ -7,23 +7,42 @@ import org.bukkit.block.BlockState;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Mock implementation of {@link Bell}.
+ * Mock implementation of a {@link Bell}.
+ *
+ * @see TileStateMock
  */
 public class BellMock extends TileStateMock implements Bell
 {
 
+	/**
+	 * Constructs a new {@link BellMock} for the provided {@link Material}.
+	 * Only supports {@link Material#BELL}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public BellMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.BELL);
 	}
 
+	/**
+	 * Constructs a new {@link BellMock} for the provided {@link Block}.
+	 * Only supports {@link Material#BELL}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected BellMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.BELL);
 	}
 
+	/**
+	 * Constructs a new {@link BellMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected BellMock(@NotNull BellMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BellMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BellMock.java
@@ -6,6 +6,9 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of {@link Bell}.
+ */
 public class BellMock extends TileStateMock implements Bell
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BlastFurnaceMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BlastFurnaceMock.java
@@ -7,23 +7,42 @@ import org.bukkit.block.BlockState;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Mock implementation of {@link BlastFurnace}.
+ * Mock implementation of a {@link BlastFurnace}.
+ *
+ * @see AbstractFurnaceMock
  */
 public class BlastFurnaceMock extends AbstractFurnaceMock implements BlastFurnace
 {
 
+	/**
+	 * Constructs a new {@link BlastFurnaceMock} for the provided {@link Material}.
+	 * Only supports {@link Material#BLAST_FURNACE}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public BlastFurnaceMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.BLAST_FURNACE);
 	}
 
+	/**
+	 * Constructs a new {@link BlastFurnaceMock} for the provided {@link Block}.
+	 * Only supports {@link Material#BLAST_FURNACE}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected BlastFurnaceMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.BLAST_FURNACE);
 	}
 
+	/**
+	 * Constructs a new {@link BlastFurnaceMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected BlastFurnaceMock(@NotNull BlastFurnaceMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BlastFurnaceMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BlastFurnaceMock.java
@@ -6,6 +6,9 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of {@link BlastFurnace}.
+ */
 public class BlastFurnaceMock extends AbstractFurnaceMock implements BlastFurnace
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
@@ -74,21 +74,46 @@ public class BlockStateMock implements BlockState
 	}
 
 	// region Type Checking
+
+	/**
+	 * Ensures the provided material is one of the expected materials provided.
+	 *
+	 * @param material The material to test.
+	 * @param expected The expected materials.
+	 */
 	protected void checkType(@NotNull Material material, @NotNull Material @NotNull ... expected)
 	{
 		Preconditions.checkArgument(Arrays.stream(expected).anyMatch(m -> material == m), "Cannot create a " + getClass().getSimpleName() + " from " + material);
 	}
 
+	/**
+	 * Ensures the provided block type is one of the expected materials provided.
+	 *
+	 * @param block    The block to test.
+	 * @param expected The expected materials.
+	 */
 	protected void checkType(@NotNull Block block, @NotNull Material... expected)
 	{
 		checkType(block.getType(), expected);
 	}
 
-	protected void checkType(@NotNull Material material, @NotNull Tag<Material> tag)
+	/**
+	 * Ensures the provided material is contained in the {@link Tag}.
+	 *
+	 * @param material The material to test.
+	 * @param expected The expected tag.
+	 */
+	protected void checkType(@NotNull Material material, @NotNull Tag<Material> expected)
 	{
-		Preconditions.checkArgument(tag.isTagged(material), "Cannot create a " + getClass().getSimpleName() + " from " + material);
+		Preconditions.checkArgument(expected.isTagged(material), "Cannot create a " + getClass().getSimpleName() + " from " + material);
 	}
 
+	/**
+	 * Ensures the provided block type is contained in the {@link Tag}.
+	 *
+	 * @param block    The material to test.
+	 * @param expected The expected tag.
+	 */
 	protected void checkType(@NotNull Block block, @NotNull Tag<Material> expected)
 	{
 		checkType(block.getType(), expected);
@@ -346,6 +371,13 @@ public class BlockStateMock implements BlockState
 //		}
 	}
 
+	/**
+	 * Attempts to construct a BlockStateMock by the provided block.
+	 * Will return a basic {@link BlockStateMock} if no implementation is found.
+	 *
+	 * @param block The block to create the BlockState from.
+	 * @return The BlockState.
+	 */
 	@NotNull
 	public static BlockStateMock mockState(@NotNull Block block)
 	{

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
@@ -25,7 +25,7 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Mock implementation of {@link BlockState}.
+ * Mock implementation of a {@link BlockState}.
  * Also manages the creation of new BlockStates with the appropriate mock class.
  */
 public class BlockStateMock implements BlockState
@@ -35,6 +35,11 @@ public class BlockStateMock implements BlockState
 	private @Nullable Block block;
 	private Material material;
 
+	/**
+	 * Constructs a new {@link BlockStateMock} for the provided {@link Material}.
+	 *
+	 * @param material The material this state is for.
+	 */
 	public BlockStateMock(@NotNull Material material)
 	{
 		Preconditions.checkNotNull(material, "Material cannot be null");
@@ -42,6 +47,11 @@ public class BlockStateMock implements BlockState
 		this.material = material;
 	}
 
+	/**
+	 * Constructs a new {@link BlockStateMock} for the provided {@link Block}.
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected BlockStateMock(@NotNull Block block)
 	{
 		Preconditions.checkNotNull(block, "Block cannot be null");
@@ -50,6 +60,11 @@ public class BlockStateMock implements BlockState
 		this.material = block.getType();
 	}
 
+	/**
+	 * Constructs a new {@link BlockStateMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected BlockStateMock(@NotNull BlockStateMock state)
 	{
 		Preconditions.checkNotNull(state, "BlockStateMock cannot be null");

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
@@ -24,6 +24,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+/**
+ * Mock implementation of {@link BlockState}.
+ * Also manages the creation of new BlockStates with the appropriate mock class.
+ */
 public class BlockStateMock implements BlockState
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BrewingStandMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BrewingStandMock.java
@@ -9,6 +9,9 @@ import org.bukkit.block.BrewingStand;
 import org.bukkit.inventory.BrewerInventory;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of {@link BrewingStand}.
+ */
 public class BrewingStandMock extends ContainerMock implements BrewingStand
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BrewingStandMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BrewingStandMock.java
@@ -10,7 +10,9 @@ import org.bukkit.inventory.BrewerInventory;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Mock implementation of {@link BrewingStand}.
+ * Mock implementation of a {@link BrewingStand}.
+ *
+ * @see ContainerMock
  */
 public class BrewingStandMock extends ContainerMock implements BrewingStand
 {
@@ -18,18 +20,35 @@ public class BrewingStandMock extends ContainerMock implements BrewingStand
 	private int brewingTime;
 	private int fuelLevel;
 
+	/**
+	 * Constructs a new {@link BrewingStandMock} for the provided {@link Material}.
+	 * Only supports {@link Material#BREWING_STAND}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public BrewingStandMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.BREWING_STAND);
 	}
 
+	/**
+	 * Constructs a new {@link BrewingStandMock} for the provided {@link Block}.
+	 * Only supports {@link Material#BREWING_STAND}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected BrewingStandMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.BREWING_STAND);
 	}
 
+	/**
+	 * Constructs a new {@link BrewingStandMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected BrewingStandMock(@NotNull BrewingStandMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/CampfireMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/CampfireMock.java
@@ -11,7 +11,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Mock implementation of {@link Campfire}.
+ * Mock implementation of a {@link Campfire}.
+ *
+ * @see TileStateMock
  */
 public class CampfireMock extends TileStateMock implements Campfire
 {
@@ -23,18 +25,35 @@ public class CampfireMock extends TileStateMock implements Campfire
 	private int[] cookingTime = new int[MAX_SLOTS];
 	private boolean[] cookingDisabled = new boolean[MAX_SLOTS];
 
+	/**
+	 * Constructs a new {@link CampfireMock} for the provided {@link Material}.
+	 * Only supports materials in {@link Tag#CAMPFIRES}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public CampfireMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Tag.CAMPFIRES);
 	}
 
+	/**
+	 * Constructs a new {@link CampfireMock} for the provided {@link Block}.
+	 * Only supports materials in {@link Tag#CAMPFIRES}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected CampfireMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Tag.CAMPFIRES);
 	}
 
+	/**
+	 * Constructs a new {@link CampfireMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected CampfireMock(@NotNull CampfireMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/CampfireMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/CampfireMock.java
@@ -10,6 +10,9 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Mock implementation of {@link Campfire}.
+ */
 public class CampfireMock extends TileStateMock implements Campfire
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ChestMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ChestMock.java
@@ -15,25 +15,44 @@ import org.jetbrains.annotations.Nullable;
 import java.util.UUID;
 
 /**
- * Mock implementation of {@link Chest}.
+ * Mock implementation of a {@link Chest}.
+ *
+ * @see TileStateMock
  */
 public class ChestMock extends ContainerMock implements Chest
 {
 
 	private boolean isOpen = false;
 
+	/**
+	 * Constructs a new {@link ChestMock} for the provided {@link Material}.
+	 * Only supports {@link Material#CHEST} and {@link Material#TRAPPED_CHEST}.
+	 *
+	 * @param material The material this state is for.
+	 */
 	public ChestMock(@NotNull Material material)
 	{
 		super(material);
-		checkType(material, Material.CHEST);
+		checkType(material, Material.CHEST, Material.TRAPPED_CHEST);
 	}
 
+	/**
+	 * Constructs a new {@link ChestMock} for the provided {@link Block}.
+	 * Only supports {@link Material#CHEST} and {@link Material#TRAPPED_CHEST}.
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected ChestMock(@NotNull Block block)
 	{
 		super(block);
-		checkType(block, Material.CHEST);
+		checkType(block, Material.CHEST, Material.TRAPPED_CHEST);
 	}
 
+	/**
+	 * Constructs a new {@link ChestMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected ChestMock(@NotNull ChestMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ChestMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ChestMock.java
@@ -15,9 +15,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.UUID;
 
 /**
- * This {@link ContainerMock} represents a {@link Chest} or Trapped {@link Chest}.
- *
- * @author TheBusyBiscuit
+ * Mock implementation of {@link Chest}.
  */
 public class ChestMock extends ContainerMock implements Chest
 {

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/CommandBlockMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/CommandBlockMock.java
@@ -9,6 +9,9 @@ import org.bukkit.block.CommandBlock;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Mock implementation of {@link CommandBlock} and {@link CommandBlockHolderMock}.
+ */
 public class CommandBlockMock extends TileStateMock implements CommandBlock, CommandBlockHolderMock
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/CommandBlockMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/CommandBlockMock.java
@@ -10,7 +10,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Mock implementation of {@link CommandBlock} and {@link CommandBlockHolderMock}.
+ * Mock implementation of a {@link CommandBlock}.
+ *
+ * @see TileStateMock
  */
 public class CommandBlockMock extends TileStateMock implements CommandBlock, CommandBlockHolderMock
 {
@@ -18,18 +20,35 @@ public class CommandBlockMock extends TileStateMock implements CommandBlock, Com
 	private Component name;
 	private String command;
 
+	/**
+	 * Constructs a new {@link CommandBlockMock} for the provided {@link Material}.
+	 * Only supports {@link Material#COMMAND_BLOCK}, {@link Material#REPEATING_COMMAND_BLOCK}, and {@link Material#CHAIN_COMMAND_BLOCK}.
+	 *
+	 * @param material The material this state is for.
+	 */
 	public CommandBlockMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.COMMAND_BLOCK, Material.REPEATING_COMMAND_BLOCK, Material.CHAIN_COMMAND_BLOCK);
 	}
 
+	/**
+	 * Constructs a new {@link CommandBlockMock} for the provided {@link Block}.
+	 * Only supports {@link Material#COMMAND_BLOCK}, {@link Material#REPEATING_COMMAND_BLOCK}, and {@link Material#CHAIN_COMMAND_BLOCK}.
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected CommandBlockMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.COMMAND_BLOCK, Material.REPEATING_COMMAND_BLOCK, Material.CHAIN_COMMAND_BLOCK);
 	}
 
+	/**
+	 * Constructs a new {@link CommandBlockMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected CommandBlockMock(@NotNull CommandBlockMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ComparatorMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ComparatorMock.java
@@ -5,6 +5,9 @@ import org.bukkit.block.Block;
 import org.bukkit.block.Comparator;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of {@link Comparator}.
+ */
 public class ComparatorMock extends TileStateMock implements Comparator
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ComparatorMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ComparatorMock.java
@@ -6,23 +6,42 @@ import org.bukkit.block.Comparator;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Mock implementation of {@link Comparator}.
+ * Mock implementation of a {@link Comparator}.
+ *
+ * @see TileStateMock
  */
 public class ComparatorMock extends TileStateMock implements Comparator
 {
 
+	/**
+	 * Constructs a new {@link ComparatorMock} for the provided {@link Material}.
+	 * Only supports {@link Material#COMPARATOR}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public ComparatorMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.COMPARATOR);
 	}
 
+	/**
+	 * Constructs a new {@link ComparatorMock} for the provided {@link Block}.
+	 * Only supports {@link Material#COMPARATOR}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected ComparatorMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.COMPARATOR);
 	}
 
+	/**
+	 * Constructs a new {@link ComparatorMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected ComparatorMock(@NotNull ComparatorMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ConduitMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ConduitMock.java
@@ -5,6 +5,9 @@ import org.bukkit.block.Block;
 import org.bukkit.block.Conduit;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of {@link Conduit}.
+ */
 public class ConduitMock extends TileStateMock implements Conduit
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ConduitMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ConduitMock.java
@@ -6,23 +6,42 @@ import org.bukkit.block.Conduit;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Mock implementation of {@link Conduit}.
+ * Mock implementation of a {@link Conduit}.
+ *
+ * @see TileStateMock
  */
 public class ConduitMock extends TileStateMock implements Conduit
 {
 
+	/**
+	 * Constructs a new {@link ConduitMock} for the provided {@link Material}.
+	 * Only supports {@link Material#CONDUIT}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public ConduitMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.CONDUIT);
 	}
 
+	/**
+	 * Constructs a new {@link ConduitMock} for the provided {@link Block}.
+	 * Only supports {@link Material#CONDUIT}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected ConduitMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.CONDUIT);
 	}
 
+	/**
+	 * Constructs a new {@link ConduitMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected ConduitMock(@NotNull ConduitMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ContainerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ContainerMock.java
@@ -12,7 +12,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Mock implementation of {@link Container}.
+ * Mock implementation of a {@link Container}.
+ *
+ * @see TileStateMock
  */
 public abstract class ContainerMock extends TileStateMock implements Container
 {
@@ -21,18 +23,33 @@ public abstract class ContainerMock extends TileStateMock implements Container
 	private @Nullable Component customName;
 	private @NotNull String lock = "";
 
+	/**
+	 * Constructs a new {@link ContainerMock} for the provided {@link Material}.
+	 *
+	 * @param material The material this state is for.
+	 */
 	protected ContainerMock(@NotNull Material material)
 	{
 		super(material);
 		this.inventory = createInventory();
 	}
 
+	/**
+	 * Constructs a new {@link ContainerMock} for the provided {@link Block}.
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected ContainerMock(@NotNull Block block)
 	{
 		super(block);
 		this.inventory = createInventory();
 	}
 
+	/**
+	 * Constructs a new {@link ContainerMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected ContainerMock(@NotNull ContainerMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ContainerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ContainerMock.java
@@ -58,6 +58,9 @@ public abstract class ContainerMock extends TileStateMock implements Container
 		this.lock = state.getLock();
 	}
 
+	/**
+	 * @return A new inventory, of the correct type for the state.
+	 */
 	protected abstract InventoryMock createInventory();
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ContainerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ContainerMock.java
@@ -12,9 +12,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * The {@link ContainerMock} is an extension of a {@link TileStateMock} which can also hold an {@link Inventory}.
- *
- * @author TheBusyBiscuit
+ * Mock implementation of {@link Container}.
  */
 public abstract class ContainerMock extends TileStateMock implements Container
 {

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/CreatureSpawnerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/CreatureSpawnerMock.java
@@ -12,7 +12,9 @@ import org.jetbrains.annotations.NotNull;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * Mock implementation of {@link CreatureSpawner}.
+ * Mock implementation of a {@link CreatureSpawner}.
+ *
+ * @see TileStateMock
  */
 public class CreatureSpawnerMock extends TileStateMock implements CreatureSpawner
 {
@@ -26,18 +28,35 @@ public class CreatureSpawnerMock extends TileStateMock implements CreatureSpawne
 	private int requiredPlayerRange = 16;
 	private int spawnRange = 4;
 
+	/**
+	 * Constructs a new {@link CreatureSpawnerMock} for the provided {@link Material}.
+	 * Only supports {@link Material#SPAWNER}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public CreatureSpawnerMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.SPAWNER);
 	}
 
+	/**
+	 * Constructs a new {@link CreatureSpawnerMock} for the provided {@link Block}.
+	 * Only supports {@link Material#SPAWNER}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected CreatureSpawnerMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.SPAWNER);
 	}
 
+	/**
+	 * Constructs a new {@link CreatureSpawnerMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected CreatureSpawnerMock(@NotNull CreatureSpawnerMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/CreatureSpawnerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/CreatureSpawnerMock.java
@@ -11,6 +11,9 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.ThreadLocalRandom;
 
+/**
+ * Mock implementation of {@link CreatureSpawner}.
+ */
 public class CreatureSpawnerMock extends TileStateMock implements CreatureSpawner
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/DaylightDetectorMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/DaylightDetectorMock.java
@@ -5,6 +5,9 @@ import org.bukkit.block.Block;
 import org.bukkit.block.DaylightDetector;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of {@link DaylightDetector}.
+ */
 public class DaylightDetectorMock extends TileStateMock implements DaylightDetector
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/DaylightDetectorMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/DaylightDetectorMock.java
@@ -6,23 +6,42 @@ import org.bukkit.block.DaylightDetector;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Mock implementation of {@link DaylightDetector}.
+ * Mock implementation of a {@link DaylightDetector}.
+ *
+ * @see TileStateMock
  */
 public class DaylightDetectorMock extends TileStateMock implements DaylightDetector
 {
 
+	/**
+	 * Constructs a new {@link DaylightDetectorMock} for the provided {@link Material}.
+	 * Only supports {@link Material#DAYLIGHT_DETECTOR}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public DaylightDetectorMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.DAYLIGHT_DETECTOR);
 	}
 
+	/**
+	 * Constructs a new {@link DaylightDetectorMock} for the provided {@link Block}.
+	 * Only supports {@link Material#DAYLIGHT_DETECTOR}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected DaylightDetectorMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.DAYLIGHT_DETECTOR);
 	}
 
+	/**
+	 * Constructs a new {@link CreatureSpawnerMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected DaylightDetectorMock(@NotNull DaylightDetectorMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/DispenserMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/DispenserMock.java
@@ -15,23 +15,42 @@ import org.jetbrains.annotations.Nullable;
 import java.util.UUID;
 
 /**
- * Mock implementation of {@link Dispenser}.
+ * Mock implementation of a {@link Dispenser}.
+ *
+ * @see ContainerMock
  */
 public class DispenserMock extends ContainerMock implements Dispenser
 {
 
+	/**
+	 * Constructs a new {@link DispenserMock} for the provided {@link Material}.
+	 * Only supports {@link Material#DISPENSER}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public DispenserMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.DISPENSER);
 	}
 
+	/**
+	 * Constructs a new {@link DispenserMock} for the provided {@link Block}.
+	 * Only supports {@link Material#DISPENSER}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected DispenserMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.DISPENSER);
 	}
 
+	/**
+	 * Constructs a new {@link DispenserMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected DispenserMock(@NotNull DispenserMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/DispenserMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/DispenserMock.java
@@ -15,9 +15,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.UUID;
 
 /**
- * This {@link ContainerMock} represents a {@link Dispenser}.
- *
- * @author TheBusyBiscuit
+ * Mock implementation of {@link Dispenser}.
  */
 public class DispenserMock extends ContainerMock implements Dispenser
 {

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/DispenserProjectileSourceMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/DispenserProjectileSourceMock.java
@@ -11,12 +11,19 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Mock implementation of a {@link BlockProjectileSource}, specifically for the {@link DispenserMock}.
+ *
+ * @see DispenserMock
  */
 class DispenserProjectileSourceMock implements BlockProjectileSource
 {
 
 	private final @NotNull DispenserMock dispenser;
 
+	/**
+	 * Constructs a new {@link DispenserProjectileSourceMock} for the provided {@link DispenserMock}.
+	 *
+	 * @param dispenser The dispenser this projectile source is for.
+	 */
 	DispenserProjectileSourceMock(@NotNull DispenserMock dispenser)
 	{
 		this.dispenser = dispenser;

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/DispenserProjectileSourceMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/DispenserProjectileSourceMock.java
@@ -10,9 +10,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * This is a {@link BlockProjectileSource} mock specifically for the {@link DispenserMock}.
- *
- * @author TheBusyBiscuit
+ * Mock implementation of a {@link BlockProjectileSource}, specifically for the {@link DispenserMock}.
  */
 class DispenserProjectileSourceMock implements BlockProjectileSource
 {

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/DropperMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/DropperMock.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.UUID;
 
 /**
- * This {@link ContainerMock} represents a {@link Dropper}.
+ * Mock implementation of a {@link Dropper}.
  *
  * @author TheBusyBiscuit
  */

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/DropperMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/DropperMock.java
@@ -16,23 +16,40 @@ import java.util.UUID;
 /**
  * Mock implementation of a {@link Dropper}.
  *
- * @author TheBusyBiscuit
+ * @see ContainerMock
  */
 public class DropperMock extends ContainerMock implements Dropper
 {
 
+	/**
+	 * Constructs a new {@link DispenserMock} for the provided {@link Material}.
+	 * Only supports {@link Material#DISPENSER}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public DropperMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.DROPPER);
 	}
 
+	/**
+	 * Constructs a new {@link DispenserMock} for the provided {@link Block}.
+	 * Only supports {@link Material#DISPENSER}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected DropperMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.DROPPER);
 	}
 
+	/**
+	 * Constructs a new {@link DispenserMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected DropperMock(@NotNull DropperMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/EnchantingTableMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/EnchantingTableMock.java
@@ -9,6 +9,9 @@ import org.bukkit.block.EnchantingTable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Mock implementation of an {@link EnchantingTable}.
+ */
 public class EnchantingTableMock extends TileStateMock implements EnchantingTable
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/EnchantingTableMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/EnchantingTableMock.java
@@ -11,24 +11,43 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Mock implementation of an {@link EnchantingTable}.
+ *
+ * @see TileStateMock
  */
 public class EnchantingTableMock extends TileStateMock implements EnchantingTable
 {
 
 	private Component customName;
 
+	/**
+	 * Constructs a new {@link EnchantingTableMock} for the provided {@link Material}.
+	 * Only supports {@link Material#ENCHANTING_TABLE}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public EnchantingTableMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.ENCHANTING_TABLE);
 	}
 
+	/**
+	 * Constructs a new {@link EnchantingTableMock} for the provided {@link Block}.
+	 * Only supports {@link Material#ENCHANTING_TABLE}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected EnchantingTableMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.ENCHANTING_TABLE);
 	}
 
+	/**
+	 * Constructs a new {@link EnchantingTableMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected EnchantingTableMock(@NotNull EnchantingTableMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/EndGatewayMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/EndGatewayMock.java
@@ -11,6 +11,9 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
+/**
+ * Mock implementation of a {@link EndGateway}.
+ */
 public class EndGatewayMock extends TileStateMock implements EndGateway
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/EndGatewayMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/EndGatewayMock.java
@@ -13,6 +13,8 @@ import java.util.Objects;
 
 /**
  * Mock implementation of a {@link EndGateway}.
+ *
+ * @see TileStateMock
  */
 public class EndGatewayMock extends TileStateMock implements EndGateway
 {
@@ -21,18 +23,35 @@ public class EndGatewayMock extends TileStateMock implements EndGateway
 	private boolean exactTeleport;
 	private @Nullable Location exitLocation;
 
+	/**
+	 * Constructs a new {@link EndGatewayMock} for the provided {@link Material}.
+	 * Only supports {@link Material#END_GATEWAY}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public EndGatewayMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.END_GATEWAY);
 	}
 
+	/**
+	 * Constructs a new {@link EndGatewayMock} for the provided {@link Block}.
+	 * Only supports {@link Material#END_GATEWAY}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected EndGatewayMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.END_GATEWAY);
 	}
 
+	/**
+	 * Constructs a new {@link EndGatewayMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected EndGatewayMock(@NotNull EndGatewayMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/EnderChestMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/EnderChestMock.java
@@ -7,10 +7,7 @@ import org.bukkit.block.EnderChest;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * A simple mock of the {@link EnderChest} {@link BlockState}, it is a pretty generic implementation of
- * {@link TileStateMock}.
- *
- * @author TheBusyBiscuit
+ * Mock implementation of an {@link EnderChest}.
  */
 public class EnderChestMock extends TileStateMock implements EnderChest
 {

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/EnderChestMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/EnderChestMock.java
@@ -8,24 +8,43 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Mock implementation of an {@link EnderChest}.
+ *
+ * @see TileStateMock
  */
 public class EnderChestMock extends TileStateMock implements EnderChest
 {
 
 	private boolean isOpen = false;
 
+	/**
+	 * Constructs a new {@link EnderChestMock} for the provided {@link Material}.
+	 * Only supports {@link Material#ENDER_CHEST}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public EnderChestMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.ENDER_CHEST);
 	}
 
+	/**
+	 * Constructs a new {@link EnderChestMock} for the provided {@link Block}.
+	 * Only supports {@link Material#ENDER_CHEST}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected EnderChestMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.ENDER_CHEST);
 	}
 
+	/**
+	 * Constructs a new {@link EnderChestMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected EnderChestMock(@NotNull EnderChestMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/HopperMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/HopperMock.java
@@ -15,22 +15,41 @@ import java.util.UUID;
 
 /**
  * Mock implementation of a {@link Hopper}.
+ *
+ * @see ContainerMock
  */
 public class HopperMock extends ContainerMock implements Hopper
 {
 
+	/**
+	 * Constructs a new {@link HopperMock} for the provided {@link Material}.
+	 * Only supports {@link Material#HOPPER}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public HopperMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.HOPPER);
 	}
 
+	/**
+	 * Constructs a new {@link HopperMock} for the provided {@link Block}.
+	 * Only supports {@link Material#HOPPER}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected HopperMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.HOPPER);
 	}
 
+	/**
+	 * Constructs a new {@link HopperMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected HopperMock(@NotNull HopperMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/HopperMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/HopperMock.java
@@ -14,9 +14,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.UUID;
 
 /**
- * This {@link ContainerMock} represents a {@link Hopper}.
- *
- * @author TheBusyBiscuit
+ * Mock implementation of a {@link Hopper}.
  */
 public class HopperMock extends ContainerMock implements Hopper
 {

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/JigsawMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/JigsawMock.java
@@ -8,22 +8,41 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Mock implementation of a {@link Jigsaw}.
+ *
+ * @see TileStateMock
  */
 public class JigsawMock extends TileStateMock implements Jigsaw
 {
 
+	/**
+	 * Constructs a new {@link JigsawMock} for the provided {@link Material}.
+	 * Only supports {@link Material#JIGSAW}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public JigsawMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.JIGSAW);
 	}
 
+	/**
+	 * Constructs a new {@link JigsawMock} for the provided {@link Block}.
+	 * Only supports {@link Material#JIGSAW}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected JigsawMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.JIGSAW);
 	}
 
+	/**
+	 * Constructs a new {@link JigsawMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected JigsawMock(@NotNull JigsawMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/JigsawMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/JigsawMock.java
@@ -6,6 +6,9 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.Jigsaw;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of a {@link Jigsaw}.
+ */
 public class JigsawMock extends TileStateMock implements Jigsaw
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/JukeboxMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/JukeboxMock.java
@@ -10,6 +10,8 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Mock implementation of a {@link Jukebox}.
+ *
+ * @see TileStateMock
  */
 public class JukeboxMock extends TileStateMock implements Jukebox
 {
@@ -17,6 +19,12 @@ public class JukeboxMock extends TileStateMock implements Jukebox
 	private ItemStack recordItem;
 	private boolean playing;
 
+	/**
+	 * Constructs a new {@link JukeboxMock} for the provided {@link Material}.
+	 * Only supports {@link Material#JUKEBOX}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public JukeboxMock(@NotNull Material material)
 	{
 		super(material);
@@ -24,6 +32,12 @@ public class JukeboxMock extends TileStateMock implements Jukebox
 		setRecord(null);
 	}
 
+	/**
+	 * Constructs a new {@link JukeboxMock} for the provided {@link Block}.
+	 * Only supports {@link Material#JUKEBOX}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected JukeboxMock(@NotNull Block block)
 	{
 		super(block);
@@ -31,6 +45,11 @@ public class JukeboxMock extends TileStateMock implements Jukebox
 		setRecord(null);
 	}
 
+	/**
+	 * Constructs a new {@link JukeboxMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected JukeboxMock(@NotNull JukeboxMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/JukeboxMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/JukeboxMock.java
@@ -8,6 +8,9 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Mock implementation of a {@link Jukebox}.
+ */
 public class JukeboxMock extends TileStateMock implements Jukebox
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/LecternMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/LecternMock.java
@@ -14,24 +14,43 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Mock implementation of a {@link Lectern}.
+ *
+ * @see ContainerMock
  */
 public class LecternMock extends ContainerMock implements Lectern
 {
 
 	private int currentPage;
 
+	/**
+	 * Constructs a new {@link LecternMock} for the provided {@link Material}.
+	 * Only supports {@link Material#LECTERN}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public LecternMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.LECTERN);
 	}
 
+	/**
+	 * Constructs a new {@link LecternMock} for the provided {@link Block}.
+	 * Only supports {@link Material#LECTERN}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected LecternMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.LECTERN);
 	}
 
+	/**
+	 * Constructs a new {@link LecternMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected LecternMock(@NotNull LecternMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/LecternMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/LecternMock.java
@@ -12,6 +12,9 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Mock implementation of a {@link Lectern}.
+ */
 public class LecternMock extends ContainerMock implements Lectern
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/SculkCatalystMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/SculkCatalystMock.java
@@ -8,22 +8,41 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Mock implementation of a {@link SculkCatalyst}.
+ *
+ * @see TileStateMock
  */
 public class SculkCatalystMock extends TileStateMock implements SculkCatalyst
 {
 
+	/**
+	 * Constructs a new {@link SculkCatalystMock} for the provided {@link Material}.
+	 * Only supports {@link Material#SCULK_CATALYST}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public SculkCatalystMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.SCULK_CATALYST);
 	}
 
+	/**
+	 * Constructs a new {@link SculkCatalystMock} for the provided {@link Block}.
+	 * Only supports {@link Material#SCULK_CATALYST}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected SculkCatalystMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.SCULK_CATALYST);
 	}
 
+	/**
+	 * Constructs a new {@link SculkCatalystMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected SculkCatalystMock(@NotNull SculkCatalystMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/SculkCatalystMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/SculkCatalystMock.java
@@ -6,6 +6,9 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.SculkCatalyst;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of a {@link SculkCatalyst}.
+ */
 public class SculkCatalystMock extends TileStateMock implements SculkCatalyst
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/SculkSensorMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/SculkSensorMock.java
@@ -9,6 +9,8 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Mock implementation of a {@link SculkSensor}.
+ *
+ * @see TileStateMock
  */
 public class SculkSensorMock extends TileStateMock implements SculkSensor
 {
@@ -16,18 +18,35 @@ public class SculkSensorMock extends TileStateMock implements SculkSensor
 	private int lastVibrationFrequency;
 	private int listenerRange;
 
+	/**
+	 * Constructs a new {@link SculkSensorMock} for the provided {@link Material}.
+	 * Only supports {@link Material#SCULK_SENSOR}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public SculkSensorMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.SCULK_SENSOR);
 	}
 
+	/**
+	 * Constructs a new {@link SculkSensorMock} for the provided {@link Block}.
+	 * Only supports {@link Material#SCULK_SENSOR}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected SculkSensorMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.SCULK_SENSOR);
 	}
 
+	/**
+	 * Constructs a new {@link SculkSensorMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected SculkSensorMock(@NotNull SculkSensorMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/SculkSensorMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/SculkSensorMock.java
@@ -7,6 +7,9 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.SculkSensor;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of a {@link SculkSensor}.
+ */
 public class SculkSensorMock extends TileStateMock implements SculkSensor
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/SculkShriekerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/SculkShriekerMock.java
@@ -8,24 +8,43 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Mock implementation of a {@link SculkShrieker}.
+ *
+ * @see TileStateMock
  */
 public class SculkShriekerMock extends TileStateMock implements SculkShrieker
 {
 
 	private int warningLevel;
 
+	/**
+	 * Constructs a new {@link SculkShriekerMock} for the provided {@link Material}.
+	 * Only supports {@link Material#SCULK_SHRIEKER}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public SculkShriekerMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.SCULK_SHRIEKER);
 	}
 
+	/**
+	 * Constructs a new {@link SculkShriekerMock} for the provided {@link Block}.
+	 * Only supports {@link Material#SCULK_SHRIEKER}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected SculkShriekerMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.SCULK_SHRIEKER);
 	}
 
+	/**
+	 * Constructs a new {@link SculkShriekerMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected SculkShriekerMock(@NotNull SculkShriekerMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/SculkShriekerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/SculkShriekerMock.java
@@ -6,6 +6,9 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.SculkShrieker;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of a {@link SculkShrieker}.
+ */
 public class SculkShriekerMock extends TileStateMock implements SculkShrieker
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ShulkerBoxMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ShulkerBoxMock.java
@@ -17,9 +17,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.UUID;
 
 /**
- * This {@link ContainerMock} represents a {@link ShulkerBox}.
- *
- * @author TheBusyBiscuit
+ * Mock implementation of a {@link ShulkerBox}.
  */
 public class ShulkerBoxMock extends ContainerMock implements ShulkerBox
 {

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ShulkerBoxMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ShulkerBoxMock.java
@@ -3,10 +3,10 @@ package be.seeseemelk.mockbukkit.block.state;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.inventory.InventoryMock;
 import be.seeseemelk.mockbukkit.inventory.ShulkerBoxInventoryMock;
-import com.destroystokyo.paper.MaterialTags;
 import com.google.common.base.Preconditions;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
+import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.ShulkerBox;
@@ -18,6 +18,8 @@ import java.util.UUID;
 
 /**
  * Mock implementation of a {@link ShulkerBox}.
+ *
+ * @see ContainerMock
  */
 public class ShulkerBoxMock extends ContainerMock implements ShulkerBox
 {
@@ -25,20 +27,37 @@ public class ShulkerBoxMock extends ContainerMock implements ShulkerBox
 	private final @Nullable DyeColor color;
 	private boolean isOpen = false;
 
+	/**
+	 * Constructs a new {@link ShulkerBoxMock} for the provided {@link Material}.
+	 * Only supports materials in {@link Tag#SHULKER_BOXES}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public ShulkerBoxMock(@NotNull Material material)
 	{
 		super(material);
-		checkType(material, MaterialTags.SHULKER_BOXES);
+		checkType(material, Tag.SHULKER_BOXES);
 		this.color = getFromMaterial(material);
 	}
 
+	/**
+	 * Constructs a new {@link ShulkerBoxMock} for the provided {@link Block}.
+	 * Only supports materials in {@link Tag#SHULKER_BOXES}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected ShulkerBoxMock(@NotNull Block block)
 	{
 		super(block);
-		checkType(block, MaterialTags.SHULKER_BOXES);
+		checkType(block, Tag.SHULKER_BOXES);
 		this.color = getFromMaterial(block.getType());
 	}
 
+	/**
+	 * Constructs a new {@link ShulkerBoxMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected ShulkerBoxMock(@NotNull ShulkerBoxMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/SignMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/SignMock.java
@@ -1,12 +1,12 @@
 package be.seeseemelk.mockbukkit.block.state;
 
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
-import com.destroystokyo.paper.MaterialTags;
 import com.google.common.base.Preconditions;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
+import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
@@ -17,24 +17,43 @@ import java.util.List;
 
 /**
  * Mock implementation of a {@link Sign}.
+ *
+ * @see TileStateMock
  */
 public class SignMock extends TileStateMock implements Sign
 {
 
 	private final String[] lines = { "", "", "", "" };
 
+	/**
+	 * Constructs a new {@link SignMock} for the provided {@link Material}.
+	 * Only supports materials in {@link Tag#SIGNS}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public SignMock(@NotNull Material material)
 	{
 		super(material);
-		checkType(material, MaterialTags.SIGNS);
+		checkType(material, Tag.SIGNS);
 	}
 
+	/**
+	 * Constructs a new {@link SignMock} for the provided {@link Block}.
+	 * Only supports materials in {@link Tag#SIGNS}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected SignMock(@NotNull Block block)
 	{
 		super(block);
-		checkType(block, MaterialTags.SIGNS);
+		checkType(block, Tag.SIGNS);
 	}
 
+	/**
+	 * Constructs a new {@link SignMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected SignMock(@NotNull SignMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/SignMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/SignMock.java
@@ -16,9 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * This {@link ContainerMock} represents a {@link Sign}.
- *
- * @author TheBusyBiscuit
+ * Mock implementation of a {@link Sign}.
  */
 public class SignMock extends TileStateMock implements Sign
 {

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/SkullMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/SkullMock.java
@@ -20,6 +20,8 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Mock implementation of a {@link Skull}.
+ *
+ * @see TileStateMock
  */
 public class SkullMock extends TileStateMock implements Skull
 {
@@ -28,18 +30,35 @@ public class SkullMock extends TileStateMock implements Skull
 
 	private @Nullable PlayerProfileMock profile;
 
+	/**
+	 * Constructs a new {@link SkullMock} for the provided {@link Material}.
+	 * Only supports materials in {@link MaterialTags#SKULLS}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public SkullMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, MaterialTags.SKULLS);
 	}
 
+	/**
+	 * Constructs a new {@link SkullMock} for the provided {@link Block}.
+	 * Only supports materials in {@link MaterialTags#SKULLS}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected SkullMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, MaterialTags.SKULLS);
 	}
 
+	/**
+	 * Constructs a new {@link SkullMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected SkullMock(@NotNull SkullMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/SkullMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/SkullMock.java
@@ -18,6 +18,9 @@ import org.bukkit.block.data.Rotatable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Mock implementation of a {@link Skull}.
+ */
 public class SkullMock extends TileStateMock implements Skull
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/SmokerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/SmokerMock.java
@@ -6,6 +6,9 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.Smoker;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of a {@link Smoker}.
+ */
 public class SmokerMock extends AbstractFurnaceMock implements Smoker
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/SmokerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/SmokerMock.java
@@ -8,22 +8,41 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Mock implementation of a {@link Smoker}.
+ *
+ * @see AbstractFurnaceMock
  */
 public class SmokerMock extends AbstractFurnaceMock implements Smoker
 {
 
+	/**
+	 * Constructs a new {@link SmokerMock} for the provided {@link Material}.
+	 * Only supports {@link Material#SMOKER}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public SmokerMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.SMOKER);
 	}
 
+	/**
+	 * Constructs a new {@link SmokerMock} for the provided {@link Block}.
+	 * Only supports {@link Material#SMOKER}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected SmokerMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.SMOKER);
 	}
 
+	/**
+	 * Constructs a new {@link SmokerMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected SmokerMock(@NotNull SmokerMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/StructureMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/StructureMock.java
@@ -14,6 +14,8 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Mock implementation of a {@link Structure}.
+ *
+ * @see TileStateMock
  */
 public class StructureMock extends TileStateMock implements Structure
 {
@@ -34,18 +36,35 @@ public class StructureMock extends TileStateMock implements Structure
 	private long seed = 0L;
 	private String metadata = "";
 
+	/**
+	 * Constructs a new {@link StructureMock} for the provided {@link Material}.
+	 * Only supports {@link Material#STRUCTURE_BLOCK}
+	 *
+	 * @param material The material this state is for.
+	 */
 	public StructureMock(@NotNull Material material)
 	{
 		super(material);
 		checkType(material, Material.STRUCTURE_BLOCK);
 	}
 
+	/**
+	 * Constructs a new {@link StructureMock} for the provided {@link Block}.
+	 * Only supports {@link Material#STRUCTURE_BLOCK}
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected StructureMock(@NotNull Block block)
 	{
 		super(block);
 		checkType(block, Material.STRUCTURE_BLOCK);
 	}
 
+	/**
+	 * Constructs a new {@link StructureMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected StructureMock(@NotNull StructureMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/StructureMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/StructureMock.java
@@ -12,6 +12,9 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.util.BlockVector;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of a {@link Structure}.
+ */
 public class StructureMock extends TileStateMock implements Structure
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/TileStateMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/TileStateMock.java
@@ -10,10 +10,7 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * This {@link BlockStateMock} represents a {@link TileState} which is capable of storing persistent data using a
- * {@link PersistentDataContainerMock}.
- *
- * @author TheBusyBiscuit
+ * Mock implementation of {@link TileState}.
  */
 public abstract class TileStateMock extends BlockStateMock implements TileState
 {

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/TileStateMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/TileStateMock.java
@@ -10,25 +10,42 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Mock implementation of {@link TileState}.
+ * Mock implementation of a {@link TileState}.
+ *
+ * @see BlockStateMock
  */
 public abstract class TileStateMock extends BlockStateMock implements TileState
 {
 
 	private final @NotNull PersistentDataContainerMock container;
 
+	/**
+	 * Constructs a new {@link SculkCatalystMock} for the provided {@link Material}.
+	 *
+	 * @param material The material this state is for.
+	 */
 	protected TileStateMock(@NotNull Material material)
 	{
 		super(material);
 		this.container = new PersistentDataContainerMock();
 	}
 
+	/**
+	 * Constructs a new {@link SculkCatalystMock} for the provided {@link Block}.
+	 *
+	 * @param block The block this state is for.
+	 */
 	protected TileStateMock(@NotNull Block block)
 	{
 		super(block);
 		this.container = new PersistentDataContainerMock();
 	}
 
+	/**
+	 * Constructs a new {@link SculkCatalystMock} by cloning the data from an existing one.
+	 *
+	 * @param state The state to clone.
+	 */
 	protected TileStateMock(@NotNull TileStateMock state)
 	{
 		super(state);

--- a/src/main/java/be/seeseemelk/mockbukkit/boss/BossBarMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/boss/BossBarMock.java
@@ -15,6 +15,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * Mock implementation of {@link BossBar}.
+ */
 public class BossBarMock implements BossBar
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/boss/BossBarMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/boss/BossBarMock.java
@@ -29,6 +29,14 @@ public class BossBarMock implements BossBar
 	private boolean visible = true;
 	private double progress = 1.0;
 
+	/**
+	 * Constructs a new {@link BossBarMock} with the provided parameters.
+	 *
+	 * @param title The title of the bossbar.
+	 * @param color The color of the bossbar.
+	 * @param style The style of the bossbar.
+	 * @param flags The flags to set on the bossbar.
+	 */
 	public BossBarMock(@NotNull String title, @NotNull BarColor color, @NotNull BarStyle style, BarFlag @NotNull ... flags)
 	{
 		this.title = title;

--- a/src/main/java/be/seeseemelk/mockbukkit/boss/KeyedBossBarMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/boss/KeyedBossBarMock.java
@@ -15,6 +15,15 @@ public class KeyedBossBarMock extends BossBarMock implements KeyedBossBar
 
 	private final @NotNull NamespacedKey key;
 
+	/**
+	 * Constructs a new {@link KeyedBossBarMock} with the provided parameters.
+	 *
+	 * @param key   The bossbar's namespaced key.
+	 * @param title The title of the bossbar.
+	 * @param color The color of the bossbar.
+	 * @param style The style of the bossbar.
+	 * @param flags The flags to set on the bossbar.
+	 */
 	public KeyedBossBarMock(@NotNull NamespacedKey key, @NotNull String title, @NotNull BarColor color, @NotNull BarStyle style, BarFlag... flags)
 	{
 		super(title, color, style, flags);

--- a/src/main/java/be/seeseemelk/mockbukkit/boss/KeyedBossBarMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/boss/KeyedBossBarMock.java
@@ -7,6 +7,9 @@ import org.bukkit.boss.BarStyle;
 import org.bukkit.boss.KeyedBossBar;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of {@link KeyedBossBar}.
+ */
 public class KeyedBossBarMock extends BossBarMock implements KeyedBossBar
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/command/CommandBlockHolderMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/command/CommandBlockHolderMock.java
@@ -6,6 +6,9 @@ import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Mock interface of a {@link CommandBlockHolder}.
+ */
 public interface CommandBlockHolderMock extends CommandBlockHolder
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/command/CommandResult.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/command/CommandResult.java
@@ -9,6 +9,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 
+/**
+ * Represents the result of a command invocation.
+ */
 public class CommandResult
 {
 
@@ -25,7 +28,7 @@ public class CommandResult
 	/**
 	 * Check if the command executed successfully.
 	 *
-	 * @return {@code true} if the command executed successfully, {@code false} if a problem occured.
+	 * @return {@code true} if the command executed successfully, {@code false} if a problem occurred.
 	 */
 	public boolean hasSucceeded()
 	{
@@ -52,6 +55,7 @@ public class CommandResult
 	 * Assets if the given message was not the next message send to the command sender.
 	 *
 	 * @param message The message to check for.
+	 * @see MessageTarget#nextMessage()
 	 */
 	public void assertResponse(String message)
 	{
@@ -71,6 +75,8 @@ public class CommandResult
 	 *
 	 * @param format  The formatted message to check for.
 	 * @param objects The objects to place into the formatted message.
+	 * @see #assertResponse(String)
+	 * @see MessageTarget#nextMessage()
 	 */
 	public void assertResponse(@NotNull String format, Object... objects)
 	{
@@ -79,6 +85,8 @@ public class CommandResult
 
 	/**
 	 * Asserts if more messages have been sent to the command sender.
+	 *
+	 * @see MessageTarget#nextMessage()
 	 */
 	public void assertNoResponse()
 	{

--- a/src/main/java/be/seeseemelk/mockbukkit/command/CommandResult.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/command/CommandResult.java
@@ -1,6 +1,7 @@
 package be.seeseemelk.mockbukkit.command;
 
 import com.google.common.base.Preconditions;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -18,6 +19,13 @@ public class CommandResult
 	private final boolean success;
 	private final @NotNull MessageTarget sender;
 
+	/**
+	 * Constructs a new {@link CommandResult} with the provided parameters.
+	 *
+	 * @param success Whether the command succeeded (returned true).
+	 * @param sender  The message target who executed the command.
+	 */
+	@ApiStatus.Internal
 	public CommandResult(boolean success, @NotNull MessageTarget sender)
 	{
 		Preconditions.checkNotNull(sender, "Sender cannot be null");

--- a/src/main/java/be/seeseemelk/mockbukkit/command/ConsoleCommandSenderMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/command/ConsoleCommandSenderMock.java
@@ -22,6 +22,9 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link ConsoleCommandSender}.
+ */
 public class ConsoleCommandSenderMock implements ConsoleCommandSender, MessageTarget
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/command/MessageTarget.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/command/MessageTarget.java
@@ -8,6 +8,9 @@ import org.jetbrains.annotations.Nullable;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
+/**
+ * Represents an object that can receive messages.
+ */
 @FunctionalInterface
 public interface MessageTarget
 {

--- a/src/main/java/be/seeseemelk/mockbukkit/command/MockCommandMap.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/command/MockCommandMap.java
@@ -6,6 +6,9 @@ import org.bukkit.command.CommandMap;
 import org.bukkit.command.SimpleCommandMap;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of a {@link CommandMap}.
+ */
 public class MockCommandMap extends SimpleCommandMap implements CommandMap
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/command/MockCommandMap.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/command/MockCommandMap.java
@@ -4,6 +4,7 @@ import be.seeseemelk.mockbukkit.ServerMock;
 import com.google.common.base.Preconditions;
 import org.bukkit.command.CommandMap;
 import org.bukkit.command.SimpleCommandMap;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -12,6 +13,10 @@ import org.jetbrains.annotations.NotNull;
 public class MockCommandMap extends SimpleCommandMap implements CommandMap
 {
 
+	/**
+	 * @param serverMock The ServerMock this command map is for.
+	 */
+	@ApiStatus.Internal
 	public MockCommandMap(@NotNull ServerMock serverMock)
 	{
 		super(serverMock);

--- a/src/main/java/be/seeseemelk/mockbukkit/configuration/ServerConfiguration.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/configuration/ServerConfiguration.java
@@ -1,8 +1,19 @@
 package be.seeseemelk.mockbukkit.configuration;
 
+import be.seeseemelk.mockbukkit.ServerMock;
 import net.kyori.adventure.text.Component;
+import org.bukkit.Server;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Represents all configuration options that can be retrieved from a {@link Server}.
+ * This class is used internally, and should not be considered public API.
+ * As such, breaking changes may occur here at any time.
+ *
+ * @see ServerMock
+ */
+@ApiStatus.Internal
 public class ServerConfiguration
 {
 
@@ -195,7 +206,7 @@ public class ServerConfiguration
 
 		private final String key;
 
-		private LevelType(String key)
+		LevelType(String key)
 		{
 			this.key = key;
 		}

--- a/src/main/java/be/seeseemelk/mockbukkit/configuration/ServerConfiguration.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/configuration/ServerConfiguration.java
@@ -34,174 +34,326 @@ public class ServerConfiguration
 	private int simulationDistance = 10;
 	private boolean hideOnlinePlayers = false;
 
+	/**
+	 * @return The view distance.
+	 * @see ServerMock#getViewDistance()
+	 */
 	public int getViewDistance()
 	{
 		return this.viewDistance;
 	}
 
+	/**
+	 * @param viewDistance The view distance.
+	 * @see ServerMock#setViewDistance(int)
+	 */
 	public void setViewDistance(int viewDistance)
 	{
 		this.viewDistance = viewDistance;
 	}
 
+	/**
+	 * @return The level type.
+	 * @see ServerMock#getWorldType
+	 */
 	public LevelType getLevelType()
 	{
 		return this.levelType;
 	}
 
+	/**
+	 * @param levelType The level type.
+	 * @see ServerMock#setWorldType(LevelType)
+	 */
 	public void setLevelType(LevelType levelType)
 	{
 		this.levelType = levelType;
 	}
 
+	/**
+	 * @return Generate structures.
+	 * @see ServerMock#getGenerateStructures()
+	 */
 	public boolean isGenerateStructures()
 	{
 		return this.generateStructures;
 	}
 
+	/**
+	 * @param generateStructures Generate structures.
+	 * @see ServerMock#setGenerateStructures(boolean)
+	 */
 	public void setGenerateStructures(boolean generateStructures)
 	{
 		this.generateStructures = generateStructures;
 	}
 
+	/**
+	 * @return Allow end.
+	 * @see ServerMock#getAllowEnd()
+	 */
 	public boolean isAllowEnd()
 	{
 		return this.allowEnd;
 	}
 
+	/**
+	 * @param allowEnd Allow end.
+	 * @see ServerMock#setAllowEnd(boolean)
+	 */
 	public void setAllowEnd(boolean allowEnd)
 	{
 		this.allowEnd = allowEnd;
 	}
 
+	/**
+	 * @return Allow nether.
+	 * @see ServerMock#getAllowNether()
+	 */
 	public boolean isAllowNether()
 	{
 		return this.allowNether;
 	}
 
+	/**
+	 * @param allowNether Allow end.
+	 * @see ServerMock#setAllowNether(boolean)
+	 */
 	public void setAllowNether(boolean allowNether)
 	{
 		this.allowNether = allowNether;
 	}
 
+	/**
+	 * @return Update folder.
+	 */
 	public String getUpdateFolder()
 	{
 		return this.updateFolder;
 	}
 
+	/**
+	 * @param updateFolder Update folder.
+	 * @see ServerMock#setUpdateFolder(String)
+	 */
 	public void setUpdateFolder(String updateFolder)
 	{
 		this.updateFolder = updateFolder;
 	}
 
+	/**
+	 * @return Send chat previews.
+	 * @see ServerMock#setShouldSendChatPreviews(boolean)
+	 */
 	public boolean shouldSendChatPreviews()
 	{
 		return this.sendChatPreviews;
 	}
 
+	/**
+	 * @param shouldSendChatPreviews Send chat previews.
+	 * @see ServerMock#setShouldSendChatPreviews(boolean)
+	 */
 	public void setShouldSendChatPreviews(boolean shouldSendChatPreviews)
 	{
 		this.sendChatPreviews = shouldSendChatPreviews;
 	}
 
+	/**
+	 * @return Enforce secure profiles.
+	 * @see ServerMock#isEnforcingSecureProfiles()
+	 */
 	public boolean isEnforceSecureProfiles()
 	{
 		return this.enforceSecureProfiles;
 	}
 
+	/**
+	 * @param enforceSecureProfiles Enforce secure profiles.
+	 * @see ServerMock#setEnforcingSecureProfiles(boolean)
+	 */
 	public void setEnforceSecureProfiles(boolean enforceSecureProfiles)
 	{
 		this.enforceSecureProfiles = enforceSecureProfiles;
 	}
 
+	/**
+	 * @return Online mode.
+	 * @see ServerMock#getOnlineMode()
+	 */
 	public boolean isOnlineMode()
 	{
 		return this.onlineMode;
 	}
 
+	/**
+	 * @param onlineMode Online mode.
+	 * @see ServerMock#setOnlineMode(boolean)
+	 */
 	public void setOnlineMode(boolean onlineMode)
 	{
 		this.onlineMode = onlineMode;
 	}
 
+	/**
+	 * @return Allow flight.
+	 * @see ServerMock#getAllowFlight()
+	 */
 	public boolean isAllowFlight()
 	{
 		return this.allowFlight;
 	}
 
+	/**
+	 * @param allowFlight Allow flight.
+	 * @see ServerMock#setAllowFlight(boolean)
+	 */
 	public void setAllowFlight(boolean allowFlight)
 	{
 		this.allowFlight = allowFlight;
 	}
 
+	/**
+	 * @return Hardcore mode.
+	 * @see ServerMock#isHardcore()
+	 */
 	public boolean isHardcore()
 	{
 		return this.hardcore;
 	}
 
+	/**
+	 * @param hardcore Hardcore mode.
+	 * @see ServerMock#setHardcore(boolean)
+	 */
 	public void setHardcore(boolean hardcore)
 	{
 		this.hardcore = hardcore;
 	}
 
+	/**
+	 * @return Max chained neighbour updates.
+	 * @see ServerMock#getMaxChainedNeighborUpdates()
+	 */
 	public int getMaxChainedNeighbourUpdates()
 	{
 		return this.maxChainedNeighbourUpdates;
 	}
 
+	/**
+	 * @param maxChainedNeighbourUpdates Max chained neighbour updates.
+	 * @see ServerMock#setMaxChainedNeighborUpdates(int)
+	 */
 	public void setMaxChainedNeighbourUpdates(int maxChainedNeighbourUpdates)
 	{
 		this.maxChainedNeighbourUpdates = maxChainedNeighbourUpdates;
 	}
 
+	/**
+	 * @return Shutdown message.
+	 * @see ServerMock#getShutdownMessage()
+	 */
 	public @NotNull Component getShutdownMessage()
 	{
 		return shutdownMessage;
 	}
 
+	/**
+	 * @param shutdownMessage Shutdown message.
+	 * @see ServerMock#setShutdownMessage(Component)
+	 */
 	public void setShutdownMessage(@NotNull Component shutdownMessage)
 	{
 		this.shutdownMessage = shutdownMessage;
 	}
 
+	/**
+	 * @return Max world size.
+	 * @see ServerMock#getMaxWorldSize()
+	 */
 	public int getMaxWorldSize()
 	{
 		return maxWorldSize;
 	}
 
+	/**
+	 * @param maxWorldSize Max world size.
+	 * @see ServerMock#setMaxWorldSize(int)
+	 */
 	public void setMaxWorldSize(int maxWorldSize)
 	{
 		this.maxWorldSize = maxWorldSize;
 	}
 
+	/**
+	 * @return Simulation distance.
+	 * @see ServerMock#getSimulationDistance()
+	 */
 	public int getSimulationDistance()
 	{
 		return simulationDistance;
 	}
 
+	/**
+	 * @param simulationDistance Simulation distance.
+	 * @see ServerMock#setSimulationDistance(int)
+	 */
 	public void setSimulationDistance(int simulationDistance)
 	{
 		this.simulationDistance = simulationDistance;
 	}
 
+	/**
+	 * @return Hide online players.
+	 * @see ServerMock#getHideOnlinePlayers()
+	 */
 	public boolean isHideOnlinePlayers()
 	{
 		return hideOnlinePlayers;
 	}
 
+	/**
+	 * @param hideOnlinePlayers Hide online players
+	 * @see ServerMock#setHideOnlinePlayers(boolean)
+	 */
 	public void setHideOnlinePlayers(boolean hideOnlinePlayers)
 	{
 		this.hideOnlinePlayers = hideOnlinePlayers;
 	}
 
+	/**
+	 * Enum representing all different world types.
+	 * <a href="https://minecraft.fandom.com/wiki/World_preset">Wiki</a>
+	 */
 	public enum LevelType
 	{
+		/**
+		 * Regular.
+		 */
 		DEFAULT("minecraft:normal"),
+		/**
+		 * Super-flat.
+		 */
 		FLAT("minecraft:flat"),
+		/**
+		 * Large biomes.
+		 */
 		LARGE_BIOMES("minecraft:large_biomes"),
+		/**
+		 * Amplified.
+		 */
 		AMPLIFIED("minecraft:amplified"),
+		/**
+		 * Single biome.
+		 */
 		SINGLE_BIOME_SURFACE("minecraft:single_biome_surface"),
+		/**
+		 * Debug.
+		 */
 		DEFAULT_1_1("default_1_1"),
+		/**
+		 * Custom.
+		 */
 		CUSTOMIZED("customized");
 
 		private final String key;
@@ -211,6 +363,9 @@ public class ServerConfiguration
 			this.key = key;
 		}
 
+		/**
+		 * @return The type key.
+		 */
 		public String getKey()
 		{
 			return key;

--- a/src/main/java/be/seeseemelk/mockbukkit/enchantments/EnchantmentMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/enchantments/EnchantmentMock.java
@@ -27,6 +27,12 @@ public class EnchantmentMock extends Enchantment
 	private boolean isTreasure;
 	private boolean isCursed;
 
+	/**
+	 * Constructs a new {@link EnchantmentMock} with the provided {@link NamespacedKey} and name.
+	 *
+	 * @param key  The key for the enchantment.
+	 * @param name The name of the enchantment.
+	 */
 	public EnchantmentMock(@NotNull NamespacedKey key, @NotNull String name)
 	{
 		super(key);

--- a/src/main/java/be/seeseemelk/mockbukkit/enchantments/EnchantmentMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/enchantments/EnchantmentMock.java
@@ -102,6 +102,12 @@ public class EnchantmentMock extends Enchantment
 		return this.maxLevel;
 	}
 
+	/**
+	 * Sets the return value of {@link #getMaxLevel()}.
+	 *
+	 * @param maxLevel The max level.
+	 * @see #getMaxLevel()
+	 */
 	public void setMaxLevel(int maxLevel)
 	{
 		this.maxLevel = maxLevel;
@@ -113,6 +119,12 @@ public class EnchantmentMock extends Enchantment
 		return this.startLevel;
 	}
 
+	/**
+	 * Sets the return value of {@link #getStartLevel()}.
+	 *
+	 * @param startLevel The start level.
+	 * @see #getStartLevel()
+	 */
 	public void setStartLevel(int startLevel)
 	{
 		this.startLevel = startLevel;
@@ -124,6 +136,12 @@ public class EnchantmentMock extends Enchantment
 		return this.itemTarget;
 	}
 
+	/**
+	 * Sets the return value of {@link #getItemTarget()}.
+	 *
+	 * @param itemTarget The item target.
+	 * @see #getItemTarget()
+	 */
 	public void setItemTarget(@NotNull EnchantmentTarget itemTarget)
 	{
 		Preconditions.checkNotNull(itemTarget, "EnchantmentTarget cannot be null");
@@ -136,6 +154,12 @@ public class EnchantmentMock extends Enchantment
 		return this.isTreasure;
 	}
 
+	/**
+	 * Sets the return value of {@link #isTreasure()}.
+	 *
+	 * @param isTreasure Whether the enchantment is treasure.
+	 * @see #isTreasure()
+	 */
 	public void setTreasure(boolean isTreasure)
 	{
 		this.isTreasure = isTreasure;
@@ -147,6 +171,12 @@ public class EnchantmentMock extends Enchantment
 		return this.isCursed;
 	}
 
+	/**
+	 * Sets the return value of {@link #isCursed()}.
+	 *
+	 * @param isCursed Whether the enchantment is cursed.
+	 * @see #isCursed()
+	 */
 	public void setCursed(boolean isCursed)
 	{
 		this.isCursed = isCursed;

--- a/src/main/java/be/seeseemelk/mockbukkit/enchantments/EnchantmentMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/enchantments/EnchantmentMock.java
@@ -14,6 +14,9 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
 
+/**
+ * Mock implementation of an {@link Enchantment}.
+ */
 public class EnchantmentMock extends Enchantment
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/enchantments/EnchantmentsMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/enchantments/EnchantmentsMock.java
@@ -3,15 +3,19 @@ package be.seeseemelk.mockbukkit.enchantments;
 import com.google.common.base.Preconditions;
 import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Used to keep track of all vanilla enchantments.
+ */
+@ApiStatus.Internal
 public final class EnchantmentsMock
 {
 
-	private EnchantmentsMock()
-	{
-	}
-
+	/**
+	 * Registers all vanilla enchantments.
+	 */
 	public static void registerDefaultEnchantments()
 	{
 		register("protection");
@@ -54,12 +58,22 @@ public final class EnchantmentsMock
 		register("swift_sneak");
 	}
 
+	/**
+	 * Registers an enchantment.
+	 *
+	 * @param name Name of the enchantment.
+	 */
 	private static void register(@NotNull String name)
 	{
 		Preconditions.checkNotNull(name, "Name cannot be null");
 		NamespacedKey key = NamespacedKey.minecraft(name);
 		if (Enchantment.getByKey(key) == null)
 			Enchantment.registerEnchantment(new EnchantmentMock(key, name));
+	}
+
+	private EnchantmentsMock()
+	{
+		throw new UnsupportedOperationException("Utility class");
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/AbstractHorseMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/AbstractHorseMock.java
@@ -12,6 +12,11 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of an {@link AbstractHorse}.
+ *
+ * @see AnimalsMock
+ */
 public abstract class AbstractHorseMock extends AnimalsMock implements AbstractHorse
 {
 
@@ -24,6 +29,12 @@ public abstract class AbstractHorseMock extends AnimalsMock implements AbstractH
 	private boolean isMouthOpen;
 	private boolean rearing;
 
+	/**
+	 * Constructs a new {@link AbstractHorseMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	protected AbstractHorseMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);
@@ -119,6 +130,11 @@ public abstract class AbstractHorseMock extends AnimalsMock implements AbstractH
 		}
 	}
 
+	/**
+	 * Sets the return value of {@link #getOwner()} and {@link #getOwnerUniqueId()}.
+	 *
+	 * @param uuid The UUID to set.
+	 */
 	public void setOwnerUUID(@Nullable UUID uuid)
 	{
 		this.owner = uuid;

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/AbstractProjectileMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/AbstractProjectileMock.java
@@ -7,12 +7,20 @@ import org.jetbrains.annotations.NotNull;
 import java.util.UUID;
 
 /**
- * The {@link AbstractProjectileMock} is an {@link EntityMock} representing a generic {@link Projectile}.
+ * Mock implementation of a {@link Projectile}.
  * Not everything that extends {@link AbstractProjectileMock} extends {@link ProjectileMock}.
+ *
+ * @see EntityMock
  */
 public abstract class AbstractProjectileMock extends EntityMock implements Projectile
 {
 
+	/**
+	 * Constructs a new {@link AbstractProjectileMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	protected AbstractProjectileMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/AbstractSkeletonMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/AbstractSkeletonMock.java
@@ -14,6 +14,11 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+/**
+ * Mock implementation of an {@link AbstractSkeleton}.
+ *
+ * @see MonsterMock
+ */
 public abstract class AbstractSkeletonMock extends MonsterMock implements AbstractSkeleton
 {
 
@@ -21,6 +26,12 @@ public abstract class AbstractSkeletonMock extends MonsterMock implements Abstra
 	private boolean isChargingAttack = false;
 	private final Map<LivingEntity, Pair<Float, Boolean>> attackedMobs = new HashMap<>();
 
+	/**
+	 * Constructs a new {@link AbstractSkeletonMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	protected AbstractSkeletonMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/AgeableMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/AgeableMock.java
@@ -6,12 +6,23 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of an {@link Ageable}.
+ *
+ * @see CreatureMock
+ */
 public class AgeableMock extends CreatureMock implements Ageable
 {
 
 	private int age;
 	private boolean ageLocked;
 
+	/**
+	 * Constructs a new {@link AgeableMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public AgeableMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/AllayMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/AllayMock.java
@@ -19,12 +19,23 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+/**
+ * Mock implementation of an {@link Allay}.
+ *
+ * @see CreatureMock
+ */
 public class AllayMock extends CreatureMock implements Allay
 {
 
 	private final @NotNull Inventory inventory;
 	private Material currentItem;
 
+	/**
+	 * Constructs a new {@link AgeableMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public AllayMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);
@@ -97,7 +108,7 @@ public class AllayMock extends CreatureMock implements Allay
 	 * @param item    The {@link Material} to pick up
 	 * @param message The message to display if the assertion fails
 	 */
-	public void assertCurrentItem(@NotNull Material item, String message)
+	public void assertCurrentItem(@NotNull Material item, @Nullable String message)
 	{
 		if (item != this.currentItem)
 		{
@@ -111,12 +122,23 @@ public class AllayMock extends CreatureMock implements Allay
 		return this.inventory;
 	}
 
+	/**
+	 * Asserts that the Allay's inventory contains an item.
+	 *
+	 * @param item The item to check.
+	 */
 	public void assertInventoryContains(ItemStack item)
 	{
 		assertInventoryContains(item, "Inventory does not contain the given ItemStack");
 	}
 
-	private void assertInventoryContains(ItemStack item, String s)
+	/**
+	 * Asserts that the Allay's inventory contains an item.
+	 *
+	 * @param item The item to check.
+	 * @param s    The message to fail with.
+	 */
+	public void assertInventoryContains(ItemStack item, String s)
 	{
 		if (!inventory.contains(item))
 		{

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/AmbientMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/AmbientMock.java
@@ -6,9 +6,20 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of an {@link Ambient}.
+ *
+ * @see MobMock
+ */
 public class AmbientMock extends MobMock implements Ambient
 {
 
+	/**
+	 * Constructs a new {@link AmbientMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public AmbientMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/AnimalsMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/AnimalsMock.java
@@ -11,12 +11,23 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of an {@link Animals}.
+ *
+ * @see AgeableMock
+ */
 public class AnimalsMock extends AgeableMock implements Animals
 {
 
 	private @Nullable UUID breedCause;
 	private int isInLoveTicks;
 
+	/**
+	 * Constructs a new Animal on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public AnimalsMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ArmorStandMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ArmorStandMock.java
@@ -19,9 +19,9 @@ import java.util.Set;
 import java.util.UUID;
 
 /**
- * This is the mock of an {@link ArmorStand}.
+ * Mock implementation of an {@link ArmorStand}.
  *
- * @author TheBusyBiscuit
+ * @see LivingEntityMock
  */
 public class ArmorStandMock extends LivingEntityMock implements ArmorStand
 {
@@ -41,6 +41,12 @@ public class ArmorStandMock extends LivingEntityMock implements ArmorStand
 
 	private final Set<EquipmentSlot> disabledSlots = EnumSet.noneOf(EquipmentSlot.class);
 
+	/**
+	 * Constructs a new {@link ArmorStandMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public ArmorStandMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/AxolotlMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/AxolotlMock.java
@@ -11,6 +11,11 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of an {@link Axolotl}.
+ *
+ * @see AnimalsMock
+ */
 public class AxolotlMock extends AnimalsMock implements Axolotl
 {
 
@@ -19,6 +24,12 @@ public class AxolotlMock extends AnimalsMock implements Axolotl
 
 	private boolean fromBucket = false;
 
+	/**
+	 * Constructs a new {@link AxolotlMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public AxolotlMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/BatMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/BatMock.java
@@ -10,11 +10,22 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of an {@link Bat}.
+ *
+ * @see AmbientMock
+ */
 public class BatMock extends AmbientMock implements Bat
 {
 
 	private boolean awake = true;
 
+	/**
+	 * Constructs a new {@link BatMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public BatMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/BeeMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/BeeMock.java
@@ -12,6 +12,11 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Bee}.
+ *
+ * @see AnimalsMock
+ */
 public class BeeMock extends AnimalsMock implements Bee
 {
 
@@ -23,6 +28,12 @@ public class BeeMock extends AnimalsMock implements Bee
 	private int cannotEnterHiveTicks = 0;
 	private @NotNull TriState rollingOverride = TriState.NOT_SET;
 
+	/**
+	 * Constructs a new {@link BeeMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public BeeMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/BlazeMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/BlazeMock.java
@@ -7,9 +7,20 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Blaze}.
+ *
+ * @see MonsterMock
+ */
 public class BlazeMock extends MonsterMock implements Blaze
 {
 
+	/**
+	 * Constructs a new {@link BlazeMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public BlazeMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/CatMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/CatMock.java
@@ -8,6 +8,11 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Cat}.
+ *
+ * @see TameableAnimalMock
+ */
 public class CatMock extends TameableAnimalMock implements Cat
 {
 
@@ -16,6 +21,12 @@ public class CatMock extends TameableAnimalMock implements Cat
 	private boolean isLyingDown = false;
 	private boolean isHeadUp = false;
 
+	/**
+	 * Constructs a new {@link CatMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public CatMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/CaveSpiderMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/CaveSpiderMock.java
@@ -7,9 +7,20 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link CaveSpider}.
+ *
+ * @see SpiderMock
+ */
 public class CaveSpiderMock extends SpiderMock implements CaveSpider
 {
 
+	/**
+	 * Constructs a new {@link CaveSpiderMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public CaveSpiderMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ChestedHorseMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ChestedHorseMock.java
@@ -6,11 +6,22 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link ChestedHorse}.
+ *
+ * @see AbstractHorseMock
+ */
 public abstract class ChestedHorseMock extends AbstractHorseMock implements ChestedHorse
 {
 
 	private boolean hasChest;
 
+	/**
+	 * Constructs a new {@link ChestedHorseMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	protected ChestedHorseMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ChickenMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ChickenMock.java
@@ -11,9 +11,20 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Chicken}.
+ *
+ * @see AnimalsMock
+ */
 public class ChickenMock extends AnimalsMock implements Chicken
 {
 
+	/**
+	 * Constructs a new {@link ChickenMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public ChickenMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/CodMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/CodMock.java
@@ -9,9 +9,20 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Cod}.
+ *
+ * @see FishMock
+ */
 public class CodMock extends FishMock implements Cod
 {
 
+	/**
+	 * Constructs a new {@link CodMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public CodMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/CowMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/CowMock.java
@@ -7,9 +7,20 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Cow}.
+ *
+ * @see AnimalsMock
+ */
 public class CowMock extends AnimalsMock implements Cow
 {
 
+	/**
+	 * Constructs a new {@link CowMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public CowMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/CreatureMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/CreatureMock.java
@@ -6,9 +6,20 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Creature}.
+ *
+ * @see MobMock
+ */
 public abstract class CreatureMock extends MobMock implements Creature
 {
 
+	/**
+	 * Constructs a new {@link CreatureMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	protected CreatureMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/CreeperMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/CreeperMock.java
@@ -11,6 +11,11 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Creeper}.
+ *
+ * @see MonsterMock
+ */
 public class CreeperMock extends MonsterMock implements Creeper
 {
 
@@ -20,6 +25,12 @@ public class CreeperMock extends MonsterMock implements Creeper
 	private int explosionRadius = 3;
 	private boolean ignited = false;
 
+	/**
+	 * Constructs a new {@link CreeperMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public CreeperMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/DonkeyMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/DonkeyMock.java
@@ -7,9 +7,20 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Donkey}.
+ *
+ * @see ChestedHorseMock
+ */
 public class DonkeyMock extends ChestedHorseMock implements Donkey
 {
 
+	/**
+	 * Constructs a new {@link DonkeyMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public DonkeyMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EggMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EggMock.java
@@ -1,7 +1,6 @@
 package be.seeseemelk.mockbukkit.entity;
 
 import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import com.google.common.base.Preconditions;
 import org.bukkit.Material;
 import org.bukkit.entity.Egg;
@@ -11,11 +10,22 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of an {@link Egg}.
+ *
+ * @see ThrowableProjectileMock
+ */
 public class EggMock extends ThrowableProjectileMock implements Egg
 {
 
 	private @NotNull ItemStack item = new ItemStack(Material.EGG);
 
+	/**
+	 * Constructs a new {@link EggMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public EggMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EndermanMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EndermanMock.java
@@ -12,6 +12,11 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of an {@link Enderman}.
+ *
+ * @see MonsterMock
+ */
 public class EndermanMock extends MonsterMock implements Enderman
 {
 
@@ -19,6 +24,12 @@ public class EndermanMock extends MonsterMock implements Enderman
 	private boolean isScreaming = false;
 	private boolean hasBeenStaredAt = false;
 
+	/**
+	 * Constructs a new {@link EndermanMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public EndermanMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);
@@ -39,7 +50,7 @@ public class EndermanMock extends MonsterMock implements Enderman
 	@Deprecated
 	public @NotNull MaterialData getCarriedMaterial()
 	{
-		checkHasBlock();
+		assertHasBlock();
 		return new MaterialData(carriedBlock.getMaterial());
 	}
 
@@ -54,7 +65,7 @@ public class EndermanMock extends MonsterMock implements Enderman
 	@Override
 	public @Nullable BlockData getCarriedBlock()
 	{
-		checkHasBlock();
+		assertHasBlock();
 		return this.carriedBlock;
 	}
 
@@ -89,7 +100,10 @@ public class EndermanMock extends MonsterMock implements Enderman
 		this.hasBeenStaredAt = hasBeenStaredAt;
 	}
 
-	private void checkHasBlock()
+	/**
+	 * Asserts that this Enderman is holding a block.
+	 */
+	public void assertHasBlock()
 	{
 		Preconditions.checkState(this.carriedBlock != null, "Carried Block must be set before using this method");
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -59,6 +59,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * Mock implementation of an {@link Entity}.
+ *
+ * @see Entity.Spigot
+ * @see MessageTarget
+ */
 public abstract class EntityMock extends Entity.Spigot implements Entity, MessageTarget
 {
 
@@ -89,6 +95,12 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	private boolean silent;
 	private boolean gravity = true;
 
+	/**
+	 * Constructs a new EntityMock on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	protected EntityMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		Preconditions.checkNotNull(server, "Server cannot be null");

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -335,6 +335,13 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 		return false;
 	}
 
+	/**
+	 * Handles teleporting an entity without firing an event.
+	 * This will set the entity to the new location, mark teleport as true, and set the teleport cause.
+	 *
+	 * @param location The location to teleport to.
+	 * @param cause    The teleport cause.
+	 */
 	protected void teleportWithoutEvent(@NotNull Location location, @NotNull TeleportCause cause)
 	{
 		setLocation(location);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ExperienceOrbMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ExperienceOrbMock.java
@@ -2,7 +2,6 @@ package be.seeseemelk.mockbukkit.entity;
 
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.ExperienceOrb;
 import org.jetbrains.annotations.NotNull;
@@ -11,20 +10,33 @@ import org.jetbrains.annotations.Nullable;
 import java.util.UUID;
 
 /**
- * This is a simple mock of the {@link ExperienceOrb} {@link Entity}.
+ * Mock implementation of an {@link ExperienceOrb}.
  *
- * @author TheBusyBiscuit
+ * @see EntityMock
  */
 public class ExperienceOrbMock extends EntityMock implements ExperienceOrb
 {
 
 	private int experience;
 
+	/**
+	 * Constructs a new {@link ExperienceOrbMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public ExperienceOrbMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		this(server, uuid, 0);
 	}
 
+	/**
+	 * Constructs a new {@link ExperienceOrbMock} on the provided {@link ServerMock} with a specified {@link UUID} an experience amount.
+	 *
+	 * @param server     The server to create the entity on.
+	 * @param uuid       The UUID of the entity.
+	 * @param experience The amount of experience the orb has.
+	 */
 	public ExperienceOrbMock(@NotNull ServerMock server, @NotNull UUID uuid, int experience)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/FireworkMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/FireworkMock.java
@@ -4,7 +4,6 @@ import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.inventory.meta.FireworkMetaMock;
 import com.google.common.base.Preconditions;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Firework;
 import org.bukkit.entity.LivingEntity;
@@ -16,10 +15,9 @@ import org.jetbrains.annotations.Nullable;
 import java.util.UUID;
 
 /**
- * This is a simple mock of the {@link Firework} {@link Entity}. It takes a {@link FireworkMeta} to carry all
- * properties.
+ * Mock implementation of a {@link Firework}.
  *
- * @author TheBusyBiscuit
+ * @see ProjectileMock
  */
 public class FireworkMock extends ProjectileMock implements Firework
 {
@@ -27,11 +25,24 @@ public class FireworkMock extends ProjectileMock implements Firework
 	private FireworkMeta meta;
 	private boolean shotAtAngle = false;
 
+	/**
+	 * Constructs a new {@link FireworkMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public FireworkMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		this(server, uuid, new FireworkMetaMock());
 	}
 
+	/**
+	 * Constructs a new {@link FireworkMock} on the provided {@link ServerMock} with a specified {@link UUID} and {@link FireworkMeta}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 * @param meta   The FireworkMeta to apply.
+	 */
 	public FireworkMock(@NotNull ServerMock server, @NotNull UUID uuid, @NotNull FireworkMeta meta)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/FishHookMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/FishHookMock.java
@@ -14,6 +14,11 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link FishHook}.
+ *
+ * @see ProjectileMock
+ */
 public class FishHookMock extends ProjectileMock implements FishHook
 {
 
@@ -24,6 +29,12 @@ public class FishHookMock extends ProjectileMock implements FishHook
 	private @Nullable Entity hookedEntity;
 	private @NotNull HookState state = HookState.UNHOOKED;
 
+	/**
+	 * Constructs a new {@link FishHookMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public FishHookMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/FishMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/FishMock.java
@@ -3,16 +3,26 @@ package be.seeseemelk.mockbukkit.entity;
 import be.seeseemelk.mockbukkit.ServerMock;
 import org.bukkit.Sound;
 import org.bukkit.entity.Fish;
-import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Fish}.
+ *
+ * @see CreatureMock
+ */
 public abstract class FishMock extends CreatureMock implements Fish
 {
 
 	private boolean isFromBucket = false;
 
+	/**
+	 * Constructs a new {@link FishMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	protected FishMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);
@@ -29,9 +39,6 @@ public abstract class FishMock extends CreatureMock implements Fish
 	{
 		this.isFromBucket = fromBucket;
 	}
-
-	@Override
-	public abstract @NotNull ItemStack getBaseBucketItem();
 
 	@Override
 	public @NotNull Sound getPickupSound()

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/FlyingMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/FlyingMock.java
@@ -6,9 +6,20 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Flying}.
+ *
+ * @see MobMock
+ */
 public abstract class FlyingMock extends MobMock implements Flying
 {
 
+	/**
+	 * Constructs a new {@link FlyingMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	protected FlyingMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/FoxMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/FoxMock.java
@@ -10,6 +10,11 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Fox}.
+ *
+ * @see AnimalsMock
+ */
 public class FoxMock extends AnimalsMock implements Fox
 {
 
@@ -24,6 +29,12 @@ public class FoxMock extends AnimalsMock implements Fox
 	private boolean defending = false;
 	private boolean sitting = false;
 
+	/**
+	 * Constructs a new {@link FoxMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public FoxMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);
@@ -60,11 +71,7 @@ public class FoxMock extends AnimalsMock implements Fox
 		this.sleeping = sleeping;
 	}
 
-	/**
-	 * Checks if the Fox is sleeping
-	 *
-	 * @return True if he is sleeping, false if not
-	 */
+	@Override
 	public boolean isSleeping()
 	{
 		return this.sleeping;

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/FrogMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/FrogMock.java
@@ -10,12 +10,23 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Frog}.
+ *
+ * @see AnimalsMock
+ */
 public class FrogMock extends AnimalsMock implements Frog
 {
 
 	private @Nullable Entity tongueTarget = null;
 	private Variant variant = Variant.TEMPERATE;
 
+	/**
+	 * Constructs a new {@link FrogMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public FrogMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/GhastMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/GhastMock.java
@@ -8,12 +8,23 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Ghast}.
+ *
+ * @see FlyingMock
+ */
 public class GhastMock extends FlyingMock implements Ghast
 {
 
 	private boolean isCharging = false;
 	private int explosionPower = 1;
 
+	/**
+	 * Constructs a new {@link GhastMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public GhastMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/GiantMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/GiantMock.java
@@ -7,9 +7,20 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Giant}.
+ *
+ * @see MonsterMock
+ */
 public class GiantMock extends MonsterMock implements Giant
 {
 
+	/**
+	 * Constructs a new {@link GiantMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public GiantMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/GoatMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/GoatMock.java
@@ -13,6 +13,11 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+/**
+ * Mock implementation of a {@link Goat}.
+ *
+ * @see AnimalsMock
+ */
 public class GoatMock extends AnimalsMock implements Goat
 {
 
@@ -22,6 +27,12 @@ public class GoatMock extends AnimalsMock implements Goat
 
 	private final List<LivingEntity> attackedMobs = new LinkedList<>();
 
+	/**
+	 * Constructs a new {@link GoatMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public GoatMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/HangingMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/HangingMock.java
@@ -9,11 +9,22 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Hanging}.
+ *
+ * @see EntityMock
+ */
 public class HangingMock extends EntityMock implements Hanging
 {
 
 	private BlockFace facing;
 
+	/**
+	 * Constructs a new {@link HangingMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public HangingMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/HorseMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/HorseMock.java
@@ -9,6 +9,11 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Horse}.
+ *
+ * @see AbstractHorseMock
+ */
 public class HorseMock extends AbstractHorseMock implements Horse
 {
 
@@ -16,6 +21,12 @@ public class HorseMock extends AbstractHorseMock implements Horse
 	private Style style;
 	private HorseInventory inventory;
 
+	/**
+	 * Constructs a new {@link HorseMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public HorseMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/HumanEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/HumanEntityMock.java
@@ -10,7 +10,6 @@ import be.seeseemelk.mockbukkit.inventory.PlayerInventoryMock;
 import be.seeseemelk.mockbukkit.inventory.PlayerInventoryViewMock;
 import be.seeseemelk.mockbukkit.inventory.SimpleInventoryViewMock;
 import com.google.common.base.Preconditions;
-import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -39,6 +38,12 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+/**
+ * Mock implementation of a {@link HumanEntity}.
+ *
+ * @see LivingEntityMock
+ * @see PlayerMock
+ */
 public abstract class HumanEntityMock extends LivingEntityMock implements HumanEntity
 {
 
@@ -52,6 +57,12 @@ public abstract class HumanEntityMock extends LivingEntityMock implements HumanE
 	private float saturation = 5.0F;
 	private int foodLevel = 20;
 
+	/**
+	 * Constructs a new {@link HumanEntityMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	protected HumanEntityMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/HumanEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/HumanEntityMock.java
@@ -53,6 +53,9 @@ public abstract class HumanEntityMock extends LivingEntityMock implements HumanE
 	private @Nullable ItemStack cursor = null;
 	private @NotNull GameMode gameMode = GameMode.SURVIVAL;
 	private @Nullable Location lastDeathLocation = new Location(new WorldMock(), 0, 0, 0);
+	/**
+	 * How much EXP this {@link HumanEntity} has.
+	 */
 	protected int expLevel = 0;
 	private float saturation = 5.0F;
 	private int foodLevel = 20;

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ItemEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ItemEntityMock.java
@@ -12,9 +12,9 @@ import org.jetbrains.annotations.Nullable;
 import java.util.UUID;
 
 /**
- * This is a mock of a dropped {@link Item} entity. It can hold an {@link ItemStack}, that pretty much covers it all.
+ * Mock implementation of an {@link Item}.
  *
- * @author TheBusyBiscuit
+ * @see EntityMock
  */
 public class ItemEntityMock extends EntityMock implements Item
 {
@@ -24,9 +24,17 @@ public class ItemEntityMock extends EntityMock implements Item
 	// The default pickup delay
 	private int delay = 10;
 
+	/**
+	 * Constructs a new {@link ItemEntityMock} on the provided {@link ServerMock} with a specified {@link UUID} and {@link ItemStack}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 * @param item   The item this entity represents.
+	 */
 	public ItemEntityMock(@NotNull ServerMock server, @NotNull UUID uuid, @NotNull ItemStack item)
 	{
 		super(server, uuid);
+		Preconditions.checkNotNull(item, "Item cannot be null");
 		this.item = item.clone();
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -64,13 +64,22 @@ import java.util.UUID;
 public abstract class LivingEntityMock extends EntityMock implements LivingEntity
 {
 
+	/**
+	 * How much health the entity has.
+	 */
 	protected double health;
 	private int maxAirTicks = 300;
 	private int remainingAirTicks = 300;
+	/**
+	 * Whether the entity is alive.
+	 */
 	protected boolean alive = true;
 	private boolean gliding = false;
 	private boolean jumping = false;
 
+	/**
+	 * The attributes this entity has.
+	 */
 	protected Map<Attribute, AttributeInstanceMock> attributes;
 	private final EntityEquipment equipment = new EntityEquipmentMock(this);
 	private final Set<UUID> collidableExemptions = new HashSet<>();

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -56,6 +56,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link LivingEntity}.
+ *
+ * @see EntityMock
+ */
 public abstract class LivingEntityMock extends EntityMock implements LivingEntity
 {
 
@@ -80,6 +85,12 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	private final Set<ActivePotionEffect> activeEffects = new HashSet<>();
 	private boolean invisible = false;
 
+	/**
+	 * Constructs a new {@link LivingEntityMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	protected LivingEntityMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LlamaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LlamaMock.java
@@ -17,6 +17,11 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+/**
+ * Mock implementation of a {@link Llama}.
+ *
+ * @see ChestedHorseMock
+ */
 public class LlamaMock extends ChestedHorseMock implements Llama
 {
 
@@ -28,6 +33,12 @@ public class LlamaMock extends ChestedHorseMock implements Llama
 
 	private final @NotNull LlamaInventoryMock inventory;
 
+	/**
+	 * Constructs a new {@link LlamaMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public LlamaMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/MinecartMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/MinecartMock.java
@@ -13,6 +13,11 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Minecart}.
+ *
+ * @see VehicleMock
+ */
 public abstract class MinecartMock extends VehicleMock implements Minecart
 {
 
@@ -24,6 +29,12 @@ public abstract class MinecartMock extends VehicleMock implements Minecart
 	private BlockData displayBlock;
 	private int displayBlockOffset;
 
+	/**
+	 * Constructs a new {@link MinecartMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	protected MinecartMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/MobMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/MobMock.java
@@ -15,12 +15,23 @@ import org.jetbrains.annotations.Nullable;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
+/**
+ * Mock implementation of a {@link Mob}.
+ *
+ * @see LivingEntityMock
+ */
 public abstract class MobMock extends LivingEntityMock implements Mob
 {
 
 	private boolean aware = true;
 	private boolean leftHanded;
 
+	/**
+	 * Constructs a new {@link MobMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	protected MobMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/MockRangedEntity.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/MockRangedEntity.java
@@ -3,10 +3,14 @@ package be.seeseemelk.mockbukkit.entity;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import com.destroystokyo.paper.entity.RangedEntity;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Mob;
 import org.jetbrains.annotations.NotNull;
 
-public interface MockRangedEntity<T extends Mob> extends RangedEntity
+/**
+ * Mock implementation of a {@link RangedEntity}.
+ *
+ * @see MobMock
+ */
+public interface MockRangedEntity<T extends MobMock> extends RangedEntity
 {
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/MonsterMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/MonsterMock.java
@@ -7,9 +7,20 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Monster}.
+ *
+ * @see CreatureMock
+ */
 public abstract class MonsterMock extends CreatureMock implements Monster
 {
 
+	/**
+	 * Constructs a new {@link MonsterMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	protected MonsterMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/MuleMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/MuleMock.java
@@ -7,9 +7,20 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Mule}.
+ *
+ * @see ChestedHorseMock
+ */
 public class MuleMock extends ChestedHorseMock implements Mule
 {
 
+	/**
+	 * Constructs a new {@link MuleMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public MuleMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/MushroomCowMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/MushroomCowMock.java
@@ -11,11 +11,22 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link MushroomCow}.
+ *
+ * @see CowMock
+ */
 public class MushroomCowMock extends CowMock implements MushroomCow
 {
 
 	private @NotNull Variant variant = Variant.RED;
 
+	/**
+	 * Constructs a new {@link MushroomCowMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public MushroomCowMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/OfflinePlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/OfflinePlayerMock.java
@@ -54,9 +54,18 @@ public class OfflinePlayerMock implements OfflinePlayer
 		this(UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes()), name);
 	}
 
+	/**
+	 * Makes this offline player join the server.
+	 * A new PlayerMock will be constructed, and added to the server.
+	 * Will throw an {@link IllegalStateException} if the player is already online.
+	 *
+	 * @param server The server to join.
+	 * @return The created PlayerMock.
+	 */
 	public @NotNull PlayerMock join(@NotNull ServerMock server)
 	{
 		Preconditions.checkNotNull(server, "Server cannot be null");
+		Preconditions.checkState(!isOnline(), "Player already online");
 		PlayerMock player = new PlayerMock(server, this.name, this.uuid);
 		server.addPlayer(player);
 		return player;

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/OfflinePlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/OfflinePlayerMock.java
@@ -20,9 +20,9 @@ import java.util.Map;
 import java.util.UUID;
 
 /**
- * A Mock specifically for {@link OfflinePlayer}. Not interchangeable with {@link PlayerMock}.
+ * Mock implementation of an {@link OfflinePlayer}.
+ * Not interchangeable with {@link PlayerMock}.
  *
- * @author TheBusyBiscuit
  * @see PlayerMock
  */
 public class OfflinePlayerMock implements OfflinePlayer
@@ -31,6 +31,12 @@ public class OfflinePlayerMock implements OfflinePlayer
 	private final @NotNull UUID uuid;
 	private final @Nullable String name;
 
+	/**
+	 * Constructs a new {@link OfflinePlayerMock} on the provided {@link ServerMock} with a specified {@link UUID} and name.
+	 *
+	 * @param uuid The UUID of the player.
+	 * @param name The name of the player.
+	 */
 	public OfflinePlayerMock(@NotNull UUID uuid, @Nullable String name)
 	{
 		Preconditions.checkNotNull(uuid, "UUID cannot be null");
@@ -38,6 +44,11 @@ public class OfflinePlayerMock implements OfflinePlayer
 		this.name = name;
 	}
 
+	/**
+	 * Constructs a new {@link OfflinePlayerMock} on the provided {@link ServerMock} with a random {@link UUID} and specified name.
+	 *
+	 * @param name The name of the player.
+	 */
 	public OfflinePlayerMock(@Nullable String name)
 	{
 		this(UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes()), name);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PigMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PigMock.java
@@ -9,6 +9,11 @@ import org.jetbrains.annotations.NotNull;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
+/**
+ * Mock implementation of an {@link Pig}.
+ *
+ * @see AnimalsMock
+ */
 public class PigMock extends AnimalsMock implements Pig
 {
 
@@ -16,6 +21,12 @@ public class PigMock extends AnimalsMock implements Pig
 	private int boostTicks = 0;
 	private int currentBoostTicks = 0;
 
+	/**
+	 * Constructs a new {@link PigMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public PigMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -119,6 +119,11 @@ import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+/**
+ * Mock implementation of a {@link Player}.
+ *
+ * @see HumanEntityMock
+ */
 public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -2,6 +2,7 @@ package be.seeseemelk.mockbukkit.entity;
 
 import be.seeseemelk.mockbukkit.AsyncCatcher;
 import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.MockPlayerList;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.map.MapViewMock;
@@ -163,6 +164,14 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 
 	private final List<ItemStack> consumedItems = new LinkedList<>();
 
+	/**
+	 * Constructs a new {@link PlayerMock} for the provided server with the specified name.
+	 * The players UUID will be generated from the name.
+	 *
+	 * @param server The player's server.
+	 * @param name   The player's name.
+	 * @see ServerMock#addPlayer
+	 */
 	public PlayerMock(@NotNull ServerMock server, @NotNull String name)
 	{
 		this(server, name, UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(StandardCharsets.UTF_8)));
@@ -170,6 +179,15 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 		this.scoreboard = server.getScoreboardManager().getMainScoreboard();
 	}
 
+	/**
+	 * Constructs a new {@link PlayerMock} for the provided server with the specified name and {@link UUID}.
+	 * Does NOT add the player to the server.
+	 *
+	 * @param server The player's server.
+	 * @param name   The player's name.
+	 * @param uuid   The player's {@link UUID}.
+	 * @see ServerMock#addPlayer
+	 */
 	public PlayerMock(@NotNull ServerMock server, @NotNull String name, @NotNull UUID uuid)
 	{
 		super(server, uuid);
@@ -725,6 +743,13 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 		return server.getPlayerList().hasPlayedBefore(getUniqueId());
 	}
 
+	/**
+	 * No longer used.
+	 *
+	 * @param time N/A.
+	 * @see MockPlayerList#setLastSeen(UUID, long)
+	 * @deprecated Moved to {@link MockPlayerList}.
+	 */
 	@Deprecated(forRemoval = true)
 	public void setLastPlayed(long time)
 	{
@@ -949,6 +974,12 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 		this.sneaking = sneaking;
 	}
 
+	/**
+	 * Simulates sneaking.
+	 *
+	 * @param sneak Whether the player is beginning to sneak.
+	 * @return The event.
+	 */
 	public @NotNull PlayerToggleSneakEvent simulateSneak(boolean sneak)
 	{
 		PlayerToggleSneakEvent event = new PlayerToggleSneakEvent(this, sneak);
@@ -972,6 +1003,12 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 		this.sprinting = sprinting;
 	}
 
+	/**
+	 * Simulates sprinting.
+	 *
+	 * @param sprint Whether the player is beginning to sprint.
+	 * @return The event.
+	 */
 	public @NotNull PlayerToggleSprintEvent simulateSprint(boolean sprint)
 	{
 		PlayerToggleSprintEvent event = new PlayerToggleSprintEvent(this, sprint);
@@ -1825,6 +1862,12 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 		this.flying = value;
 	}
 
+	/**
+	 * Simulates toggling flight.
+	 *
+	 * @param fly Whether the player is starting to fly.
+	 * @return The event.
+	 */
 	public @NotNull PlayerToggleFlightEvent simulateToggleFlight(boolean fly)
 	{
 		PlayerToggleFlightEvent event = new PlayerToggleFlightEvent(this, fly);
@@ -2045,11 +2088,17 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 		sendTitle(title, subtitle);
 	}
 
+	/**
+	 * @return The next title sent to the player.
+	 */
 	public @Nullable String nextTitle()
 	{
 		return title.poll();
 	}
 
+	/**
+	 * @return The next subtitle sent to the player.
+	 */
 	public @Nullable String nextSubTitle()
 	{
 		return subitles.poll();
@@ -2564,6 +2613,9 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 		return playerSpigotMock;
 	}
 
+	/**
+	 * Mock implementation of a {@link Player.Spigot}.
+	 */
 	public class PlayerSpigotMock extends Player.Spigot
 	{
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMockFactory.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMockFactory.java
@@ -7,6 +7,10 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Random;
 import java.util.UUID;
 
+
+/**
+ * Used to construct random {@link PlayerMock}s and {@link OfflinePlayerMock}s.
+ */
 public final class PlayerMockFactory
 {
 
@@ -14,6 +18,11 @@ public final class PlayerMockFactory
 	private final Random random = new Random();
 	private int currentNameIndex;
 
+	/**
+	 * Constructs a new {@link PlayerMockFactory} for the provided {@link ServerMock}.
+	 *
+	 * @param server The server to create the factory for.
+	 */
 	public PlayerMockFactory(@NotNull ServerMock server)
 	{
 		Preconditions.checkNotNull(server, "Server cannot be null");

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PolarBearMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PolarBearMock.java
@@ -7,11 +7,22 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link PolarBear}.
+ *
+ * @see AnimalsMock
+ */
 public class PolarBearMock extends AnimalsMock implements PolarBear
 {
 
 	private boolean isStanding = false;
 
+	/**
+	 * Constructs a new {@link PolarBearMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public PolarBearMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ProjectileMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ProjectileMock.java
@@ -10,13 +10,21 @@ import org.jetbrains.annotations.Nullable;
 import java.util.UUID;
 
 /**
- * The {@link ProjectileMock} is an {@link EntityMock} representing a generic {@link Projectile}.
+ * Mock implementation of a {@link Projectile}.
+ *
+ * @see AbstractProjectileMock
  */
 public abstract class ProjectileMock extends AbstractProjectileMock implements Projectile
 {
 
 	private @Nullable ProjectileSource source;
 
+	/**
+	 * Constructs a new {@link ProjectileMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	protected ProjectileMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PufferFishMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PufferFishMock.java
@@ -10,11 +10,22 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link PufferFish}.
+ *
+ * @see FishMock
+ */
 public class PufferFishMock extends FishMock implements PufferFish
 {
 
 	private int puffState = 0;
 
+	/**
+	 * Constructs a new {@link PufferFishMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public PufferFishMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/SalmonMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/SalmonMock.java
@@ -10,9 +10,20 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Salmon}.
+ *
+ * @see FishMock
+ */
 public class SalmonMock extends FishMock implements Salmon
 {
 
+	/**
+	 * Constructs a new {@link SalmonMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public SalmonMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/SheepMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/SheepMock.java
@@ -8,12 +8,23 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Sheep}.
+ *
+ * @see AnimalsMock
+ */
 public class SheepMock extends AnimalsMock implements Sheep
 {
 
 	private boolean sheared = false;
 	private DyeColor color = DyeColor.WHITE;
 
+	/**
+	 * Constructs a new {@link SheepMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public SheepMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/SimpleEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/SimpleEntityMock.java
@@ -1,83 +1,38 @@
 package be.seeseemelk.mockbukkit.entity;
 
 import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.UnimplementedOperationException;
-import org.bukkit.block.BlockFace;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Pose;
-import org.bukkit.util.BoundingBox;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
 /**
- * A very simple class that allows one to create an instance of an entity when a specific type of entity is not
- * required. This should only be used for testing code that doesn't care what type of entity it is.
+ * A very simple class that allows one to create an instance of an {@link EntityMock} when a specific type of entity is not required.
+ * This should only be used for testing code that doesn't care what type of entity it is.
+ *
+ * @see EntityMock
  */
 public class SimpleEntityMock extends EntityMock
 {
 
 	/**
-	 * Creates a {@code SimpleEntityMock} with a specified UUID.
+	 * Constructs a new {@link SimpleEntityMock} on the provided {@link ServerMock} with a specified {@link UUID}.
 	 *
-	 * @param server The server this entity lives on.
-	 * @param uuid   The UUID that the entity should have.
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
 	 */
 	public SimpleEntityMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);
 	}
 
-	@Override
-	public @NotNull EntityType getType()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
 	/**
-	 * Creates a {@code SimpleEntityMock} with a random UUID.
+	 * Constructs a new {@link SimpleEntityMock} on the provided {@link ServerMock} with a random {@link UUID}.
 	 *
-	 * @param server The server this entity lives on.
+	 * @param server The server to create the entity on.
 	 */
 	public SimpleEntityMock(@NotNull ServerMock server)
 	{
 		this(server, UUID.randomUUID());
-	}
-
-	@Override
-	public boolean isPersistent()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public void setPersistent(boolean persistent)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public @NotNull BoundingBox getBoundingBox()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public @NotNull BlockFace getFacing()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public @NotNull Pose getPose()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/SimpleMobMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/SimpleMobMock.java
@@ -5,14 +5,31 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * A very simple class that allows one to create an instance of a {@link MobMock} when a specific type of entity is not required.
+ * This should only be used for testing code that doesn't care what type of entity it is.
+ *
+ * @see MobMock
+ */
 public class SimpleMobMock extends MobMock
 {
 
+	/**
+	 * Constructs a new {@link SimpleMobMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public SimpleMobMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);
 	}
 
+	/**
+	 * Constructs a new {@link SimpleMobMock} on the provided {@link ServerMock} with a random {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 */
 	public SimpleMobMock(@NotNull ServerMock server)
 	{
 		this(server, UUID.randomUUID());

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/SimpleMonsterMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/SimpleMonsterMock.java
@@ -6,14 +6,31 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * A very simple class that allows one to create an instance of a {@link MonsterMock} when a specific type of entity is not required.
+ * This should only be used for testing code that doesn't care what type of entity it is.
+ *
+ * @see MonsterMock
+ */
 public class SimpleMonsterMock extends MonsterMock implements Monster
 {
 
+	/**
+	 * Constructs a new {@link SimpleMonsterMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public SimpleMonsterMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);
 	}
 
+	/**
+	 * Constructs a new {@link SimpleMonsterMock} on the provided {@link ServerMock} with a random {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 */
 	public SimpleMonsterMock(@NotNull ServerMock server)
 	{
 		this(server, UUID.randomUUID());

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/SkeletonHorseMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/SkeletonHorseMock.java
@@ -7,12 +7,23 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link SkeletonHorse}.
+ *
+ * @see AbstractHorseMock
+ */
 public class SkeletonHorseMock extends AbstractHorseMock implements SkeletonHorse
 {
 
 	private boolean isTrapped = false;
 	private int trapTime = 0;
 
+	/**
+	 * Constructs a new {@link SkeletonHorseMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public SkeletonHorseMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/SkeletonMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/SkeletonMock.java
@@ -8,6 +8,11 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Skeleton}.
+ *
+ * @see AbstractSkeletonMock
+ */
 public class SkeletonMock extends AbstractSkeletonMock implements Skeleton
 {
 
@@ -15,6 +20,12 @@ public class SkeletonMock extends AbstractSkeletonMock implements Skeleton
 	private int conversionTime = 0;
 	private int inPowderedSnow = 0;
 
+	/**
+	 * Constructs a new {@link SkeletonMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public SkeletonMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/SpiderMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/SpiderMock.java
@@ -7,9 +7,20 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Spider}.
+ *
+ * @see MonsterMock
+ */
 public class SpiderMock extends MonsterMock implements Spider
 {
 
+	/**
+	 * Constructs a new {@link SpiderMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public SpiderMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/StrayMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/StrayMock.java
@@ -7,9 +7,20 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Stray}.
+ *
+ * @see AbstractSkeletonMock
+ */
 public class StrayMock extends AbstractSkeletonMock implements Stray
 {
 
+	/**
+	 * Constructs a new {@link StrayMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public StrayMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/TadpoleMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/TadpoleMock.java
@@ -10,11 +10,22 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Tadpole}.
+ *
+ * @see FishMock
+ */
 public class TadpoleMock extends FishMock implements Tadpole
 {
 
 	private int age = 0;
 
+	/**
+	 * Constructs a new {@link TadpoleMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public TadpoleMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/TameableAnimalMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/TameableAnimalMock.java
@@ -1,8 +1,10 @@
 package be.seeseemelk.mockbukkit.entity;
 
 import be.seeseemelk.mockbukkit.ServerMock;
+import com.google.common.base.Preconditions;
 import org.bukkit.entity.AnimalTamer;
 import org.bukkit.entity.Creature;
+import org.bukkit.entity.Sittable;
 import org.bukkit.entity.Tameable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -22,7 +24,7 @@ public class TameableAnimalMock extends AnimalsMock implements Tameable, Creatur
 	private boolean sitting;
 
 	/**
-	 * Constructs a new {@link TameableAnimalMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 * Constructs a new  on the provided {@link ServerMock} with a specified {@link UUID}.
 	 *
 	 * @param server The server to create the entity on.
 	 * @param uuid   The UUID of the entity.
@@ -32,6 +34,13 @@ public class TameableAnimalMock extends AnimalsMock implements Tameable, Creatur
 		super(server, uuid);
 	}
 
+	/**
+	 * Sets the owner of this animal by UUID.
+	 *
+	 * @param uuid The UUID.
+	 * @see #getOwner()
+	 * @see #getOwnerUniqueId()
+	 */
 	public void setOwnerUUID(@Nullable UUID uuid)
 	{
 		this.owner = uuid;
@@ -91,14 +100,30 @@ public class TameableAnimalMock extends AnimalsMock implements Tameable, Creatur
 		return this.owner;
 	}
 
+	/**
+	 * Checks if the animal is sitting.
+	 *
+	 * @return Whether the animal is sitting.
+	 * @throws IllegalStateException If the animal doesn't implement {@link Sittable}.
+	 * @see Sittable#isSitting
+	 */
 	// Sitting methods implemented here for animals that implement Sittable.
 	public boolean isSitting()
 	{
+		Preconditions.checkState(this instanceof Sittable, "Not sittable");
 		return this.sitting;
 	}
 
+	/**
+	 * Sets whether the animal is sitting.
+	 *
+	 * @param sitting Whether the animal is sitting.
+	 * @throws IllegalStateException If the animal doesn't implement {@link Sittable}.
+	 * @see Sittable#setSitting(boolean)
+	 */
 	public void setSitting(boolean sitting)
 	{
+		Preconditions.checkState(this instanceof Sittable, "Not sittable");
 		this.sitting = sitting;
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/TameableAnimalMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/TameableAnimalMock.java
@@ -9,6 +9,11 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Tameable} {@link Creature}.
+ *
+ * @see AnimalsMock
+ */
 public class TameableAnimalMock extends AnimalsMock implements Tameable, Creature
 {
 
@@ -16,6 +21,12 @@ public class TameableAnimalMock extends AnimalsMock implements Tameable, Creatur
 	private boolean tamed;
 	private boolean sitting;
 
+	/**
+	 * Constructs a new {@link TameableAnimalMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public TameableAnimalMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ThrowableProjectileMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ThrowableProjectileMock.java
@@ -6,9 +6,20 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link ThrowableProjectile}.
+ *
+ * @see ProjectileMock
+ */
 public abstract class ThrowableProjectileMock extends ProjectileMock implements ThrowableProjectile
 {
 
+	/**
+	 * Constructs a new {@link ThrowableProjectileMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	protected ThrowableProjectileMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/TropicalFishMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/TropicalFishMock.java
@@ -12,6 +12,11 @@ import org.jetbrains.annotations.NotNull;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
+/**
+ * Mock implementation of a {@link TropicalFish}.
+ *
+ * @see FishMock
+ */
 public class TropicalFishMock extends FishMock implements TropicalFish
 {
 
@@ -19,6 +24,12 @@ public class TropicalFishMock extends FishMock implements TropicalFish
 	private @NotNull DyeColor bodyColor;
 	private @NotNull Pattern pattern;
 
+	/**
+	 * Constructs a new {@link TropicalFishMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public TropicalFishMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/VehicleMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/VehicleMock.java
@@ -6,9 +6,20 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Vehicle}.
+ *
+ * @see EntityMock
+ */
 public abstract class VehicleMock extends EntityMock implements Vehicle
 {
 
+	/**
+	 * Constructs a new {@link VehicleMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	protected VehicleMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/WardenMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/WardenMock.java
@@ -14,11 +14,22 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Warden}.
+ *
+ * @see MonsterMock
+ */
 public class WardenMock extends MonsterMock implements Warden
 {
 
 	private final Map<Entity, Integer> angerPerEntity = new HashMap<>();
 
+	/**
+	 * Constructs a new {@link WardenMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public WardenMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/WitherSkeletonMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/WitherSkeletonMock.java
@@ -7,9 +7,20 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link WitherSkeleton}.
+ *
+ * @see AbstractSkeletonMock
+ */
 public class WitherSkeletonMock extends AbstractSkeletonMock implements WitherSkeleton
 {
 
+	/**
+	 * Constructs a new {@link WitherSkeletonMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public WitherSkeletonMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/WolfMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/WolfMock.java
@@ -9,6 +9,11 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Wolf}.
+ *
+ * @see TameableAnimalMock
+ */
 public class WolfMock extends TameableAnimalMock implements Wolf
 {
 
@@ -17,6 +22,12 @@ public class WolfMock extends TameableAnimalMock implements Wolf
 	private boolean isWet = false;
 	private boolean interested = false;
 
+	/**
+	 * Constructs a new {@link WolfMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public WolfMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ZombieHorseMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ZombieHorseMock.java
@@ -7,9 +7,20 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link ZombieHorse}.
+ *
+ * @see AbstractHorseMock
+ */
 public class ZombieHorseMock extends AbstractHorseMock implements ZombieHorse
 {
 
+	/**
+	 * Constructs a new {@link ZombieHorseMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public ZombieHorseMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ZombieMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ZombieMock.java
@@ -10,6 +10,11 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Mock implementation of a {@link Zombie}.
+ *
+ * @see MonsterMock
+ */
 public class ZombieMock extends MonsterMock implements Zombie
 {
 
@@ -19,6 +24,12 @@ public class ZombieMock extends MonsterMock implements Zombie
 	private boolean converting;
 	private int conversionTime;
 
+	/**
+	 * Constructs a new {@link ZombieMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
 	public ZombieMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);

--- a/src/main/java/be/seeseemelk/mockbukkit/exception/EventHandlerException.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/exception/EventHandlerException.java
@@ -13,6 +13,11 @@ public class EventHandlerException extends RuntimeException
 	@Serial
 	private static final long serialVersionUID = 6093700474770834429L;
 
+	/**
+	 * Constructs a new runtime exception with the specified cause and a detail message of (cause==null ? null : cause.toString())
+	 *
+	 * @param cause The cause of the exception.
+	 */
 	public EventHandlerException(@NotNull Throwable cause)
 	{
 		super(cause);

--- a/src/main/java/be/seeseemelk/mockbukkit/generator/BiomeProviderMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/generator/BiomeProviderMock.java
@@ -8,6 +8,9 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
+/**
+ * Mock implementation of a {@link BiomeProvider}.
+ */
 public class BiomeProviderMock extends BiomeProvider
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/help/HelpMapMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/help/HelpMapMock.java
@@ -19,9 +19,7 @@ import java.util.TreeMap;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * The {@link HelpMapMock} is our mock of Bukkit's {@link HelpMap}.
- *
- * @author NeumimTo
+ * Mock implementation of a {@link HelpMap}.
  */
 public class HelpMapMock implements HelpMap
 {
@@ -83,6 +81,11 @@ public class HelpMapMock implements HelpMap
 		factories.put(commandClass, factory);
 	}
 
+	/**
+	 * Asserts that a {@link HelpTopicFactory} is registered.
+	 *
+	 * @param factory The factory to check.
+	 */
 	public void assertRegistered(@NotNull HelpTopicFactory<?> factory)
 	{
 		Preconditions.checkNotNull(factory, "Factory cannot be null");

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/AbstractHorseInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/AbstractHorseInventoryMock.java
@@ -6,11 +6,21 @@ import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Mock implementation of an {@link AbstractHorseInventory}.
+ *
+ * @see InventoryMock
+ */
 public class AbstractHorseInventoryMock extends InventoryMock implements AbstractHorseInventory
 {
 
 	private static final int SADDLE_SLOT = 0;
 
+	/**
+	 * Constructs a new {@link AbstractHorseInventoryMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public AbstractHorseInventoryMock(@Nullable InventoryHolder holder)
 	{
 		super(holder, 2, InventoryType.CHEST);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/AnvilInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/AnvilInventoryMock.java
@@ -2,10 +2,16 @@ package be.seeseemelk.mockbukkit.inventory;
 
 import com.google.common.base.Preconditions;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.AbstractHorseInventory;
 import org.bukkit.inventory.AnvilInventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Mock implementation of an {@link AnvilInventory}.
+ *
+ * @see InventoryMock
+ */
 public class AnvilInventoryMock extends InventoryMock implements AnvilInventory
 {
 
@@ -14,6 +20,11 @@ public class AnvilInventoryMock extends InventoryMock implements AnvilInventory
 	private int repairCost = 0;
 	private int maxRepairCost = 40;
 
+	/**
+	 * Constructs a new {@link AnvilInventoryMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public AnvilInventoryMock(@Nullable InventoryHolder holder)
 	{
 		super(holder, InventoryType.ANVIL);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/BarrelInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/BarrelInventoryMock.java
@@ -5,9 +5,20 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of a Barrel {@link InventoryType}.
+ *
+ * @see InventoryMock
+ * @see InventoryType#BARREL
+ */
 public class BarrelInventoryMock extends InventoryMock
 {
 
+	/**
+	 * Constructs a new {@link BarrelInventoryMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public BarrelInventoryMock(InventoryHolder holder)
 	{
 		super(holder, 27, InventoryType.BARREL);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/BeaconInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/BeaconInventoryMock.java
@@ -1,17 +1,28 @@
 package be.seeseemelk.mockbukkit.inventory;
 
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.AnvilInventory;
 import org.bukkit.inventory.BeaconInventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Mock implementation of a {@link BeaconInventory}.
+ *
+ * @see InventoryMock
+ */
 public class BeaconInventoryMock extends InventoryMock implements BeaconInventory
 {
 
 	private static final int ITEM_SLOT = 0;
 
+	/**
+	 * Constructs a new {@link AbstractHorseInventoryMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public BeaconInventoryMock(@Nullable InventoryHolder holder)
 	{
 		super(holder, InventoryType.BEACON);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/BrewerInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/BrewerInventoryMock.java
@@ -9,12 +9,22 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Mock implementation of a {@link BrewerInventory}.
+ *
+ * @see InventoryMock
+ */
 public class BrewerInventoryMock extends InventoryMock implements BrewerInventory
 {
 
 	private static final int INGREDIENT_SLOT = 3;
 	private static final int FUEL_SLOT = 4;
 
+	/**
+	 * Constructs a new {@link BrewerInventoryMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public BrewerInventoryMock(InventoryHolder holder)
 	{
 		super(holder, InventoryType.BREWING);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/CartographyInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/CartographyInventoryMock.java
@@ -1,14 +1,25 @@
 package be.seeseemelk.mockbukkit.inventory;
 
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.AbstractHorseInventory;
 import org.bukkit.inventory.CartographyInventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Mock implementation of a {@link CartographyInventory}.
+ *
+ * @see InventoryMock
+ */
 public class CartographyInventoryMock extends InventoryMock implements CartographyInventory
 {
 
+	/**
+	 * Constructs a new {@link CartographyInventoryMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public CartographyInventoryMock(@Nullable InventoryHolder holder)
 	{
 		super(holder, InventoryType.CARTOGRAPHY);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/ChestInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/ChestInventoryMock.java
@@ -18,6 +18,8 @@ public class ChestInventoryMock extends InventoryMock
 	 * Constructs a new {@link ChestInventoryMock} for the given holder.
 	 *
 	 * @param holder The holder of the inventory.
+	 * @param size   The size of the inventory.
+	 * @see InventoryMock#InventoryMock(InventoryHolder, int, InventoryType)
 	 */
 	public ChestInventoryMock(InventoryHolder holder, int size)
 	{

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/ChestInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/ChestInventoryMock.java
@@ -5,9 +5,20 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of a Chest {@link InventoryType}.
+ *
+ * @see InventoryMock
+ * @see InventoryType#CHEST
+ */
 public class ChestInventoryMock extends InventoryMock
 {
 
+	/**
+	 * Constructs a new {@link ChestInventoryMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public ChestInventoryMock(InventoryHolder holder, int size)
 	{
 		super(holder, size, InventoryType.CHEST);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/DispenserInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/DispenserInventoryMock.java
@@ -5,9 +5,20 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of a Dispenser {@link InventoryType}.
+ *
+ * @see InventoryMock
+ * @see InventoryType#DISPENSER
+ */
 public class DispenserInventoryMock extends InventoryMock
 {
 
+	/**
+	 * Constructs a new {@link DispenserInventoryMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public DispenserInventoryMock(InventoryHolder holder)
 	{
 		super(holder, 9, InventoryType.DISPENSER);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/DropperInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/DropperInventoryMock.java
@@ -5,9 +5,20 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of a Dropper {@link InventoryType}.
+ *
+ * @see InventoryMock
+ * @see InventoryType#DROPPER
+ */
 public class DropperInventoryMock extends InventoryMock
 {
 
+	/**
+	 * Constructs a new {@link DropperInventoryMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public DropperInventoryMock(InventoryHolder holder)
 	{
 		super(holder, 9, InventoryType.DROPPER);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/EnchantingInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/EnchantingInventoryMock.java
@@ -1,17 +1,28 @@
 package be.seeseemelk.mockbukkit.inventory;
 
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.AbstractHorseInventory;
 import org.bukkit.inventory.EnchantingInventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Mock implementation of an {@link EnchantingInventory}.
+ *
+ * @see InventoryMock
+ */
 public class EnchantingInventoryMock extends InventoryMock implements EnchantingInventory
 {
 
 	private static final int ITEM_SLOT = 0;
 	private static final int SECONDARY_SLOT = 1;
 
+	/**
+	 * Constructs a new {@link EnchantingInventoryMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public EnchantingInventoryMock(@Nullable InventoryHolder holder)
 	{
 		super(holder, InventoryType.ENCHANTING);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/EnderChestInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/EnderChestInventoryMock.java
@@ -1,19 +1,22 @@
 package be.seeseemelk.mockbukkit.inventory;
 
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
-import org.bukkit.block.EnderChest;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.InventoryHolder;
 
 /**
- * This {@link InventoryMock} mocks an {@link EnderChest} but pretty much behaves like any small chest. A
- * {@link PlayerMock} carries an instance of an {@link EnderChestInventoryMock}.
+ * Mock implementation of an Ender Chest {@link InventoryType}.
  *
- * @author TheBusyBiscuit
+ * @see InventoryMock
+ * @see InventoryType#ENDER_CHEST
  */
 public class EnderChestInventoryMock extends InventoryMock
 {
 
+	/**
+	 * Constructs a new {@link EnderChestInventoryMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public EnderChestInventoryMock(InventoryHolder holder)
 	{
 		super(holder, 27, InventoryType.ENDER_CHEST);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/EntityEquipmentMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/EntityEquipmentMock.java
@@ -36,6 +36,11 @@ public class EntityEquipmentMock implements EntityEquipment
 	private @NotNull ItemStack leggings = new ItemStack(Material.AIR);
 	private @NotNull ItemStack boots = new ItemStack(Material.AIR);
 
+	/**
+	 * Constructs a new {@link EntityEquipmentMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public EntityEquipmentMock(@NotNull LivingEntityMock holder)
 	{
 		Preconditions.checkNotNull(holder, "Holder cannot be null");

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/FurnaceInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/FurnaceInventoryMock.java
@@ -6,6 +6,7 @@ import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.block.Furnace;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.AbstractHorseInventory;
 import org.bukkit.inventory.FurnaceInventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
@@ -14,6 +15,11 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Set;
 
+/**
+ * Mock implementation of a {@link FurnaceInventory}.
+ *
+ * @see InventoryMock
+ */
 public class FurnaceInventoryMock extends InventoryMock implements FurnaceInventory
 {
 
@@ -21,6 +27,11 @@ public class FurnaceInventoryMock extends InventoryMock implements FurnaceInvent
 	private static final int FUEL_SLOT = 1;
 	private static final int RESULT_SLOT = 2;
 
+	/**
+	 * Constructs a new {@link FurnaceInventoryMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public FurnaceInventoryMock(@Nullable InventoryHolder holder)
 	{
 		super(holder, InventoryType.FURNACE);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/GrindstoneInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/GrindstoneInventoryMock.java
@@ -1,13 +1,24 @@
 package be.seeseemelk.mockbukkit.inventory;
 
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.AbstractHorseInventory;
 import org.bukkit.inventory.GrindstoneInventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of a {@link GrindstoneInventory}.
+ *
+ * @see InventoryMock
+ */
 public class GrindstoneInventoryMock extends InventoryMock implements GrindstoneInventory
 {
 
+	/**
+	 * Constructs a new {@link GrindstoneInventoryMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public GrindstoneInventoryMock(InventoryHolder holder)
 	{
 		super(holder, InventoryType.GRINDSTONE);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/HopperInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/HopperInventoryMock.java
@@ -5,9 +5,20 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of a Hopper {@link InventoryType}.
+ *
+ * @see InventoryMock
+ * @see InventoryType#HOPPER
+ */
 public class HopperInventoryMock extends InventoryMock
 {
 
+	/**
+	 * Constructs a new {@link HopperInventoryMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public HopperInventoryMock(InventoryHolder holder)
 	{
 		super(holder, 9, InventoryType.HOPPER);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/HorseInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/HorseInventoryMock.java
@@ -5,11 +5,21 @@ import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Mock implementation of a {@link HorseInventory}.
+ *
+ * @see InventoryMock
+ */
 public class HorseInventoryMock extends AbstractHorseInventoryMock implements HorseInventory
 {
 
 	private static final int ARMOR_SLOT = 1;
 
+	/**
+	 * Constructs a new {@link HorseInventoryMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public HorseInventoryMock(InventoryHolder holder)
 	{
 		super(holder);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/InventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/InventoryMock.java
@@ -583,6 +583,11 @@ public class InventoryMock implements Inventory
 		return true;
 	}
 
+	/**
+	 * Creates a snapshot of the inventory.
+	 *
+	 * @return An inventory snapshot.
+	 */
 	@NotNull
 	public Inventory getSnapshot()
 	{

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/InventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/InventoryMock.java
@@ -25,6 +25,9 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+/**
+ * Mock implementation of an {@link Inventory}.
+ */
 public class InventoryMock implements Inventory
 {
 
@@ -37,6 +40,13 @@ public class InventoryMock implements Inventory
 	private int maxStackSize = MAX_STACK_SIZE;
 	private final @NotNull List<HumanEntity> viewers = new ArrayList<>();
 
+	/**
+	 * Constructs a new {@link InventoryMock} for the given holder, with a specific size and {@link InventoryType}.
+	 *
+	 * @param holder The holder of the inventory.
+	 * @param size   The size of the inventory. Must be 2, or a multiple of 9 between 9 and 54.
+	 * @param type   The type of the inventory.
+	 */
 	public InventoryMock(@Nullable InventoryHolder holder, int size, @NotNull InventoryType type)
 	{
 		Preconditions.checkArgument(2 == size || (9 <= size && size <= 54 && size % 9 == 0),
@@ -49,6 +59,13 @@ public class InventoryMock implements Inventory
 		items = new ItemStack[size];
 	}
 
+	/**
+	 * Constructs a new {@link InventoryMock} for the given holder with a specific {@link InventoryType}.
+	 * The size will be {@link InventoryType#getDefaultSize()}.
+	 *
+	 * @param holder The holder of the inventory.
+	 * @param type   The type of the inventory.
+	 */
 	public InventoryMock(@Nullable InventoryHolder holder, @NotNull InventoryType type)
 	{
 		Preconditions.checkNotNull(type, "The InventoryType must not be null!");

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/InventoryViewMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/InventoryViewMock.java
@@ -6,6 +6,9 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of an {@link InventoryView}.
+ */
 public abstract class InventoryViewMock extends InventoryView
 {
 
@@ -15,6 +18,15 @@ public abstract class InventoryViewMock extends InventoryView
 	private InventoryType type;
 	private final String name;
 
+	/**
+	 * Constructs a new {@link InventoryViewMock} with the provided parameters.
+	 *
+	 * @param player The player this view is for.
+	 * @param name   The name of the view (title).
+	 * @param top    The top inventory.
+	 * @param bottom The bottom inventory.
+	 * @param type   The type of the inventory.
+	 */
 	protected InventoryViewMock(HumanEntity player, String name, Inventory top, Inventory bottom, InventoryType type)
 	{
 		this.player = player;

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/ItemFactoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/ItemFactoryMock.java
@@ -31,6 +31,7 @@ import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.AbstractHorseInventory;
 import org.bukkit.inventory.ItemFactory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -44,6 +45,9 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.function.UnaryOperator;
 
+/**
+ * Mock implementation of an {@link ItemFactory}.
+ */
 public class ItemFactoryMock implements ItemFactory
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/LecternInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/LecternInventoryMock.java
@@ -2,6 +2,7 @@ package be.seeseemelk.mockbukkit.inventory;
 
 import org.bukkit.block.Lectern;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.AbstractHorseInventory;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.LecternInventory;
@@ -9,11 +10,18 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * This {@link InventoryMock} mocks an {@link org.bukkit.block.Lectern} but pretty much behaves like any small chest.
+ * Mock implementation of a {@link LecternInventory}.
+ *
+ * @see InventoryMock
  */
 public class LecternInventoryMock extends InventoryMock implements LecternInventory
 {
 
+	/**
+	 * Constructs a new {@link LecternInventoryMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public LecternInventoryMock(InventoryHolder holder)
 	{
 		super(holder, InventoryType.LECTERN);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/LlamaInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/LlamaInventoryMock.java
@@ -1,16 +1,26 @@
 package be.seeseemelk.mockbukkit.inventory;
 
-
+import org.bukkit.inventory.AbstractHorseInventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.LlamaInventory;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Mock implementation of a {@link LlamaInventory}.
+ *
+ * @see InventoryMock
+ */
 public class LlamaInventoryMock extends AbstractHorseInventoryMock implements LlamaInventory
 {
 
 	private static final int DECOR_SLOT = 1;
 
+	/**
+	 * Constructs a new {@link LlamaInventoryMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public LlamaInventoryMock(@Nullable InventoryHolder holder)
 	{
 		super(holder);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/LoomInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/LoomInventoryMock.java
@@ -1,14 +1,25 @@
 package be.seeseemelk.mockbukkit.inventory;
 
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.AbstractHorseInventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.LoomInventory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Mock implementation of a {@link LoomInventory}.
+ *
+ * @see InventoryMock
+ */
 public class LoomInventoryMock extends InventoryMock implements LoomInventory
 {
 
+	/**
+	 * Constructs a new {@link LoomInventoryMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public LoomInventoryMock(@Nullable InventoryHolder holder)
 	{
 		super(holder, InventoryType.LOOM);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryMock.java
@@ -13,6 +13,11 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 
+/**
+ * Mock implementation of a {@link PlayerInventory}.
+ *
+ * @see InventoryMock
+ */
 public class PlayerInventoryMock extends InventoryMock implements PlayerInventory, EntityEquipment
 {
 
@@ -25,6 +30,11 @@ public class PlayerInventoryMock extends InventoryMock implements PlayerInventor
 	protected static final int OFF_HAND = 40;
 	private int mainHandSlot = 0;
 
+	/**
+	 * Constructs a new {@link PlayerInventoryMock}.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public PlayerInventoryMock(HumanEntity holder)
 	{
 		super(holder, InventoryType.PLAYER);
@@ -359,7 +369,11 @@ public class PlayerInventoryMock extends InventoryMock implements PlayerInventor
 		throw new UnsupportedOperationException("Cannot set drop chance for PlayerInventory");
 	}
 
-	static @NotNull ItemStack notNull(@Nullable ItemStack itemStack)
+	/**
+	 * @param itemStack The item.
+	 * @return A new ItemStack of AIR if the provided item is null, otherwise the provided item.
+	 */
+	private static @NotNull ItemStack notNull(@Nullable ItemStack itemStack)
 	{
 		return itemStack == null ? new ItemStack(Material.AIR) : itemStack;
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryMock.java
@@ -21,12 +21,33 @@ import java.util.Arrays;
 public class PlayerInventoryMock extends InventoryMock implements PlayerInventory, EntityEquipment
 {
 
+	/**
+	 * The starting slot of the hotbar.
+	 */
 	protected static final int HOTBAR = 0;
+	/**
+	 * The ending slot of the hotbar.
+	 */
 	protected static final int SLOT_BAR = 9;
+	/**
+	 * The slot boots are in.
+	 */
 	protected static final int BOOTS = 36;
+	/**
+	 * The slot leggings are in.
+	 */
 	protected static final int LEGGINGS = 37;
+	/**
+	 * The slot the chestplate is in.
+	 */
 	protected static final int CHESTPLATE = 38;
+	/**
+	 * The slot the helmet is in.
+	 */
 	protected static final int HELMET = 39;
+	/**
+	 * The slot of the offhand.
+	 */
 	protected static final int OFF_HAND = 40;
 	private int mainHandSlot = 0;
 

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryViewMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/PlayerInventoryViewMock.java
@@ -2,11 +2,23 @@ package be.seeseemelk.mockbukkit.inventory;
 
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of an {@link InventoryView} for players.
+ *
+ * @see InventoryViewMock
+ */
 public class PlayerInventoryViewMock extends InventoryViewMock
 {
 
+	/**
+	 * Constructs a new {@link PlayerInventoryViewMock} for the provided player, with the specified top inventory.
+	 *
+	 * @param player The player to create the view for.
+	 * @param top    The top inventory.
+	 */
 	public PlayerInventoryViewMock(@NotNull HumanEntity player, @NotNull Inventory top)
 	{
 		super(player, "Inventory", top, player.getInventory(), top.getType());

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/ShulkerBoxInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/ShulkerBoxInventoryMock.java
@@ -5,9 +5,20 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of a Shulker Box {@link InventoryType}.
+ *
+ * @see InventoryMock
+ * @see InventoryType#SHULKER_BOX
+ */
 public class ShulkerBoxInventoryMock extends InventoryMock
 {
 
+	/**
+	 * Constructs a new {@link ShulkerBoxInventoryMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public ShulkerBoxInventoryMock(InventoryHolder holder)
 	{
 		super(holder, 27, InventoryType.SHULKER_BOX);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/SimpleInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/SimpleInventoryMock.java
@@ -5,6 +5,10 @@ import org.bukkit.inventory.InventoryHolder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * A basic inventory.
+ * @see InventoryMock
+ */
 public class SimpleInventoryMock extends InventoryMock
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/SimpleInventoryViewMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/SimpleInventoryViewMock.java
@@ -4,9 +4,22 @@ import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 
+/**
+ * A basic inventory view.
+ *
+ * @see InventoryViewMock
+ */
 public class SimpleInventoryViewMock extends InventoryViewMock
 {
 
+	/**
+	 * Constructs a new {@link SimpleInventoryViewMock} with the provided parameters, and "Inventory" as the name.
+	 *
+	 * @param player The player this view is for.
+	 * @param top    The top inventory.
+	 * @param bottom The bottom inventory.
+	 * @param type   The type of the inventory.
+	 */
 	public SimpleInventoryViewMock(HumanEntity player, Inventory top, Inventory bottom, InventoryType type)
 	{
 		super(player, "Inventory", top, bottom, type);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/SmithingInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/SmithingInventoryMock.java
@@ -2,18 +2,28 @@ package be.seeseemelk.mockbukkit.inventory;
 
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.AbstractHorseInventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.SmithingInventory;
 import org.jetbrains.annotations.Nullable;
 
-
+/**
+ * Mock implementation of an {@link SmithingInventory}.
+ *
+ * @see InventoryMock
+ */
 public class SmithingInventoryMock extends InventoryMock implements SmithingInventory
 {
 
 	private static final int RESULT_SLOT = 0;
 
+	/**
+	 * Constructs a new {@link SmithingInventoryMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public SmithingInventoryMock(@Nullable InventoryHolder holder)
 	{
 		super(holder, InventoryType.SMITHING);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/StonecutterInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/StonecutterInventoryMock.java
@@ -1,14 +1,25 @@
 package be.seeseemelk.mockbukkit.inventory;
 
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.AbstractHorseInventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.StonecutterInventory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Mock implementation of a {@link StonecutterInventory}.
+ *
+ * @see InventoryMock
+ */
 public class StonecutterInventoryMock extends InventoryMock implements StonecutterInventory
 {
 
+	/**
+	 * Constructs a new {@link StonecutterInventoryMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public StonecutterInventoryMock(@Nullable InventoryHolder holder)
 	{
 		super(holder, InventoryType.STONECUTTER);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/WorkbenchInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/WorkbenchInventoryMock.java
@@ -10,11 +10,21 @@ import org.bukkit.inventory.Recipe;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Mock implementation of a {@link CraftingInventory}.
+ *
+ * @see InventoryMock
+ */
 public class WorkbenchInventoryMock extends InventoryMock implements CraftingInventory
 {
 
 	private @Nullable ItemStack result = null;
 
+	/**
+	 * Constructs a new {@link WorkbenchInventoryMock} for the given holder.
+	 *
+	 * @param holder The holder of the inventory.
+	 */
 	public WorkbenchInventoryMock(@Nullable InventoryHolder holder)
 	{
 		super(holder, InventoryType.WORKBENCH);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ArmorStandMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ArmorStandMetaMock.java
@@ -3,6 +3,11 @@ package be.seeseemelk.mockbukkit.inventory.meta;
 import com.destroystokyo.paper.inventory.meta.ArmorStandMeta;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of an {@link ArmorStandMeta}.
+ *
+ * @see ItemMetaMock
+ */
 public class ArmorStandMetaMock extends ItemMetaMock implements ArmorStandMeta
 {
 
@@ -12,11 +17,19 @@ public class ArmorStandMetaMock extends ItemMetaMock implements ArmorStandMeta
 	private boolean small;
 	private boolean marker;
 
+	/**
+	 * Constructs a new {@link ArmorStandMetaMock}.
+	 */
 	public ArmorStandMetaMock()
 	{
 		super();
 	}
 
+	/**
+	 * Constructs a new {@link ArmorStandMetaMock}, cloning the data from another.
+	 *
+	 * @param meta The meta to clone.
+	 */
 	public ArmorStandMetaMock(@NotNull ArmorStandMeta meta)
 	{
 		super(meta);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/AxolotlBucketMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/AxolotlBucketMetaMock.java
@@ -4,16 +4,29 @@ import org.bukkit.entity.Axolotl;
 import org.bukkit.inventory.meta.AxolotlBucketMeta;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of an {@link AxolotlBucketMeta}.
+ *
+ * @see ItemMetaMock
+ */
 public class AxolotlBucketMetaMock extends ItemMetaMock implements AxolotlBucketMeta
 {
 
 	private Axolotl.Variant variant;
 
+	/**
+	 * Constructs a new {@link AxolotlBucketMetaMock}.
+	 */
 	public AxolotlBucketMetaMock()
 	{
 		super();
 	}
 
+	/**
+	 * Constructs a new {@link AxolotlBucketMetaMock}, cloning the data from another.
+	 *
+	 * @param meta The meta to clone.
+	 */
 	public AxolotlBucketMetaMock(@NotNull AxolotlBucketMeta meta)
 	{
 		super(meta);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BannerMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BannerMetaMock.java
@@ -9,12 +9,20 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Mock implementation of an {@link BannerMeta}.
+ *
+ * @see ItemMetaMock
+ */
 public class BannerMetaMock extends ItemMetaMock implements BannerMeta
 {
 
 	private @Nullable DyeColor baseColor;
 	private List<Pattern> patterns;
 
+	/**
+	 * Constructs a new {@link BannerMetaMock}.
+	 */
 	public BannerMetaMock()
 	{
 		super();
@@ -22,6 +30,11 @@ public class BannerMetaMock extends ItemMetaMock implements BannerMeta
 		this.patterns = new ArrayList<>();
 	}
 
+	/**
+	 * Constructs a new {@link BannerMetaMock}, cloning the data from another.
+	 *
+	 * @param meta The meta to clone.
+	 */
 	public BannerMetaMock(@NotNull BannerMeta meta)
 	{
 		super(meta);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BookMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BookMetaMock.java
@@ -18,10 +18,10 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Created by SimplyBallistic on 26/10/2018
+ * Mock implementation of a {@link BookMeta}.
  *
- * @author SimplyBallistic
- **/
+ * @see ItemMetaMock
+ */
 public class BookMetaMock extends ItemMetaMock implements BookMeta
 {
 
@@ -29,11 +29,19 @@ public class BookMetaMock extends ItemMetaMock implements BookMeta
 	private @NotNull List<String> pages = new ArrayList<>();
 	private @Nullable String author;
 
+	/**
+	 * Constructs a new {@link BookMetaMock}.
+	 */
 	public BookMetaMock()
 	{
 		super();
 	}
 
+	/**
+	 * Constructs a new {@link BookMetaMock}, cloning the data from another.
+	 *
+	 * @param meta The meta to clone.
+	 */
 	public BookMetaMock(@NotNull BookMeta meta)
 	{
 		super(meta);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BundleMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BundleMetaMock.java
@@ -1,5 +1,6 @@
 package be.seeseemelk.mockbukkit.inventory.meta;
 
+import com.destroystokyo.paper.inventory.meta.ArmorStandMeta;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import org.bukkit.inventory.ItemStack;
@@ -10,11 +11,19 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Mock implementation of a {@link BundleMeta}.
+ *
+ * @see ItemMetaMock
+ */
 public class BundleMetaMock extends ItemMetaMock implements BundleMeta
 {
 
 	private List<ItemStack> items;
 
+	/**
+	 * Constructs a new {@link BundleMetaMock}.
+	 */
 	public BundleMetaMock()
 	{
 		super();
@@ -22,6 +31,11 @@ public class BundleMetaMock extends ItemMetaMock implements BundleMeta
 		this.items = new ArrayList<>();
 	}
 
+	/**
+	 * Constructs a new {@link BundleMetaMock}, cloning the data from another.
+	 *
+	 * @param meta The meta to clone.
+	 */
 	public BundleMetaMock(@NotNull BundleMeta meta)
 	{
 		super(meta);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/CompassMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/CompassMetaMock.java
@@ -2,23 +2,37 @@ package be.seeseemelk.mockbukkit.inventory.meta;
 
 import com.google.common.base.Preconditions;
 import org.bukkit.Location;
+import org.bukkit.inventory.meta.BundleMeta;
 import org.bukkit.inventory.meta.CompassMeta;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
+/**
+ * Mock implementation of a {@link CompassMeta}.
+ *
+ * @see ItemMetaMock
+ */
 public class CompassMetaMock extends ItemMetaMock implements CompassMeta
 {
 
 	private @Nullable Location lodestone;
 	private boolean tracked;
 
+	/**
+	 * Constructs a new {@link CompassMetaMock}.
+	 */
 	public CompassMetaMock()
 	{
 		super();
 	}
 
+	/**
+	 * Constructs a new {@link CompassMetaMock}, cloning the data from another.
+	 *
+	 * @param meta The meta to clone.
+	 */
 	public CompassMetaMock(@NotNull CompassMeta meta)
 	{
 		super(meta);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/CrossbowMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/CrossbowMetaMock.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.CompassMeta;
 import org.bukkit.inventory.meta.CrossbowMeta;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -12,11 +13,19 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * Mock implementation of a {@link CrossbowMeta}.
+ *
+ * @see ItemMetaMock
+ */
 public class CrossbowMetaMock extends ItemMetaMock implements CrossbowMeta
 {
 
 	private List<ItemStack> projectiles;
 
+	/**
+	 * Constructs a new {@link CrossbowMetaMock}.
+	 */
 	public CrossbowMetaMock()
 	{
 		super();
@@ -24,6 +33,11 @@ public class CrossbowMetaMock extends ItemMetaMock implements CrossbowMeta
 		this.projectiles = new ArrayList<>();
 	}
 
+	/**
+	 * Constructs a new {@link CrossbowMetaMock}, cloning the data from another.
+	 *
+	 * @param meta The meta to clone.
+	 */
 	public CrossbowMetaMock(@NotNull CrossbowMeta meta)
 	{
 		super(meta);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/EnchantedBookMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/EnchantedBookMetaMock.java
@@ -1,5 +1,6 @@
 package be.seeseemelk.mockbukkit.inventory.meta;
 
+import com.destroystokyo.paper.inventory.meta.ArmorStandMeta;
 import com.google.common.collect.ImmutableMap;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
@@ -9,21 +10,28 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * This {@link ItemMetaMock} mocks the implementation of {@link EnchantmentStorageMeta}.
- * It keeps an internal {@link HashMap} for all stored {@link Enchantment Enchantments}.
+ * Mock implementation of an {@link EnchantmentStorageMeta}.
  *
- * @author TheBusyBiscuit
+ * @see ItemMetaMock
  */
 public class EnchantedBookMetaMock extends ItemMetaMock implements EnchantmentStorageMeta
 {
 
 	private @NotNull Map<Enchantment, Integer> storedEnchantments = new HashMap<>();
 
+	/**
+	 * Constructs a new {@link EnchantedBookMetaMock}.
+	 */
 	public EnchantedBookMetaMock()
 	{
 		super();
 	}
 
+	/**
+	 * Constructs a new {@link EnchantedBookMetaMock}, cloning the data from another.
+	 *
+	 * @param meta The meta to clone.
+	 */
 	public EnchantedBookMetaMock(@NotNull EnchantmentStorageMeta meta)
 	{
 		super(meta);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/FireworkEffectMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/FireworkEffectMetaMock.java
@@ -1,22 +1,36 @@
 package be.seeseemelk.mockbukkit.inventory.meta;
 
 import org.bukkit.FireworkEffect;
+import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.bukkit.inventory.meta.FireworkEffectMeta;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
+/**
+ * Mock implementation of an {@link FireworkEffectMeta}.
+ *
+ * @see ItemMetaMock
+ */
 public class FireworkEffectMetaMock extends ItemMetaMock implements FireworkEffectMeta
 {
 
 	private @Nullable FireworkEffect effect;
 
+	/**
+	 * Constructs a new {@link FireworkEffectMetaMock}.
+	 */
 	public FireworkEffectMetaMock()
 	{
 		super();
 	}
 
+	/**
+	 * Constructs a new {@link FireworkEffectMetaMock}, cloning the data from another.
+	 *
+	 * @param meta The meta to clone.
+	 */
 	public FireworkEffectMetaMock(@NotNull FireworkEffectMeta meta)
 	{
 		super(meta);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/FireworkMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/FireworkMetaMock.java
@@ -3,23 +3,37 @@ package be.seeseemelk.mockbukkit.inventory.meta;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import org.bukkit.FireworkEffect;
+import org.bukkit.inventory.meta.FireworkEffectMeta;
 import org.bukkit.inventory.meta.FireworkMeta;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Mock implementation of an {@link FireworkMeta}.
+ *
+ * @see ItemMetaMock
+ */
 public class FireworkMetaMock extends ItemMetaMock implements FireworkMeta
 {
 
 	private @NotNull List<FireworkEffect> effects = new ArrayList<>();
 	private int power = 0;
 
+	/**
+	 * Constructs a new {@link FireworkMetaMock}.
+	 */
 	public FireworkMetaMock()
 	{
 		super();
 	}
 
+	/**
+	 * Constructs a new {@link FireworkMetaMock}, cloning the data from another.
+	 *
+	 * @param meta The meta to clone.
+	 */
 	public FireworkMetaMock(@NotNull FireworkMeta meta)
 	{
 		super(meta);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -43,6 +43,9 @@ import java.util.stream.Collectors;
 
 import static java.util.Objects.nonNull;
 
+/**
+ * Mock implementation of an {@link ItemMeta}, {@link Damageable}, and {@link Repairable}.
+ */
 public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 {
 
@@ -59,10 +62,18 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	private boolean unbreakable = false;
 	private @Nullable Integer customModelData = null;
 
+	/**
+	 * Constructs a new {@link ItemMetaMock}.
+	 */
 	public ItemMetaMock()
 	{
 	}
 
+	/**
+	 * Constructs a new {@link ItemMetaMock}, cloning the data from another.
+	 *
+	 * @param meta The meta to clone.
+	 */
 	public ItemMetaMock(@NotNull ItemMeta meta)
 	{
 		unbreakable = meta.isUnbreakable();
@@ -78,17 +89,17 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 		{
 			lore = meta.lore().stream().map(c -> GsonComponentSerializer.gson().serialize(c)).collect(Collectors.toList());
 		}
-		if (meta instanceof Damageable)
+		if (meta instanceof Damageable d)
 		{
-			this.damage = ((Damageable) meta).getDamage();
+			this.damage = d.getDamage();
 		}
-		if (meta instanceof Repairable)
+		if (meta instanceof Repairable r)
 		{
-			this.repairCost = ((Repairable) meta).getRepairCost();
+			this.repairCost = r.getRepairCost();
 		}
-		if (meta instanceof ItemMetaMock)
+		if (meta instanceof ItemMetaMock m)
 		{
-			this.persistentDataContainer = ((ItemMetaMock) meta).persistentDataContainer;
+			this.persistentDataContainer = m.persistentDataContainer;
 		}
 		if (meta.hasAttributeModifiers())
 		{

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/KnowledgeBookMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/KnowledgeBookMetaMock.java
@@ -1,5 +1,6 @@
 package be.seeseemelk.mockbukkit.inventory.meta;
 
+import com.destroystokyo.paper.inventory.meta.ArmorStandMeta;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.meta.KnowledgeBookMeta;
 import org.jetbrains.annotations.NotNull;
@@ -8,10 +9,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+
 /**
- * This {@link ItemMetaMock} mocks the implementation of {@link KnowledgeBookMeta}.
+ * Mock implementation of an {@link KnowledgeBookMeta}.
  *
- * @author TheBusyBiscuit
+ * @see ItemMetaMock
  */
 public class KnowledgeBookMetaMock extends ItemMetaMock implements KnowledgeBookMeta
 {
@@ -20,11 +22,19 @@ public class KnowledgeBookMetaMock extends ItemMetaMock implements KnowledgeBook
 
 	private final List<NamespacedKey> recipes = new ArrayList<>();
 
+	/**
+	 * Constructs a new {@link KnowledgeBookMetaMock}.
+	 */
 	public KnowledgeBookMetaMock()
 	{
 		super();
 	}
 
+	/**
+	 * Constructs a new {@link KnowledgeBookMetaMock}, cloning the data from another.
+	 *
+	 * @param meta The meta to clone.
+	 */
 	public KnowledgeBookMetaMock(@NotNull KnowledgeBookMeta meta)
 	{
 		super(meta);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/LeatherArmorMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/LeatherArmorMetaMock.java
@@ -1,5 +1,6 @@
 package be.seeseemelk.mockbukkit.inventory.meta;
 
+import com.destroystokyo.paper.inventory.meta.ArmorStandMeta;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
@@ -9,21 +10,29 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 
 /**
- * This {@link ItemMetaMock} mocks the implementation of {@link LeatherArmorMeta}.
+ * Mock implementation of an {@link LeatherArmorMeta}.
  *
- * @author TheBusyBiscuit
- **/
+ * @see ItemMetaMock
+ */
 public class LeatherArmorMetaMock extends ItemMetaMock implements LeatherArmorMeta
 {
 
 	private Color color;
 
+	/**
+	 * Constructs a new {@link LeatherArmorMetaMock}.
+	 */
 	public LeatherArmorMetaMock()
 	{
 		super();
 		this.color = Bukkit.getItemFactory().getDefaultLeatherColor();
 	}
 
+	/**
+	 * Constructs a new {@link LeatherArmorMetaMock}, cloning the data from another.
+	 *
+	 * @param meta The meta to clone.
+	 */
 	public LeatherArmorMetaMock(@NotNull LeatherArmorMeta meta)
 	{
 		super(meta);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/MapMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/MapMetaMock.java
@@ -1,6 +1,7 @@
 package be.seeseemelk.mockbukkit.inventory.meta;
 
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import com.destroystokyo.paper.inventory.meta.ArmorStandMeta;
 import org.bukkit.Color;
 import org.bukkit.inventory.meta.MapMeta;
 import org.bukkit.map.MapView;
@@ -9,6 +10,11 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
+/**
+ * Mock implementation of an {@link MapMeta}.
+ *
+ * @see ItemMetaMock
+ */
 public class MapMetaMock extends ItemMetaMock implements MapMeta
 {
 
@@ -21,11 +27,19 @@ public class MapMetaMock extends ItemMetaMock implements MapMeta
 	private @Nullable Color color;
 	private byte scaling = SCALING_EMPTY;
 
+	/**
+	 * Constructs a new {@link MapMetaMock}.
+	 */
 	public MapMetaMock()
 	{
 		super();
 	}
 
+	/**
+	 * Constructs a new {@link MapMetaMock}, cloning the data from another.
+	 *
+	 * @param meta The meta to clone.
+	 */
 	public MapMetaMock(@NotNull MapMeta meta)
 	{
 		super(meta);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/PotionMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/PotionMetaMock.java
@@ -1,6 +1,7 @@
 package be.seeseemelk.mockbukkit.inventory.meta;
 
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import com.destroystokyo.paper.inventory.meta.ArmorStandMeta;
 import com.google.common.collect.ImmutableList;
 import org.bukkit.Color;
 import org.bukkit.inventory.meta.PotionMeta;
@@ -18,9 +19,9 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * This {@link ItemMetaMock} mocks the implementation of {@link SuspiciousStewMeta}.
+ * Mock implementation of a {@link PotionMeta}.
  *
- * @author TheBusyBiscuit
+ * @see ItemMetaMock
  */
 public class PotionMetaMock extends ItemMetaMock implements PotionMeta
 {
@@ -29,11 +30,19 @@ public class PotionMetaMock extends ItemMetaMock implements PotionMeta
 	private @NotNull PotionData basePotionData = new PotionData(PotionType.UNCRAFTABLE);
 	private @Nullable Color color;
 
+	/**
+	 * Constructs a new {@link PotionMetaMock}.
+	 */
 	public PotionMetaMock()
 	{
 		super();
 	}
 
+	/**
+	 * Constructs a new {@link PotionMetaMock}, cloning the data from another.
+	 *
+	 * @param meta The meta to clone.
+	 */
 	public PotionMetaMock(@NotNull PotionMeta meta)
 	{
 		super(meta);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SkullMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SkullMetaMock.java
@@ -4,7 +4,6 @@ import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.entity.OfflinePlayerMock;
 import com.google.common.base.Strings;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.entity.Player;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.profile.PlayerProfile;
 import org.jetbrains.annotations.NotNull;
@@ -13,22 +12,28 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 
 /**
- * An {@link ItemMetaMock} for the {@link SkullMeta} interface. The owning {@link Player} is stored via his name.
- * <p>
- * Created by SimplyBallistic on 27/10/2018
+ * Mock implementation of a {@link SkullMeta}.
  *
- * @author SimplyBallistic
- **/
+ * @see ItemMetaMock
+ */
 public class SkullMetaMock extends ItemMetaMock implements SkullMeta
 {
 
 	private @Nullable String owner;
 
+	/**
+	 * Constructs a new {@link SkullMetaMock}.
+	 */
 	public SkullMetaMock()
 	{
 		super();
 	}
 
+	/**
+	 * Constructs a new {@link SkullMetaMock}, cloning the data from another.
+	 *
+	 * @param meta The meta to clone.
+	 */
 	public SkullMetaMock(@NotNull SkullMeta meta)
 	{
 		super(meta);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SpawnEggMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SpawnEggMetaMock.java
@@ -4,14 +4,27 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.meta.SpawnEggMeta;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of an {@link SpawnEggMeta}.
+ *
+ * @see ItemMetaMock
+ */
 public class SpawnEggMetaMock extends ItemMetaMock implements SpawnEggMeta
 {
 
+	/**
+	 * Constructs a new {@link SpawnEggMetaMock}.
+	 */
 	public SpawnEggMetaMock()
 	{
 		super();
 	}
 
+	/**
+	 * Constructs a new {@link SpawnEggMetaMock}, cloning the data from another.
+	 *
+	 * @param meta The meta to clone.
+	 */
 	public SpawnEggMetaMock(@NotNull SpawnEggMeta meta)
 	{
 		super(meta);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SuspiciousStewMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SuspiciousStewMetaMock.java
@@ -11,20 +11,28 @@ import java.util.Iterator;
 import java.util.List;
 
 /**
- * This {@link ItemMetaMock} mocks the implementation of {@link SuspiciousStewMeta}.
+ * Mock implementation of a {@link SuspiciousStewMeta}.
  *
- * @author TheBusyBiscuit
+ * @see ItemMetaMock
  */
 public class SuspiciousStewMetaMock extends ItemMetaMock implements SuspiciousStewMeta
 {
 
 	private @NotNull List<PotionEffect> effects = new ArrayList<>();
 
+	/**
+	 * Constructs a new {@link ArmorStandMetaMock}.
+	 */
 	public SuspiciousStewMetaMock()
 	{
 		super();
 	}
 
+	/**
+	 * Constructs a new {@link ArmorStandMetaMock}, cloning the data from another.
+	 *
+	 * @param meta The meta to clone.
+	 */
 	public SuspiciousStewMetaMock(@NotNull SuspiciousStewMeta meta)
 	{
 		super(meta);

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/TropicalFishBucketMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/TropicalFishBucketMetaMock.java
@@ -1,11 +1,17 @@
 package be.seeseemelk.mockbukkit.inventory.meta;
 
+import com.destroystokyo.paper.inventory.meta.ArmorStandMeta;
 import org.apache.commons.lang3.Validate;
 import org.bukkit.DyeColor;
 import org.bukkit.entity.TropicalFish;
 import org.bukkit.inventory.meta.TropicalFishBucketMeta;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of an {@link TropicalFishBucketMeta}.
+ *
+ * @see ItemMetaMock
+ */
 public class TropicalFishBucketMetaMock extends ItemMetaMock implements TropicalFishBucketMeta
 {
 
@@ -13,11 +19,19 @@ public class TropicalFishBucketMetaMock extends ItemMetaMock implements Tropical
 	private DyeColor bodyColor;
 	private TropicalFish.Pattern pattern;
 
+	/**
+	 * Constructs a new {@link TropicalFishBucketMetaMock}.
+	 */
 	public TropicalFishBucketMetaMock()
 	{
 		super();
 	}
 
+	/**
+	 * Constructs a new {@link TropicalFishBucketMetaMock}, cloning the data from another.
+	 *
+	 * @param meta The meta to clone.
+	 */
 	public TropicalFishBucketMetaMock(@NotNull TropicalFishBucketMeta meta)
 	{
 		super(meta);

--- a/src/main/java/be/seeseemelk/mockbukkit/map/MapCanvasMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/map/MapCanvasMock.java
@@ -13,6 +13,9 @@ import java.awt.Image;
 import java.util.Arrays;
 import java.util.function.BiConsumer;
 
+/**
+ * Mock implementation of a {@link MapCanvas}.
+ */
 public class MapCanvasMock implements MapCanvas
 {
 
@@ -23,6 +26,11 @@ public class MapCanvasMock implements MapCanvas
 	private byte[][] base;
 	private @NotNull MapCursorCollection cursors = new MapCursorCollection();
 
+	/**
+	 * Constructs a new {@link MapCanvasMock} for the provided {@link MapViewMock}.
+	 *
+	 * @param mapView The map view this canvas is for.
+	 */
 	protected MapCanvasMock(MapViewMock mapView)
 	{
 		this.mapView = mapView;
@@ -83,7 +91,14 @@ public class MapCanvasMock implements MapCanvas
 		return base[x][y];
 	}
 
-	protected void setBase(byte[][] base)
+	/**
+	 * Sets the base for use in {@link #getBasePixel(int, int)} and {@link #getBasePixelColor(int, int)}.
+	 *
+	 * @param base The base to set.
+	 * @see #getBasePixel(int, int)
+	 * @see #getBasePixelColor(int, int)
+	 */
+	public void setBase(byte[][] base)
 	{
 		this.base = base;
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/map/MapRendererMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/map/MapRendererMock.java
@@ -7,6 +7,9 @@ import org.bukkit.map.MapRenderer;
 import org.bukkit.map.MapView;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of a {@link MapRenderer}.
+ */
 public class MapRendererMock extends MapRenderer
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/map/MapViewMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/map/MapViewMock.java
@@ -1,10 +1,12 @@
 package be.seeseemelk.mockbukkit.map;
 
+import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import org.bukkit.World;
 import org.bukkit.map.MapRenderer;
 import org.bukkit.map.MapView;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,6 +15,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Mock implementation of a {@link MapView}.
+ */
 public class MapViewMock implements MapView
 {
 
@@ -23,6 +28,15 @@ public class MapViewMock implements MapView
 	private Scale scale;
 	private boolean locked;
 
+	/**
+	 * Constructs a new {@link MapViewMock} for the given world with the specified ID.
+	 * This is for internal use only, please use {@link ServerMock#createMap(World)} for creating maps.
+	 *
+	 * @param world The world this map is for.
+	 * @param id    The ID of the mop.
+	 * @see ServerMock#createMap(World)
+	 */
+	@ApiStatus.Internal
 	public MapViewMock(World world, int id)
 	{
 		this.world = world;
@@ -41,7 +55,7 @@ public class MapViewMock implements MapView
 	@Override
 	public boolean isVirtual()
 	{
-		return this.renderers.size() > 0 && !(this.renderers.get(0) instanceof MapRendererMock);
+		return !this.renderers.isEmpty() && !(this.renderers.get(0) instanceof MapRendererMock);
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/metadata/MetadataTable.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/metadata/MetadataTable.java
@@ -29,6 +29,8 @@ public class MetadataTable implements Metadatable
 
 	/**
 	 * Constructs a new empty {@link MetadataTable} with the contents cloned from another.
+	 *
+	 * @param table The table to clone.
 	 */
 	@ApiStatus.Internal
 	public MetadataTable(@NotNull MetadataTable table)

--- a/src/main/java/be/seeseemelk/mockbukkit/metadata/MetadataTable.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/metadata/MetadataTable.java
@@ -3,22 +3,34 @@ package be.seeseemelk.mockbukkit.metadata;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.metadata.Metadatable;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Mock implementation of a {@link Metadatable}.
+ */
 public class MetadataTable implements Metadatable
 {
 
 	private final @NotNull Map<String, Map<Plugin, MetadataValue>> metadata;
 
+	/**
+	 * Constructs a new empty {@link MetadataTable}.
+	 */
+	@ApiStatus.Internal
 	public MetadataTable()
 	{
 		metadata = new HashMap<>();
 	}
 
+	/**
+	 * Constructs a new empty {@link MetadataTable} with the contents cloned from another.
+	 */
+	@ApiStatus.Internal
 	public MetadataTable(@NotNull MetadataTable table)
 	{
 		this.metadata = new HashMap<>(table.metadata);

--- a/src/main/java/be/seeseemelk/mockbukkit/persistence/PersistentDataContainerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/persistence/PersistentDataContainerMock.java
@@ -142,6 +142,12 @@ public class PersistentDataContainerMock implements PersistentDataContainer
 		return Collections.unmodifiableSet(map.keySet());
 	}
 
+	/**
+	 * Serializes the held data.
+	 *
+	 * @return The serialized data.
+	 * @see #deserialize(Map)
+	 */
 	public @NotNull Map<String, Object> serialize()
 	{
 		return map.entrySet().stream().collect(Collectors.toMap(e -> e.getKey().toString(), Map.Entry::getValue));

--- a/src/main/java/be/seeseemelk/mockbukkit/persistence/PersistentDataContainerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/persistence/PersistentDataContainerMock.java
@@ -16,7 +16,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * This is a Mock of the {@link PersistentDataContainer} interface to allow the "persistent" storage of data. Only that
+ * This is a mock of the {@link PersistentDataContainer} interface to allow the "persistent" storage of data. Only that
  * it isn't persistent of course since it only ever exists in a test environment.
  *
  * @author TheBusyBiscuit
@@ -27,11 +27,19 @@ public class PersistentDataContainerMock implements PersistentDataContainer
 	private final PersistentDataAdapterContext context = new PersistentDataAdapterContextMock();
 	private final @NotNull Map<NamespacedKey, Object> map;
 
+	/**
+	 * Constructs a new {@link PersistentDataContainerMock} with no stored data.
+	 */
 	public PersistentDataContainerMock()
 	{
 		this.map = new HashMap<>();
 	}
 
+	/**
+	 * Constructs a new {@link PersistentDataContainerMock}, cloning the data of another.
+	 *
+	 * @param mock The {@link PersistentDataContainerMock} to clone.
+	 */
 	public PersistentDataContainerMock(@NotNull PersistentDataContainerMock mock)
 	{
 		this.map = new HashMap<>(mock.map);
@@ -139,6 +147,12 @@ public class PersistentDataContainerMock implements PersistentDataContainer
 		return map.entrySet().stream().collect(Collectors.toMap(e -> e.getKey().toString(), Map.Entry::getValue));
 	}
 
+	/**
+	 * Deserializes a {@link PersistentDataContainerMock} from a map.
+	 *
+	 * @param args The map to deserialize.
+	 * @return The deserialized {@link PersistentDataContainerMock}.
+	 */
 	public static @NotNull PersistentDataContainerMock deserialize(@NotNull Map<String, Object> args)
 	{
 		PersistentDataContainerMock mock = new PersistentDataContainerMock();

--- a/src/main/java/be/seeseemelk/mockbukkit/persistence/PersistentDataHolderMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/persistence/PersistentDataHolderMock.java
@@ -15,6 +15,9 @@ public class PersistentDataHolderMock implements PersistentDataHolder
 
 	private final @NotNull PersistentDataContainer container;
 
+	/**
+	 * Constructs a new {@link PersistentDataHolderMock}.
+	 */
 	public PersistentDataHolderMock()
 	{
 		this.container = new PersistentDataContainerMock();

--- a/src/main/java/be/seeseemelk/mockbukkit/plugin/ListenerEntry.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/plugin/ListenerEntry.java
@@ -50,6 +50,9 @@ public class ListenerEntry
 		return listener;
 	}
 
+	/**
+	 * @return The method this listener is attached to.
+	 */
 	public @NotNull Method getMethod()
 	{
 		return method;

--- a/src/main/java/be/seeseemelk/mockbukkit/plugin/ListenerEntry.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/plugin/ListenerEntry.java
@@ -34,11 +34,17 @@ public class ListenerEntry
 		method.setAccessible(true);
 	}
 
+	/**
+	 * @return The plugin that owns the listener.
+	 */
 	public Plugin getPlugin()
 	{
 		return plugin;
 	}
 
+	/**
+	 * @return The listener.
+	 */
 	public Listener getListener()
 	{
 		return listener;

--- a/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
@@ -32,6 +32,7 @@ import org.bukkit.plugin.UnknownDependencyException;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.java.JavaPluginLoader;
 import org.bukkit.plugin.java.JavaPluginUtils;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -66,6 +67,9 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+/**
+ * Mock implementation of a {@link PluginManager}.
+ */
 public class PluginManagerMock implements PluginManager
 {
 
@@ -83,6 +87,12 @@ public class PluginManagerMock implements PluginManager
 	private final List<Class<?>> pluginConstructorTypes = Arrays.asList(JavaPluginLoader.class,
 			PluginDescriptionFile.class, File.class, File.class);
 
+	/**
+	 * Constructs a new {@link PluginManagerMock} for the provided {@link ServerMock}.
+	 *
+	 * @param server The server this is for.
+	 */
+	@ApiStatus.Internal
 	@SuppressWarnings("deprecation")
 	public PluginManagerMock(@NotNull ServerMock server)
 	{
@@ -299,6 +309,12 @@ public class PluginManagerMock implements PluginManager
 				"No compatible constructor for " + class1.getName() + " with parameters " + str);
 	}
 
+	/**
+	 * Creates a new unique temporary directory.
+	 *
+	 * @return The directory.
+	 * @throws IOException If an IO error occurs.
+	 */
 	public @NotNull File getParentTemporaryDirectory() throws IOException
 	{
 		if (parentTemporaryDirectory == null)
@@ -705,6 +721,11 @@ public class PluginManagerMock implements PluginManager
 		}
 	}
 
+	/**
+	 * Unregisters all listeners for a plugin.
+	 *
+	 * @param plugin The plugin.
+	 */
 	public void unregisterPluginEvents(@NotNull Plugin plugin)
 	{
 		List<Listener> listListener = listeners.get(plugin.getName());

--- a/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
@@ -497,6 +497,7 @@ public class PluginManagerMock implements PluginManager
 	 *
 	 * @param event The asynchronous {@link Event} to call.
 	 * @param func  A function to invoke after the event has been called.
+	 * @param <T>   The event type.
 	 */
 	public <T extends Event> void callEventAsynchronously(@NotNull T event, Consumer<T> func)
 	{

--- a/src/main/java/be/seeseemelk/mockbukkit/potion/ActivePotionEffect.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/potion/ActivePotionEffect.java
@@ -19,6 +19,11 @@ public final class ActivePotionEffect
 	private final @NotNull PotionEffect effect;
 	private final long timestamp;
 
+	/**
+	 * Constructs a new {@link ActivePotionEffect} with the provided {@link PotionEffect}.
+	 *
+	 * @param effect The effect that's been applied.
+	 */
 	public ActivePotionEffect(@NotNull PotionEffect effect)
 	{
 		this.effect = effect;

--- a/src/main/java/be/seeseemelk/mockbukkit/potion/MockPotionEffectType.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/potion/MockPotionEffectType.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 /**
  * This {@link MockPotionEffectType} mocks an actual {@link PotionEffectType} by taking an id, a name, whether it is
- * instant and a RGB {@link Color} variable.
+ * instant and an RGB {@link Color} variable.
  *
  * @author TheBusyBiscuit
  */
@@ -28,6 +28,15 @@ public class MockPotionEffectType extends PotionEffectType
 	private final Color color;
 	private final @NotNull Map<Attribute, AttributeModifier> attributeModifiers;
 
+	/**
+	 * Constructs a new {@link MockPotionEffectType} with the provided parameters.
+	 *
+	 * @param key     The key of the effect type.
+	 * @param id      The numerical ID of the effect type.
+	 * @param name    The name of the effect type.
+	 * @param instant Whether the effect type is instantly applied.
+	 * @param color   The color of the effect type.
+	 */
 	public MockPotionEffectType(@NotNull NamespacedKey key, int id, String name, boolean instant, Color color)
 	{
 		super(id, key);

--- a/src/main/java/be/seeseemelk/mockbukkit/profile/PlayerProfileMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/profile/PlayerProfileMock.java
@@ -6,6 +6,7 @@ import com.destroystokyo.paper.profile.ProfileProperty;
 import com.google.common.base.Preconditions;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.profile.PlayerTextures;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -20,6 +21,9 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Mock implementation of a {@link PlayerProfile}.
+ */
 public class PlayerProfileMock implements PlayerProfile
 {
 
@@ -27,11 +31,24 @@ public class PlayerProfileMock implements PlayerProfile
 	private @Nullable UUID uuid;
 	private final @NotNull Set<ProfileProperty> properties;
 
+	/**
+	 * Constructs a new {@link PlayerProfileMock} for an {@link OfflinePlayer}.
+	 *
+	 * @param player The player.
+	 */
+	@ApiStatus.Internal
 	public PlayerProfileMock(@NotNull OfflinePlayer player)
 	{
 		this(player.getName(), player.getUniqueId());
 	}
 
+	/**
+	 * Constructs a new {@link PlayerProfileMock} with a name and {@link UUID}.
+	 *
+	 * @param name The name of the player.
+	 * @param uuid The UUID of the player.
+	 */
+	@ApiStatus.Internal
 	public PlayerProfileMock(@Nullable String name, @Nullable UUID uuid)
 	{
 		this.name = name;
@@ -39,10 +56,16 @@ public class PlayerProfileMock implements PlayerProfile
 		this.properties = new HashSet<>();
 	}
 
+	/**
+	 * Constructs a new {@link PlayerProfileMock}, cloning the data from another.
+	 *
+	 * @param profile The profile to clone.
+	 */
+	@ApiStatus.Internal
 	public PlayerProfileMock(@NotNull PlayerProfileMock profile)
 	{
 		this.name = profile.getName();
-		this.uuid = profile.getUniqueId();
+		this.uuid = profile.getId();
 		this.properties = new HashSet<>(profile.getProperties());
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/scheduler/AsyncTaskException.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scheduler/AsyncTaskException.java
@@ -1,13 +1,24 @@
 package be.seeseemelk.mockbukkit.scheduler;
 
+import java.io.Serial;
+
+/**
+ * Thrown when an asynchronous task throws an exception.
+ */
 public class AsyncTaskException extends RuntimeException
 {
 
+	@Serial
 	private static final long serialVersionUID = -4501059063243851677L;
 
-	public AsyncTaskException(Exception e)
+	/**
+	 * Constructs a new {@link AsyncTaskException} with the specified cause and a detail message of (cause==null ? null : cause.toString())
+	 *
+	 * @param cause The exception thrown in the asynchronous task.
+	 */
+	public AsyncTaskException(Exception cause)
 	{
-		super(e);
+		super(cause);
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -31,6 +31,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 
+/**
+ * Mock implementation of a {@link BukkitScheduler}.
+ */
 public class BukkitSchedulerMock implements BukkitScheduler
 {
 
@@ -105,11 +108,25 @@ public class BukkitSchedulerMock implements BukkitScheduler
 		}
 	}
 
+	/**
+	 * Executes an asynchronous event.
+	 *
+	 * @param event The event to execute.
+	 * @return A future representing the task.
+	 */
 	public @NotNull Future<?> executeAsyncEvent(@NotNull Event event)
 	{
 		return executeAsyncEvent(event, null);
 	}
 
+	/**
+	 * Executes an asynchronous event.
+	 *
+	 * @param event The event to execute.
+	 * @param func  A consumer to call after the event is invoked.
+	 * @param <T>   The event type.
+	 * @return A future representing the task.
+	 */
 	public <T extends Event> @NotNull Future<?> executeAsyncEvent(@NotNull T event, @Nullable Consumer<T> func)
 	{
 		MockBukkit.ensureMocking();
@@ -254,6 +271,9 @@ public class BukkitSchedulerMock implements BukkitScheduler
 		}
 	}
 
+	/**
+	 * Blocks until all asynchronous event invocations are finished.
+	 */
 	public void waitAsyncEventsFinished()
 	{
 		for (Future<?> futureEvent : List.copyOf(queuedAsyncEvents))
@@ -552,6 +572,11 @@ public class BukkitSchedulerMock implements BukkitScheduler
 		};
 	}
 
+	/**
+	 * Gets the amount of thread currently executing asynchronous tasks.
+	 *
+	 * @return The amount of active task threads.
+	 */
 	protected int getActiveRunningCount()
 	{
 		return pool.getActiveCount();

--- a/src/main/java/be/seeseemelk/mockbukkit/scheduler/RepeatingTask.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scheduler/RepeatingTask.java
@@ -6,17 +6,40 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Consumer;
 
+/**
+ * A {@link ScheduledTask} that can be repeated.
+ */
 public class RepeatingTask extends ScheduledTask
 {
 
 	private final long period;
 
+	/**
+	 * Constructs a new {@link RepeatingTask} with the provided parameters.
+	 *
+	 * @param id            The task ID.
+	 * @param plugin        The plugin owning the task.
+	 * @param isSync        Whether the task is synchronous.
+	 * @param scheduledTick The tick the task is scheduled to run at.
+	 * @param period        How often the task should run.
+	 * @param runnable      The runnable to run.
+	 */
 	public RepeatingTask(int id, Plugin plugin, boolean isSync, long scheduledTick, long period, @NotNull Runnable runnable)
 	{
 		super(id, plugin, isSync, scheduledTick, runnable);
 		this.period = period;
 	}
 
+	/**
+	 * Constructs a new {@link RepeatingTask} with the provided parameters.
+	 *
+	 * @param id            The task ID.
+	 * @param plugin        The plugin owning the task.
+	 * @param isSync        Whether the task is synchronous.
+	 * @param scheduledTick The tick the task is scheduled to run at.
+	 * @param period        How often the task should run.
+	 * @param consumer      The consumer to run.
+	 */
 	public RepeatingTask(int id, Plugin plugin, boolean isSync, long scheduledTick, long period, @NotNull Consumer<BukkitTask> consumer)
 	{
 		super(id, plugin, isSync, scheduledTick, consumer);

--- a/src/main/java/be/seeseemelk/mockbukkit/scheduler/ScheduledTask.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scheduler/ScheduledTask.java
@@ -3,6 +3,7 @@ package be.seeseemelk.mockbukkit.scheduler;
 import com.google.common.base.Preconditions;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitTask;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -11,6 +12,9 @@ import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.function.Consumer;
 
+/**
+ * Mock implementation of a {@link BukkitTask}.
+ */
 public class ScheduledTask implements BukkitTask
 {
 
@@ -24,18 +28,46 @@ public class ScheduledTask implements BukkitTask
 	private final @Nullable Consumer<BukkitTask> consumer;
 	private final List<Runnable> cancelListeners = new LinkedList<>();
 
+	/**
+	 * Constructs a new {@link ScheduledTask} with the provided parameters.
+	 *
+	 * @param id            The task ID.
+	 * @param plugin        The plugin owning the task.
+	 * @param isSync        Whether the task is synchronous.
+	 * @param scheduledTick The tick the task is scheduled to run at.
+	 * @param runnable      The runnable to run.
+	 */
 	public ScheduledTask(int id, Plugin plugin, boolean isSync, long scheduledTick, @NotNull Runnable runnable)
 	{
 		this(id, plugin, isSync, scheduledTick, runnable, null);
 		Preconditions.checkNotNull(runnable, "Runnable cannot be null");
 	}
 
+	/**
+	 * Constructs a new {@link ScheduledTask} with the provided parameters.
+	 *
+	 * @param id            The task ID.
+	 * @param plugin        The plugin owning the task.
+	 * @param isSync        Whether the task is synchronous.
+	 * @param scheduledTick The tick the task is scheduled to run at.
+	 * @param consumer      The consumer to run.
+	 */
 	public ScheduledTask(int id, Plugin plugin, boolean isSync, long scheduledTick, @NotNull Consumer<BukkitTask> consumer)
 	{
 		this(id, plugin, isSync, scheduledTick, null, consumer);
 		Preconditions.checkNotNull(consumer, "Consumer cannot be null");
 	}
 
+	/**
+	 * Constructs a new {@link ScheduledTask} with the provided parameters.
+	 *
+	 * @param id            The task ID.
+	 * @param plugin        The plugin owning the task.
+	 * @param isSync        Whether the task is synchronous.
+	 * @param scheduledTick The tick the task is scheduled to run at.
+	 * @param runnable      The runnable to run.
+	 * @param consumer      The consumer to run.
+	 */
 	private ScheduledTask(int id, Plugin plugin, boolean isSync, long scheduledTick, @Nullable Runnable runnable, @Nullable Consumer<BukkitTask> consumer)
 	{
 		this.id = id;
@@ -48,11 +80,21 @@ public class ScheduledTask implements BukkitTask
 	}
 
 
+	/**
+	 * @return Whether the task is running.
+	 */
 	public boolean isRunning()
 	{
 		return this.running;
 	}
 
+	/**
+	 * Sets whether the task is running.
+	 * Should not be used outside of {@link BukkitSchedulerMock}.
+	 *
+	 * @param running Whether the task is running.
+	 */
+	@ApiStatus.Internal
 	public void setRunning(boolean running)
 	{
 		this.running = running;

--- a/src/main/java/be/seeseemelk/mockbukkit/scoreboard/CriteriaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scoreboard/CriteriaMock.java
@@ -5,6 +5,9 @@ import org.bukkit.scoreboard.Criteria;
 import org.bukkit.scoreboard.RenderType;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of a {@link Criteria}.
+ */
 public class CriteriaMock implements Criteria
 {
 
@@ -12,6 +15,11 @@ public class CriteriaMock implements Criteria
 	private final boolean readOnly;
 	private final RenderType defaultRenderType;
 
+	/**
+	 * Constructs a new {@link CriteriaMock} with the provided name.
+	 *
+	 * @param name The name of the criteria.
+	 */
 	public CriteriaMock(@NotNull String name)
 	{
 		Preconditions.checkNotNull(name, "Name cannot be null");

--- a/src/main/java/be/seeseemelk/mockbukkit/scoreboard/ObjectiveMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scoreboard/ObjectiveMock.java
@@ -17,6 +17,9 @@ import org.jetbrains.annotations.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Mock implementation of an {@link Objective}.
+ */
 public class ObjectiveMock implements Objective
 {
 
@@ -28,6 +31,15 @@ public class ObjectiveMock implements Objective
 	private @Nullable DisplaySlot displaySlot;
 	private RenderType renderType;
 
+	/**
+	 * Constructs a new {@link ObjectiveMock} with the provided parameters.
+	 *
+	 * @param scoreboard  The scoreboard this objective is part of.
+	 * @param name        The name of the objective.
+	 * @param displayName The display name of the objective.
+	 * @param criteria    The criteria of the objective.
+	 * @param renderType  The render type of the objective.
+	 */
 	public ObjectiveMock(@NotNull ScoreboardMock scoreboard, @NotNull String name, @Nullable Component displayName,
 						 @NotNull Criteria criteria, @NotNull RenderType renderType)
 	{

--- a/src/main/java/be/seeseemelk/mockbukkit/scoreboard/ScoreMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scoreboard/ScoreMock.java
@@ -6,6 +6,9 @@ import org.bukkit.scoreboard.Scoreboard;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Mock implementation of a {@link Score}.
+ */
 public class ScoreMock implements Score
 {
 
@@ -15,6 +18,12 @@ public class ScoreMock implements Score
 	private int score = 0;
 	private boolean set = false;
 
+	/**
+	 * Constructs a new {@link ScoreMock} for the provided objective with the specified entry.
+	 *
+	 * @param objective The objective.
+	 * @param entry     The entry.
+	 */
 	public ScoreMock(ObjectiveMock objective, String entry)
 	{
 		this.objective = objective;

--- a/src/main/java/be/seeseemelk/mockbukkit/scoreboard/ScoreboardManagerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scoreboard/ScoreboardManagerMock.java
@@ -4,6 +4,9 @@ import be.seeseemelk.mockbukkit.AsyncCatcher;
 import org.bukkit.scoreboard.ScoreboardManager;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Mock implementation of a {@link ScoreboardManager}.
+ */
 public class ScoreboardManagerMock implements ScoreboardManager
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/scoreboard/ScoreboardMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scoreboard/ScoreboardMock.java
@@ -24,6 +24,9 @@ import java.util.stream.Collectors;
 
 import static net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection;
 
+/**
+ * Mock implementation of a {@link Scoreboard}.
+ */
 public class ScoreboardMock implements Scoreboard
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/scoreboard/TeamMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scoreboard/TeamMock.java
@@ -23,6 +23,9 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Level;
 
+/**
+ * Mock implementation of a {@link Team}.
+ */
 public class TeamMock implements Team
 {
 
@@ -37,6 +40,12 @@ public class TeamMock implements Team
 	private final EnumMap<Option, OptionStatus> options = new EnumMap<>(Option.class);
 	private @Nullable ScoreboardMock board;
 
+	/**
+	 * Constructs a new {@link TeamMock} for the provided {@link ScoreboardMock} with the specified name.
+	 *
+	 * @param name  The name of the team.
+	 * @param board The scoreboard the team is for.
+	 */
 	public TeamMock(@NotNull String name, ScoreboardMock board)
 	{
 		this.name = name;

--- a/src/main/java/be/seeseemelk/mockbukkit/services/ServicesManagerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/services/ServicesManagerMock.java
@@ -2,7 +2,11 @@ package be.seeseemelk.mockbukkit.services;
 
 import org.bukkit.plugin.SimpleServicesManager;
 
-//We can use the default Service Manager (SimpleServicesManager) from Bukkit
+/**
+ * The default service manager.
+ *
+ * @see SimpleServicesManager
+ */
 public class ServicesManagerMock extends SimpleServicesManager
 {
 

--- a/src/main/java/be/seeseemelk/mockbukkit/sound/AudioExperience.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/sound/AudioExperience.java
@@ -5,6 +5,7 @@ import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.SoundCategory;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -21,6 +22,16 @@ public final class AudioExperience
 	private final float volume;
 	private final float pitch;
 
+	/**
+	 * Constructs a new {@link AudioExperience} with the provided parameters.
+	 *
+	 * @param sound    The sound name that was heard.
+	 * @param category The category of the sound.
+	 * @param loc      The location the sound was played at.
+	 * @param volume   The volume of the sound.
+	 * @param pitch    The pitch of the sound.
+	 */
+	@ApiStatus.Internal
 	public AudioExperience(@NotNull String sound, @NotNull SoundCategory category, @NotNull Location loc, float volume,
 						   float pitch)
 	{
@@ -35,12 +46,29 @@ public final class AudioExperience
 		this.pitch = pitch;
 	}
 
+	/**
+	 * Constructs a new {@link AudioExperience} with the provided parameters.
+	 *
+	 * @param sound    The sound name that was heard.
+	 * @param category The category of the sound.
+	 * @param loc      The location the sound was played at.
+	 * @param volume   The volume of the sound.
+	 * @param pitch    The pitch of the sound.
+	 */
+	@ApiStatus.Internal
 	public AudioExperience(@NotNull Sound sound, @NotNull SoundCategory category, @NotNull Location loc, float volume,
 						   float pitch)
 	{
 		this(sound.getKey().getKey(), category, loc, volume, pitch);
 	}
 
+	/**
+	 * Constructs a new {@link AudioExperience} with the provided sound and location.
+	 *
+	 * @param sound The sound name that was heard.
+	 * @param loc   The location the sound was played at.
+	 */
+	@ApiStatus.Internal
 	public AudioExperience(net.kyori.adventure.sound.@NotNull Sound sound, @NotNull Location loc)
 	{
 		this(sound.name().asString(), switch (sound.source())

--- a/src/main/java/be/seeseemelk/mockbukkit/sound/SoundReceiver.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/sound/SoundReceiver.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * This interface provides methods to assert sounds that were heard. This is implemented by {@link PlayerMock}, however
- * the sheer amount of assertion methods did warrant a seperate a file at some point.
+ * the sheer amount of assertion methods did warrant a separate a file at some point.
  *
  * @author TheBusyBiscuit
  * @see PlayerMock
@@ -29,12 +29,20 @@ public interface SoundReceiver
 	@NotNull
 	List<AudioExperience> getHeardSounds();
 
+	/**
+	 * Adds a heard sound.
+	 *
+	 * @param audioExperience An {@link AudioExperience} representing the heard sound.
+	 */
 	default void addHeardSound(@NotNull AudioExperience audioExperience)
 	{
 		Preconditions.checkNotNull(audioExperience, "An audio experience must not be null.");
 		getHeardSounds().add(audioExperience);
 	}
 
+	/**
+	 * Clears all heard sounds.
+	 */
 	default void clearSounds()
 	{
 		getHeardSounds().clear();
@@ -74,42 +82,92 @@ public interface SoundReceiver
 		assertSoundHeard("Sound Heard Assertion failed", sound);
 	}
 
+	/**
+	 * Asserts that a sound was heard.
+	 *
+	 * @param sound     The sound that should've been heard.
+	 * @param predicate A predicate to test the {@link AudioExperience} against.
+	 */
 	default void assertSoundHeard(@NotNull Sound sound, @NotNull Predicate<AudioExperience> predicate)
 	{
 		assertSoundHeard("Sound Heard Assertion failed", sound, predicate);
 	}
 
+	/**
+	 * Asserts that a sound was heard.
+	 *
+	 * @param sound     The sound that should've been heard.
+	 * @param predicate A predicate to test the {@link AudioExperience} against.
+	 */
 	default void assertSoundHeard(net.kyori.adventure.sound.@NotNull Sound sound, @NotNull Predicate<AudioExperience> predicate)
 	{
 		assertSoundHeard("Sound Heard Assertion failed", sound, predicate);
 	}
 
+	/**
+	 * Asserts that a sound was heard.
+	 *
+	 * @param sound     The sound name that should've been heard.
+	 * @param predicate A predicate to test the {@link AudioExperience} against.
+	 */
 	default void assertSoundHeard(@NotNull String sound, @NotNull Predicate<AudioExperience> predicate)
 	{
 		assertSoundHeard("Sound Heard Assertion failed", sound, predicate);
 	}
 
+	/**
+	 * Asserts that a sound was heard.
+	 *
+	 * @param message The message to fail with.
+	 * @param sound   The sound that should've been heard.
+	 */
 	default void assertSoundHeard(@NotNull String message, @NotNull Sound sound)
 	{
 		assertSoundHeard(message, sound, e -> true);
 	}
 
+	/**
+	 * Asserts that a sound was heard.
+	 *
+	 * @param message The message to fail with.
+	 * @param sound   The sound that should've been heard.
+	 */
 	default void assertSoundHeard(@NotNull String message, net.kyori.adventure.sound.@NotNull Sound sound)
 	{
 		assertSoundHeard(message, sound, e -> true);
 	}
 
+	/**
+	 * Asserts that a sound was heard.
+	 *
+	 * @param message The message to fail with.
+	 * @param sound   The sound name that should've been heard.
+	 */
 	default void assertSoundHeard(@NotNull String message, @NotNull String sound)
 	{
 		assertSoundHeard(message, sound, e -> true);
 	}
 
+	/**
+	 * Asserts that a sound was heard.
+	 *
+	 * @param message   The message to fail with.
+	 * @param sound     The sound that should've been heard.
+	 * @param predicate A predicate to test the {@link AudioExperience} against.
+	 */
 	default void assertSoundHeard(@NotNull String message, @NotNull Sound sound,
 								  @NotNull Predicate<AudioExperience> predicate)
 	{
 		assertSoundHeard(message, sound.getKey().getKey(), predicate);
 	}
 
+	/**
+	 * Asserts that a sound was heard.
+	 *
+	 * @param message   The message to fail with.
+	 * @param sound     The sound that should've been heard.
+	 * @param predicate A predicate to test the {@link AudioExperience} against.
+	 */
 	default void assertSoundHeard(@NotNull String message, net.kyori.adventure.sound.@NotNull Sound sound,
 								  @NotNull Predicate<AudioExperience> predicate)
 	{
@@ -119,6 +177,13 @@ public interface SoundReceiver
 		assertSoundHeard(message, sound.name().asString(), test.and(predicate));
 	}
 
+	/**
+	 * Asserts that a sound was heard.
+	 *
+	 * @param message   The message to fail with.
+	 * @param sound     The sound name that should've been heard.
+	 * @param predicate A predicate to test the {@link AudioExperience} against.
+	 */
 	default void assertSoundHeard(@NotNull String message, @NotNull String sound,
 								  @NotNull Predicate<AudioExperience> predicate)
 	{

--- a/src/main/java/be/seeseemelk/mockbukkit/statistic/StatisticsMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/statistic/StatisticsMock.java
@@ -2,6 +2,7 @@ package be.seeseemelk.mockbukkit.statistic;
 
 import com.google.common.base.Preconditions;
 import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.Statistic;
 import org.bukkit.Statistic.Type;
 import org.bukkit.entity.EntityType;
@@ -21,91 +22,138 @@ public class StatisticsMock
 	private final Map<Statistic, Map<EntityType, Integer>> entityStatistics = new EnumMap<>(Statistic.class);
 
 	/**
-	 * Implementation of {@link org.bukkit.OfflinePlayer#setStatistic(Statistic, int)}
+	 * Sets the given statistic for this player.
+	 *
+	 * @param statistic Statistic to set
+	 * @param value     The value to set this statistic to
+	 * @see OfflinePlayer#setStatistic(Statistic, int)
 	 */
-	public void setStatistic(@NotNull Statistic statistic, int amount)
+	public void setStatistic(@NotNull Statistic statistic, int value)
 	{
-		checkGreaterThanEqualTo0(amount);
+		checkGreaterThanEqualTo0(value);
 		Preconditions.checkArgument(statistic.getType() == Type.UNTYPED, "statistic must be provided with parameter");
-		untypedStatistics.put(statistic, amount);
+		untypedStatistics.put(statistic, value);
 	}
 
 	/**
-	 * Implementation of {@link org.bukkit.OfflinePlayer#setStatistic(Statistic, Material, int)}
+	 * Sets the given statistic for this player for the given material.
+	 *
+	 * @param statistic Statistic to set
+	 * @param material  Material to offset the statistic with
+	 * @param value     The value to set this statistic to
+	 * @see OfflinePlayer#setStatistic(Statistic, Material, int)
 	 */
-	public void setStatistic(@NotNull Statistic statistic, @NotNull Material material, int amount)
+	public void setStatistic(@NotNull Statistic statistic, @NotNull Material material, int value)
 	{
-		checkGreaterThanEqualTo0(amount);
+		checkGreaterThanEqualTo0(value);
 		Preconditions.checkArgument(statistic.getType() == Type.ITEM || statistic.getType() == Type.BLOCK, "statistic must take a material parameter");
-		materialStatistics.computeIfAbsent(statistic, k -> new EnumMap<>(Material.class)).put(material, amount);
+		materialStatistics.computeIfAbsent(statistic, k -> new EnumMap<>(Material.class)).put(material, value);
 	}
 
 	/**
-	 * Implementation of {@link org.bukkit.OfflinePlayer#setStatistic(Statistic, EntityType, int)}
+	 * Sets the given statistic for this player for the given entity.
+	 *
+	 * @param statistic  Statistic to set
+	 * @param entityType EntityType to offset the statistic with
+	 * @param value      The value to set this statistic to
+	 * @see OfflinePlayer#setStatistic(Statistic, EntityType, int)
 	 */
-	public void setStatistic(@NotNull Statistic statistic, @NotNull EntityType entity, int amount)
+	public void setStatistic(@NotNull Statistic statistic, @NotNull EntityType entityType, int value)
 	{
-		checkGreaterThanEqualTo0(amount);
+		checkGreaterThanEqualTo0(value);
 		Preconditions.checkArgument(statistic.getType() == Type.ENTITY, "statistic must take an entity parameter");
-		entityStatistics.computeIfAbsent(statistic, k -> new EnumMap<>(EntityType.class)).put(entity, amount);
+		entityStatistics.computeIfAbsent(statistic, k -> new EnumMap<>(EntityType.class)).put(entityType, value);
 	}
 
 	/**
-	 * Implementation of {@link org.bukkit.OfflinePlayer#incrementStatistic(Statistic, int)}
+	 * Increments the given statistic for this player.
+	 *
+	 * @param statistic Statistic to increment
+	 * @param value     Amount to increment this statistic by
+	 * @see OfflinePlayer#incrementStatistic(Statistic, int)
 	 */
-	public void incrementStatistic(@NotNull Statistic statistic, int amount)
+	public void incrementStatistic(@NotNull Statistic statistic, int value)
 	{
-		checkGreaterThan0(amount);
-		setStatistic(statistic, getStatistic(statistic) + amount);
+		checkGreaterThan0(value);
+		setStatistic(statistic, getStatistic(statistic) + value);
 	}
 
 	/**
-	 * Implementation of {@link org.bukkit.OfflinePlayer#incrementStatistic(Statistic, Material, int)}
+	 * Increments the given statistic for this player for the given material.
+	 *
+	 * @param statistic Statistic to increment
+	 * @param material  Material to offset the statistic with
+	 * @param value     Amount to increment this statistic by
+	 * @see OfflinePlayer#incrementStatistic(Statistic, Material, int)
 	 */
-	public void incrementStatistic(@NotNull Statistic statistic, @NotNull Material material, int amount)
+	public void incrementStatistic(@NotNull Statistic statistic, @NotNull Material material, int value)
 	{
-		checkGreaterThan0(amount);
-		setStatistic(statistic, material, getStatistic(statistic, material) + amount);
+		checkGreaterThan0(value);
+		setStatistic(statistic, material, getStatistic(statistic, material) + value);
 	}
 
 	/**
-	 * Implementation of {@link org.bukkit.OfflinePlayer#incrementStatistic(Statistic, EntityType, int)}
+	 * Increments the given statistic for this player for the given entity.
+	 *
+	 * @param statistic  Statistic to increment
+	 * @param entityType EntityType to offset the statistic with
+	 * @param value      Amount to increment this statistic by
+	 * @see OfflinePlayer#incrementStatistic(Statistic, EntityType, int)
 	 */
-	public void incrementStatistic(@NotNull Statistic statistic, @NotNull EntityType entity, int amount)
+	public void incrementStatistic(@NotNull Statistic statistic, @NotNull EntityType entityType, int value)
 	{
-		checkGreaterThan0(amount);
-		setStatistic(statistic, entity, getStatistic(statistic, entity) + amount);
+		checkGreaterThan0(value);
+		setStatistic(statistic, entityType, getStatistic(statistic, entityType) + value);
 	}
 
 	/**
-	 * Implementation of {@link org.bukkit.OfflinePlayer#decrementStatistic(Statistic, int)}
+	 * Decrements the given statistic for this player.
+	 *
+	 * @param statistic Statistic to decrement
+	 * @param value     Amount to decrement this statistic by
+	 * @see OfflinePlayer#decrementStatistic(Statistic, int)
 	 */
-	public void decrementStatistic(@NotNull Statistic statistic, int amount)
+	public void decrementStatistic(@NotNull Statistic statistic, int value)
 	{
-		checkGreaterThan0(amount);
-		setStatistic(statistic, getStatistic(statistic) - amount);
+		checkGreaterThan0(value);
+		setStatistic(statistic, getStatistic(statistic) - value);
 	}
 
 	/**
-	 * Implementation of {@link org.bukkit.OfflinePlayer#decrementStatistic(Statistic, Material, int)}
+	 * Decrements the given statistic for this player for the given material.
+	 *
+	 * @param statistic Statistic to decrement
+	 * @param material  Material to offset the statistic with
+	 * @param value     Amount to decrement this statistic by
+	 * @see OfflinePlayer#decrementStatistic(Statistic, Material, int)
 	 */
-	public void decrementStatistic(@NotNull Statistic statistic, @NotNull Material material, int amount)
+	public void decrementStatistic(@NotNull Statistic statistic, @NotNull Material material, int value)
 	{
-		checkGreaterThan0(amount);
-		setStatistic(statistic, material, getStatistic(statistic, material) - amount);
+		checkGreaterThan0(value);
+		setStatistic(statistic, material, getStatistic(statistic, material) - value);
 	}
 
 	/**
-	 * Implementation of {@link org.bukkit.OfflinePlayer#decrementStatistic(Statistic, EntityType, int)}
+	 * Decrements the given statistic for this player for the given entity.
+	 *
+	 * @param statistic  Statistic to decrement
+	 * @param entityType EntityType to offset the statistic with
+	 * @param value      Amount to decrement this statistic by
+	 *                   for the statistic
+	 * @see OfflinePlayer#decrementStatistic(Statistic, EntityType, int)
 	 */
-	public void decrementStatistic(@NotNull Statistic statistic, @NotNull EntityType entity, int amount)
+	public void decrementStatistic(@NotNull Statistic statistic, @NotNull EntityType entityType, int value)
 	{
-		checkGreaterThan0(amount);
-		setStatistic(statistic, entity, getStatistic(statistic, entity) - amount);
+		checkGreaterThan0(value);
+		setStatistic(statistic, entityType, getStatistic(statistic, entityType) - value);
 	}
 
 	/**
-	 * Implementation of {@link org.bukkit.OfflinePlayer#getStatistic(Statistic)}
+	 * Gets the value of the given statistic for this player.
+	 *
+	 * @param statistic Statistic to check
+	 * @return the value of the given statistic
+	 * @see OfflinePlayer#getStatistic(Statistic)
 	 */
 	public int getStatistic(@NotNull Statistic statistic)
 	{
@@ -114,7 +162,12 @@ public class StatisticsMock
 	}
 
 	/**
-	 * Implementation of {@link org.bukkit.OfflinePlayer#getStatistic(Statistic, Material)}
+	 * Gets the value of the given statistic for this player.
+	 *
+	 * @param statistic Statistic to check
+	 * @param material  Material offset of the statistic
+	 * @return the value of the given statistic
+	 * @see OfflinePlayer#getStatistic(Statistic, Material)
 	 */
 	public int getStatistic(@NotNull Statistic statistic, @NotNull Material material)
 	{
@@ -128,9 +181,14 @@ public class StatisticsMock
 	}
 
 	/**
-	 * Implementation of {@link org.bukkit.OfflinePlayer#getStatistic(Statistic, EntityType)}
+	 * Gets the value of the given statistic for this player.
+	 *
+	 * @param statistic  Statistic to check
+	 * @param entityType EntityType offset of the statistic
+	 * @return the value of the given statistic for the statistic
+	 * @see OfflinePlayer#getStatistic(Statistic, EntityType)
 	 */
-	public int getStatistic(@NotNull Statistic statistic, @NotNull EntityType entity)
+	public int getStatistic(@NotNull Statistic statistic, @NotNull EntityType entityType)
 	{
 		Preconditions.checkArgument(statistic.getType() == Type.ENTITY, "statistic must take an entity parameter");
 		Map<EntityType, Integer> map = entityStatistics.get(statistic);
@@ -138,11 +196,11 @@ public class StatisticsMock
 		{
 			return 0;
 		}
-		return map.getOrDefault(entity, 0);
+		return map.getOrDefault(entityType, 0);
 	}
 
 	/**
-	 * Ensures that the provided amount is greater than
+	 * Ensures that the provided value is greater than
 	 *
 	 * @param amount the amount to check
 	 */

--- a/src/main/java/be/seeseemelk/mockbukkit/tags/MaterialTagMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/tags/MaterialTagMock.java
@@ -21,6 +21,12 @@ public class MaterialTagMock implements Tag<Material>
 	private final NamespacedKey key;
 	private final @NotNull Set<Material> items;
 
+	/**
+	 * Constructs a new {@link MaterialTagMock} with the provided {@link NamespacedKey} and items.
+	 *
+	 * @param key   The key for the tag.
+	 * @param items The items included in the tag.
+	 */
 	public MaterialTagMock(NamespacedKey key, Material... items)
 	{
 		this.key = key;

--- a/src/main/java/be/seeseemelk/mockbukkit/tags/TagMisconfigurationException.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/tags/TagMisconfigurationException.java
@@ -4,6 +4,8 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.Tag;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.Serial;
+
 /**
  * An {@link TagMisconfigurationException} is thrown whenever a {@link Tag} contains illegal, invalid or unknown values.
  *
@@ -12,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
 public class TagMisconfigurationException extends Exception
 {
 
+	@Serial
 	private static final long serialVersionUID = 5412127960821774280L;
 
 	/**

--- a/src/main/java/be/seeseemelk/mockbukkit/tags/TagRegistry.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/tags/TagRegistry.java
@@ -41,6 +41,9 @@ public enum TagRegistry
 		return tags;
 	}
 
+	/**
+	 * @return Whether the tags are empty.
+	 */
 	public boolean isEmpty()
 	{
 		return tags.isEmpty();

--- a/src/main/java/be/seeseemelk/mockbukkit/tags/TagRegistry.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/tags/TagRegistry.java
@@ -29,12 +29,18 @@ public enum TagRegistry
 
 	private final Map<NamespacedKey, TagWrapperMock> tags = new HashMap<>();
 
+	/**
+	 * @return The name of the registry.
+	 */
 	@NotNull
 	public final String getRegistry()
 	{
 		return name().toLowerCase(Locale.ROOT);
 	}
 
+	/**
+	 * @return A map of all tags.
+	 */
 	@NotNull
 	public final Map<NamespacedKey, TagWrapperMock> getTags()
 	{

--- a/src/main/java/be/seeseemelk/mockbukkit/tags/TagWrapperMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/tags/TagWrapperMock.java
@@ -24,6 +24,12 @@ public class TagWrapperMock implements Tag<Material>
 	private final Set<Material> materials = new HashSet<>();
 	private final Set<TagWrapperMock> additionalTags = new HashSet<>();
 
+	/**
+	 * Constructs a new {@link TagWrapperMock} with the provided {@link TagRegistry} and {@link NamespacedKey}.
+	 *
+	 * @param registry The registry this wrapper is part of.
+	 * @param key      The key of this wrapper.
+	 */
 	public TagWrapperMock(@NotNull TagRegistry registry, @NotNull NamespacedKey key)
 	{
 		this.registry = registry;
@@ -43,6 +49,12 @@ public class TagWrapperMock implements Tag<Material>
 		return registry;
 	}
 
+	/**
+	 * Reloads all tags.
+	 *
+	 * @throws TagMisconfigurationException If something goes wrong while reading a tag.
+	 * @throws FileNotFoundException        If a tag file isn't found.
+	 */
 	public void reload() throws TagMisconfigurationException, FileNotFoundException
 	{
 		this.materials.clear();

--- a/src/main/java/be/seeseemelk/mockbukkit/tags/TagWrapperMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/tags/TagWrapperMock.java
@@ -43,6 +43,9 @@ public class TagWrapperMock implements Tag<Material>
 		return key;
 	}
 
+	/**
+	 * @return The registry this tag wrapper is part of.
+	 */
 	@NotNull
 	public TagRegistry getRegistry()
 	{
@@ -111,6 +114,9 @@ public class TagWrapperMock implements Tag<Material>
 		}
 	}
 
+	/**
+	 * @return All additional tags this tag inherits.
+	 */
 	@NotNull
 	public Set<TagWrapperMock> getSubTags()
 	{

--- a/src/main/java/be/seeseemelk/mockbukkit/tags/TagsMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/tags/TagsMock.java
@@ -23,11 +23,15 @@ import java.util.logging.Level;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+/**
+ * Used for loading the internal registry of tags.
+ */
 public final class TagsMock
 {
 
 	private TagsMock()
 	{
+		throw new UnsupportedOperationException("Utility class");
 	}
 
 	/**
@@ -60,7 +64,7 @@ public final class TagsMock
 	/**
 	 * This will load all {@link Tag Tags} for the given {@link TagRegistry}.
 	 *
-	 * @param server
+	 * @param server       The server to add the tags to.
 	 * @param registry     Our {@link TagRegistry}
 	 * @param skipIfExists Whether to skip an already loaded {@link TagRegistry}
 	 * @throws URISyntaxException When a {@link URI} is malformed

--- a/src/main/java/org/bukkit/plugin/java/PluginClassLoaderUtils.java
+++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoaderUtils.java
@@ -17,9 +17,22 @@ public class PluginClassLoaderUtils
 
 	private PluginClassLoaderUtils()
 	{
-		// Do not instantiate this.
+		throw new UnsupportedOperationException("Utility class");
 	}
 
+	/**
+	 * Constructs a new {@link PluginClassLoader}.
+	 *
+	 * @param loader        The plugin loader.
+	 * @param parent        The classloader parent.
+	 * @param description   The plugin description file.
+	 * @param dataFolder    The plugin's data folder.
+	 * @param file          The plugin's file.
+	 * @param libraryLoader The library loader.
+	 * @return The constructed {@link PluginClassLoader}.
+	 * @throws IOException            If an IO exception occurs.
+	 * @throws InvalidPluginException If the plugin is invalid.
+	 */
 	public static @NotNull PluginClassLoader createPluginClassLoader(@NotNull JavaPluginLoader loader,
 																	 @Nullable ClassLoader parent, @NotNull PluginDescriptionFile description, @NotNull File dataFolder,
 																	 @NotNull File file, @NotNull ClassLoader libraryLoader) throws IOException, InvalidPluginException

--- a/src/test/java/be/seeseemelk/mockbukkit/WorldMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/WorldMockTest.java
@@ -604,14 +604,21 @@ class WorldMockTest
 	void spawn_NullLocation_ThrowsException()
 	{
 		WorldMock world = new WorldMock();
-		assertThrowsExactly(IllegalArgumentException.class, () -> world.spawn(null, Zombie.class));
+		assertThrowsExactly(NullPointerException.class, () -> world.spawn(null, Zombie.class));
 	}
 
 	@Test
 	void spawn_NullClass_ThrowsException()
 	{
 		WorldMock world = new WorldMock();
-		assertThrowsExactly(IllegalArgumentException.class, () -> world.spawn(new Location(world, 0, 5, 0), null));
+		assertThrowsExactly(NullPointerException.class, () -> world.spawn(new Location(world, 0, 5, 0), null));
+	}
+
+	@Test
+	void spawn_NullReason_ThrowsException()
+	{
+		WorldMock world = new WorldMock();
+		assertThrowsExactly(NullPointerException.class, () -> world.spawn(new Location(world, 0, 5, 0), Zombie.class, (CreatureSpawnEvent.SpawnReason) null));
 	}
 
 	@Test

--- a/src/test/java/be/seeseemelk/mockbukkit/block/state/ShulkerBoxMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/state/ShulkerBoxMockTest.java
@@ -3,9 +3,9 @@ package be.seeseemelk.mockbukkit.block.state;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.WorldMock;
 import be.seeseemelk.mockbukkit.block.BlockMock;
-import com.destroystokyo.paper.MaterialTags;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
+import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.ShulkerBox;
 import org.jetbrains.annotations.NotNull;
@@ -49,7 +49,7 @@ class ShulkerBoxMockTest
 	@Test
 	void constructor_Material()
 	{
-		for (Material material : MaterialTags.SHULKER_BOXES.getValues())
+		for (Material material : Tag.SHULKER_BOXES.getValues())
 		{
 			assertDoesNotThrow(() -> new ShulkerBoxMock(material));
 		}
@@ -64,7 +64,7 @@ class ShulkerBoxMockTest
 	@Test
 	void constructor_Block()
 	{
-		for (Material material : MaterialTags.SHULKER_BOXES.getValues())
+		for (Material material : Tag.SHULKER_BOXES.getValues())
 		{
 			assertDoesNotThrow(() -> new ShulkerBoxMock(new BlockMock(material)));
 		}

--- a/src/test/java/be/seeseemelk/mockbukkit/block/state/SignMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/state/SignMockTest.java
@@ -6,6 +6,7 @@ import be.seeseemelk.mockbukkit.block.BlockMock;
 import com.destroystokyo.paper.MaterialTags;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
+import org.bukkit.Tag;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,7 +37,7 @@ class SignMockTest
 	}
 
 	@AfterEach
-	void tearDown() throws Exception
+	void tearDown()
 	{
 		MockBukkit.unmock();
 	}
@@ -44,7 +45,7 @@ class SignMockTest
 	@Test
 	void constructor_Material()
 	{
-		for (Material material : MaterialTags.SIGNS.getValues())
+		for (Material material : Tag.SIGNS.getValues())
 		{
 			assertDoesNotThrow(() -> new SignMock(material));
 		}
@@ -59,7 +60,7 @@ class SignMockTest
 	@Test
 	void constructor_Block()
 	{
-		for (Material material : MaterialTags.SIGNS.getValues())
+		for (Material material : Tag.SIGNS.getValues())
 		{
 			assertDoesNotThrow(() -> new SignMock(new BlockMock(material)));
 		}


### PR DESCRIPTION
# Description
Adds Javadocs to many classes and methods that were missing while improving some of the existing ones. With this, there are no more Javadoc warning when compiling :partying_face:

This will probably be easier to review commit-by-commit since each package has been modified in its own commit.

Packages left to complete:
- [x] configuration
- [x] entity
- [x] exception
- [x] generator
- [x] help
- [x] inventory
  - [x] meta
- [x] map
- [x] metadata
- [x] persistence
- [x] plugin
- [x] potion
- [x] profile
- [x] scheduler
- [x] scoreboard
- [x] sound
- [x] statistic
- [x] tags
- [x] root

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
