### PR TITLE
Implement BlockData for BlockStates

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
@@ -75,7 +75,7 @@ public class BlockStateMock implements BlockState
 		this.metadataTable = new MetadataTable(state.metadataTable);
 		this.material = state.getType();
 		this.block = state.isPlaced() ? state.getBlock() : null;
-		this.blockData = state.blockData;
+		this.blockData = state.blockData.clone();
 	}
 
 	// region Type Checking
@@ -327,14 +327,14 @@ public class BlockStateMock implements BlockState
 	@Override
 	public @NotNull BlockData getBlockData()
 	{
-		return this.blockData;
+		return this.blockData.clone();
 	}
 
 	@Override
 	public void setBlockData(BlockData data)
 	{
 		this.material = data.getMaterial();
-		this.blockData = data;
+		this.blockData = data.clone();
 	}
 
 	/**

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
@@ -2,6 +2,7 @@ package be.seeseemelk.mockbukkit.block.state;
 
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.block.BlockMock;
+import be.seeseemelk.mockbukkit.block.data.BlockDataMock;
 import be.seeseemelk.mockbukkit.metadata.MetadataTable;
 import com.destroystokyo.paper.MaterialTags;
 import com.google.common.base.Preconditions;
@@ -32,6 +33,7 @@ public class BlockStateMock implements BlockState
 {
 
 	private final @NotNull MetadataTable metadataTable;
+	private BlockData blockData;
 	private @Nullable Block block;
 	private Material material;
 
@@ -45,6 +47,7 @@ public class BlockStateMock implements BlockState
 		Preconditions.checkNotNull(material, "Material cannot be null");
 		this.metadataTable = new MetadataTable();
 		this.material = material;
+		this.blockData = BlockDataMock.mock(material);
 	}
 
 	/**
@@ -58,6 +61,7 @@ public class BlockStateMock implements BlockState
 		this.metadataTable = new MetadataTable();
 		this.block = block;
 		this.material = block.getType();
+		this.blockData = BlockDataMock.mock(material);
 	}
 
 	/**
@@ -71,6 +75,7 @@ public class BlockStateMock implements BlockState
 		this.metadataTable = new MetadataTable(state.metadataTable);
 		this.material = state.getType();
 		this.block = state.isPlaced() ? state.getBlock() : null;
+		this.blockData = state.blockData;
 	}
 
 	// region Type Checking
@@ -229,6 +234,7 @@ public class BlockStateMock implements BlockState
 	public void setType(Material type)
 	{
 		this.material = type;
+		this.blockData = BlockDataMock.mock(type);
 	}
 
 	@Override
@@ -321,15 +327,14 @@ public class BlockStateMock implements BlockState
 	@Override
 	public @NotNull BlockData getBlockData()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.blockData;
 	}
 
 	@Override
 	public void setBlockData(BlockData data)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.material = data.getMaterial();
+		this.blockData = data;
 	}
 
 	/**

--- a/src/test/java/be/seeseemelk/mockbukkit/block/data/BlockDataMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/data/BlockDataMockTest.java
@@ -108,4 +108,5 @@ class BlockDataMockTest
 		blockData.checkType(block, Tag.PLANKS);
 	}
 
+
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/block/state/BlockStateMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/state/BlockStateMockTest.java
@@ -3,11 +3,13 @@ package be.seeseemelk.mockbukkit.block.state;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.WorldMock;
 import be.seeseemelk.mockbukkit.block.BlockMock;
+import be.seeseemelk.mockbukkit.block.data.BlockDataMock;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Chest;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.type.TrapDoor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,7 +18,9 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -123,5 +127,25 @@ class BlockStateMockTest
 		Block block = new BlockMock(Material.JUNGLE_TRAPDOOR);
 		BlockState state = block.getState();
 		assertInstanceOf(TrapDoor.class, state.getBlockData());
+	}
+
+	@Test
+	void clone_copyBlockData(){
+		Block block = new BlockMock(Material.CHEST);
+		BlockStateMock state = new ChestMock(block);
+		BlockState stateCopy = state.getSnapshot();
+		assertNotSame(stateCopy.getBlockData(), state.getBlockData());
+		assertEquals(stateCopy.getBlockData(), state.getBlockData());
+	}
+
+	@Test
+	void setBlockData_assertClone(){
+		Block block = new BlockMock(Material.CHEST);
+		BlockStateMock state = new ChestMock(block);
+		BlockDataMock data = BlockDataMock.mock(Material.CHEST);
+		state.setBlockData(data);
+		BlockData dataCopy = state.getBlockData();
+		assertNotSame(data, dataCopy);
+		assertEquals(data, dataCopy);
 	}
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/block/state/BlockStateMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/state/BlockStateMockTest.java
@@ -118,7 +118,8 @@ class BlockStateMockTest
 	}
 
 	@Test
-	void constructor_blockDataIsSet(){
+	void constructor_blockDataIsSet()
+	{
 		Block block = new BlockMock(Material.JUNGLE_TRAPDOOR);
 		BlockState state = block.getState();
 		assertInstanceOf(TrapDoor.class, state.getBlockData());

--- a/src/test/java/be/seeseemelk/mockbukkit/block/state/BlockStateMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/state/BlockStateMockTest.java
@@ -8,12 +8,14 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Chest;
+import org.bukkit.block.data.type.TrapDoor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -106,4 +108,19 @@ class BlockStateMockTest
 		assertEquals(Material.IRON_BLOCK, block.getType());
 	}
 
+	@Test
+	void setType_SetToMaterialWithBlockDataMockSubclass()
+	{
+		Block block = new BlockMock();
+		BlockState state = block.getState();
+		state.setType(Material.JUNGLE_TRAPDOOR);
+		assertInstanceOf(TrapDoor.class, state.getBlockData());
+	}
+
+	@Test
+	void constructor_blockDataIsSet(){
+		Block block = new BlockMock(Material.JUNGLE_TRAPDOOR);
+		BlockState state = block.getState();
+		assertInstanceOf(TrapDoor.class, state.getBlockData());
+	}
 }


### PR DESCRIPTION
# Description
BlockData is not implemented for BlockStateMock currently. These changes should remedy that. (I mainly copied over some code from BlockMock)

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
