### PR TITLE
Remove hamcrest as a dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,12 +26,11 @@ repositories {
 }
 
 dependencies {
-    //Paper API
+    // Paper API
     api "io.papermc.paper:paper-api:${gradle.ext.apiVersionFull}"
 
-    //Dependencies for Unit Tests
+    // Dependencies for Unit Tests
     implementation 'org.junit.jupiter:junit-jupiter:5.9.1'
-    implementation 'org.hamcrest:hamcrest-library:2.2'
 
     // General utilities for the project
     implementation 'net.kyori:adventure-platform-bungeecord:4.1.2'

--- a/src/test/java/be/seeseemelk/mockbukkit/MockBukkitTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/MockBukkitTest.java
@@ -8,8 +8,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -109,7 +107,7 @@ class MockBukkitTest
 	{
 		MockBukkit.mock();
 		TestPlugin plugin = MockBukkit.load(TestPlugin.class, Integer.valueOf(5));
-		assertThat(plugin.extra, equalTo(5));
+		assertEquals(5, plugin.extra);
 	}
 
 	@Test
@@ -163,8 +161,8 @@ class MockBukkitTest
 		MockBukkit.mock();
 		MockBukkit.loadJar("extra/TestPlugin/TestPlugin.jar");
 		Plugin[] plugins = MockBukkit.getMock().getPluginManager().getPlugins();
-		assertThat(plugins.length, equalTo(1));
-		assertThat(plugins[0].getName(), equalTo("TestPlugin"));
+		assertEquals(1, plugins.length);
+		assertEquals("TestPlugin", plugins[0].getName());
 	}
 
 	@Test
@@ -174,7 +172,7 @@ class MockBukkitTest
 		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
 		FileConfiguration config = plugin.getConfig();
 		String value = config.getString("foo");
-		assertThat(value, equalTo("bar"));
+		assertEquals("bar", value);
 	}
 
 	@Test

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -76,9 +76,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -277,7 +274,7 @@ class ServerMockTest
 	{
 		UUID id = UUID.randomUUID();
 		OfflinePlayer offlinePlayer = server.getOfflinePlayer(id);
-		assertThat(offlinePlayer.getUniqueId(), equalTo(id));
+		assertEquals(id, offlinePlayer.getUniqueId());
 	}
 
 	@ParameterizedTest
@@ -580,7 +577,8 @@ class ServerMockTest
 		PlayerMock playerAB = server.addPlayer("PlayerAB");
 		server.addPlayer("PlayerB");
 		List<Player> players = server.matchPlayer("PlayerA");
-		assertThat(players, containsInAnyOrder(playerA, playerAB));
+		assertTrue(players.contains(playerA));
+		assertTrue(players.contains(playerAB));
 	}
 
 	@Test
@@ -700,7 +698,8 @@ class ServerMockTest
 		PlayerMock playerA = server.addPlayer();
 		PlayerMock playerB = server.addPlayer();
 
-		assertThat(server.getPlayerList().getOnlinePlayers(), containsInAnyOrder(playerA, playerB));
+		assertTrue(server.getPlayerList().getOnlinePlayers().contains(playerA));
+		assertTrue(server.getPlayerList().getOnlinePlayers().contains(playerB));
 	}
 
 	@Test
@@ -981,14 +980,14 @@ class ServerMockTest
 	@Test
 	void testGetViewDistanceDefault()
 	{
-		assertEquals(10,server.getViewDistance());
+		assertEquals(10, server.getViewDistance());
 	}
 
 	@Test
 	void testSetViewDistance()
 	{
 		server.setViewDistance(2);
-		assertEquals(2,server.getViewDistance());
+		assertEquals(2, server.getViewDistance());
 	}
 
 	@Test


### PR DESCRIPTION
# Description
Hamcrest was being used in a total of 6 tests, and it's not worth having an entire dependency for that, when regular JUnit assertions do the job perfectly well.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, update the patch version. (if the current version is `0.4.1`, the new version should be `0.4.2`)
- If the PR adds a new feature to MockBukkit, update minor version. (if the current version is `0.4.1`, the new version should be `0.5.0`)

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
