### PR TITLE
Rename all BlockData mocks to include 'Data' in the name

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/AmethystClusterDataMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/AmethystClusterDataMock.java
@@ -14,16 +14,16 @@ import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.WATERLOGGED;
 /**
  * Mock implementation of {@link AmethystCluster}.
  */
-public class AmethystClusterMock extends BlockDataMock implements AmethystCluster
+public class AmethystClusterDataMock extends BlockDataMock implements AmethystCluster
 {
 
 	/**
-	 * Constructs a new {@link BedMock} for the provided {@link Material}.
+	 * Constructs a new {@link AmethystClusterDataMock} for the provided {@link Material}.
 	 * Only supports {@link Material#AMETHYST_CLUSTER}
 	 *
 	 * @param type The material this data is for.
 	 */
-	public AmethystClusterMock(@NotNull Material type)
+	public AmethystClusterDataMock(@NotNull Material type)
 	{
 		super(type);
 		checkType(type, Material.AMETHYST_CLUSTER);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/BedDataMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/BedDataMock.java
@@ -15,16 +15,16 @@ import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.PART;
 /**
  * Mock implementation of {@link Bed}.
  */
-public class BedMock extends BlockDataMock implements Bed
+public class BedDataMock extends BlockDataMock implements Bed
 {
 
 	/**
-	 * Constructs a new {@link BedMock} for the provided {@link Material}.
+	 * Constructs a new {@link BedDataMock} for the provided {@link Material}.
 	 * Only supports materials in {@link Tag#BEDS}
 	 *
 	 * @param type The material this data is for.
 	 */
-	public BedMock(@NotNull Material type)
+	public BedDataMock(@NotNull Material type)
 	{
 		super(type);
 		checkType(type, Tag.BEDS);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/BlockDataMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/BlockDataMock.java
@@ -275,8 +275,8 @@ public class BlockDataMock implements BlockData
 		// Special cases
 		return switch (material)
 				{
-					case AMETHYST_CLUSTER -> new AmethystClusterMock(material);
-					case LEVER -> new SwitchMock(material);
+					case AMETHYST_CLUSTER -> new AmethystClusterDataMock(material);
+					case LEVER -> new SwitchDataMock(material);
 					default -> new BlockDataMock(material);
 				};
 	}
@@ -293,7 +293,7 @@ public class BlockDataMock implements BlockData
 		Preconditions.checkNotNull(material, NULL_MATERIAL_EXCEPTION_MESSAGE);
 		if (MaterialTags.BEDS.isTagged(material))
 		{
-			return new BedMock(material);
+			return new BedDataMock(material);
 		}
 		return null;
 	}
@@ -310,27 +310,27 @@ public class BlockDataMock implements BlockData
 		Preconditions.checkNotNull(material, NULL_MATERIAL_EXCEPTION_MESSAGE);
 		if (Tag.SLABS.isTagged(material))
 		{
-			return new SlabMock(material);
+			return new SlabDataMock(material);
 		}
 		else if (Tag.STAIRS.isTagged(material))
 		{
-			return new StairsMock(material);
+			return new StairsDataMock(material);
 		}
 		else if (Tag.TRAPDOORS.isTagged(material))
 		{
-			return new TrapDoorMock(material);
+			return new TrapDoorDataMock(material);
 		}
 		else if (Tag.CAMPFIRES.isTagged(material))
 		{
-			return new CampfireMock(material);
+			return new CampfireDataMock(material);
 		}
 		else if (Tag.WALL_SIGNS.isTagged(material))
 		{
-			return new WallSignMock(material);
+			return new WallSignDataMock(material);
 		}
 		else if (Tag.BUTTONS.isTagged(material))
 		{
-			return new SwitchMock(material);
+			return new SwitchDataMock(material);
 		}
 		return null;
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/CampfireDataMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/CampfireDataMock.java
@@ -17,16 +17,16 @@ import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.WATERLOGGED;
 /**
  * Mock implementation of {@link Campfire}.
  */
-public class CampfireMock extends BlockDataMock implements Campfire
+public class CampfireDataMock extends BlockDataMock implements Campfire
 {
 
 	/**
-	 * Constructs a new {@link BedMock} for the provided {@link Material}.
+	 * Constructs a new {@link CampfireDataMock} for the provided {@link Material}.
 	 * Only supports materials in {@link Tag#CAMPFIRES}
 	 *
 	 * @param type The material this data is for.
 	 */
-	public CampfireMock(@NotNull Material type)
+	public CampfireDataMock(@NotNull Material type)
 	{
 		super(type);
 		checkType(type, Tag.CAMPFIRES);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/SlabDataMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/SlabDataMock.java
@@ -12,16 +12,16 @@ import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.WATERLOGGED;
 /**
  * Mock implementation of {@link Slab}.
  */
-public class SlabMock extends BlockDataMock implements Slab
+public class SlabDataMock extends BlockDataMock implements Slab
 {
 
 	/**
-	 * Constructs a new {@link BedMock} for the provided {@link Material}.
+	 * Constructs a new {@link SlabDataMock} for the provided {@link Material}.
 	 * Only supports materials in {@link Tag#SLABS}
 	 *
 	 * @param type The material this data is for.
 	 */
-	public SlabMock(@NotNull Material type)
+	public SlabDataMock(@NotNull Material type)
 	{
 		super(type);
 		checkType(type, Tag.SLABS);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/StairsDataMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/StairsDataMock.java
@@ -17,16 +17,16 @@ import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.WATERLOGGED;
 /**
  * Mock implementation of {@link Stairs}.
  */
-public class StairsMock extends BlockDataMock implements Stairs
+public class StairsDataMock extends BlockDataMock implements Stairs
 {
 
 	/**
-	 * Constructs a new {@link BedMock} for the provided {@link Material}.
+	 * Constructs a new {@link StairsDataMock} for the provided {@link Material}.
 	 * Only supports materials in {@link Tag#STAIRS}
 	 *
 	 * @param type The material this data is for.
 	 */
-	public StairsMock(@NotNull Material type)
+	public StairsDataMock(@NotNull Material type)
 	{
 		super(type);
 		checkType(type, Tag.STAIRS);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/SwitchDataMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/SwitchDataMock.java
@@ -13,16 +13,16 @@ import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.FACE;
 import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.FACING;
 import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.POWERED;
 
-public class SwitchMock extends BlockDataMock implements Switch
+public class SwitchDataMock extends BlockDataMock implements Switch
 {
 
 	/**
-	 * Constructs a new {@link SwitchMock} for the provided {@link Material}. Only
+	 * Constructs a new {@link SwitchDataMock} for the provided {@link Material}. Only
 	 * supports materials in {@link Tag#BUTTONS} and {@link Material#LEVER}
 	 *
 	 * @param type The material this data is for.
 	 */
-	public SwitchMock(@NotNull Material type)
+	public SwitchDataMock(@NotNull Material type)
 	{
 		super(type);
 		Set<Material> possibleTypes = Tag.BUTTONS.getValues();

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/TrapDoorDataMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/TrapDoorDataMock.java
@@ -18,16 +18,16 @@ import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.WATERLOGGED;
 /**
  * Mock implementation of {@link TrapDoor}.
  */
-public class TrapDoorMock extends BlockDataMock implements TrapDoor
+public class TrapDoorDataMock extends BlockDataMock implements TrapDoor
 {
 
 	/**
-	 * Constructs a new {@link BedMock} for the provided {@link Material}.
+	 * Constructs a new {@link TrapDoorDataMock} for the provided {@link Material}.
 	 * Only supports materials in {@link Tag#TRAPDOORS}
 	 *
 	 * @param type The material this data is for.
 	 */
-	public TrapDoorMock(@NotNull Material type)
+	public TrapDoorDataMock(@NotNull Material type)
 	{
 		super(type);
 		checkType(type, Tag.TRAPDOORS);

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/WallSignDataMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/WallSignDataMock.java
@@ -15,16 +15,16 @@ import static be.seeseemelk.mockbukkit.block.data.BlockDataKey.WATERLOGGED;
 /**
  * Mock implementation of a {@link WallSign}.
  */
-public class WallSignMock extends BlockDataMock implements WallSign
+public class WallSignDataMock extends BlockDataMock implements WallSign
 {
 
 	/**
-	 * Constructs a new {@link WallSignMock} for the provided {@link Material}. Only
+	 * Constructs a new {@link WallSignDataMock} for the provided {@link Material}. Only
 	 * supports materials in {@link Tag#WALL_SIGNS}
 	 *
 	 * @param type The material this data is for.
 	 */
-	public WallSignMock(@NotNull Material type)
+	public WallSignDataMock(@NotNull Material type)
 	{
 		super(type);
 		checkType(type, Tag.WALL_SIGNS);

--- a/src/test/java/be/seeseemelk/mockbukkit/ChunkSnapshotMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ChunkSnapshotMockTest.java
@@ -1,6 +1,6 @@
 package be.seeseemelk.mockbukkit;
 
-import be.seeseemelk.mockbukkit.block.data.AmethystClusterMock;
+import be.seeseemelk.mockbukkit.block.data.AmethystClusterDataMock;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.ChunkSnapshot;
@@ -74,12 +74,12 @@ class ChunkSnapshotMockTest
 	@Test
 	void getBlockData_PreservesData()
 	{
-		AmethystClusterMock blockData = (AmethystClusterMock) Bukkit.createBlockData(Material.AMETHYST_CLUSTER);
+		AmethystClusterDataMock blockData = (AmethystClusterDataMock) Bukkit.createBlockData(Material.AMETHYST_CLUSTER);
 		blockData.setWaterlogged(true);
 		blockData.setFacing(BlockFace.SOUTH);
 		chunk.getBlock(0, 1, 0).setBlockData(blockData);
 
-		AmethystClusterMock snapshotData = (AmethystClusterMock) chunk.getChunkSnapshot().getBlockData(0, 1, 0);
+		AmethystClusterDataMock snapshotData = (AmethystClusterDataMock) chunk.getChunkSnapshot().getBlockData(0, 1, 0);
 
 		assertEquals(Material.AMETHYST_CLUSTER, snapshotData.getMaterial());
 		assertTrue(snapshotData.isWaterlogged());

--- a/src/test/java/be/seeseemelk/mockbukkit/block/data/AmethystClusterDataMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/data/AmethystClusterDataMockTest.java
@@ -14,15 +14,15 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
-class AmethystClusterMockTest
+class AmethystClusterDataMockTest
 {
 
-	private AmethystClusterMock cluster;
+	private AmethystClusterDataMock cluster;
 
 	@BeforeEach
 	void setUp()
 	{
-		this.cluster = new AmethystClusterMock(Material.AMETHYST_CLUSTER);
+		this.cluster = new AmethystClusterDataMock(Material.AMETHYST_CLUSTER);
 	}
 
 	@Test
@@ -35,13 +35,13 @@ class AmethystClusterMockTest
 	@Test
 	void constructor_Material()
 	{
-		assertDoesNotThrow(() -> new AmethystClusterMock(Material.AMETHYST_CLUSTER));
+		assertDoesNotThrow(() -> new AmethystClusterDataMock(Material.AMETHYST_CLUSTER));
 	}
 
 	@Test
 	void constructor_Material_WrongType_ThrowsException()
 	{
-		assertThrowsExactly(IllegalArgumentException.class, () -> new AmethystClusterMock(Material.BEDROCK));
+		assertThrowsExactly(IllegalArgumentException.class, () -> new AmethystClusterDataMock(Material.BEDROCK));
 	}
 
 	@Test
@@ -89,7 +89,7 @@ class AmethystClusterMockTest
 	@Test
 	void blockDataMock_Mock_CorrectType()
 	{
-		assertInstanceOf(AmethystClusterMock.class, BlockDataMock.mock(Material.AMETHYST_CLUSTER));
+		assertInstanceOf(AmethystClusterDataMock.class, BlockDataMock.mock(Material.AMETHYST_CLUSTER));
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/block/data/BedDataMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/data/BedDataMockTest.java
@@ -1,9 +1,10 @@
 package be.seeseemelk.mockbukkit.block.data;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
+import com.destroystokyo.paper.MaterialTags;
 import org.bukkit.Material;
-import org.bukkit.Tag;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.type.Bed;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,22 +17,21 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class WallSignMockTest
+class BedDataMockTest
 {
 
-	private WallSignMock sign;
+	private BedDataMock bed;
 
 	@BeforeEach
 	void setUp()
 	{
 		MockBukkit.mock();
-		sign = new WallSignMock(Material.ACACIA_WALL_SIGN);
+		this.bed = new BedDataMock(Material.RED_BED);
 	}
 
 	@AfterEach
-	void tearDown()
+	void teardown()
 	{
 		MockBukkit.unmock();
 	}
@@ -39,23 +39,21 @@ class WallSignMockTest
 	@Test
 	void constructor_DefaultValues()
 	{
-		assertEquals(BlockFace.NORTH, sign.getFacing());
-		assertFalse(sign.isWaterlogged());
+		assertEquals(Bed.Part.FOOT, bed.getPart());
+		assertFalse(bed.isOccupied());
+		assertEquals(BlockFace.NORTH, bed.getFacing());
 	}
 
 	@Test
 	void constructor_Material()
 	{
-		for (Material wallSignType : Tag.WALL_SIGNS.getValues())
-		{
-			assertDoesNotThrow(() -> new WallSignMock(wallSignType));
-		}
+		assertDoesNotThrow(() -> new BedDataMock(Material.RED_BED));
 	}
 
 	@Test
 	void constructor_Material_WrongType_ThrowsException()
 	{
-		assertThrowsExactly(IllegalArgumentException.class, () -> new WallSignMock(Material.BEDROCK));
+		assertThrowsExactly(IllegalArgumentException.class, () -> new BedDataMock(Material.BEDROCK));
 	}
 
 	@Test
@@ -63,10 +61,9 @@ class WallSignMockTest
 	{
 		for (BlockFace face : BlockFace.values())
 		{
-			if (!sign.getFaces().contains(face))
+			if (!bed.getFaces().contains(face))
 				continue;
-			assertDoesNotThrow(() -> sign.setFacing(face));
-			assertEquals(face, sign.getFacing());
+			assertDoesNotThrow(() -> bed.setFacing(face));
 		}
 	}
 
@@ -75,9 +72,9 @@ class WallSignMockTest
 	{
 		for (BlockFace face : BlockFace.values())
 		{
-			if (sign.getFaces().contains(face))
+			if (bed.getFaces().contains(face))
 				continue;
-			assertThrowsExactly(IllegalArgumentException.class, () -> sign.setFacing(face));
+			assertThrowsExactly(IllegalArgumentException.class, () -> bed.setFacing(face));
 		}
 	}
 
@@ -85,45 +82,28 @@ class WallSignMockTest
 	void getFaces()
 	{
 		Set<BlockFace> validFaces = Set.of(BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST);
-		assertEquals(validFaces, sign.getFaces());
+		assertEquals(validFaces, bed.getFaces());
 	}
 
 	@Test
 	void getFacing_Immutable()
 	{
-		Set<BlockFace> faces = sign.getFaces();
+		Set<BlockFace> faces = bed.getFaces();
 		assertThrows(UnsupportedOperationException.class, () -> faces.add(BlockFace.NORTH_EAST));
-	}
-
-	@Test
-	void getFacing_notNull()
-	{
-		assertThrows(NullPointerException.class, () -> sign.setFacing(null));
-	}
-
-	@Test
-	void setWaterLogged()
-	{
-		sign.setWaterlogged(true);
-		assertTrue(sign.isWaterlogged());
-		sign.setWaterlogged(false);
-		assertFalse(sign.isWaterlogged());
 	}
 
 	@Test
 	void getAsString()
 	{
-		sign.setWaterlogged(true);
-		sign.setFacing(BlockFace.SOUTH);
-		assertEquals("minecraft:acacia_wall_sign[facing=south,waterlogged=true]", sign.getAsString());
+		assertEquals("minecraft:red_bed[facing=north,occupied=false,part=foot]", bed.getAsString());
 	}
 
 	@Test
 	void blockDataMock_Mock_CorrectType()
 	{
-		for (Material material : Tag.WALL_SIGNS.getValues())
+		for (Material material : MaterialTags.BEDS.getValues())
 		{
-			assertInstanceOf(WallSignMock.class, BlockDataMock.mock(material));
+			assertInstanceOf(BedDataMock.class, BlockDataMock.mock(material));
 		}
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/block/data/CampfireDataMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/data/CampfireDataMockTest.java
@@ -16,16 +16,16 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class CampfireMockTest
+class CampfireDataMockTest
 {
 
-	private CampfireMock campfire;
+	private CampfireDataMock campfire;
 
 	@BeforeEach
 	void setUp()
 	{
 		MockBukkit.mock();
-		this.campfire = new CampfireMock(Material.CAMPFIRE);
+		this.campfire = new CampfireDataMock(Material.CAMPFIRE);
 	}
 
 	@AfterEach
@@ -37,13 +37,13 @@ class CampfireMockTest
 	@Test
 	void constructor_Material()
 	{
-		assertDoesNotThrow(() -> new CampfireMock(Material.CAMPFIRE));
+		assertDoesNotThrow(() -> new CampfireDataMock(Material.CAMPFIRE));
 	}
 
 	@Test
 	void constructor_Material_WrongType_ThrowsException()
 	{
-		assertThrowsExactly(IllegalArgumentException.class, () -> new CampfireMock(Material.BEDROCK));
+		assertThrowsExactly(IllegalArgumentException.class, () -> new CampfireDataMock(Material.BEDROCK));
 	}
 
 	@Test
@@ -93,7 +93,7 @@ class CampfireMockTest
 	{
 		for (Material material : Tag.CAMPFIRES.getValues())
 		{
-			assertInstanceOf(CampfireMock.class, BlockDataMock.mock(material));
+			assertInstanceOf(CampfireDataMock.class, BlockDataMock.mock(material));
 		}
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/block/data/SlabDataMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/data/SlabDataMockTest.java
@@ -14,27 +14,27 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class SlabMockTest
+class SlabDataMockTest
 {
 
-	private SlabMock slab;
+	private SlabDataMock slab;
 
 	@BeforeEach
 	void setUp()
 	{
-		this.slab = new SlabMock(Material.OAK_SLAB);
+		this.slab = new SlabDataMock(Material.OAK_SLAB);
 	}
 
 	@Test
 	void constructor_Material()
 	{
-		assertDoesNotThrow(() -> new SlabMock(Material.OAK_SLAB));
+		assertDoesNotThrow(() -> new SlabDataMock(Material.OAK_SLAB));
 	}
 
 	@Test
 	void constructor_Material_WrongType_ThrowsException()
 	{
-		assertThrowsExactly(IllegalArgumentException.class, () -> new SlabMock(Material.BEDROCK));
+		assertThrowsExactly(IllegalArgumentException.class, () -> new SlabDataMock(Material.BEDROCK));
 	}
 
 	@Test
@@ -75,7 +75,7 @@ class SlabMockTest
 	{
 		for (Material material : Tag.SLABS.getValues())
 		{
-			assertInstanceOf(SlabMock.class, BlockDataMock.mock(material));
+			assertInstanceOf(SlabDataMock.class, BlockDataMock.mock(material));
 		}
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/block/data/StairsDataMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/data/StairsDataMockTest.java
@@ -5,6 +5,7 @@ import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.Bisected;
+import org.bukkit.block.data.type.Stairs;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class TrapDoorMockTest
+class StairsDataMockTest
 {
 
 	private static final Set<BlockFace> VALID_FACES = Set.of(
@@ -30,13 +31,13 @@ class TrapDoorMockTest
 			BlockFace.WEST
 	);
 
-	private TrapDoorMock trapDoor;
+	private StairsDataMock stairs;
 
 	@BeforeEach
 	void setUp()
 	{
 		MockBukkit.mock();
-		this.trapDoor = new TrapDoorMock(Material.BIRCH_TRAPDOOR);
+		this.stairs = new StairsDataMock(Material.BIRCH_STAIRS);
 	}
 
 	@AfterEach
@@ -48,36 +49,48 @@ class TrapDoorMockTest
 	@Test
 	void constructor_DefaultValues()
 	{
-		assertEquals(Bisected.Half.BOTTOM, trapDoor.getHalf());
-		assertFalse(trapDoor.isOpen());
-		assertFalse(trapDoor.isPowered());
-		assertFalse(trapDoor.isWaterlogged());
-		assertEquals(BlockFace.NORTH, trapDoor.getFacing());
+		assertEquals(Stairs.Shape.STRAIGHT, stairs.getShape());
+		assertFalse(stairs.isWaterlogged());
+		assertEquals(BlockFace.NORTH, stairs.getFacing());
+		assertEquals(Bisected.Half.BOTTOM, stairs.getHalf());
 	}
 
 	@Test
 	void constructor_Material()
 	{
-		assertDoesNotThrow(() -> new TrapDoorMock(Material.BIRCH_TRAPDOOR));
+		assertDoesNotThrow(() -> new StairsDataMock(Material.BIRCH_STAIRS));
 	}
 
 	@Test
 	void constructor_Material_WrongType_ThrowsException()
 	{
-		assertThrowsExactly(IllegalArgumentException.class, () -> new TrapDoorMock(Material.WET_SPONGE));
+		assertThrowsExactly(IllegalArgumentException.class, () -> new StairsDataMock(Material.CHISELED_DEEPSLATE));
+	}
+
+	@Test
+	void setShape_Valid()
+	{
+		stairs.setShape(Stairs.Shape.INNER_RIGHT);
+		assertEquals(Stairs.Shape.INNER_RIGHT, stairs.getShape());
+	}
+
+	@Test
+	void setShape_NullInput_ThrowsException()
+	{
+		assertThrowsExactly(NullPointerException.class, () -> stairs.setShape(null));
 	}
 
 	@Test
 	void setHalf_Valid()
 	{
-		trapDoor.setHalf(Bisected.Half.TOP);
-		assertEquals(Bisected.Half.TOP, trapDoor.getHalf());
+		stairs.setHalf(Bisected.Half.TOP);
+		assertEquals(Bisected.Half.TOP, stairs.getHalf());
 	}
 
 	@Test
 	void setHalf_NullInput_ThrowsException()
 	{
-		assertThrowsExactly(NullPointerException.class, () -> trapDoor.setHalf(null));
+		assertThrowsExactly(NullPointerException.class, () -> stairs.setHalf(null));
 	}
 
 	@Test
@@ -85,8 +98,8 @@ class TrapDoorMockTest
 	{
 		for (BlockFace face : VALID_FACES)
 		{
-			trapDoor.setFacing(face);
-			assertEquals(face, trapDoor.getFacing());
+			stairs.setFacing(face);
+			assertEquals(face, stairs.getFacing());
 		}
 	}
 
@@ -96,51 +109,37 @@ class TrapDoorMockTest
 		final Set<BlockFace> invalidFaces = Arrays.stream(BlockFace.values())
 				.filter(face -> !VALID_FACES.contains(face))
 				.collect(Collectors.toSet());
-		for (BlockFace invalid : invalidFaces)
+		for (BlockFace face : invalidFaces)
 		{
-			assertThrowsExactly(IllegalArgumentException.class, () -> trapDoor.setFacing(invalid));
+			assertThrowsExactly(IllegalArgumentException.class, () -> stairs.setFacing(face));
 		}
 	}
 
 	@Test
 	void setFacing_NullInput_ThrowsException()
 	{
-		assertThrowsExactly(NullPointerException.class, () -> trapDoor.setFacing(null));
+		assertThrowsExactly(NullPointerException.class, () -> stairs.setFacing(null));
 	}
 
 	@Test
 	void getFaces_HasCorrectValues()
 	{
-		assertEquals(VALID_FACES, trapDoor.getFaces());
+		assertEquals(VALID_FACES, stairs.getFaces());
 	}
 
 	@Test
-	void setOpen_Valid()
+	void setWaterlogged()
 	{
-		trapDoor.setOpen(true);
-		assertTrue(trapDoor.isOpen());
-	}
-
-	@Test
-	void setPowered_Valid()
-	{
-		trapDoor.setPowered(true);
-		assertTrue(trapDoor.isPowered());
-	}
-
-	@Test
-	void setWaterlogged_Valid()
-	{
-		trapDoor.setWaterlogged(true);
-		assertTrue(trapDoor.isWaterlogged());
+		stairs.setWaterlogged(true);
+		assertTrue(stairs.isWaterlogged());
 	}
 
 	@Test
 	void blockDataMock_Mock_CorrectType()
 	{
-		for (Material material : Tag.TRAPDOORS.getValues())
+		for (Material material : Tag.STAIRS.getValues())
 		{
-			assertInstanceOf(TrapDoorMock.class, BlockDataMock.mock(material));
+			assertInstanceOf(StairsDataMock.class, BlockDataMock.mock(material));
 		}
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/block/data/SwitchDataMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/data/SwitchDataMockTest.java
@@ -24,16 +24,16 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class SwitchMockTest
+class SwitchDataMockTest
 {
 
-	SwitchMock switchMock;
+	SwitchDataMock switchDataMock;
 
 	@BeforeEach
 	void setUp()
 	{
 		MockBukkit.mock();
-		switchMock = new SwitchMock(Material.ACACIA_BUTTON);
+		switchDataMock = new SwitchDataMock(Material.ACACIA_BUTTON);
 	}
 
 	@AfterEach
@@ -45,22 +45,22 @@ class SwitchMockTest
 	@Test
 	void constructor_DefaultValues()
 	{
-		assertEquals(BlockFace.NORTH, switchMock.getFacing());
-		assertFalse(switchMock.isPowered());
+		assertEquals(BlockFace.NORTH, switchDataMock.getFacing());
+		assertFalse(switchDataMock.isPowered());
 	}
 
 	@ParameterizedTest
 	@MethodSource("getPossibleMaterials")
 	void constructor_Material(Material material)
 	{
-		assertDoesNotThrow(() -> new SwitchMock(material));
+		assertDoesNotThrow(() -> new SwitchDataMock(material));
 
 	}
 
 	@Test
 	void constructor_Material_WrongType_ThrowsException()
 	{
-		assertThrowsExactly(IllegalArgumentException.class, () -> new WallSignMock(Material.BEDROCK));
+		assertThrowsExactly(IllegalArgumentException.class, () -> new WallSignDataMock(Material.BEDROCK));
 	}
 
 	@Test
@@ -68,10 +68,10 @@ class SwitchMockTest
 	{
 		for (BlockFace face : BlockFace.values())
 		{
-			if (!switchMock.getFaces().contains(face))
+			if (!switchDataMock.getFaces().contains(face))
 				continue;
-			assertDoesNotThrow(() -> switchMock.setFacing(face));
-			assertEquals(face, switchMock.getFacing());
+			assertDoesNotThrow(() -> switchDataMock.setFacing(face));
+			assertEquals(face, switchDataMock.getFacing());
 		}
 	}
 
@@ -80,9 +80,9 @@ class SwitchMockTest
 	{
 		for (BlockFace face : BlockFace.values())
 		{
-			if (switchMock.getFaces().contains(face))
+			if (switchDataMock.getFaces().contains(face))
 				continue;
-			assertThrowsExactly(IllegalArgumentException.class, () -> switchMock.setFacing(face));
+			assertThrowsExactly(IllegalArgumentException.class, () -> switchDataMock.setFacing(face));
 		}
 	}
 
@@ -90,67 +90,67 @@ class SwitchMockTest
 	void getFaces()
 	{
 		Set<BlockFace> validFaces = Set.of(BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST);
-		assertEquals(validFaces, switchMock.getFaces());
+		assertEquals(validFaces, switchDataMock.getFaces());
 	}
 
 	@Test
 	void getFacing_Immutable()
 	{
-		Set<BlockFace> faces = switchMock.getFaces();
+		Set<BlockFace> faces = switchDataMock.getFaces();
 		assertThrows(UnsupportedOperationException.class, () -> faces.add(BlockFace.NORTH_EAST));
 	}
 
 	@Test
 	void setFacing_notNull()
 	{
-		assertThrows(NullPointerException.class, () -> switchMock.setFacing(null));
+		assertThrows(NullPointerException.class, () -> switchDataMock.setFacing(null));
 	}
 
 	@Test
 	void setPowered()
 	{
-		switchMock.setPowered(true);
-		assertTrue(switchMock.isPowered());
-		switchMock.setPowered(false);
-		assertFalse(switchMock.isPowered());
+		switchDataMock.setPowered(true);
+		assertTrue(switchDataMock.isPowered());
+		switchDataMock.setPowered(false);
+		assertFalse(switchDataMock.isPowered());
 	}
 
 	@Test
 	void getAsString()
 	{
-		switchMock.setFacing(BlockFace.NORTH);
-		switchMock.setAttachedFace(AttachedFace.WALL);
-		switchMock.setPowered(false);
-		assertEquals("minecraft:acacia_button[face=wall,facing=north,powered=false]", switchMock.getAsString());
+		switchDataMock.setFacing(BlockFace.NORTH);
+		switchDataMock.setAttachedFace(AttachedFace.WALL);
+		switchDataMock.setPowered(false);
+		assertEquals("minecraft:acacia_button[face=wall,facing=north,powered=false]", switchDataMock.getAsString());
 	}
 
 	@ParameterizedTest
 	@EnumSource
 	void setAttachedFace(AttachedFace face)
 	{
-		switchMock.setAttachedFace(face);
-		assertEquals(face, switchMock.getAttachedFace());
+		switchDataMock.setAttachedFace(face);
+		assertEquals(face, switchDataMock.getAttachedFace());
 	}
 
 	@Test
 	void setAttachedFace_notNull()
 	{
-		assertThrows(NullPointerException.class, () -> switchMock.setAttachedFace(null));
+		assertThrows(NullPointerException.class, () -> switchDataMock.setAttachedFace(null));
 	}
 
 	@ParameterizedTest
 	@MethodSource("getPossibleMaterials")
 	void blockDataMock_Mock_CorrectType(Material material)
 	{
-		assertInstanceOf(SwitchMock.class, BlockDataMock.mock(material));
+		assertInstanceOf(SwitchDataMock.class, BlockDataMock.mock(material));
 	}
 
 	@ParameterizedTest
 	@EnumSource
 	void setFace(Face face)
 	{
-		switchMock.setFace(face);
-		assertEquals(face, switchMock.getFace());
+		switchDataMock.setFace(face);
+		assertEquals(face, switchDataMock.getFace());
 	}
 
 	private static Stream<Material> getPossibleMaterials()

--- a/src/test/java/be/seeseemelk/mockbukkit/block/data/TrapDoorDataMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/data/TrapDoorDataMockTest.java
@@ -5,7 +5,6 @@ import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.Bisected;
-import org.bukkit.block.data.type.Stairs;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class StairsMockTest
+class TrapDoorDataMockTest
 {
 
 	private static final Set<BlockFace> VALID_FACES = Set.of(
@@ -31,13 +30,13 @@ class StairsMockTest
 			BlockFace.WEST
 	);
 
-	private StairsMock stairs;
+	private TrapDoorDataMock trapDoor;
 
 	@BeforeEach
 	void setUp()
 	{
 		MockBukkit.mock();
-		this.stairs = new StairsMock(Material.BIRCH_STAIRS);
+		this.trapDoor = new TrapDoorDataMock(Material.BIRCH_TRAPDOOR);
 	}
 
 	@AfterEach
@@ -49,48 +48,36 @@ class StairsMockTest
 	@Test
 	void constructor_DefaultValues()
 	{
-		assertEquals(Stairs.Shape.STRAIGHT, stairs.getShape());
-		assertFalse(stairs.isWaterlogged());
-		assertEquals(BlockFace.NORTH, stairs.getFacing());
-		assertEquals(Bisected.Half.BOTTOM, stairs.getHalf());
+		assertEquals(Bisected.Half.BOTTOM, trapDoor.getHalf());
+		assertFalse(trapDoor.isOpen());
+		assertFalse(trapDoor.isPowered());
+		assertFalse(trapDoor.isWaterlogged());
+		assertEquals(BlockFace.NORTH, trapDoor.getFacing());
 	}
 
 	@Test
 	void constructor_Material()
 	{
-		assertDoesNotThrow(() -> new StairsMock(Material.BIRCH_STAIRS));
+		assertDoesNotThrow(() -> new TrapDoorDataMock(Material.BIRCH_TRAPDOOR));
 	}
 
 	@Test
 	void constructor_Material_WrongType_ThrowsException()
 	{
-		assertThrowsExactly(IllegalArgumentException.class, () -> new StairsMock(Material.CHISELED_DEEPSLATE));
-	}
-
-	@Test
-	void setShape_Valid()
-	{
-		stairs.setShape(Stairs.Shape.INNER_RIGHT);
-		assertEquals(Stairs.Shape.INNER_RIGHT, stairs.getShape());
-	}
-
-	@Test
-	void setShape_NullInput_ThrowsException()
-	{
-		assertThrowsExactly(NullPointerException.class, () -> stairs.setShape(null));
+		assertThrowsExactly(IllegalArgumentException.class, () -> new TrapDoorDataMock(Material.WET_SPONGE));
 	}
 
 	@Test
 	void setHalf_Valid()
 	{
-		stairs.setHalf(Bisected.Half.TOP);
-		assertEquals(Bisected.Half.TOP, stairs.getHalf());
+		trapDoor.setHalf(Bisected.Half.TOP);
+		assertEquals(Bisected.Half.TOP, trapDoor.getHalf());
 	}
 
 	@Test
 	void setHalf_NullInput_ThrowsException()
 	{
-		assertThrowsExactly(NullPointerException.class, () -> stairs.setHalf(null));
+		assertThrowsExactly(NullPointerException.class, () -> trapDoor.setHalf(null));
 	}
 
 	@Test
@@ -98,8 +85,8 @@ class StairsMockTest
 	{
 		for (BlockFace face : VALID_FACES)
 		{
-			stairs.setFacing(face);
-			assertEquals(face, stairs.getFacing());
+			trapDoor.setFacing(face);
+			assertEquals(face, trapDoor.getFacing());
 		}
 	}
 
@@ -109,37 +96,51 @@ class StairsMockTest
 		final Set<BlockFace> invalidFaces = Arrays.stream(BlockFace.values())
 				.filter(face -> !VALID_FACES.contains(face))
 				.collect(Collectors.toSet());
-		for (BlockFace face : invalidFaces)
+		for (BlockFace invalid : invalidFaces)
 		{
-			assertThrowsExactly(IllegalArgumentException.class, () -> stairs.setFacing(face));
+			assertThrowsExactly(IllegalArgumentException.class, () -> trapDoor.setFacing(invalid));
 		}
 	}
 
 	@Test
 	void setFacing_NullInput_ThrowsException()
 	{
-		assertThrowsExactly(NullPointerException.class, () -> stairs.setFacing(null));
+		assertThrowsExactly(NullPointerException.class, () -> trapDoor.setFacing(null));
 	}
 
 	@Test
 	void getFaces_HasCorrectValues()
 	{
-		assertEquals(VALID_FACES, stairs.getFaces());
+		assertEquals(VALID_FACES, trapDoor.getFaces());
 	}
 
 	@Test
-	void setWaterlogged()
+	void setOpen_Valid()
 	{
-		stairs.setWaterlogged(true);
-		assertTrue(stairs.isWaterlogged());
+		trapDoor.setOpen(true);
+		assertTrue(trapDoor.isOpen());
+	}
+
+	@Test
+	void setPowered_Valid()
+	{
+		trapDoor.setPowered(true);
+		assertTrue(trapDoor.isPowered());
+	}
+
+	@Test
+	void setWaterlogged_Valid()
+	{
+		trapDoor.setWaterlogged(true);
+		assertTrue(trapDoor.isWaterlogged());
 	}
 
 	@Test
 	void blockDataMock_Mock_CorrectType()
 	{
-		for (Material material : Tag.STAIRS.getValues())
+		for (Material material : Tag.TRAPDOORS.getValues())
 		{
-			assertInstanceOf(StairsMock.class, BlockDataMock.mock(material));
+			assertInstanceOf(TrapDoorDataMock.class, BlockDataMock.mock(material));
 		}
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/block/data/WallSignDataMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/data/WallSignDataMockTest.java
@@ -1,10 +1,9 @@
 package be.seeseemelk.mockbukkit.block.data;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
-import com.destroystokyo.paper.MaterialTags;
 import org.bukkit.Material;
+import org.bukkit.Tag;
 import org.bukkit.block.BlockFace;
-import org.bukkit.block.data.type.Bed;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,21 +16,22 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class BedMockTest
+class WallSignDataMockTest
 {
 
-	private BedMock bed;
+	private WallSignDataMock sign;
 
 	@BeforeEach
 	void setUp()
 	{
 		MockBukkit.mock();
-		this.bed = new BedMock(Material.RED_BED);
+		sign = new WallSignDataMock(Material.ACACIA_WALL_SIGN);
 	}
 
 	@AfterEach
-	void teardown()
+	void tearDown()
 	{
 		MockBukkit.unmock();
 	}
@@ -39,21 +39,23 @@ class BedMockTest
 	@Test
 	void constructor_DefaultValues()
 	{
-		assertEquals(Bed.Part.FOOT, bed.getPart());
-		assertFalse(bed.isOccupied());
-		assertEquals(BlockFace.NORTH, bed.getFacing());
+		assertEquals(BlockFace.NORTH, sign.getFacing());
+		assertFalse(sign.isWaterlogged());
 	}
 
 	@Test
 	void constructor_Material()
 	{
-		assertDoesNotThrow(() -> new BedMock(Material.RED_BED));
+		for (Material wallSignType : Tag.WALL_SIGNS.getValues())
+		{
+			assertDoesNotThrow(() -> new WallSignDataMock(wallSignType));
+		}
 	}
 
 	@Test
 	void constructor_Material_WrongType_ThrowsException()
 	{
-		assertThrowsExactly(IllegalArgumentException.class, () -> new BedMock(Material.BEDROCK));
+		assertThrowsExactly(IllegalArgumentException.class, () -> new WallSignDataMock(Material.BEDROCK));
 	}
 
 	@Test
@@ -61,9 +63,10 @@ class BedMockTest
 	{
 		for (BlockFace face : BlockFace.values())
 		{
-			if (!bed.getFaces().contains(face))
+			if (!sign.getFaces().contains(face))
 				continue;
-			assertDoesNotThrow(() -> bed.setFacing(face));
+			assertDoesNotThrow(() -> sign.setFacing(face));
+			assertEquals(face, sign.getFacing());
 		}
 	}
 
@@ -72,9 +75,9 @@ class BedMockTest
 	{
 		for (BlockFace face : BlockFace.values())
 		{
-			if (bed.getFaces().contains(face))
+			if (sign.getFaces().contains(face))
 				continue;
-			assertThrowsExactly(IllegalArgumentException.class, () -> bed.setFacing(face));
+			assertThrowsExactly(IllegalArgumentException.class, () -> sign.setFacing(face));
 		}
 	}
 
@@ -82,28 +85,45 @@ class BedMockTest
 	void getFaces()
 	{
 		Set<BlockFace> validFaces = Set.of(BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST);
-		assertEquals(validFaces, bed.getFaces());
+		assertEquals(validFaces, sign.getFaces());
 	}
 
 	@Test
 	void getFacing_Immutable()
 	{
-		Set<BlockFace> faces = bed.getFaces();
+		Set<BlockFace> faces = sign.getFaces();
 		assertThrows(UnsupportedOperationException.class, () -> faces.add(BlockFace.NORTH_EAST));
+	}
+
+	@Test
+	void getFacing_notNull()
+	{
+		assertThrows(NullPointerException.class, () -> sign.setFacing(null));
+	}
+
+	@Test
+	void setWaterLogged()
+	{
+		sign.setWaterlogged(true);
+		assertTrue(sign.isWaterlogged());
+		sign.setWaterlogged(false);
+		assertFalse(sign.isWaterlogged());
 	}
 
 	@Test
 	void getAsString()
 	{
-		assertEquals("minecraft:red_bed[facing=north,occupied=false,part=foot]", bed.getAsString());
+		sign.setWaterlogged(true);
+		sign.setFacing(BlockFace.SOUTH);
+		assertEquals("minecraft:acacia_wall_sign[facing=south,waterlogged=true]", sign.getAsString());
 	}
 
 	@Test
 	void blockDataMock_Mock_CorrectType()
 	{
-		for (Material material : MaterialTags.BEDS.getValues())
+		for (Material material : Tag.WALL_SIGNS.getValues())
 		{
-			assertInstanceOf(BedMock.class, BlockDataMock.mock(material));
+			assertInstanceOf(WallSignDataMock.class, BlockDataMock.mock(material));
 		}
 	}
 


### PR DESCRIPTION
# Description
Renames all BlockData mocks and associated tests to include `Data` in the name, making it easier to differentiate against BlockData. E.g. `BedMock` is now `BedDataMock`.

# Checklist
The following items should be checked before the pull request can be merged.

- [x] Unit tests added.
- [x] Code follows existing code format.

# Info on creating a pull request
- Make sure that unit tests are added which test the relevant changes.
- Make sure that the changes follow the existing code format.

# For maintainer
When a PR is approved, the maintainer should label this PR with `release/*`.

- If the PR fixes a bug in MockBukkit, add the `release/patch` Tag.
- If the PR adds a new feature to MockBukkit, add  the `release/minor` Tag.

Note that a PR that fixes an `UnimplementedOperationException` should be considered a new version and not a bugfix.
