### PR TITLE
Implement UnsafeValues#fromLegacy for non-legacy materials

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
@@ -1,6 +1,7 @@
 package be.seeseemelk.mockbukkit;
 
 import com.destroystokyo.paper.util.VersionFetcher;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Multimap;
 import io.papermc.paper.inventory.ItemRarity;
 import net.kyori.adventure.text.Component;
@@ -104,9 +105,9 @@ public class MockUnsafeValues implements UnsafeValues
 
 
 	@Override
-	public @NotNull Material toLegacy(@NotNull Material material)
+	public Material toLegacy(Material material)
 	{
-		if (material.isLegacy())
+		if (material == null || material.isLegacy())
 		{
 			return material;
 		}
@@ -116,20 +117,29 @@ public class MockUnsafeValues implements UnsafeValues
 	@Override
 	public Material fromLegacy(Material material)
 	{
-		return material;
+		if (material == null || !material.isLegacy())
+		{
+			return material;
+		}
+		throw new UnimplementedOperationException();
 	}
 
 	@Override
 	public Material fromLegacy(MaterialData material)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return fromLegacy(material, false);
 	}
 
 	@Override
-	public Material fromLegacy(MaterialData material, boolean itemPriority)
+	public Material fromLegacy(MaterialData materialData, boolean itemPriority)
 	{
-		// TODO Auto-generated method stub
+		// Paper will blindly call #getItemType even if materialData is null, so we might as well enforce that it isn't.
+		Preconditions.checkNotNull(materialData, "materialData cannot be null");
+		Material material = materialData.getItemType();
+		if (material == null || !material.isLegacy())
+		{
+			return material;
+		}
 		throw new UnimplementedOperationException();
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/UnsafeValuesTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/UnsafeValuesTest.java
@@ -1,5 +1,7 @@
 package be.seeseemelk.mockbukkit;
 
+import org.bukkit.Material;
+import org.bukkit.material.MaterialData;
 import org.bukkit.plugin.InvalidDescriptionException;
 import org.bukkit.plugin.InvalidPluginException;
 import org.bukkit.plugin.PluginDescriptionFile;
@@ -11,9 +13,12 @@ import java.io.StringReader;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@SuppressWarnings("deprecation")
 class UnsafeValuesTest
 {
 
@@ -30,7 +35,7 @@ class UnsafeValuesTest
 	}
 
 	@AfterEach
-	void teardown()
+	void tearDown()
 	{
 		MockBukkit.unmock();
 	}
@@ -93,6 +98,62 @@ class UnsafeValuesTest
 			mockUnsafeValues.setMinimumApiVersion("1.15");
 			checkVersion("1.13");
 		});
+	}
+
+	@Test
+	void fromLegacy_Material_NotLegacy_ReturnsSame()
+	{
+		for (Material material : Material.values())
+		{
+			if (material.isLegacy())
+				continue;
+			assertEquals(material, mockUnsafeValues.fromLegacy(material));
+		}
+	}
+
+	@Test
+	void fromLegacy_Material_Legacy_Throws()
+	{
+		for (Material material : Material.values())
+		{
+			if (!material.isLegacy())
+				continue;
+			assertThrows(UnimplementedOperationException.class, () -> mockUnsafeValues.fromLegacy(material));
+		}
+	}
+
+	@Test
+	void fromLegacy_Material_Null_ReturnsNull()
+	{
+		assertNull(mockUnsafeValues.fromLegacy((Material) null));
+	}
+
+	@Test
+	void fromLegacy_MaterialData_NotLegacy_ReturnsSame()
+	{
+		for (Material material : Material.values())
+		{
+			if (material.isLegacy())
+				continue;
+			assertEquals(material, mockUnsafeValues.fromLegacy(new MaterialData(material)));
+		}
+	}
+
+	@Test
+	void fromLegacy_MaterialData_Legacy_Throws()
+	{
+		for (Material material : Material.values())
+		{
+			if (!material.isLegacy())
+				continue;
+			assertThrows(UnimplementedOperationException.class, () -> mockUnsafeValues.fromLegacy(new MaterialData(material)));
+		}
+	}
+
+	@Test
+	void fromLegacy_MaterialData_Null_ReturnsNull()
+	{
+		assertThrows(NullPointerException.class, () -> mockUnsafeValues.fromLegacy((MaterialData) null));
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/UnsafeValuesTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/UnsafeValuesTest.java
@@ -146,7 +146,8 @@ class UnsafeValuesTest
 		{
 			if (!material.isLegacy())
 				continue;
-			assertThrows(UnimplementedOperationException.class, () -> mockUnsafeValues.fromLegacy(new MaterialData(material)));
+			MaterialData materialData = new MaterialData(material);
+			assertThrows(UnimplementedOperationException.class, () -> mockUnsafeValues.fromLegacy(materialData));
 		}
 	}
 


### PR DESCRIPTION
# Description
Implements `UnsafeValues#fromLegacy` for non-legacy materials. If a legacy material is passed in, an `UnimplementedOperationException` is thrown.

Closes #300.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
