### PR TITLE
Fix #hasPlayedBefore not behaving as it should

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/MockPlayerList.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockPlayerList.java
@@ -38,6 +38,7 @@ public class MockPlayerList
 	private final Map<UUID, Long> lastLogins = Collections.synchronizedMap(new HashMap<>());
 	private final Map<UUID, Long> lastSeen = Collections.synchronizedMap(new HashMap<>());
 	private final Map<UUID, Long> firstPlayed = Collections.synchronizedMap(new HashMap<>());
+	private final Map<UUID, Boolean> hasPlayedBefore = Collections.synchronizedMap(new HashMap<>());
 
 	private final @NotNull BanList ipBans = new MockBanList();
 	private final @NotNull BanList profileBans = new MockBanList();
@@ -71,12 +72,26 @@ public class MockPlayerList
 		this.lastLogins.put(player.getUniqueId(), System.currentTimeMillis());
 		this.onlinePlayers.add(player);
 		this.offlinePlayers.add(player);
+		this.hasPlayedBefore.put(player.getUniqueId(), this.hasPlayedBefore.containsKey(player.getUniqueId()));
 	}
 
 	public void disconnectPlayer(@NotNull PlayerMock player)
 	{
 		this.lastSeen.put(player.getUniqueId(), System.currentTimeMillis());
 		this.onlinePlayers.remove(player);
+	}
+
+	/**
+	 * Checks if a player has played before.
+	 *
+	 * @param uuid The UUID of the player.
+	 * @return Whether the player has played before.
+	 * @see Player#hasPlayedBefore()
+	 */
+	public boolean hasPlayedBefore(@NotNull UUID uuid)
+	{
+		Preconditions.checkNotNull(uuid, "UUID cannot be null");
+		return this.hasPlayedBefore.getOrDefault(uuid, false);
 	}
 
 	public void addOfflinePlayer(@NotNull OfflinePlayer player)
@@ -153,7 +168,7 @@ public class MockPlayerList
 	/**
 	 * Sets the return value of {@link #getLastLogin(UUID)}.
 	 *
-	 * @param uuid     UUID of the player to set last login time for.
+	 * @param uuid      UUID of the player to set last login time for.
 	 * @param lastLogin The last login time. Must be non-negative.
 	 */
 	public void setLastLogin(UUID uuid, long lastLogin)

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/OfflinePlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/OfflinePlayerMock.java
@@ -16,7 +16,6 @@ import org.bukkit.profile.PlayerProfile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Arrays;
 import java.util.Map;
 import java.util.UUID;
 
@@ -136,7 +135,7 @@ public class OfflinePlayerMock implements OfflinePlayer
 	public boolean hasPlayedBefore()
 	{
 		MockBukkit.ensureMocking();
-		return Arrays.stream(MockBukkit.getMock().getPlayerList().getOfflinePlayers()).anyMatch(p -> p.getUniqueId().equals(getUniqueId()));
+		return MockBukkit.getMock().getPlayerList().hasPlayedBefore(getUniqueId());
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -219,7 +219,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	 */
 	public boolean reconnect()
 	{
-		if (!hasPlayedBefore())
+		if (Arrays.stream(server.getPlayerList().getOfflinePlayers()).noneMatch(it -> it.getUniqueId().equals(this.getUniqueId())))
 		{
 			throw new IllegalStateException("Player was never online");
 		}
@@ -717,7 +717,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public boolean hasPlayedBefore()
 	{
-		return Arrays.stream(this.server.getPlayerList().getOfflinePlayers()).anyMatch(p -> p.getUniqueId().equals(getUniqueId()));
+		return server.getPlayerList().hasPlayedBefore(getUniqueId());
 	}
 
 	@Deprecated(forRemoval = true)

--- a/src/test/java/be/seeseemelk/mockbukkit/MockPlayerListTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/MockPlayerListTest.java
@@ -258,4 +258,38 @@ class MockPlayerListTest
 		assertEquals(10, playerList.getLastLogin(uuid));
 	}
 
+	@Test
+	void hasPlayedBefore_NeverOnline_False()
+	{
+		assertFalse(playerList.hasPlayedBefore(UUID.randomUUID()));
+	}
+
+	@Test
+	void hasPlayedBefore_FirstJoin_False()
+	{
+		PlayerMock player = server.addPlayer();
+		assertFalse(playerList.hasPlayedBefore(player.getUniqueId()));
+	}
+
+	@Test
+	void hasPlayedBefore_SecondJoin_True()
+	{
+		PlayerMock player = server.addPlayer();
+		player.disconnect();
+		player.reconnect();
+
+		assertTrue(playerList.hasPlayedBefore(player.getUniqueId()));
+	}
+
+	@Test
+	void hasPlayedBefore_SecondJoin_Offline_True()
+	{
+		PlayerMock player = server.addPlayer();
+		player.disconnect();
+		player.reconnect();
+		player.disconnect();
+
+		assertTrue(playerList.hasPlayedBefore(player.getUniqueId()));
+	}
+
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -1906,7 +1906,6 @@ class PlayerMockTest
 	@Test
 	void testAssertInventoryViewDefault()
 	{
-		;
 		player.assertInventoryView(InventoryType.CRAFTING);
 	}
 
@@ -2229,22 +2228,6 @@ class PlayerMockTest
 		PlayerMock player = server.addPlayer();
 
 		assertThrows(UnsupportedOperationException.class, () -> player.setLastPlayed(0));
-	}
-
-	@Test
-	void hasPlayedBefore_AddedToServer_True()
-	{
-		PlayerMock player = server.addPlayer();
-
-		assertTrue(player.hasPlayedBefore());
-	}
-
-	@Test
-	void hasPlayedBefore_NotAddedToServer_False()
-	{
-		PlayerMock player = new PlayerMock(server, "player");
-
-		assertFalse(player.hasPlayedBefore());
 	}
 
 }


### PR DESCRIPTION
# Description
In CraftBukkit, `#hasPlayedBefore` will be false the entire time a player is playing on the server for the first time. Once they rejoin, then it will be marked as true.

In MockBukkit, it would check if they were ever online at the time of calling, meaning it would almost always return true, even when it's the first time they're playing.

You can see this behavior in `CraftPlayer#readExtraData`. When this method is called, `hasPlayedBefore` is set to true. This is the only location this happens, and this method is only called when reading player data on join.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
