### PR TITLE
implements ServerMock.getRegistry

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ReflectionAccessException.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ReflectionAccessException.java
@@ -1,0 +1,33 @@
+package be.seeseemelk.mockbukkit;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.opentest4j.TestAbortedException;
+
+import java.io.Serial;
+
+/**
+ * Exception thrown after a failure of a reflective access, usually meaning the MockBukkit`s implementation has to be updated.
+ * <p>
+ * This is a {@link TestAbortedException} and causes your Test to be skipped instead of just failing.
+ *
+ * @author NeumimTo
+ */
+public class ReflectionAccessException extends TestAbortedException
+{
+
+	@Serial
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Constructs a new exception with the provided message.
+	 *
+	 * @param message The message.
+	 */
+	@ApiStatus.Internal
+	public ReflectionAccessException(@NotNull String message)
+	{
+		super(message);
+	}
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/RegistryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/RegistryMock.java
@@ -1,0 +1,81 @@
+package be.seeseemelk.mockbukkit;
+
+import io.papermc.paper.world.structure.ConfiguredStructure;
+import org.bukkit.Keyed;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.generator.structure.Structure;
+import org.bukkit.generator.structure.StructureType;
+import org.bukkit.inventory.meta.trim.TrimMaterial;
+import org.bukkit.inventory.meta.trim.TrimPattern;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.util.Iterator;
+import java.util.stream.Stream;
+
+public class RegistryMock
+{
+
+	public static <T extends Keyed> Registry<?> createRegistry(Class<T> tClass)
+	{
+
+		if (tClass == Structure.class
+				|| tClass == StructureType.class
+				|| tClass == TrimMaterial.class
+				|| tClass == TrimPattern.class
+				|| tClass == ConfiguredStructure.class)
+		{
+			return new Registry<>()
+			{
+				@Override
+				public @Nullable Keyed get(@NotNull NamespacedKey key)
+				{
+					throw new UnimplementedOperationException("Registry for type " + tClass + " not implemented");
+				}
+
+				@NotNull
+				@Override
+				public Iterator<Keyed> iterator()
+				{
+					throw new UnimplementedOperationException("Registry for type " + tClass + " not implemented");
+				}
+			};
+		}
+
+
+		return Stream.of(Registry.class.getDeclaredFields())
+				.filter(a -> Registry.class.isAssignableFrom(a.getType()))
+				.filter(a -> Modifier.isPublic(a.getModifiers()))
+				.filter(a -> Modifier.isStatic(a.getModifiers()))
+				.filter(a -> genericTypeMatches(a, tClass))
+				.map(RegistryMock::getValue)
+				.findAny()
+				.orElseThrow(() -> new UnimplementedOperationException("Could not find registry for " + tClass.getSimpleName()));
+	}
+
+	private static boolean genericTypeMatches(Field a, Class clazz)
+	{
+		if (a.getGenericType() instanceof ParameterizedType type)
+		{
+			return type.getActualTypeArguments()[0] == clazz;
+		}
+		return false;
+	}
+
+	private static Registry<?> getValue(Field a)
+	{
+		try
+		{
+			return (Registry<?>) a.get(null);
+		}
+		catch (IllegalAccessException e)
+		{
+			throw new RuntimeException(e);
+		}
+	}
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/RegistryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/RegistryMock.java
@@ -74,7 +74,7 @@ public class RegistryMock
 		}
 		catch (IllegalAccessException e)
 		{
-			throw new RuntimeException(e);
+			throw new ReflectionAccessException("Could not access field " + a.getDeclaringClass().getSimpleName() + "." + a.getName());
 		}
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/RegistryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/RegistryMock.java
@@ -20,6 +20,11 @@ import java.util.stream.Stream;
 public class RegistryMock
 {
 
+	private RegistryMock()
+	{
+		throw new UnsupportedOperationException("Utility class");
+	}
+
 	public static <T extends Keyed> Registry<?> createRegistry(Class<T> tClass)
 	{
 
@@ -46,7 +51,6 @@ public class RegistryMock
 			};
 		}
 
-
 		return Stream.of(Registry.class.getDeclaredFields())
 				.filter(a -> Registry.class.isAssignableFrom(a.getType()))
 				.filter(a -> Modifier.isPublic(a.getModifiers()))
@@ -57,7 +61,7 @@ public class RegistryMock
 				.orElseThrow(() -> new UnimplementedOperationException("Could not find registry for " + tClass.getSimpleName()));
 	}
 
