### PR TITLE
Fix onDisable function being called twice

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/plugin/MockBukkitPluginLoader.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/plugin/MockBukkitPluginLoader.java
@@ -63,7 +63,6 @@ public class MockBukkitPluginLoader implements PluginLoader
 	@Override
 	public void disablePlugin(@NotNull Plugin plugin)
 	{
-		plugin.onDisable();
 		((JavaPlugin) plugin).setEnabled(false);
 		plugin.getServer().getPluginManager().callEvent(new PluginDisableEvent(plugin));
 	}


### PR DESCRIPTION
# Description
The `Plugin#onDisable` method is called twice. This is due to paper's setEnable(false) already calling the onDisable method, there shouldn't be a need to call it again.

![image](https://github.com/MockBukkit/MockBukkit/assets/30431861/ea5180fb-87b7-4b22-8798-2a255ae025f1)


# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [ ] Unit tests added (if applicable).
