### PR TITLE
Fix AsyncPlayerPreLoginEvent and PlayerLoginEvent to respect login result

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -298,6 +298,18 @@ public 	class ServerMock extends Server.Spigot implements Server
 		try
 		{
 			conditionLatch.await();
+			if (preLoginEvent.getLoginResult() != AsyncPlayerPreLoginEvent.Result.ALLOWED)
+			{
+				PlayerConnectionCloseEvent playerConnectionCloseEvent =
+						new PlayerConnectionCloseEvent(player.getUniqueId(),
+								player.getName(),
+								player.getAddress().getAddress(),
+								false);
+
+				getPluginManager().callEvent(playerConnectionCloseEvent);
+				playerList.disconnectPlayer(player);
+				return;
+			}
 		}
 		catch (InterruptedException e)
 		{
@@ -308,6 +320,19 @@ public 	class ServerMock extends Server.Spigot implements Server
 
 		PlayerLoginEvent playerLoginEvent = new PlayerLoginEvent(player, address.getHostString(), address.getAddress());
 		Bukkit.getPluginManager().callEvent(playerLoginEvent);
+
+		if (playerLoginEvent.getResult() != PlayerLoginEvent.Result.ALLOWED)
+		{
+			PlayerConnectionCloseEvent playerConnectionCloseEvent =
+					new PlayerConnectionCloseEvent(player.getUniqueId(),
+							player.getName(),
+							player.getAddress().getAddress(),
+							false);
+
+			getPluginManager().callEvent(playerConnectionCloseEvent);
+			playerList.disconnectPlayer(player);
+			return;
+		}
 
 		Component joinMessage = MiniMessage.miniMessage()
 				.deserialize("<name> has joined the Server!", Placeholder.component("name", player.displayName()));

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -945,6 +945,30 @@ class ServerMockTest
 	}
 
 	@Test
