### PR TITLE
Use the default implementation for Chunk#getChunkKey

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ChunkMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ChunkMock.java
@@ -62,13 +62,6 @@ public class ChunkMock implements Chunk
 	}
 
 	@Override
-	public long getChunkKey()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
 	public @NotNull World getWorld()
 	{
 		return world;

--- a/src/test/java/be/seeseemelk/mockbukkit/ChunkTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ChunkTest.java
@@ -42,6 +42,15 @@ class ChunkTest
 	}
 
 	@Test
+	void getChunkKey()
+	{
+		long chunkKey = 10L | (20L << 32); // x = 10, y = 20
+		ChunkMock chunk = world.getChunkAt(10, 20);
+		assertEquals(chunkKey, chunk.getChunkKey());
+		assertEquals(chunk, world.getChunkAt(chunkKey));
+	}
+
+	@Test
 	void getWorld_AnyChunkFromWorld_ExactWorldReference()
 	{
 		assertSame(world, world.getChunkAt(0, 0).getWorld());


### PR DESCRIPTION
# Description
The `ChunkMock#getChunkKey(int chunkKey)` method was overridden in MockBukkit, despite having a functional default implementation. This PR removes the redefinition to use it.

A chunk key is hard-coded into the test instead of using the static `Chunk#getChunkKey()` method to avoid depending on it.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