-	private static boolean genericTypeMatches(Field a, Class clazz)
+	private static boolean genericTypeMatches(Field a, Class<?> clazz)
 	{
 		if (a.getGenericType() instanceof ParameterizedType type)
 		{

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -2128,6 +2128,7 @@ public class ServerMock extends Server.Spigot implements Server
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public @Nullable <T extends Keyed> Registry<T> getRegistry(@NotNull Class<T> tClass)
 	{
 		if (!registry.containsKey(tClass))

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -37,6 +37,7 @@ import be.seeseemelk.mockbukkit.inventory.StonecutterInventoryMock;
 import be.seeseemelk.mockbukkit.inventory.WorkbenchInventoryMock;
 import be.seeseemelk.mockbukkit.inventory.meta.ItemMetaMock;
 import be.seeseemelk.mockbukkit.map.MapViewMock;
+import be.seeseemelk.mockbukkit.persistence.PersistentDataContainerMock;
 import be.seeseemelk.mockbukkit.plugin.PluginManagerMock;
 import be.seeseemelk.mockbukkit.potion.MockPotionEffectType;
 import be.seeseemelk.mockbukkit.profile.PlayerProfileMock;
@@ -197,6 +198,7 @@ public class ServerMock extends Server.Spigot implements Server
 	private final @NotNull Set<OfflinePlayer> whitelistedPlayers = new LinkedHashSet<>();
 
 	private final @NotNull ServerConfiguration serverConfiguration = new ServerConfiguration();
+	private final Map<Class<?>, Registry<?>> registry = new HashMap<>();
 
 	/**
 	 * Constructs a new ServerMock and sets it up.
@@ -2126,8 +2128,11 @@ public class ServerMock extends Server.Spigot implements Server
 	@Override
 	public @Nullable <T extends Keyed> Registry<T> getRegistry(@NotNull Class<T> tClass)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		if (!registry.containsKey(tClass))
+		{
+			registry.put(tClass, RegistryMock.createRegistry(tClass));
+		}
+		return (Registry<T>) registry.get(tClass);
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -179,6 +179,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	private final Set<String> channels = new HashSet<>();
 
 	private final List<ItemStack> consumedItems = new LinkedList<>();
+	private Locale locale;
 
 	/**
 	 * Constructs a new {@link PlayerMock} for the provided server with the specified name.
@@ -225,6 +226,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 		Random random = ThreadLocalRandom.current();
 		address = new InetSocketAddress("192.0.2." + random.nextInt(255), random.nextInt(32768, 65535));
 		scoreboard = server.getScoreboardManager().getMainScoreboard();
+		locale = Locale.ENGLISH;
 	}
 
 	/**
@@ -2353,8 +2355,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public @NotNull String getLocale()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return locale().toLanguageTag();
 	}
 
 	@Override
@@ -2477,8 +2478,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public @NotNull Locale locale()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return locale;
 	}
 
 	@Override
@@ -2983,4 +2983,8 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 
 	}
 
+	public void setLocale(@NotNull Locale locale) {
+		Objects.requireNonNull(locale, "Player`s Locale must be not null");
+		this.locale = locale;
+	}
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -34,18 +34,32 @@ import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.Art;
 import org.bukkit.Bukkit;
 import org.bukkit.DyeColor;
+import org.bukkit.Fluid;
+import org.bukkit.GameEvent;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.Sound;
+import org.bukkit.Statistic;
 import org.bukkit.Warning;
 import org.bukkit.World;
 import org.bukkit.WorldCreator;
 import org.bukkit.WorldType;
+import org.bukkit.advancement.Advancement;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.block.Biome;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.boss.KeyedBossBar;
 import org.bukkit.command.Command;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Frog;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
+import org.bukkit.entity.memory.MemoryKey;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.server.ServerLoadEvent;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
@@ -53,8 +67,13 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerKickEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.event.server.MapInitializeEvent;
+import org.bukkit.generator.structure.Structure;
+import org.bukkit.generator.structure.StructureType;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
+import org.bukkit.inventory.meta.trim.TrimMaterial;
+import org.bukkit.inventory.meta.trim.TrimPattern;
+import org.bukkit.loot.LootTables;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.map.MapView;
 import org.bukkit.potion.PotionEffectType;
@@ -1399,7 +1418,30 @@ class ServerMockTest
 
 	@Test
 	void getRegistry() {
+		assertTrue(Bukkit.getRegistry(Art.class).iterator().hasNext());
+		assertTrue(Bukkit.getRegistry(Attribute.class).iterator().hasNext());
+		assertTrue(Bukkit.getRegistry(Biome.class).iterator().hasNext());
+		assertTrue(Bukkit.getRegistry(Enchantment.class).iterator().hasNext());
+		assertTrue(Bukkit.getRegistry(EntityType.class).iterator().hasNext());
+		assertTrue(Bukkit.getRegistry(LootTables.class).iterator().hasNext());
 		assertTrue(Bukkit.getRegistry(Material.class).iterator().hasNext());
+		assertTrue(Bukkit.getRegistry(Statistic.class).iterator().hasNext());
+		assertTrue(Bukkit.getRegistry(Sound.class).iterator().hasNext());
+		assertTrue(Bukkit.getRegistry(Villager.Profession.class).iterator().hasNext());
+		assertTrue(Bukkit.getRegistry(Villager.Type.class).iterator().hasNext());
+		assertTrue(Bukkit.getRegistry(MemoryKey.class).iterator().hasNext());
+		assertTrue(Bukkit.getRegistry(Fluid.class).iterator().hasNext());
+		assertTrue(Bukkit.getRegistry(Frog.Variant.class).iterator().hasNext());
+		assertTrue(Bukkit.getRegistry(GameEvent.class).iterator().hasNext());
+		assertTrue(Bukkit.getRegistry(PotionEffectType.class).iterator().hasNext());
+
+		assertNotNull(Bukkit.getRegistry(KeyedBossBar.class).iterator());
+
+		assertThrows(UnimplementedOperationException.class, () -> Bukkit.getRegistry(Advancement.class).iterator());
+		assertThrows(UnimplementedOperationException.class, () -> Bukkit.getRegistry(TrimMaterial.class).iterator());
+		assertThrows(UnimplementedOperationException.class, () -> Bukkit.getRegistry(TrimPattern.class).iterator());
+		assertThrows(UnimplementedOperationException.class, () -> Bukkit.getRegistry(Structure.class).iterator());
+		assertThrows(UnimplementedOperationException.class, () -> Bukkit.getRegistry(StructureType.class).iterator());
 	}
 }
 

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -36,12 +36,13 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.Art;
 import org.bukkit.Bukkit;
-import org.bukkit.DyeColor;
 import org.bukkit.Fluid;
 import org.bukkit.GameEvent;
 import org.bukkit.GameMode;
+import org.bukkit.Keyed;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.Registry;
 import org.bukkit.Sound;
 import org.bukkit.Statistic;
 import org.bukkit.Warning;
@@ -61,12 +62,12 @@ import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
 import org.bukkit.entity.memory.MemoryKey;
 import org.bukkit.event.inventory.InventoryType;
-import org.bukkit.event.server.ServerLoadEvent;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerKickEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.event.server.MapInitializeEvent;
+import org.bukkit.event.server.ServerLoadEvent;
 import org.bukkit.generator.structure.Structure;
 import org.bukkit.generator.structure.StructureType;
 import org.bukkit.inventory.ItemStack;
@@ -74,23 +75,20 @@ import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.meta.trim.TrimMaterial;
 import org.bukkit.inventory.meta.trim.TrimPattern;
 import org.bukkit.loot.LootTables;
-import org.bukkit.plugin.Plugin;
 import org.bukkit.map.MapView;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scoreboard.ScoreboardManager;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.imageio.ImageIO;
-import java.awt.Graphics2D;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -101,8 +99,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1416,33 +1412,49 @@ class ServerMockTest
 		assertEquals("Test", server.getMotd());
 	}
 
-	@Test
-	void getRegistry() {
-		assertTrue(Bukkit.getRegistry(Art.class).iterator().hasNext());
-		assertTrue(Bukkit.getRegistry(Attribute.class).iterator().hasNext());
-		assertTrue(Bukkit.getRegistry(Biome.class).iterator().hasNext());
-		assertTrue(Bukkit.getRegistry(Enchantment.class).iterator().hasNext());
-		assertTrue(Bukkit.getRegistry(EntityType.class).iterator().hasNext());
-		assertTrue(Bukkit.getRegistry(LootTables.class).iterator().hasNext());
-		assertTrue(Bukkit.getRegistry(Material.class).iterator().hasNext());
-		assertTrue(Bukkit.getRegistry(Statistic.class).iterator().hasNext());
-		assertTrue(Bukkit.getRegistry(Sound.class).iterator().hasNext());
-		assertTrue(Bukkit.getRegistry(Villager.Profession.class).iterator().hasNext());
-		assertTrue(Bukkit.getRegistry(Villager.Type.class).iterator().hasNext());
-		assertTrue(Bukkit.getRegistry(MemoryKey.class).iterator().hasNext());
-		assertTrue(Bukkit.getRegistry(Fluid.class).iterator().hasNext());
-		assertTrue(Bukkit.getRegistry(Frog.Variant.class).iterator().hasNext());
-		assertTrue(Bukkit.getRegistry(GameEvent.class).iterator().hasNext());
-		assertTrue(Bukkit.getRegistry(PotionEffectType.class).iterator().hasNext());
-
-		assertNotNull(Bukkit.getRegistry(KeyedBossBar.class).iterator());
-
-		assertThrows(UnimplementedOperationException.class, () -> Bukkit.getRegistry(Advancement.class).iterator());
-		assertThrows(UnimplementedOperationException.class, () -> Bukkit.getRegistry(TrimMaterial.class).iterator());
-		assertThrows(UnimplementedOperationException.class, () -> Bukkit.getRegistry(TrimPattern.class).iterator());
-		assertThrows(UnimplementedOperationException.class, () -> Bukkit.getRegistry(Structure.class).iterator());
-		assertThrows(UnimplementedOperationException.class, () -> Bukkit.getRegistry(StructureType.class).iterator());
+	@ValueSource(classes = {
+			Art.class,
+			Attribute.class,
+			Biome.class,
+			Enchantment.class,
+			EntityType.class,
+			Fluid.class,
+			Frog.Variant.class,
+			GameEvent.class,
+			KeyedBossBar.class,
+			LootTables.class,
+			Material.class,
+			MemoryKey.class,
+			PotionEffectType.class,
+			Sound.class,
+			Statistic.class,
+			Villager.Profession.class,
+			Villager.Type.class,
+	})
+	@ParameterizedTest
+	void getRegistry_ValidType_HasValues(Class<? extends Keyed> clazz)
+	{
+		Registry<?> registry = Bukkit.getRegistry(clazz);
+		assertNotNull(registry);
+		if (clazz != KeyedBossBar.class)
+			assertTrue(registry.iterator().hasNext());
 	}
+
+	@ValueSource(classes = {
+			Advancement.class,
+			Structure.class,
+			StructureType.class,
+			TrimMaterial.class,
+			TrimPattern.class,
+	})
+	@ParameterizedTest
+	void getRegistry_InvalidType_Throws(Class<? extends Keyed> clazz)
+	{
+		Registry<? extends Keyed> registry = Bukkit.getRegistry(clazz);
+		assertNotNull(registry);
+		assertThrows(UnimplementedOperationException.class, () -> registry.iterator());
+	}
+
 }
 
 class TestRecipe implements Recipe

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -34,6 +34,8 @@ import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.DyeColor;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
@@ -63,7 +65,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.imageio.ImageIO;
@@ -78,6 +82,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1391,6 +1397,10 @@ class ServerMockTest
 		assertEquals("Test", server.getMotd());
 	}
 
+	@Test
+	void getRegistry() {
+		assertTrue(Bukkit.getRegistry(Material.class).iterator().hasNext());
+	}
 }
 
 class TestRecipe implements Recipe


### PR DESCRIPTION
# Description
Partially implements Server.getRegistry

Registries for Structure, StructureType, TrimMaterial, TrimPattern, ConfiguredStructure are not implemented due to bukkit weird implementation, ill leave these for somebody else to handle.

# Checklist
The following items should be checked before the pull request can be merged.
- [ x] Code follows existing style.
- [ x] Unit tests added (if applicable).