+	void testAddPlayerWithDisallowedAsyncPreLoginResult()
+	{
+		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
+		server.getPluginManager().registerEvents(plugin, plugin);
+		plugin.denyAsyncPreLoginEvent = true;
+		PlayerMock player = server.addPlayer();
+
+		assertFalse(server.getOnlinePlayers().contains(player));
+		server.getPluginManager().assertEventFired(PlayerConnectionCloseEvent.class);
+	}
+
+	@Test
+	void testAddPlayerWithDisallowedLoginResult()
+	{
+		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
+		server.getPluginManager().registerEvents(plugin, plugin);
+		plugin.denyLoginEvent = true;
+		PlayerMock player = server.addPlayer();
+
+		assertFalse(server.getOnlinePlayers().contains(player));
+		server.getPluginManager().assertEventFired(PlayerConnectionCloseEvent.class);
+	}
+
+	@Test
 	void testGetBannedPlayersDefault()
 	{
 		assertEquals(0, server.getBannedPlayers().size());

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -65,6 +65,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.entity.SpawnCategory;
 import org.bukkit.entity.Villager;
 import org.bukkit.entity.memory.MemoryKey;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -947,9 +949,7 @@ class ServerMockTest
 	@Test
 	void testAddPlayerWithDisallowedAsyncPreLoginResult()
 	{
-		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
-		server.getPluginManager().registerEvents(plugin, plugin);
-		plugin.denyAsyncPreLoginEvent = true;
+		server.getPluginManager().registerEvents(new EventDenier(), MockBukkit.createMockPlugin());
 		PlayerMock player = server.addPlayer();
 
 		assertFalse(server.getOnlinePlayers().contains(player));
@@ -959,9 +959,7 @@ class ServerMockTest
 	@Test
 	void testAddPlayerWithDisallowedLoginResult()
 	{
-		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
-		server.getPluginManager().registerEvents(plugin, plugin);
-		plugin.denyLoginEvent = true;
+		server.getPluginManager().registerEvents(new EventDenier(), MockBukkit.createMockPlugin());
 		PlayerMock player = server.addPlayer();
 
 		assertFalse(server.getOnlinePlayers().contains(player));
@@ -1780,4 +1778,17 @@ class TestRecipe implements Recipe
 		return result;
 	}
 
+}
+
+class EventDenier implements Listener
+{
+	@EventHandler
+	void onPlayerConnectionClose(AsyncPlayerPreLoginEvent event){
+		event.setLoginResult(AsyncPlayerPreLoginEvent.Result.KICK_OTHER);
+	}
+
+	@EventHandler
+	void onPlayerLogin(PlayerLoginEvent  event){
+		event.setResult(PlayerLoginEvent.Result.KICK_OTHER);
+	}
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -947,16 +947,6 @@ class ServerMockTest
 	}
 
 	@Test
-	void testAddPlayerWithDisallowedAsyncPreLoginResult()
-	{
-		server.getPluginManager().registerEvents(new EventDenier(), MockBukkit.createMockPlugin());
-		PlayerMock player = server.addPlayer();
-
-		assertFalse(server.getOnlinePlayers().contains(player));
-		server.getPluginManager().assertEventFired(PlayerConnectionCloseEvent.class);
-	}
-
-	@Test
 	void testAddPlayerWithDisallowedLoginResult()
 	{
 		server.getPluginManager().registerEvents(new EventDenier(), MockBukkit.createMockPlugin());

--- a/src/test/java/be/seeseemelk/mockbukkit/TestPlugin.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/TestPlugin.java
@@ -9,7 +9,9 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -38,6 +40,8 @@ public class TestPlugin extends JavaPlugin implements Listener
 	public @NotNull CyclicBarrier barrier = new CyclicBarrier(2);
 	public final @Nullable Object extra;
 	public boolean classLoadSucceed = false;
+	public boolean denyAsyncPreLoginEvent = false;
+	public boolean denyLoginEvent = false;
 
 	public TestPlugin()
 	{
@@ -123,6 +127,24 @@ public class TestPlugin extends JavaPlugin implements Listener
 			catch (InterruptedException | BrokenBarrierException e)
 			{
 			}
+		}
+	}
+
+	@EventHandler
+	public void onAsyncPreLogin(AsyncPlayerPreLoginEvent event)
+	{
+		if (denyAsyncPreLoginEvent)
+		{
+			event.setLoginResult(AsyncPlayerPreLoginEvent.Result.KICK_OTHER);
+		}
+	}
+
+	@EventHandler
+	public void onLogin(PlayerLoginEvent event)
+	{
+		if (denyLoginEvent)
+		{
+			event.setResult(PlayerLoginEvent.Result.KICK_OTHER);
 		}
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/TestPlugin.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/TestPlugin.java
@@ -9,9 +9,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
-import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -40,8 +38,6 @@ public class TestPlugin extends JavaPlugin implements Listener
 	public @NotNull CyclicBarrier barrier = new CyclicBarrier(2);
 	public final @Nullable Object extra;
 	public boolean classLoadSucceed = false;
-	public boolean denyAsyncPreLoginEvent = false;
-	public boolean denyLoginEvent = false;
 
 	public TestPlugin()
 	{
@@ -127,24 +123,6 @@ public class TestPlugin extends JavaPlugin implements Listener
 			catch (InterruptedException | BrokenBarrierException e)
 			{
 			}
-		}
-	}
-
-	@EventHandler
-	public void onAsyncPreLogin(AsyncPlayerPreLoginEvent event)
-	{
-		if (denyAsyncPreLoginEvent)
-		{
-			event.setLoginResult(AsyncPlayerPreLoginEvent.Result.KICK_OTHER);
-		}
-	}
-
-	@EventHandler
-	public void onLogin(PlayerLoginEvent event)
-	{
-		if (denyLoginEvent)
-		{
-			event.setResult(PlayerLoginEvent.Result.KICK_OTHER);
 		}
 	}
 


### PR DESCRIPTION
# Description
<!-- State the changes of the pull request below. -->
`AsyncPlayerPreLoginEvent` and `PlayerLoginEvent` will now respect the login result set by listeners. If login events are disallowed, players will be disconnected and the `PlayerConnectionCloseEvent` will be called. The motivation behind this was that, when writing tests with MockBukkit, I expected the `PlayerJoinEvent` to not be called after I had already cancelled the `PlayerLoginEvent` (this matches Spigot behavior).

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
