### PR TITLE
Add PlayerSpawnLocationEvent in ServerMock.addPlayer

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -125,6 +125,7 @@ import org.bukkit.scoreboard.Criteria;
 import org.bukkit.structure.StructureManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.spigotmc.event.player.PlayerSpawnLocationEvent;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -322,6 +323,10 @@ public class ServerMock extends Server.Spigot implements Server
 			playerList.disconnectPlayer(player);
 			return;
 		}
+
+		PlayerSpawnLocationEvent playerSpawnLocationEvent = new PlayerSpawnLocationEvent(player, player.getLocation());
+		getPluginManager().callEvent(playerSpawnLocationEvent);
+		player.setLocation(playerSpawnLocationEvent.getSpawnLocation());
 
 		registerEntity(player);
 	}

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -86,6 +86,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.spigotmc.event.player.PlayerSpawnLocationEvent;
 
 import javax.imageio.ImageIO;
 import java.awt.*;
@@ -204,6 +205,13 @@ class ServerMockTest
 	{
 		PlayerMock player = server.addPlayer();
 		server.getPluginManager().assertEventFired(PlayerLoginEvent.class);
+	}
+
+	@Test
+	void addPlayer_Calls_PlayerSpawnLocationEvent()
+	{
+		PlayerMock player = server.addPlayer();
+		server.getPluginManager().assertEventFired(PlayerSpawnLocationEvent.class);
 	}
 
 	@Test


### PR DESCRIPTION
# Description
This pull request adds support of org.spigotmc.event.player.PlayerSpawnLocationEvent to the ServerMock#addPlayer() method.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
