### PR TITLE
Fix Minecraft Version attribute in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,16 +21,16 @@ body:
       label: Minecraft Version
       description: What Minecraft version of MockBukkit are you using?
       options:
-        - 1.8
-        - 1.12
-        - 1.13
-        - 1.14
-        - 1.15
-        - 1.16
-        - 1.17
-        - 1.18
-        - 1.19
-        - 1.20
+        - "1.8"
+        - "1.12"
+        - "1.13"
+        - "1.14"
+        - "1.15"
+        - "1.16"
+        - "1.17"
+        - "1.18"
+        - "1.19"
+        - "1.20"
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
Numeric attributes that have decimals that end with a 0 will be truncated (e.g. 1.20 turns into 1.2). To fix this, we use string attributes instead

# Description

Fixes an issue in the bug template where "1.2" was being displayed instead of "1.20":

![image](https://github.com/MockBukkit/MockBukkit/assets/4613171/a03695ca-68b6-4576-b11a-9cc96885882c)

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
