### PR TITLE
Adds Minecart Entity Mocks

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
@@ -13,6 +13,7 @@ import be.seeseemelk.mockbukkit.entity.CatMock;
 import be.seeseemelk.mockbukkit.entity.CaveSpiderMock;
 import be.seeseemelk.mockbukkit.entity.ChickenMock;
 import be.seeseemelk.mockbukkit.entity.CodMock;
+import be.seeseemelk.mockbukkit.entity.CommandMinecartMock;
 import be.seeseemelk.mockbukkit.entity.CowMock;
 import be.seeseemelk.mockbukkit.entity.CreeperMock;
 import be.seeseemelk.mockbukkit.entity.DonkeyMock;
@@ -22,6 +23,7 @@ import be.seeseemelk.mockbukkit.entity.ElderGuardianMock;
 import be.seeseemelk.mockbukkit.entity.EndermanMock;
 import be.seeseemelk.mockbukkit.entity.EntityMock;
 import be.seeseemelk.mockbukkit.entity.ExperienceOrbMock;
+import be.seeseemelk.mockbukkit.entity.ExplosiveMinecartMock;
 import be.seeseemelk.mockbukkit.entity.FireworkMock;
 import be.seeseemelk.mockbukkit.entity.FishHookMock;
 import be.seeseemelk.mockbukkit.entity.FoxMock;
@@ -30,6 +32,7 @@ import be.seeseemelk.mockbukkit.entity.GhastMock;
 import be.seeseemelk.mockbukkit.entity.GiantMock;
 import be.seeseemelk.mockbukkit.entity.GoatMock;
 import be.seeseemelk.mockbukkit.entity.GuardianMock;
+import be.seeseemelk.mockbukkit.entity.HopperMinecartMock;
 import be.seeseemelk.mockbukkit.entity.HorseMock;
 import be.seeseemelk.mockbukkit.entity.ItemEntityMock;
 import be.seeseemelk.mockbukkit.entity.LargeFireballMock;
@@ -41,12 +44,15 @@ import be.seeseemelk.mockbukkit.entity.PigMock;
 import be.seeseemelk.mockbukkit.entity.PolarBearMock;
 import be.seeseemelk.mockbukkit.entity.PoweredMinecartMock;
 import be.seeseemelk.mockbukkit.entity.PufferFishMock;
+import be.seeseemelk.mockbukkit.entity.RideableMinecartMock;
 import be.seeseemelk.mockbukkit.entity.SalmonMock;
 import be.seeseemelk.mockbukkit.entity.SheepMock;
 import be.seeseemelk.mockbukkit.entity.SkeletonHorseMock;
 import be.seeseemelk.mockbukkit.entity.SkeletonMock;
 import be.seeseemelk.mockbukkit.entity.SmallFireballMock;
+import be.seeseemelk.mockbukkit.entity.SpawnerMinecartMock;
 import be.seeseemelk.mockbukkit.entity.SpiderMock;
+import be.seeseemelk.mockbukkit.entity.StorageMinecartMock;
 import be.seeseemelk.mockbukkit.entity.StrayMock;
 import be.seeseemelk.mockbukkit.entity.TadpoleMock;
 import be.seeseemelk.mockbukkit.entity.TropicalFishMock;
@@ -159,7 +165,13 @@ import org.bukkit.entity.WitherSkull;
 import org.bukkit.entity.Wolf;
 import org.bukkit.entity.Zombie;
 import org.bukkit.entity.ZombieHorse;
+import org.bukkit.entity.minecart.CommandMinecart;
+import org.bukkit.entity.minecart.ExplosiveMinecart;
+import org.bukkit.entity.minecart.HopperMinecart;
 import org.bukkit.entity.minecart.PoweredMinecart;
+import org.bukkit.entity.minecart.RideableMinecart;
+import org.bukkit.entity.minecart.SpawnerMinecart;
+import org.bukkit.entity.minecart.StorageMinecart;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntitySpawnEvent;
 import org.bukkit.event.entity.ItemSpawnEvent;
@@ -1193,6 +1205,30 @@ public class WorldMock implements World
 		else if (clazz == Camel.class)
 		{
 			return new CamelMock(server, UUID.randomUUID());
+		}
+		else if (clazz == CommandMinecart.class)
+		{
+			return new CommandMinecartMock(server, UUID.randomUUID());
+		}
+		else if (clazz == ExplosiveMinecart.class)
+		{
+			return new ExplosiveMinecartMock(server, UUID.randomUUID());
+		}
+		else if (clazz == HopperMinecart.class)
+		{
+			return new HopperMinecartMock(server, UUID.randomUUID());
+		}
+		else if (clazz == SpawnerMinecart.class)
+		{
+			return new SpawnerMinecartMock(server, UUID.randomUUID());
+		}
+		else if (clazz == RideableMinecart.class)
+		{
+			return new RideableMinecartMock(server, UUID.randomUUID());
+		}
+		else if (clazz == StorageMinecart.class)
+		{
+			return new StorageMinecartMock(server, UUID.randomUUID());
 		}
 		throw new UnimplementedOperationException();
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/CommandMinecartMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/CommandMinecartMock.java
@@ -86,4 +86,5 @@ public class CommandMinecartMock extends MinecartMock implements CommandMinecart
 	{
 		return EntityType.MINECART_COMMAND;
 	}
