### PR TITLE
Allows setting lines as null for a sign

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/SignMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/SignMock.java
@@ -120,7 +120,7 @@ public class SignMock extends TileStateMock implements Sign
 
 	@Override
 	@Deprecated
-	public void setLine(int index, String line) throws IndexOutOfBoundsException
+	public void setLine(int index, @NotNull String line) throws IndexOutOfBoundsException
 	{
 		this.lines[index] = line != null ? line : "";
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/SignMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/SignMock.java
@@ -120,10 +120,9 @@ public class SignMock extends TileStateMock implements Sign
 
 	@Override
 	@Deprecated
-	public void setLine(int index, @NotNull String line) throws IndexOutOfBoundsException
+	public void setLine(int index, String line) throws IndexOutOfBoundsException
 	{
-		Preconditions.checkNotNull(line, "Line cannot be null!");
-		this.lines[index] = line;
+		this.lines[index] = line != null ? line : "";
 	}
 
 	@Override

--- a/src/test/java/be/seeseemelk/mockbukkit/block/state/SignMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/state/SignMockTest.java
@@ -95,9 +95,9 @@ class SignMockTest
 	}
 
 	@Test
-	void testLineNotNull()
+	void testLineNull()
 	{
-		assertThrows(NullPointerException.class, () -> sign.setLine(0, null));
+		assertDoesNotThrow(() -> sign.setLine(0, null));
 	}
 
 	@Test

--- a/src/test/java/be/seeseemelk/mockbukkit/block/state/SignMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/state/SignMockTest.java
@@ -97,7 +97,8 @@ class SignMockTest
 	@Test
 	void testLineNull()
 	{
-		assertDoesNotThrow(() -> sign.setLine(0, null));
+		sign.setLine(0, null);
+		assertEquals("",sign.getLine(0));
 	}
 
 	@Test


### PR DESCRIPTION
# Description
Just noticed an inconsistency with paper behavior for signs. Yes lines are allowed to be set as null, although this just gives an empty line.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
