### PR TITLE
Fix registry mocking not working after latest bukkit commit

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/RegistryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/RegistryMock.java
@@ -1,7 +1,9 @@
 package be.seeseemelk.mockbukkit;
 
 import io.papermc.paper.world.structure.ConfiguredStructure;
+import org.bukkit.GameEvent;
 import org.bukkit.Keyed;
+import org.bukkit.MusicInstrument;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.generator.structure.Structure;
@@ -15,6 +17,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 public class RegistryMock
@@ -32,7 +35,9 @@ public class RegistryMock
 				|| tClass == StructureType.class
 				|| tClass == TrimMaterial.class
 				|| tClass == TrimPattern.class
-				|| tClass == ConfiguredStructure.class)
+				|| tClass == ConfiguredStructure.class
+				|| tClass == MusicInstrument.class
+				|| tClass == GameEvent.class)
 		{
 			return new Registry<>()
 			{
@@ -57,6 +62,7 @@ public class RegistryMock
 				.filter(a -> Modifier.isStatic(a.getModifiers()))
 				.filter(a -> genericTypeMatches(a, tClass))
 				.map(RegistryMock::getValue)
+				.filter(Objects::nonNull)
 				.findAny()
 				.orElseThrow(() -> new UnimplementedOperationException("Could not find registry for " + tClass.getSimpleName()));
 	}

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -32,6 +32,7 @@ import com.destroystokyo.paper.event.player.PlayerConnectionCloseEvent;
 import com.destroystokyo.paper.event.server.WhitelistToggleEvent;
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
+import io.papermc.paper.world.structure.ConfiguredStructure;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.Art;
@@ -41,6 +42,7 @@ import org.bukkit.GameEvent;
 import org.bukkit.GameMode;
 import org.bukkit.Keyed;
 import org.bukkit.Material;
+import org.bukkit.MusicInstrument;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.Registry;
 import org.bukkit.Sound;
@@ -1428,7 +1430,6 @@ class ServerMockTest
 			EntityType.class,
 			Fluid.class,
 			Frog.Variant.class,
-			GameEvent.class,
 			KeyedBossBar.class,
 			LootTables.class,
 			Material.class,
@@ -1454,6 +1455,9 @@ class ServerMockTest
 			StructureType.class,
 			TrimMaterial.class,
 			TrimPattern.class,
+			ConfiguredStructure.class,
+			MusicInstrument.class,
+			GameEvent.class
 	})
 	@ParameterizedTest
 	void getRegistry_InvalidType_Throws(Class<? extends Keyed> clazz)


### PR DESCRIPTION
# Description
<!-- State the changes of the pull request below. -->
Adds the MusicInstrument and GameEvent classes as unimplemented, the music instrument registry is brand new and the game event one has been moved to a proper registry. The change can be seen [here](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/commits/aa067abf06677a782c54d46341c161b817aeee05#src/main/java/org/bukkit/Registry.java).

The null check added to the stream is to fix the [NPE](https://github.com/TownyAdvanced/Towny/actions/runs/6058106813/job/16442348424?pr=6964#step:4:227) I was seeing, it should now throw at the more descriptive UnimplementedOperationException which will allow for easier debugging next time this happens.
# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
