### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/configuration/ServerConfiguration.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/configuration/ServerConfiguration.java
@@ -378,7 +378,7 @@ public class ServerConfiguration
 
 	/**
 	 * Enum representing all different world types.
-	 * <a href="https://minecraft.fandom.com/wiki/World_preset">Wiki</a>
+	 * <a href="https://minecraft.wiki/w/World_preset">Wiki</a>
 	 */
 	public enum LevelType
 	{

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/HumanEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/HumanEntityMock.java
@@ -424,7 +424,7 @@ public abstract class HumanEntityMock extends LivingEntityMock implements HumanE
 	@Override
 	public int getExpToLevel()
 	{
-		// Formula from https://minecraft.gamepedia.com/Experience#Leveling_up
+		// Formula from https://minecraft.wiki/w/Experience#Leveling_up
 		if (this.expLevel >= 31)
 			return (9 * this.expLevel) - 158;
 		if (this.expLevel >= 16)

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -112,7 +112,7 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 class PlayerMockTest
 {
 
-	// Taken from https://minecraft.gamepedia.com/Experience#Leveling_up
+	// Taken from https://minecraft.wiki/w/Experience#Leveling_up
 	private static final int[] expRequired =
 			{
 					7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 33, 35, 37, 42, 47, 52, 57, 62, 67, 72, 77, 82, 87, 92, 97, 102,


### PR DESCRIPTION
# Description
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [ ] Unit tests added (if applicable).
