### PR TITLE
Fix BlockState#equals

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
@@ -366,10 +366,6 @@ public class BlockStateMock implements BlockState
 		{
 			return false;
 		}
-		if (this.isPlaced() && this.getWorld() != other.getWorld() && (this.getWorld() == null || !this.getWorld().equals(other.getWorld())))
-		{
-			return false;
-		}
 		return !this.isPlaced() || this.getLocation() == other.getLocation() || (this.getLocation() != null && this.getLocation().equals(other.getLocation()));
 //		if (this.getBlockData() != other.getBlockData() && (this.getBlockData() == null || !this.getBlockData().equals(other.getBlockData()))) {
 //			return false; Not implemented

--- a/src/test/java/be/seeseemelk/mockbukkit/block/state/BlockStateMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/state/BlockStateMockTest.java
@@ -102,6 +102,14 @@ class BlockStateMockTest
 	}
 
 	@Test
+	void testEquals()
+	{
+		Block block1 = new BlockMock(Material.DIRT);
+		Block block2 = new BlockMock(Material.DIRT);
+		assertEquals(block1.getState(), block2.getState());
+	}
+
+	@Test
 	void testUpdateForceChangesType()
 	{
 		Block block = new BlockMock(Material.CHEST);


### PR DESCRIPTION
# Description
Bukkit itself had the check because it later compares BlockPos (not world bound) where as we compare Location (world bound)

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