+
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/CommandMinecartMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/CommandMinecartMock.java
@@ -1,0 +1,89 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.minecart.CommandMinecart;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+public class CommandMinecartMock extends MinecartMock implements CommandMinecart
+{
+
+	private String command = "";
+	private int successCount;
+
+	/**
+	 * Constructs a new {@link CommandMinecartMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
+	public CommandMinecartMock(@NotNull ServerMock server, @NotNull UUID uuid)
+	{
+		super(server, uuid);
+	}
+
+	@Override
+	public @NotNull String getCommand()
+	{
+		return this.command;
+	}
+
+	@Override
+	public void setCommand(@Nullable String command)
+	{
+		if (command == null)
+		{
+			this.command = "";
+		}
+		else
+		{
+			this.command = command;
+		}
+		this.successCount = 0;
+	}
+
+	@Override
+	public @NotNull Component lastOutput()
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public void lastOutput(@Nullable Component lastOutput)
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+
+	}
+
+	@Override
+	public int getSuccessCount()
+	{
+		return this.successCount;
+	}
+
+	@Override
+	public void setSuccessCount(int successCount)
+	{
+		this.successCount = successCount;
+	}
+
+	@Override
+	public @NotNull Material getMinecartMaterial()
+	{
+		return Material.COMMAND_BLOCK_MINECART;
+	}
+
+	@Override
+	public @NotNull EntityType getType()
+	{
+		return EntityType.MINECART_COMMAND;
+	}
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ExplosiveMinecartMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ExplosiveMinecartMock.java
@@ -1,0 +1,89 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.ServerMock;
+import com.google.common.base.Preconditions;
+import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.minecart.ExplosiveMinecart;
+import org.bukkit.event.entity.ExplosionPrimeEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class ExplosiveMinecartMock extends MinecartMock implements ExplosiveMinecart
+{
+
+	private int fuseTicks = -1;
+
+	/**
+	 * Constructs a new {@link ExplosiveMinecartMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
+	public ExplosiveMinecartMock(@NotNull ServerMock server, @NotNull UUID uuid)
+	{
+		super(server, uuid);
+	}
+
+	@Override
+	public void setFuseTicks(int ticks)
+	{
+		this.fuseTicks = ticks;
+	}
+
+	@Override
+	public int getFuseTicks()
+	{
+		return this.fuseTicks;
+	}
+
+	@Override
+	public void ignite()
+	{
+		this.fuseTicks = 80;
+	}
+
+	@Override
+	public boolean isIgnited()
+	{
+		return this.fuseTicks > -1;
+	}
+
+	@Override
+	public void explode()
+	{
+		var x = this.getVelocity().getX();
+		var z = this.getVelocity().getZ();
+		explode(x * x + z * z);
+	}
+
+	@Override
+	public void explode(double power)
+	{
+		Preconditions.checkArgument(0 <= power && power <= 5,
+				"Power must be in range [0, 5] (got %s)", power);
+
+		double d1 = Math.sqrt(power);
+
+		ThreadLocalRandom random = ThreadLocalRandom.current();
+		server.getPluginManager().callEvent(new ExplosionPrimeEvent(this,
+				(float) (4.0D + random.nextDouble() * 1.5D * d1), false));
+
+		this.remove();
+	}
+
+	@Override
+	public @NotNull Material getMinecartMaterial()
+	{
+		return Material.TNT_MINECART;
+	}
+
+	@Override
+	public @NotNull EntityType getType()
+	{
+		return EntityType.MINECART_TNT;
+	}
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/HopperMinecartMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/HopperMinecartMock.java
@@ -1,0 +1,91 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import org.bukkit.Material;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.minecart.HopperMinecart;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.loot.LootTable;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class HopperMinecartMock extends LootableMinecart implements HopperMinecart
+{
+
+	private boolean enabled = true;
+	private Inventory inventory;
+
+	/**
+	 * Constructs a new {@link HopperMinecartMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
+	public HopperMinecartMock(@NotNull ServerMock server, @NotNull UUID uuid)
+	{
+		super(server, uuid);
+	}
+
+	@Override
+	public boolean isEnabled()
+	{
+		return this.enabled;
+	}
+
+	@Override
+	public void setEnabled(boolean enabled)
+	{
+		this.enabled = enabled;
+	}
+
+	@Override
+	@Deprecated(forRemoval = true)
+	public int getPickupCooldown()
+	{
+		throw new UnsupportedOperationException("Hopper minecarts don't have cooldowns");
+	}
+
+	@Override
+	@Deprecated(forRemoval = true)
+	public void setPickupCooldown(int cooldown)
+	{
+		throw new UnsupportedOperationException("Hopper minecarts don't have cooldowns");
+	}
+
+	@Override
+	public @NotNull Entity getEntity()
+	{
+		return this;
+	}
+
+	@Override
+	public @NotNull Material getMinecartMaterial()
+	{
+		return Material.HOPPER_MINECART;
+	}
+
+	@Override
+	public @NotNull Inventory getInventory()
+	{
+		if (this.inventory == null) {
+			this.inventory = server.createInventory(null, InventoryType.HOPPER);
+		}
+		return this.inventory;
+	}
+
+	@Override
+	public EntityType getType()
+	{
+		return EntityType.MINECART_HOPPER;
+	}
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LootableMinecart.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LootableMinecart.java
@@ -1,0 +1,154 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import com.destroystokyo.paper.loottable.LootableInventory;
+import com.google.common.util.concurrent.AtomicLongMap;
+import org.bukkit.Material;
+import org.bukkit.loot.LootTable;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public abstract class LootableMinecart extends MinecartMock implements LootableInventory
+{
+
+	private long nextRefill = -1;
+	private long lastFilled = -1;
+	private Map<UUID, Long> lootedPlayers;
+	private boolean refillEnabled;
+
+	/**
+	 * Constructs a new {@link LootableMinecart} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
+	protected LootableMinecart(@NotNull ServerMock server, @NotNull UUID uuid)
+	{
+		super(server, uuid);
+	}
+
+	@Override
+	public boolean isRefillEnabled()
+	{
+		return this.refillEnabled;
+	}
+
+	public void setRefillEnabled(boolean refillEnabled)
+	{
+		this.refillEnabled = refillEnabled;
+	}
+
+	@Override
+	public boolean hasBeenFilled()
+	{
+		return this.lastFilled != -1;
+	}
+
+	@Override
+	public boolean hasPlayerLooted(@NotNull UUID player)
+	{
+		return this.lootedPlayers != null && this.lootedPlayers.containsKey(player);
+	}
+
+	@Override
+	public @Nullable Long getLastLooted(@NotNull UUID player)
+	{
+		return this.lootedPlayers != null ? this.lootedPlayers.get(player) : null;
+	}
+
+	@Override
+	public boolean setHasPlayerLooted(@NotNull UUID player, boolean looted)
+	{
+		final boolean hasLooted = hasPlayerLooted(player);
+
+		if (this.lootedPlayers == null) {
+			this.lootedPlayers = new HashMap<>();
+		}
+
+		if (hasLooted != looted)
+		{
+			if (looted) {
+				if (!this.lootedPlayers.containsKey(player)) {
+					this.lootedPlayers.put(player, System.currentTimeMillis());
+				}
+			} else {
+				this.lootedPlayers.remove(player);
+			}
+		}
+		return hasLooted;
+	}
+
+	@Override
+	public boolean hasPendingRefill()
+	{
+		return this.nextRefill != -1;
+	}
+
+	@Override
+	public long getLastFilled()
+	{
+		return this.lastFilled;
+	}
+
+	@Override
+	public long getNextRefill()
+	{
+		return this.nextRefill;
+	}
+
+	@Override
+	public long setNextRefill(long refillAt)
+	{
+		final long oldRefill = this.nextRefill;
+		this.nextRefill = refillAt;
+
+		new BukkitRunnable(){
+			@Override
+			public void run()
+			{
+				if (nextRefill == server.getScheduler().getCurrentTick()) {
+					nextRefill = -1;
+					lastFilled = server.getScheduler().getCurrentTick();
+				}
+
+			}
+		}.runTaskTimer(null, 1, 1);
+
+		return oldRefill;
+	}
+
+	@Override
+	public void setLootTable(@Nullable LootTable table)
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public @Nullable LootTable getLootTable()
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public void setSeed(long seed)
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public long getSeed()
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/RideableMinecartMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/RideableMinecartMock.java
@@ -1,0 +1,30 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.ServerMock;
+import org.bukkit.Material;
+import org.bukkit.entity.minecart.RideableMinecart;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+public class RideableMinecartMock extends MinecartMock implements RideableMinecart
+{
+
+	/**
+	 * Constructs a new {@link RideableMinecartMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
+	public RideableMinecartMock(@NotNull ServerMock server, @NotNull UUID uuid)
+	{
+		super(server, uuid);
+	}
+
+	@Override
+	public @NotNull Material getMinecartMaterial()
+	{
+		return Material.MINECART;
+	}
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/RideableMinecartMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/RideableMinecartMock.java
@@ -2,6 +2,7 @@ package be.seeseemelk.mockbukkit.entity;
 
 import be.seeseemelk.mockbukkit.ServerMock;
 import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.minecart.RideableMinecart;
 import org.jetbrains.annotations.NotNull;
 
@@ -25,6 +26,12 @@ public class RideableMinecartMock extends MinecartMock implements RideableMineca
 	public @NotNull Material getMinecartMaterial()
 	{
 		return Material.MINECART;
+	}
+
+	@Override
+	public @NotNull EntityType getType()
+	{
+		return EntityType.MINECART;
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/SpawnerMinecartMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/SpawnerMinecartMock.java
@@ -1,0 +1,30 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.ServerMock;
+import org.bukkit.Material;
+import org.bukkit.entity.minecart.SpawnerMinecart;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+public class SpawnerMinecartMock extends MinecartMock implements SpawnerMinecart
+{
+
+	/**
+	 * Constructs a new {@link SpawnerMinecartMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
+	public SpawnerMinecartMock(@NotNull ServerMock server, @NotNull UUID uuid)
+	{
+		super(server, uuid);
+	}
+
+	@Override
+	public @NotNull Material getMinecartMaterial()
+	{
+		return Material.MINECART;
+	}
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/SpawnerMinecartMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/SpawnerMinecartMock.java
@@ -2,6 +2,7 @@ package be.seeseemelk.mockbukkit.entity;
 
 import be.seeseemelk.mockbukkit.ServerMock;
 import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.minecart.SpawnerMinecart;
 import org.jetbrains.annotations.NotNull;
 
@@ -25,6 +26,12 @@ public class SpawnerMinecartMock extends MinecartMock implements SpawnerMinecart
 	public @NotNull Material getMinecartMaterial()
 	{
 		return Material.MINECART;
+	}
+
+	@Override
+	public @NotNull EntityType getType()
+	{
+		return EntityType.MINECART_MOB_SPAWNER;
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/StorageMinecartMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/StorageMinecartMock.java
@@ -1,0 +1,47 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.ServerMock;
+import org.bukkit.Material;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.minecart.StorageMinecart;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.Inventory;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+public class StorageMinecartMock extends LootableMinecart implements StorageMinecart
+{
+	private Inventory inventory;
+
+	/**
+	 * Constructs a new {@link LootableMinecart} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
+	public StorageMinecartMock(@NotNull ServerMock server, @NotNull UUID uuid)
+	{
+		super(server, uuid);
+		inventory = server.createInventory(this, 3*9);
+	}
+
+	@Override
+	public @NotNull Entity getEntity()
+	{
+		return this;
+	}
+
+	@Override
+	public @NotNull Material getMinecartMaterial()
+	{
+		return Material.CHEST_MINECART;
+	}
+
+	@Override
+	public @NotNull Inventory getInventory()
+	{
+		return this.inventory;
+	}
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/StorageMinecartMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/StorageMinecartMock.java
@@ -3,8 +3,8 @@ package be.seeseemelk.mockbukkit.entity;
 import be.seeseemelk.mockbukkit.ServerMock;
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.minecart.StorageMinecart;
-import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 import org.jetbrains.annotations.NotNull;
 
@@ -43,6 +43,12 @@ public class StorageMinecartMock extends LootableMinecart implements StorageMine
 	public @NotNull Inventory getInventory()
 	{
 		return this.inventory;
+	}
+
+	@Override
+	public @NotNull EntityType getType()
+	{
+		return EntityType.MINECART_CHEST;
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/StorageMinecartMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/StorageMinecartMock.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 
 public class StorageMinecartMock extends LootableMinecart implements StorageMinecart
 {
+
 	private Inventory inventory;
 
 	/**

--- a/src/test/java/be/seeseemelk/mockbukkit/WorldMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/WorldMockTest.java
@@ -14,6 +14,7 @@ import be.seeseemelk.mockbukkit.entity.CatMock;
 import be.seeseemelk.mockbukkit.entity.CaveSpiderMock;
 import be.seeseemelk.mockbukkit.entity.ChickenMock;
 import be.seeseemelk.mockbukkit.entity.CodMock;
+import be.seeseemelk.mockbukkit.entity.CommandMinecartMock;
 import be.seeseemelk.mockbukkit.entity.CowMock;
 import be.seeseemelk.mockbukkit.entity.CreeperMock;
 import be.seeseemelk.mockbukkit.entity.DonkeyMock;
@@ -22,6 +23,7 @@ import be.seeseemelk.mockbukkit.entity.EggMock;
 import be.seeseemelk.mockbukkit.entity.ElderGuardianMock;
 import be.seeseemelk.mockbukkit.entity.EndermanMock;
 import be.seeseemelk.mockbukkit.entity.ExperienceOrbMock;
+import be.seeseemelk.mockbukkit.entity.ExplosiveMinecartMock;
 import be.seeseemelk.mockbukkit.entity.FireballMock;
 import be.seeseemelk.mockbukkit.entity.FireworkMock;
 import be.seeseemelk.mockbukkit.entity.FoxMock;
@@ -30,6 +32,7 @@ import be.seeseemelk.mockbukkit.entity.GhastMock;
 import be.seeseemelk.mockbukkit.entity.GiantMock;
 import be.seeseemelk.mockbukkit.entity.GoatMock;
 import be.seeseemelk.mockbukkit.entity.GuardianMock;
+import be.seeseemelk.mockbukkit.entity.HopperMinecartMock;
 import be.seeseemelk.mockbukkit.entity.HorseMock;
 import be.seeseemelk.mockbukkit.entity.ItemEntityMock;
 import be.seeseemelk.mockbukkit.entity.LlamaMock;
@@ -39,12 +42,15 @@ import be.seeseemelk.mockbukkit.entity.PigMock;
 import be.seeseemelk.mockbukkit.entity.PolarBearMock;
 import be.seeseemelk.mockbukkit.entity.PoweredMinecartMock;
 import be.seeseemelk.mockbukkit.entity.PufferFishMock;
+import be.seeseemelk.mockbukkit.entity.RideableMinecartMock;
 import be.seeseemelk.mockbukkit.entity.SalmonMock;
 import be.seeseemelk.mockbukkit.entity.SheepMock;
 import be.seeseemelk.mockbukkit.entity.SkeletonHorseMock;
 import be.seeseemelk.mockbukkit.entity.SkeletonMock;
 import be.seeseemelk.mockbukkit.entity.SmallFireballMock;
+import be.seeseemelk.mockbukkit.entity.SpawnerMinecartMock;
 import be.seeseemelk.mockbukkit.entity.SpiderMock;
+import be.seeseemelk.mockbukkit.entity.StorageMinecartMock;
 import be.seeseemelk.mockbukkit.entity.StrayMock;
 import be.seeseemelk.mockbukkit.entity.TadpoleMock;
 import be.seeseemelk.mockbukkit.entity.TropicalFishMock;
@@ -1078,7 +1084,13 @@ class WorldMockTest
 				Arguments.of(EntityType.FIREWORK, FireworkMock.class),
 				Arguments.of(EntityType.EXPERIENCE_ORB, ExperienceOrbMock.class),
 				Arguments.of(EntityType.MINECART_FURNACE, PoweredMinecartMock.class),
-				Arguments.of(EntityType.CAMEL, CamelMock.class)
+				Arguments.of(EntityType.CAMEL, CamelMock.class),
+				Arguments.of(EntityType.MINECART_COMMAND, CommandMinecartMock.class),
+				Arguments.of(EntityType.MINECART_TNT, ExplosiveMinecartMock.class),
+				Arguments.of(EntityType.MINECART_HOPPER, HopperMinecartMock.class),
+				Arguments.of(EntityType.MINECART_MOB_SPAWNER, SpawnerMinecartMock.class),
+				Arguments.of(EntityType.MINECART, RideableMinecartMock.class),
+				Arguments.of(EntityType.MINECART_CHEST, StorageMinecartMock.class)
 		);
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/CommandMinecartMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/CommandMinecartMockTest.java
@@ -76,5 +76,4 @@ class CommandMinecartMockTest
 		assertEquals(0, minecart.getSuccessCount());
 	}
 
-
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/CommandMinecartMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/CommandMinecartMockTest.java
@@ -1,0 +1,80 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.MockBukkitExtension;
+import be.seeseemelk.mockbukkit.MockBukkitInject;
+import be.seeseemelk.mockbukkit.ServerMock;
+import org.bukkit.Material;
+import org.bukkit.entity.minecart.CommandMinecart;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockBukkitExtension.class)
+class CommandMinecartMockTest
+{
+
+	CommandMinecart minecart;
+	@MockBukkitInject
+	ServerMock server;
+
+	@BeforeEach
+	void setUp()
+	{
+		minecart = new CommandMinecartMock(server, UUID.randomUUID());
+	}
+
+	@Test
+	void tesTGetCommandDefault()
+	{
+		assertEquals("", minecart.getCommand());
+	}
+
+	@Test
+	void testSetCommand()
+	{
+		minecart.setCommand("say Hello World!");
+		assertEquals("say Hello World!", minecart.getCommand());
+	}
+
+	@Test
+	void testSetCommandNull()
+	{
+		minecart.setCommand("say Hello World!");
+		minecart.setCommand(null);
+		assertEquals("", minecart.getCommand());
+	}
+
+	@Test
+	void testGetMinecartMaterial()
+	{
+		assertEquals(Material.COMMAND_BLOCK_MINECART, minecart.getMinecartMaterial());
+	}
+
+	@Test
+	void testGetSuccessCountDefault()
+	{
+		assertEquals(0, minecart.getSuccessCount());
+	}
+
+	@Test
+	void testGetSuccessCount()
+	{
+		minecart.setSuccessCount(42);
+		assertEquals(42, minecart.getSuccessCount());
+	}
+
+	@Test
+	void testSuccessCountResetWhenChangingCommand()
+	{
+		minecart.setSuccessCount(42);
+		assertEquals(42, minecart.getSuccessCount());
+		minecart.setCommand("say Hello World!");
+		assertEquals(0, minecart.getSuccessCount());
+	}
+
+
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/ExplosiveMinecartMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/ExplosiveMinecartMockTest.java
@@ -100,4 +100,5 @@ class ExplosiveMinecartMockTest
 	{
 		assertThrows(IllegalArgumentException.class, () -> minecart.explode(6.0f));
 	}
+
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/ExplosiveMinecartMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/ExplosiveMinecartMockTest.java
@@ -1,0 +1,103 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.MockBukkitExtension;
+import be.seeseemelk.mockbukkit.MockBukkitInject;
+import be.seeseemelk.mockbukkit.ServerMock;
+import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.minecart.ExplosiveMinecart;
+import org.bukkit.event.entity.ExplosionPrimeEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockBukkitExtension.class)
+class ExplosiveMinecartMockTest
+{
+
+	@MockBukkitInject
+	private ServerMock server;
+
+	private ExplosiveMinecart minecart;
+
+	@BeforeEach
+	void setUp()
+	{
+		minecart = new ExplosiveMinecartMock(server, UUID.randomUUID());
+	}
+
+	@Test
+	void testGetType()
+	{
+		assertEquals(EntityType.MINECART_TNT, minecart.getType());
+	}
+
+	@Test
+	void testGetMinecartMaterial()
+	{
+		assertEquals(Material.TNT_MINECART, minecart.getMinecartMaterial());
+	}
+
+	@Test
+	void testGetFuseTicksDefault()
+	{
+		assertEquals(-1, minecart.getFuseTicks());
+	}
+
+	@Test
+	void testSetFuseTicks()
+	{
+		minecart.setFuseTicks(80);
+		assertEquals(80, minecart.getFuseTicks());
+	}
+
+	@Test
+	void testIgnite()
+	{
+		minecart.ignite();
+		assertEquals(80, minecart.getFuseTicks());
+	}
+
+	@Test
+	void testIsIgnited()
+	{
+		assertFalse(minecart.isIgnited());
+		minecart.ignite();
+		assertTrue(minecart.isIgnited());
+	}
+
+	@Test
+	void testExplode()
+	{
+		minecart.explode();
+		assertTrue(minecart.isDead());
+		server.getPluginManager().assertEventFired(ExplosionPrimeEvent.class);
+	}
+
+	@Test
+	void testExplodePower()
+	{
+		minecart.explode(2.5f);
+		assertTrue(minecart.isDead());
+		server.getPluginManager().assertEventFired(ExplosionPrimeEvent.class);
+	}
+
+	@Test
+	void testExplodePowerTooSmall()
+	{
+		assertThrows(IllegalArgumentException.class, () -> minecart.explode(-1.0f));
+	}
+
+	@Test
+	void testExplodePowerTooBig()
+	{
+		assertThrows(IllegalArgumentException.class, () -> minecart.explode(6.0f));
+	}
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/HopperMinecartMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/HopperMinecartMockTest.java
@@ -1,0 +1,97 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.MockBukkitExtension;
+import be.seeseemelk.mockbukkit.MockBukkitInject;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.inventory.HopperInventoryMock;
+import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.minecart.HopperMinecart;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockBukkitExtension.class)
+public class HopperMinecartMockTest
+{
+
+	@MockBukkitInject
+	private ServerMock server;
+
+	private HopperMinecart minecart;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		minecart = new HopperMinecartMock(server, UUID.randomUUID());
+	}
+
+	@Test
+	void testIsEnabledDefault()
+	{
+		assertTrue(minecart.isEnabled());
+	}
+
+	@Test
+	void testSetEnabled()
+	{
+		minecart.setEnabled(false);
+		assertFalse(minecart.isEnabled());
+	}
+
+	@Test
+	void testGetMinecartMaterial()
+	{
+		assertEquals(minecart.getMinecartMaterial(), Material.HOPPER_MINECART);
+	}
+
+	@Test
+	void testGetEntity()
+	{
+		assertEquals(minecart.getEntity(), minecart);
+	}
+
+	@Test
+	void testGetEntityType()
+	{
+		assertEquals(EntityType.MINECART_HOPPER, minecart.getType());
+	}
+
+	@Test
+	void testGetInventory()
+	{
+		assertTrue(minecart.getInventory() instanceof HopperInventoryMock);
+		minecart.getInventory().setItem(0, new ItemStack(Material.DIRT));
+		assertEquals(Material.DIRT, minecart.getInventory().getItem(0).getType());
+	}
+
+	@Test
+	void testGetPickupCooldownThrows()
+	{
+		UnsupportedOperationException unsupportedOperationException = assertThrows(UnsupportedOperationException.class,
+				() -> minecart.getPickupCooldown());
+
+		assertEquals("Hopper minecarts don't have cooldowns", unsupportedOperationException.getMessage());
+	}
+
+	@Test
+	void testSetPickupCooldownThrows()
+	{
+		UnsupportedOperationException unsupportedOperationException = assertThrows(UnsupportedOperationException.class,
+				() -> minecart.setPickupCooldown(1));
+
+		assertEquals("Hopper minecarts don't have cooldowns", unsupportedOperationException.getMessage());
+	}
+
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/LootableMinecartMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/LootableMinecartMockTest.java
@@ -1,0 +1,129 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.MockBukkitExtension;
+import be.seeseemelk.mockbukkit.MockBukkitInject;
+import be.seeseemelk.mockbukkit.ServerMock;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockBukkitExtension.class)
+public class LootableMinecartMockTest
+{
+
+	@MockBukkitInject
+	private ServerMock server;
+	private LootableMinecart minecart;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		minecart = new StorageMinecartMock(server, UUID.randomUUID());
+	}
+
+	@Test
+	void testHasPlayerLootedDefault()
+	{
+		Player player = server.addPlayer();
+		assertFalse(minecart.hasPlayerLooted(player));
+	}
+
+	@Test
+	void testHasPlayerLooted()
+	{
+		Player player = server.addPlayer();
+		minecart.setHasPlayerLooted(player, true);
+		assertTrue(minecart.hasPlayerLooted(player));
+	}
+
+	@Test
+	void testGetLastLooted()
+	{
+		Player player = server.addPlayer();
+		long time = System.currentTimeMillis();
+		minecart.setHasPlayerLooted(player, true);
+		assertEquals(time, minecart.getLastLooted(player));
+	}
+
+	@Test
+	void testSetHasPlayerLootedTwiceSameValue() throws InterruptedException
+	{
+		Player player = server.addPlayer();
+		long time = System.currentTimeMillis();
+		minecart.setHasPlayerLooted(player, true);
+		assertEquals(time, minecart.getLastLooted(player));
+		TimeUnit.MILLISECONDS.sleep(10);
+		minecart.setHasPlayerLooted(player, true);
+		assertEquals(time, minecart.getLastLooted(player));
+	}
+
+	@Test
+	void testSetHasPlayerLootedLootedFalse()
+	{
+		Player player = server.addPlayer();
+		minecart.setHasPlayerLooted(player, true);
+		assertTrue(minecart.hasPlayerLooted(player));
+		minecart.setHasPlayerLooted(player, false);
+		assertFalse(minecart.hasPlayerLooted(player));
+	}
+
+	@Test
+	void testIsRefillEnabledDefault()
+	{
+		assertFalse(minecart.isRefillEnabled());
+	}
+
+	@Test
+	void testSetRefillEnabled()
+	{
+		minecart.setRefillEnabled(true);
+		assertTrue(minecart.isRefillEnabled());
+	}
+
+	@Test
+	void testHasBeenFilledDefault()
+	{
+		assertFalse(minecart.hasBeenFilled());
+	}
+
+	@Test
+	void testSetHasBeenFilled()
+	{
+		minecart.setNextRefill(1);
+		server.getScheduler().performTicks(2);
+		assertTrue(minecart.hasBeenFilled());
+	}
+
+	@Test
+	void testGetNextRefill()
+	{
+		minecart.setNextRefill(1);
+		assertEquals(1, minecart.getNextRefill());
+	}
+
+	@Test
+	void testGetLastFilled()
+	{
+		assertEquals(-1, minecart.getLastFilled());
+		minecart.setNextRefill(1);
+		server.getScheduler().performTicks(2);
+		assertEquals(1, minecart.getLastFilled());
+	}
+
+	@Test
+	void testHasPendingRefill()
+	{
+		assertFalse(minecart.hasPendingRefill());
+		minecart.setNextRefill(1);
+		assertTrue(minecart.hasPendingRefill());
+	}
+
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/LootableMinecartMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/LootableMinecartMockTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockBukkitExtension.class)
@@ -124,6 +125,12 @@ public class LootableMinecartMockTest
 		assertFalse(minecart.hasPendingRefill());
 		minecart.setNextRefill(1);
 		assertTrue(minecart.hasPendingRefill());
+	}
+
+	@Test
+	void testGetLastLootedMapNull()
+	{
+		assertNull(minecart.getLastLooted(UUID.randomUUID()));
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PoweredMinecartMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PoweredMinecartMockTest.java
@@ -2,6 +2,7 @@ package be.seeseemelk.mockbukkit.entity;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
+import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -70,6 +71,12 @@ class PoweredMinecartMockTest
 	void getTypeTest()
 	{
 		assertEquals(EntityType.MINECART_FURNACE, minecartFurnace.getType());
+	}
+
+	@Test
+	void testGetMinecartMaterial()
+	{
+		assertEquals(minecartFurnace.getMinecartMaterial(), Material.FURNACE_MINECART);
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/RideableMinecartMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/RideableMinecartMockTest.java
@@ -1,0 +1,36 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.MockBukkitExtension;
+import be.seeseemelk.mockbukkit.MockBukkitInject;
+import be.seeseemelk.mockbukkit.ServerMock;
+import org.bukkit.Material;
+import org.bukkit.entity.minecart.RideableMinecart;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockBukkitExtension.class)
+class RideableMinecartMockTest
+{
+
+	@MockBukkitInject
+	private ServerMock server;
+	private RideableMinecart minecart;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		minecart = new RideableMinecartMock(server, UUID.randomUUID());
+	}
+
+	@Test
+	void testGetMinecartMaterial()
+	{
+		assertEquals(minecart.getMinecartMaterial(), Material.MINECART);
+	}
+
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/RideableMinecartMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/RideableMinecartMockTest.java
@@ -4,6 +4,7 @@ import be.seeseemelk.mockbukkit.MockBukkitExtension;
 import be.seeseemelk.mockbukkit.MockBukkitInject;
 import be.seeseemelk.mockbukkit.ServerMock;
 import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.minecart.RideableMinecart;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,4 +34,9 @@ class RideableMinecartMockTest
 		assertEquals(minecart.getMinecartMaterial(), Material.MINECART);
 	}
 
+	@Test
+	void testGetType()
+	{
+		assertEquals(minecart.getType(), EntityType.MINECART);
+	}
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/SpawnerMinecartMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/SpawnerMinecartMockTest.java
@@ -1,0 +1,35 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.MockBukkitExtension;
+import be.seeseemelk.mockbukkit.MockBukkitInject;
+import be.seeseemelk.mockbukkit.ServerMock;
+import org.bukkit.Material;
+import org.bukkit.entity.minecart.SpawnerMinecart;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockBukkitExtension.class)
+class SpawnerMinecartMockTest
+{
+
+	@MockBukkitInject
+	private ServerMock server;
+	private SpawnerMinecart minecart;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		minecart = new SpawnerMinecartMock(server, UUID.randomUUID());
+	}
+
+	@Test
+	void testGetMinecartMaterial()
+	{
+		assertEquals(minecart.getMinecartMaterial(), Material.MINECART);
+	}
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/SpawnerMinecartMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/SpawnerMinecartMockTest.java
@@ -4,6 +4,7 @@ import be.seeseemelk.mockbukkit.MockBukkitExtension;
 import be.seeseemelk.mockbukkit.MockBukkitInject;
 import be.seeseemelk.mockbukkit.ServerMock;
 import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.minecart.SpawnerMinecart;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,4 +33,11 @@ class SpawnerMinecartMockTest
 	{
 		assertEquals(minecart.getMinecartMaterial(), Material.MINECART);
 	}
+
+	@Test
+	void testGetType()
+	{
+		assertEquals(minecart.getType(), EntityType.MINECART_MOB_SPAWNER);
+	}
+
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/StorageMinecartMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/StorageMinecartMockTest.java
@@ -46,4 +46,5 @@ public class StorageMinecartMockTest
 	{
 		assertEquals(minecart, minecart.getEntity());
 	}
+
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/StorageMinecartMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/StorageMinecartMockTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.UUID;
 
+import static org.bukkit.entity.EntityType.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockBukkitExtension.class)
@@ -45,6 +46,12 @@ public class StorageMinecartMockTest
 	void testGetEntity()
 	{
 		assertEquals(minecart, minecart.getEntity());
+	}
+
+	@Test
+	void testGetType()
+	{
+		assertEquals(minecart.getType(), MINECART_CHEST);
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/StorageMinecartMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/StorageMinecartMockTest.java
@@ -1,0 +1,49 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.MockBukkitExtension;
+import be.seeseemelk.mockbukkit.MockBukkitInject;
+import be.seeseemelk.mockbukkit.ServerMock;
+import org.bukkit.Material;
+import org.bukkit.entity.minecart.StorageMinecart;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockBukkitExtension.class)
+public class StorageMinecartMockTest
+{
+
+	@MockBukkitInject
+	ServerMock server;
+	StorageMinecart minecart;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		minecart = new StorageMinecartMock(server, UUID.randomUUID());
+	}
+
+	@Test
+	void testGetInventory()
+	{
+		minecart.getInventory().setItem(0, new ItemStack(Material.DIRT));
+		assertEquals(Material.DIRT, minecart.getInventory().getItem(0).getType());
+	}
+
+	@Test
+	void testGetMinecartMaterial()
+	{
+		assertEquals(minecart.getMinecartMaterial(), Material.CHEST_MINECART);
+	}
+
+	@Test
+	void testGetEntity()
+	{
+		assertEquals(minecart, minecart.getEntity());
+	}
+}


### PR DESCRIPTION
# Description
Adds the Entites for the following Minecarts

- Rideable Minecart (Minecart with Passenger)
- Storage Minecart (Minecart with Chest)
- Explosive Minecart
- Hopper Minecart
- Spawner Minecart

Furthermore both Storage Minecarts and Hopper Minecarts have an additional Abstraction Layer through the LootableMinecart. This aims to deduplicate Code. 

Also added a Missing Method and Test to the Powered Minecart

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
