### PR TITLE
Implement MockServer#unloadWorld methods

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -1418,20 +1418,20 @@ public class ServerMock extends Server.Spigot implements Server
 	public boolean unloadWorld(World world, boolean save)
 	{
 		// TODO Handle save
-        if (!(world instanceof WorldMock worldMock))
-		{
-            return false;
-        }
-        if (!worldMock.getPlayers().isEmpty())
-		{
-            return false;
-        }
-        if (new WorldUnloadEvent(worldMock).callEvent())
+		if (!(world instanceof WorldMock worldMock))
 		{
 			return false;
 		}
-        return removeWorld(worldMock);
-    }
+		if (!worldMock.getPlayers().isEmpty())
+		{
+			return false;
+		}
+		if (new WorldUnloadEvent(worldMock).callEvent())
+		{
+			return false;
+		}
+		return removeWorld(worldMock);
+	}
 
 	@Override
 	public @NotNull MapViewMock createMap(@NotNull World world)

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -1418,17 +1418,18 @@ public class ServerMock extends Server.Spigot implements Server
 	public boolean unloadWorld(World world, boolean save)
 	{
 		// TODO Handle save
-        if (!(world instanceof WorldMock worldMock)) {
+        if (!(world instanceof WorldMock worldMock))
+		{
             return false;
         }
-        if (!worldMock.getPlayers().isEmpty()) {
+        if (!worldMock.getPlayers().isEmpty())
+		{
             return false;
         }
-        WorldUnloadEvent event = new WorldUnloadEvent(worldMock);
-        event.callEvent();
-        if (event.isCancelled()) {
-            return false;
-        }
+        if (new WorldUnloadEvent(worldMock).callEvent())
+		{
+			return false;
+		}
         return removeWorld(worldMock);
     }
 

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -107,6 +107,7 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.event.server.MapInitializeEvent;
 import org.bukkit.event.server.ServerLoadEvent;
+import org.bukkit.event.world.WorldUnloadEvent;
 import org.bukkit.generator.ChunkGenerator.ChunkData;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
@@ -450,6 +451,12 @@ public class ServerMock extends Server.Spigot implements Server
 		worlds.add(world);
 	}
 
+	/**
+	 * Removes a mocked world from this server.
+	 *
+	 * @param world	The world to remove.
+	 * @return true if the world was removed, otherwise false.
+	 */
 	public boolean removeWorld(WorldMock world) {
 		AsyncCatcher.catchOp("world remove");
 		return worlds.remove(world);
@@ -1411,11 +1418,19 @@ public class ServerMock extends Server.Spigot implements Server
 	public boolean unloadWorld(World world, boolean save)
 	{
 		// TODO Handle save
-		if (world instanceof WorldMock worldMock) {
-			return removeWorld(worldMock);
-		}
-		return false;
-	}
+        if (!(world instanceof WorldMock worldMock)) {
+            return false;
+        }
+        if (!worldMock.getPlayers().isEmpty()) {
+            return false;
+        }
+        WorldUnloadEvent event = new WorldUnloadEvent(worldMock);
+        event.callEvent();
+        if (event.isCancelled()) {
+            return false;
+        }
+        return removeWorld(worldMock);
+    }
 
 	@Override
 	public @NotNull MapViewMock createMap(@NotNull World world)

--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -450,6 +450,11 @@ public class ServerMock extends Server.Spigot implements Server
 		worlds.add(world);
 	}
 
+	public boolean removeWorld(WorldMock world) {
+		AsyncCatcher.catchOp("world remove");
+		return worlds.remove(world);
+	}
+
 	/**
 	 * Executes a command as the console.
 	 *
@@ -1399,15 +1404,17 @@ public class ServerMock extends Server.Spigot implements Server
 	@Override
 	public boolean unloadWorld(String name, boolean save)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return unloadWorld(getWorld(name), save);
 	}
 
 	@Override
 	public boolean unloadWorld(World world, boolean save)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		// TODO Handle save
+		if (world instanceof WorldMock worldMock) {
+			return removeWorld(worldMock);
+		}
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
# Description
Basic implementation of the unload world method. Basically just removes the world object from the world list if it exists. Multiverse requires this as we are porting over our tests to MockBukkit. Hope this can be merged soon, thanks!

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [ ] Unit tests added (if applicable).
