### PR TITLE
Fix Compilation for 1.20.1

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
@@ -43,7 +43,7 @@ import java.util.List;
 public class MockUnsafeValues implements UnsafeValues
 {
 
-	private static final List<String> COMPATIBLE_API_VERSIONS = Arrays.asList("1.13", "1.14", "1.15", "1.16", "1.17", "1.18", "1.19","1.20");
+	private static final List<String> COMPATIBLE_API_VERSIONS = Arrays.asList("1.13", "1.14", "1.15", "1.16", "1.17", "1.18", "1.19", "1.20");
 
 	private String minimumApiVersion = "none";
 

--- a/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
@@ -306,6 +306,12 @@ public class MockUnsafeValues implements UnsafeValues
 	}
 
 	@Override
+	public @Nullable FeatureFlag getFeatureFlag(@NotNull NamespacedKey key)
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
 	public int nextEntityId()
 	{
 		// TODO Auto-generated method stub

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -52,6 +52,10 @@ import com.destroystokyo.paper.event.player.PlayerConnectionCloseEvent;
 import com.destroystokyo.paper.event.server.WhitelistToggleEvent;
 import com.google.common.base.Preconditions;
 import io.papermc.paper.datapack.DatapackManager;
+import io.papermc.paper.math.Position;
+import io.papermc.paper.threadedregions.scheduler.AsyncScheduler;
+import io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler;
+import io.papermc.paper.threadedregions.scheduler.RegionScheduler;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -1169,6 +1173,24 @@ public class ServerMock extends Server.Spigot implements Server
 	public boolean getAllowNether()
 	{
 		return this.serverConfiguration.isAllowNether();
+	}
+
+	@Override
+	public @NotNull List<String> getInitialEnabledPacks()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public @NotNull List<String> getInitialDisabledPacks()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public @NotNull DataPackManager getDataPackManager()
+	{
+		throw new UnimplementedOperationException();
 	}
 
 	/**
@@ -2324,6 +2346,66 @@ public class ServerMock extends Server.Spigot implements Server
 	public @NotNull PotionBrewer getPotionBrewer()
 	{
 		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public @NotNull RegionScheduler getRegionScheduler()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public @NotNull AsyncScheduler getAsyncScheduler()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public @NotNull GlobalRegionScheduler getGlobalRegionScheduler()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public boolean isOwnedByCurrentRegion(@NotNull World world, @NotNull Position position)
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public boolean isOwnedByCurrentRegion(@NotNull World world, @NotNull Position position, int squareRadiusChunks)
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public boolean isOwnedByCurrentRegion(@NotNull Location location)
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public boolean isOwnedByCurrentRegion(@NotNull Location location, int squareRadiusChunks)
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public boolean isOwnedByCurrentRegion(@NotNull World world, int chunkX, int chunkZ)
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public boolean isOwnedByCurrentRegion(@NotNull World world, int chunkX, int chunkZ, int squareRadiusChunks)
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public boolean isOwnedByCurrentRegion(@NotNull Entity entity)
+	{
 		throw new UnimplementedOperationException();
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
@@ -2822,6 +2822,12 @@ public class WorldMock implements World
 	}
 
 	@Override
+	public @NotNull Set<FeatureFlag> getFeatureFlags()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
 	public boolean setSpawnLocation(int x, int y, int z, float angle)
 	{
 		// TODO Auto-generated method stub

--- a/src/main/java/be/seeseemelk/mockbukkit/attribute/AttributeInstanceMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/attribute/AttributeInstanceMock.java
@@ -69,6 +69,12 @@ public class AttributeInstanceMock implements AttributeInstance
 	}
 
 	@Override
+	public void addTransientModifier(@NotNull AttributeModifier modifier)
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
 	public void removeModifier(@NotNull AttributeModifier modifier)
 	{
 		Preconditions.checkNotNull(modifier, "Modifier cannot be null");

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/BlockDataMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/BlockDataMock.java
@@ -9,6 +9,7 @@ import org.bukkit.SoundGroup;
 import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.BlockSupport;
 import org.bukkit.block.PistonMoveReaction;
 import org.bukkit.block.data.BlockData;
@@ -234,6 +235,12 @@ public class BlockDataMock implements BlockData
 	public void mirror(@NotNull Mirror mirror)
 	{
 		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public @NotNull BlockState createBlockState()
+	{
 		throw new UnimplementedOperationException();
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EndermanMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EndermanMock.java
@@ -5,13 +5,17 @@ import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.block.data.BlockDataMock;
 import be.seeseemelk.mockbukkit.entity.data.EntityState;
 import com.google.common.base.Preconditions;
+import org.bukkit.Location;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Enderman;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.material.MaterialData;
+import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.SplittableRandom;
 import java.util.UUID;
 
 /**
@@ -22,6 +26,7 @@ import java.util.UUID;
 public class EndermanMock extends MonsterMock implements Enderman
 {
 
+	private static SplittableRandom random = new SplittableRandom();
 	private @Nullable BlockData carriedBlock = null;
 	private boolean isScreaming = false;
 	private boolean hasBeenStaredAt = false;
@@ -77,6 +82,34 @@ public class EndermanMock extends MonsterMock implements Enderman
 	{
 		Preconditions.checkNotNull(blockData, "BlockData cannot be null");
 		this.carriedBlock = blockData;
+	}
+
+	@Override
+	public boolean teleport()
+	{
+		if(alive) {
+			double x = this.getLocation().x() + (random.nextDouble() - 0.5D) * 64.0D;
+			double y = this.getLocation().y() + (double) (random.nextInt(64) - 32);
+			double z = this.getLocation().z() + (random.nextDouble() - 0.5D) * 64.0D;
+			return teleport(new Location(getWorld(), x, y, z));
+		}
+		return false;
+	}
+
+	@Override
+	public boolean teleportTowards(@NotNull Entity entity)
+	{
+		if(alive) {
+			Vector vector = new Vector(this.getLocation().x() - entity.getLocation().x(),
+					(this.getLocation().y() + 1.45) - entity.getLocation().y(), this.getLocation().z() - entity.getLocation().z());
+
+			vector = vector.normalize();
+			double x = this.getLocation().x() + (random.nextDouble() - 0.5D) * 8.0D - vector.getX() * 16.0D;
+			double y = this.getLocation().y() + (double) (random.nextInt(16) - 8) - vector.getY() * 16.0D;
+			double z = this.getLocation().z() + (random.nextDouble() - 0.5D) * 8.0D - vector.getZ() * 16.0D;
+			return this.teleport(new Location(getWorld(), x, y, z));
+		}
+		return false;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EndermanMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EndermanMock.java
@@ -26,7 +26,7 @@ import java.util.UUID;
 public class EndermanMock extends MonsterMock implements Enderman
 {
 
-	private static SplittableRandom random = new SplittableRandom();
+	private static final SplittableRandom random = new SplittableRandom();
 	private @Nullable BlockData carriedBlock = null;
 	private boolean isScreaming = false;
 	private boolean hasBeenStaredAt = false;
@@ -87,7 +87,8 @@ public class EndermanMock extends MonsterMock implements Enderman
 	@Override
 	public boolean teleport()
 	{
-		if(alive) {
+		if (alive)
+		{
 			double x = this.getLocation().x() + (random.nextDouble() - 0.5D) * 64.0D;
 			double y = this.getLocation().y() + (double) (random.nextInt(64) - 32);
 			double z = this.getLocation().z() + (random.nextDouble() - 0.5D) * 64.0D;
@@ -99,7 +100,8 @@ public class EndermanMock extends MonsterMock implements Enderman
 	@Override
 	public boolean teleportTowards(@NotNull Entity entity)
 	{
-		if(alive) {
+		if (alive)
+		{
 			Vector vector = new Vector(this.getLocation().x() - entity.getLocation().x(),
 					(this.getLocation().y() + 1.45) - entity.getLocation().y(), this.getLocation().z() - entity.getLocation().z());
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -1342,5 +1342,4 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	}
 
 
-
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -13,6 +13,7 @@ import be.seeseemelk.mockbukkit.metadata.MetadataTable;
 import be.seeseemelk.mockbukkit.persistence.PersistentDataContainerMock;
 import com.google.common.base.Preconditions;
 import io.papermc.paper.entity.TeleportFlag;
+import io.papermc.paper.threadedregions.scheduler.EntityScheduler;
 import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
@@ -1307,6 +1308,12 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	}
 
 	@Override
+	public @NotNull EntityScheduler getScheduler()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
 	public boolean isSneaking()
 	{
 		// TODO Auto-generated method stub
@@ -1333,5 +1340,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
 	}
+
+
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -546,6 +546,14 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	}
 
 	@Override
+	public boolean clearActivePotionEffects()
+	{
+		final boolean res = activeEffects.size() != 0;
+		activeEffects.clear();
+		return res;
+	}
+
+	@Override
 	public boolean hasLineOfSight(@NotNull Entity other)
 	{
 		// TODO Auto-generated method stub

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -55,6 +55,7 @@ import org.bukkit.attribute.Attribute;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
+import org.bukkit.block.TileState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.sign.Side;
 import org.bukkit.conversations.Conversation;
@@ -1382,6 +1383,14 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 		{
 			throw new IllegalArgumentException("Must have at least 4 lines");
 		}
+	}
+
+	@Override
+	public void sendBlockUpdate(@NotNull Location loc, @NotNull TileState tileState) throws IllegalArgumentException
+	{
+		Preconditions.checkNotNull(loc);
+		Preconditions.checkNotNull(tileState);
+		//Pretend we sent block update
 	}
 
 	@Override

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/EndermanMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/EndermanMockTest.java
@@ -4,8 +4,10 @@ import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.block.data.BlockDataMock;
 import be.seeseemelk.mockbukkit.entity.data.EntityState;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Player;
 import org.bukkit.material.MaterialData;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +17,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -100,6 +103,23 @@ class EndermanMockTest
 		assertEquals(EntityState.DEFAULT, endermanMock.getEntityState());
 		endermanMock.setScreaming(true);
 		assertEquals(EntityState.ANGRY, endermanMock.getEntityState());
+	}
+
+	@Test
+	void testRandomTeleport()
+	{
+		Location loc = endermanMock.getLocation();
+		assertTrue(endermanMock.teleport());
+		assertNotEquals(loc, endermanMock.getLocation());
+	}
+
+	@Test
+	void testRandomTeleportToEntity()
+	{
+		Location loc = endermanMock.getLocation();
+		Player player = serverMock.addPlayer();
+		assertTrue(endermanMock.teleportTowards(player));
+		assertNotEquals(loc, endermanMock.getLocation());
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/LivingEntityMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/LivingEntityMockTest.java
@@ -7,10 +7,14 @@ import net.kyori.adventure.util.TriState;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -140,6 +144,53 @@ class LivingEntityMockTest
 	{
 		livingEntity.setLeashHolder(null);
 		assertThrows(IllegalStateException.class, () -> livingEntity.getLeashHolder());
+	}
+
+	@Test
+	void testPotionEffects()
+	{
+		PotionEffect effect = new PotionEffect(PotionEffectType.CONFUSION, 3, 1);
+		assertTrue(livingEntity.addPotionEffect(effect));
+
+		assertTrue(livingEntity.hasPotionEffect(effect.getType()));
+		assertTrue(livingEntity.getActivePotionEffects().contains(effect));
+
+		assertEquals(effect, livingEntity.getPotionEffect(effect.getType()));
+
+		livingEntity.removePotionEffect(effect.getType());
+		assertFalse(livingEntity.hasPotionEffect(effect.getType()));
+		assertFalse(livingEntity.getActivePotionEffects().contains(effect));
+
+	}
+
+	@Test
+	void clearPotionEffects()
+	{
+		PotionEffect effect = new PotionEffect(PotionEffectType.CONFUSION, 5, 1);
+		livingEntity.addPotionEffect(effect);
+		assertTrue(livingEntity.clearActivePotionEffects());
+	}
+
+	@Test
+	void testInstantEffect()
+	{
+		PotionEffect instant = new PotionEffect(PotionEffectType.HEAL, 0, 1);
+		assertTrue(livingEntity.addPotionEffect(instant));
+		assertFalse(livingEntity.hasPotionEffect(instant.getType()));
+	}
+
+	@Test
+	void testMultiplePotionEffects()
+	{
+		Collection<PotionEffect> effects = Arrays.asList(new PotionEffect(PotionEffectType.BAD_OMEN, 3, 1),
+				new PotionEffect(PotionEffectType.LUCK, 5, 2));
+
+		assertTrue(livingEntity.addPotionEffects(effects));
+
+		for (PotionEffect effect : effects)
+		{
+			assertTrue(livingEntity.hasPotionEffect(effect.getType()));
+		}
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -1060,6 +1060,14 @@ class PlayerMockTest
 	}
 
 	@Test
+	void clearPotionEffects()
+	{
+		PotionEffect effect = new PotionEffect(PotionEffectType.CONFUSION, 5, 1);
+		player.addPotionEffect(effect);
+		assertTrue(player.clearActivePotionEffects());
+	}
+
+	@Test
 	void testInstantEffect()
 	{
 		PotionEffect instant = new PotionEffect(PotionEffectType.HEAL, 0, 1);

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -6,6 +6,8 @@ import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.TestPlugin;
 import be.seeseemelk.mockbukkit.WorldMock;
 import be.seeseemelk.mockbukkit.block.BlockMock;
+import be.seeseemelk.mockbukkit.block.state.BlockStateMock;
+import be.seeseemelk.mockbukkit.block.state.TileStateMock;
 import be.seeseemelk.mockbukkit.entity.data.EntityState;
 import be.seeseemelk.mockbukkit.inventory.EnderChestInventoryMock;
 import be.seeseemelk.mockbukkit.inventory.InventoryMock;
@@ -30,6 +32,7 @@ import org.bukkit.SoundCategory;
 import org.bukkit.World;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -66,8 +69,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.map.MapCanvas;
 import org.bukkit.map.MapRenderer;
 import org.bukkit.map.MapView;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.ScoreboardManager;
 import org.jetbrains.annotations.NotNull;
@@ -81,8 +82,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.opentest4j.AssertionFailedError;
 
 import java.net.InetSocketAddress;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -1043,53 +1042,6 @@ class PlayerMockTest
 	}
 
 	@Test
-	void testPotionEffects()
-	{
-		PotionEffect effect = new PotionEffect(PotionEffectType.CONFUSION, 3, 1);
-		assertTrue(player.addPotionEffect(effect));
-
-		assertTrue(player.hasPotionEffect(effect.getType()));
-		assertTrue(player.getActivePotionEffects().contains(effect));
-
-		assertEquals(effect, player.getPotionEffect(effect.getType()));
-
-		player.removePotionEffect(effect.getType());
-		assertFalse(player.hasPotionEffect(effect.getType()));
-		assertFalse(player.getActivePotionEffects().contains(effect));
-
-	}
-
-	@Test
-	void clearPotionEffects()
-	{
-		PotionEffect effect = new PotionEffect(PotionEffectType.CONFUSION, 5, 1);
-		player.addPotionEffect(effect);
-		assertTrue(player.clearActivePotionEffects());
-	}
-
-	@Test
-	void testInstantEffect()
-	{
-		PotionEffect instant = new PotionEffect(PotionEffectType.HEAL, 0, 1);
-		assertTrue(player.addPotionEffect(instant));
-		assertFalse(player.hasPotionEffect(instant.getType()));
-	}
-
-	@Test
-	void testMultiplePotionEffects()
-	{
-		Collection<PotionEffect> effects = Arrays.asList(new PotionEffect(PotionEffectType.BAD_OMEN, 3, 1),
-				new PotionEffect(PotionEffectType.LUCK, 5, 2));
-
-		assertTrue(player.addPotionEffects(effects));
-
-		for (PotionEffect effect : effects)
-		{
-			assertTrue(player.hasPotionEffect(effect.getType()));
-		}
-	}
-
-	@Test
 	void testIllegalArgumentForSpawning()
 	{
 		World world = new WorldMock();
@@ -1504,6 +1456,36 @@ class PlayerMockTest
 		{
 			player.sendBlockDamage(loc, 0.5f);
 		});
+	}
+
+	@Test
+	void testPlayerSendBlockChange()
+	{
+		assertDoesNotThrow(() ->
+		{
+			player.sendBlockUpdate(player.getLocation(), new TileStateMock(Material.CHEST)
+			{
+				@Override
+				public @NotNull BlockState getSnapshot()
+				{
+					return new BlockStateMock(Material.CHEST);
+				}
+			});
+		});
+	}
+
+	@Test
+	void testPlayerSendBlockUpdateInvalid()
+	{
+		assertThrows(NullPointerException.class, () -> player.sendBlockUpdate(player.getLocation(), null));
+		assertThrows(NullPointerException.class, () -> player.sendBlockUpdate(null, new TileStateMock(Material.CHEST)
+		{
+			@Override
+			public @NotNull BlockState getSnapshot()
+			{
+				return new BlockStateMock(Material.CHEST);
+			}
+		}));
 	}
 
 	@Test


### PR DESCRIPTION
# Description
Fixes compilation to 1.20.1 (#792) and supersedes #793 
(was just hoping to get this pr across the finish line for 1.20.1 support cause i need it)

- This does not add FeatureFlag, Folia API, or transient attribute modifiers, just throws `UnimplementedOperationException` for compilation
- Did not add test for implemented `EndermanMock` methods, as they are random in nature and pulled directly from NMS. They could use return value tests though I guess?
- Figured methods not pulled directly from NMS or self explanatory could just have functionality implemented at a later date, as end goal was to just get this out as soon as possible
  - Jitpack's 1.20 [failed to build](https://jitpack.io/com/github/MockBukkit/MockBukkit/v1.20-v3.3.1-ga54c5e8-1/build.log), as did [latest 1.20 branch publish](https://github.com/MockBukkit/MockBukkit/actions/runs/5316249643)
# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).

