### PR TITLE
Make jacocoTestReport depend on test and check depend on jacocoTestReport

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,10 +76,11 @@ tasks {
 	}
 
 	check {
-		finalizedBy(jacocoTestReport)
+		 dependsOn(jacocoTestReport)
 	}
 
 	jacocoTestReport {
+		dependsOn(test)
 		reports {
 			xml.required.set(true)
 			html.required.set(true)
@@ -112,7 +113,7 @@ signing {
 }
 
 nexusPublishing {
-	repositories {
+	this.repositories {
 		sonatype {
 			username.set(findProperty("ossrhUsername") as String?)
 			password.set(findProperty("ossrhPassword") as String?)


### PR DESCRIPTION
# Description
Reworked #669, since we switched to the Kotlin DSL. Original Credit goes to @spscally 

Now `jacocoTestReport` runs the `test` task before generating the Report, making it also work when the `clean` task was run before.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
