### PR TITLE
Create separate build and publish pipeline

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,33 +11,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: 17
-          distribution: 'temurin'
-
-      - name: Restore caches
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', 'gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*' ,'gradle-wrapper.properties') }}
-            ${{ runner.os }}-gradle-
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-      - name: Build with Gradle
-        run: ./gradlew build -x test
-      - name: Run unit tests
-        run: ./gradlew test
-
       - name: Get merged pull request
         uses: actions-ecosystem/action-get-merged-pull-request@v1.0.1
         if: github.event_name == 'push'
@@ -74,32 +47,3 @@ jobs:
         with:
           tag: ${{ steps.bump-semver.outputs.new_version }}
           message: '${{ steps.bump-semver.outputs.new_version }}: PR #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}'
-
-      - name: Store Private key
-        uses: DamianReeves/write-file-action@v1.2
-        if: ${{ steps.bump-semver.outputs.new_version != null }}
-        with:
-          path: private.key
-          contents: ${{ secrets.PRIV_KEY }}
-          write-mode: overwrite
-
-      - name: Publish
-        if: ${{ steps.bump-semver.outputs.new_version != null }}
-        env:
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-          SIGN_KEY: ${{ secrets.PRIV_KEY_PASS }}
-        run: |
-          mkdir -p $HOME/.gnupg
-          echo use-agent >> $HOME/.gnupg/gpg.conf
-          echo pinentry-mode loopback >> $HOME/.gnupg/gpg.conf
-          echo allow-loopback-pinentry >> $HOME/.gnupg/gpg-agent.conf
-          gpg --batch --import private.key
-          gpg --batch --export-secret-keys --passphrase $SIGN_KEY "Sebastiaan de Schaetzen <sebastiaan.de.schaetzen@gmail.com>" > private.gpg
-
-          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository \
-            -Pmockbukkit.version=$(echo ${{ steps.bump-semver.outputs.new_version }} | sed -e 's:v::') \
-            -PossrhUsername=seeseemelk \
-            -PossrhPassword=$OSSRH_PASSWORD \
-            -Psigning.secretKeyRingFile=private.gpg \
-            -Psigning.keyId=${{ secrets.PRIV_KEY_ID }} \
-            -Psigning.password=$SIGN_KEY

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 name: Build
 
 on:
+  pull_request:
+    branches: [ v1.* ]
   push:
     tags:  [ v* ]
 
@@ -38,14 +40,14 @@ jobs:
 
       - name: Store Private key
         uses: DamianReeves/write-file-action@v1.2
-        if: ${{ steps.bump-semver.outputs.new_version != null }}
+        if: ${{ github.ref_type == 'tag' }}
         with:
           path: private.key
           contents: ${{ secrets.PRIV_KEY }}
           write-mode: overwrite
 
       - name: Publish
-        if: ${{ steps.bump-semver.outputs.new_version != null }}
+        if: ${{ github.ref_type == 'tag' }}
         env:
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           SIGN_KEY: ${{ secrets.PRIV_KEY_PASS }}
@@ -58,7 +60,7 @@ jobs:
           gpg --batch --export-secret-keys --passphrase $SIGN_KEY "Sebastiaan de Schaetzen <sebastiaan.de.schaetzen@gmail.com>" > private.gpg
 
           ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository \
-            -Pmockbukkit.version=$(echo ${{ steps.bump-semver.outputs.new_version }} | sed -e 's:v::') \
+            -Pmockbukkit.version=$(echo ${{ github.ref_name }} | sed -e 's:v::') \
             -PossrhUsername=seeseemelk \
             -PossrhPassword=$OSSRH_PASSWORD \
             -Psigning.secretKeyRingFile=private.gpg \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,66 @@
+name: Build
+
+on:
+  push:
+    tags:  [ v* ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Validate gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'temurin'
+
+      - name: Restore caches
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', 'gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*' ,'gradle-wrapper.properties') }}
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew build -x test
+      - name: Run unit tests
+        run: ./gradlew test
+
+      - name: Store Private key
+        uses: DamianReeves/write-file-action@v1.2
+        if: ${{ steps.bump-semver.outputs.new_version != null }}
+        with:
+          path: private.key
+          contents: ${{ secrets.PRIV_KEY }}
+          write-mode: overwrite
+
+      - name: Publish
+        if: ${{ steps.bump-semver.outputs.new_version != null }}
+        env:
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          SIGN_KEY: ${{ secrets.PRIV_KEY_PASS }}
+        run: |
+          mkdir -p $HOME/.gnupg
+          echo use-agent >> $HOME/.gnupg/gpg.conf
+          echo pinentry-mode loopback >> $HOME/.gnupg/gpg.conf
+          echo allow-loopback-pinentry >> $HOME/.gnupg/gpg-agent.conf
+          gpg --batch --import private.key
+          gpg --batch --export-secret-keys --passphrase $SIGN_KEY "Sebastiaan de Schaetzen <sebastiaan.de.schaetzen@gmail.com>" > private.gpg
+
+          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository \
+            -Pmockbukkit.version=$(echo ${{ steps.bump-semver.outputs.new_version }} | sed -e 's:v::') \
+            -PossrhUsername=seeseemelk \
+            -PossrhPassword=$OSSRH_PASSWORD \
+            -Psigning.secretKeyRingFile=private.gpg \
+            -Psigning.keyId=${{ secrets.PRIV_KEY_ID }} \
+            -Psigning.password=$SIGN_KEY

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,8 +1,6 @@
 name: Tag
 
 on:
-  pull_request:
-    branches: [ v1.* ]
   push:
     branches: [ v1.* ]
 

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Tag
 
 on:
   pull_request:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Get merged pull request
         uses: actions-ecosystem/action-get-merged-pull-request@v1.0.1
-        if: github.event_name == 'push'
+        if: ${{ github.event_name == 'push' }}
         id: pr
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description
This separates the tag step and the build/publish steps from the pipeline.

This will:
 - Prevent the issue we had with v3.0.0 where the build failed and caused the version bump to be skipped
 - Allow us to retry the build/publish step from a failed commit without causing an unnecessary version bump

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [ ] Unit tests added (if applicable).
