### PR TITLE
Fix publish by setting name in pom

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -125,6 +125,7 @@ publishing {
 	publications {
 		create<MavenPublication>("maven") {
 			pom {
+				name.set("MockBukkit")
 				description.set("MockBukkit is a mocking framework for bukkit to allow the easy unit testing of Bukkit plugins.")
 				url.set("https://github.com/MockBukkit/MockBukkit")
 				scm {


### PR DESCRIPTION
# Description
The Central repository requires every `pom.xml` to contain a name (https://central.sonatype.org/publish/requirements/#project-name-description-and-url).

MockBukkit does not contain a name. This causes Central to reject our artifact since recently.

This PR adds the name of the project to the generated `pom.xml`, so that Central should once again accept our artifacts.

# Checklist
The following items should be checked before the pull request can be merged.
- [ ] Code follows existing style.
- [ ] Unit tests added (if applicable).
