### PR TITLE
OfflinePlayerMock: fix incorrect return type

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/entity/OfflinePlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/OfflinePlayerMock.java
@@ -3,6 +3,7 @@ package be.seeseemelk.mockbukkit.entity;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import com.destroystokyo.paper.profile.PlayerProfile;
 import com.google.common.base.Preconditions;
 import org.bukkit.BanList;
 import org.bukkit.Bukkit;
@@ -12,7 +13,6 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.Statistic;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
-import org.bukkit.profile.PlayerProfile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 


### PR DESCRIPTION
# Description
This fixes a build error currently present in main.
The issue was that upstream Paper changed the specific type returned by the `getPlayerProfile` method.