### PR TITLE
Implement `getIp` and `getPort` methods on `Server`

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -1141,8 +1141,16 @@ public class ServerMock extends Server.Spigot implements Server
 	@Override
 	public int getPort()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.serverConfiguration.getServerPort();
+	}
+
+	/**
+	 * Sets the server listen port.
+	 * @param port The server listen port.
+	 * @see ServerMock#getPort()
+	 */
+	public void setPort(int port) {
+		this.serverConfiguration.setServerPort(port);
 	}
 
 	@Override
@@ -1165,8 +1173,17 @@ public class ServerMock extends Server.Spigot implements Server
 	@Override
 	public @NotNull String getIp()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.serverConfiguration.getServerIp();
+	}
+
+	/**
+	 * Sets the server listen IP.
+	 * @param serverIp The server listen IP.
+	 * @see ServerMock#getIp()
+	 */
+	public void setIp(@NotNull String serverIp)
+	{
+		this.serverConfiguration.setServerIp(serverIp);
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/configuration/ServerConfiguration.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/configuration/ServerConfiguration.java
@@ -33,6 +33,8 @@ public class ServerConfiguration
 	private int maxWorldSize = 29999984;
 	private int simulationDistance = 10;
 	private boolean hideOnlinePlayers = false;
+	private String serverIp = "";
+	private int serverPort = 25565;
 
 	/**
 	 * @return The view distance.
@@ -319,6 +321,42 @@ public class ServerConfiguration
 	public void setHideOnlinePlayers(boolean hideOnlinePlayers)
 	{
 		this.hideOnlinePlayers = hideOnlinePlayers;
+	}
+
+	/**
+	 * @return The server listen IP
+	 * @see ServerMock#getIp
+	 */
+	public String getServerIp()
+	{
+		return serverIp;
+	}
+
+	/**
+	 * @param serverIp The server listen IP
+	 * @see ServerMock#setIp
+	 */
+	public void setServerIp(String serverIp)
+	{
+		this.serverIp = serverIp;
+	}
+
+	/**
+	 * @return The server listen port
+	 * @see ServerMock#getPort
+	 */
+	public int getServerPort()
+	{
+		return serverPort;
+	}
+
+	/**
+	 * @param serverPort The server listen port
+	 * @see ServerMock#setPort
+	 */
+	public void setServerPort(int serverPort)
+	{
+		this.serverPort = serverPort;
 	}
 
 	/**

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -1039,6 +1039,19 @@ class ServerMockTest
 	}
 
 	@Test
+	void testGetPortDefault()
+	{
+		assertEquals(25565, server.getPort());
+	}
+
+	@Test
+	void testSetPort()
+	{
+		server.setPort(2212);
+		assertEquals(2212, server.getPort());
+	}
+
+	@Test
 	void testGetViewDistanceDefault()
 	{
 		assertEquals(10, server.getViewDistance());
@@ -1049,6 +1062,19 @@ class ServerMockTest
 	{
 		server.setViewDistance(2);
 		assertEquals(2, server.getViewDistance());
+	}
+
+	@Test
+	void testGetIpDefault()
+	{
+		assertEquals("", server.getIp());
+	}
+
+	@Test
+	void testSetIp()
+	{
+		server.setIp("::1");
+		assertEquals("::1", server.getIp());
 	}
 
 	@Test


### PR DESCRIPTION
# Description
Bukkit servers read these values from the server configuration properties file. While niche, these methods can be useful for unit-testing plugins that spawn TCP listeners on the server address.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
