### PR TITLE
Fix: Updated SkullMetaMock to support PlayerProfile

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -2621,6 +2621,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public void setPlayerProfile(@NotNull PlayerProfile profile)
 	{
+		Preconditions.checkNotNull(profile, "Profile cannot be null");
 		this.playerProfile = profile;
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -182,6 +182,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 
 	private final List<ItemStack> consumedItems = new LinkedList<>();
 	private Locale locale;
+	private @NotNull PlayerProfile playerProfile;
 
 	/**
 	 * Constructs a new {@link PlayerMock} for the provided server with the specified name.
@@ -229,6 +230,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 		address = new InetSocketAddress("192.0.2." + random.nextInt(255), random.nextInt(32768, 65535));
 		scoreboard = server.getScoreboardManager().getMainScoreboard();
 		locale = Locale.ENGLISH;
+		playerProfile = Bukkit.createProfile(uuid, name);
 	}
 
 	/**
@@ -2613,15 +2615,13 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public @NotNull PlayerProfile getPlayerProfile()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.playerProfile;
 	}
 
 	@Override
 	public void setPlayerProfile(@NotNull PlayerProfile profile)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.playerProfile = profile;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SkullMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SkullMetaMock.java
@@ -21,6 +21,7 @@ public class SkullMetaMock extends ItemMetaMock implements SkullMeta
 {
 
 	private @Nullable String owner;
+	private @Nullable com.destroystokyo.paper.profile.PlayerProfile playerProfile;
 
 	/**
 	 * Constructs a new {@link SkullMetaMock}.
@@ -40,6 +41,7 @@ public class SkullMetaMock extends ItemMetaMock implements SkullMeta
 		super(meta);
 
 		this.owner = meta.hasOwner() ? meta.getOwningPlayer().getName() : null;
+		this.playerProfile = meta.getPlayerProfile();
 	}
 
 	@Override
@@ -47,6 +49,7 @@ public class SkullMetaMock extends ItemMetaMock implements SkullMeta
 	{
 		SkullMetaMock mock = (SkullMetaMock) super.clone();
 		mock.setOwner(owner);
+		mock.setPlayerProfile(playerProfile);
 		return mock;
 	}
 
@@ -101,15 +104,13 @@ public class SkullMetaMock extends ItemMetaMock implements SkullMeta
 	@Override
 	public void setPlayerProfile(com.destroystokyo.paper.profile.@Nullable PlayerProfile profile)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.playerProfile = profile;
 	}
 
 	@Override
 	public com.destroystokyo.paper.profile.@Nullable PlayerProfile getPlayerProfile()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return playerProfile;
 	}
 
 	@Override

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -14,6 +14,7 @@ import be.seeseemelk.mockbukkit.inventory.EnderChestInventoryMock;
 import be.seeseemelk.mockbukkit.inventory.InventoryMock;
 import be.seeseemelk.mockbukkit.map.MapViewMock;
 import be.seeseemelk.mockbukkit.plugin.PluginManagerMock;
+import com.destroystokyo.paper.profile.PlayerProfile;
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
 import net.kyori.adventure.bossbar.BossBar;
@@ -2301,6 +2302,25 @@ class PlayerMockTest
 
 		bar.flags(Collections.singleton(BossBar.Flag.DARKEN_SCREEN));
 		assertEquals(Collections.singleton(BossBar.Flag.DARKEN_SCREEN), bossBar.flags());
+	}
+
+	@Test
+	void testPlayerProfile()
+	{
+		PlayerProfile profile = player.getPlayerProfile();
+
+		assertEquals(player.getUniqueId(), profile.getId());
+		assertEquals(player.getName(), profile.getName());
+	}
+
+	@Test
+	void testSetPlayerProfile()
+	{
+		UUID uuid = UUID.randomUUID();
+		PlayerProfile profile = Bukkit.createProfile(uuid, "Test");
+		player.setPlayerProfile(profile);
+
+		assertEquals(profile, player.getPlayerProfile());
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/SkullMetaMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/SkullMetaMockTest.java
@@ -1,7 +1,9 @@
 package be.seeseemelk.mockbukkit.inventory.meta;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.entity.OfflinePlayerMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,10 +16,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class SkullMetaMockTest
 {
 
+	private ServerMock server;
+
 	@BeforeEach
 	void setUp()
 	{
-		MockBukkit.mock();
+		server = MockBukkit.mock();
 	}
 
 	@AfterEach
@@ -56,6 +60,34 @@ class SkullMetaMockTest
 		assertTrue(meta.hasOwner());
 		assertEquals("TheBusyBiscuit", meta.getOwner());
 		assertEquals("TheBusyBiscuit", meta.getOwningPlayer().getName());
+	}
+
+	@Test
+	void testNoPlayerProfile()
+	{
+		SkullMetaMock meta = new SkullMetaMock();
+
+		assertNull(meta.getPlayerProfile());
+	}
+
+	@Test
+	void testSetNullPlayerProfile()
+	{
+		SkullMetaMock meta = new SkullMetaMock();
+
+		assertNull(meta.getPlayerProfile());
+		meta.setPlayerProfile(null);
+		assertNull(meta.getPlayerProfile());
+	}
+
+	@Test
+	void testSetPlayerProfile()
+	{
+		SkullMetaMock meta = new SkullMetaMock();
+		PlayerMock playerMock = server.addPlayer();
+
+		meta.setPlayerProfile(playerMock.getPlayerProfile());
+		assertEquals(playerMock.getPlayerProfile(), meta.getPlayerProfile());
 	}
 
 	@Test


### PR DESCRIPTION
# Description
<!-- State the changes of the pull request below. -->
Adds a playerProfile field of type
com.destroystokyo.paper.profile.PlayerProfile to the SkullMetaMock class to store player profile information associated with the skull. In the constructor, the PlayerProfile is now also initialized from the data of the original SkullMeta.
Adds methods to set and retrieve the PlayerProfile associated with the SkullMeta.
The setPlayerProfile and getPlayerProfile methods are now functional, allowing for proper management of the player profile associated with the skull.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
