### PR TITLE
Fix runTaskLaterAsync and runTaskTimerAsync not clamping delay

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -497,6 +497,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	@Override
 	public @NotNull BukkitTask runTaskLaterAsynchronously(@NotNull Plugin plugin, @NotNull Runnable task, long delay)
 	{
+		delay = Math.max(delay, 1);
 		ScheduledTask scheduledTask = new ScheduledTask(id.getAndIncrement(), plugin, false, currentTick + delay,
 				new AsyncRunnable(task));
 		scheduledTasks.addTask(scheduledTask);
@@ -512,6 +513,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	@Override
 	public @NotNull BukkitTask runTaskTimerAsynchronously(@NotNull Plugin plugin, @NotNull Runnable task, long delay, long period)
 	{
+		delay = Math.max(delay, 1);
 		RepeatingTask scheduledTask = new RepeatingTask(id.getAndIncrement(), plugin, false, currentTick + delay, period,
 				new AsyncRunnable(task));
 		scheduledTasks.addTask(scheduledTask);


### PR DESCRIPTION
# Description
Without this, the task will never run if a delay of `0` is passed in.

Tests for the scheduler are a complete mess and should be almost entirely re-written in its own PR.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
