### PR TITLE
Add ChunkMock#getBlocks, fix biomes

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ChunkMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ChunkMock.java
@@ -17,7 +17,9 @@ import org.bukkit.util.BoundingBox;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.function.Predicate;
 
 /**
@@ -103,6 +105,27 @@ public class ChunkMock implements Chunk
 		return getBlock(coordinate.x, coordinate.y, coordinate.z);
 	}
 
+	/**
+	 * Gets all blocks in this chunk.
+	 *
+	 * @return A list of all blocks in this chunk.
+	 */
+	public @NotNull List<Block> getBlocks()
+	{
+		List<Block> blocks = new ArrayList<>(getCubicSize());
+		for (int blockX = 0; blockX < 16; blockX++)
+		{
+			for (int blockY = world.getMinHeight(); blockY < world.getMaxHeight(); blockY++)
+			{
+				for (int blockZ = 0; blockZ < 16; blockZ++)
+				{
+					blocks.add(getBlock(blockX, blockY, blockZ));
+				}
+			}
+		}
+		return blocks;
+	}
+
 	@Override
 	public @NotNull ChunkSnapshot getChunkSnapshot()
 	{
@@ -110,26 +133,18 @@ public class ChunkMock implements Chunk
 	}
 
 	@Override
-	@SuppressWarnings("UnstableApiUsage")
+	@SuppressWarnings("UnstableApiUsage") // ImmutableMap#builderWithExpectedSize
 	public @NotNull ChunkSnapshot getChunkSnapshot(boolean includeMaxblocky, boolean includeBiome, boolean includeBiomeTempRain)
 	{
-		// Cubic size of the chunk (w * w * h).
-		int size = (16 * 16) * Math.abs((world.getMaxHeight() - world.getMinHeight()));
-		ImmutableMap.Builder<Coordinate, BlockData> blockData = ImmutableMap.builderWithExpectedSize(size);
-		ImmutableMap.Builder<Coordinate, Biome> biomes = ImmutableMap.builderWithExpectedSize(size);
-		for (int blockX = 0; blockX < 16; blockX++)
+		ImmutableMap.Builder<Coordinate, BlockData> blockData = ImmutableMap.builderWithExpectedSize(getCubicSize());
+		ImmutableMap.Builder<Coordinate, Biome> biomes = ImmutableMap.builderWithExpectedSize(getCubicSize());
+		for (Block block : getBlocks())
 		{
-			for (int blockY = world.getMinHeight(); blockY < world.getMaxHeight(); blockY++)
+			Coordinate chunkLocalCoordinate = new Coordinate(block.getX() % 16, block.getY(), block.getZ() % 16);
+			blockData.put(chunkLocalCoordinate, block.getBlockData());
+			if (includeBiome || includeBiomeTempRain)
 			{
-				for (int blockZ = 0; blockZ < 16; blockZ++)
-				{
-					Coordinate coord = new Coordinate(blockX, blockY, blockZ);
-					blockData.put(coord, getBlock(blockX, blockY, blockZ).getBlockData());
-					if (includeBiome || includeBiomeTempRain)
-					{
-						biomes.put(coord, world.getBiome(blockX << 4, blockY, blockZ << 4));
-					}
-				}
+				biomes.put(chunkLocalCoordinate, block.getBiome());
 			}
 		}
 		return new ChunkSnapshotMock(x, z, world.getMinHeight(), world.getMaxHeight(), world.getName(), world.getFullTime(), blockData.build(), (includeBiome || includeBiomeTempRain) ? biomes.build() : null);
@@ -291,6 +306,11 @@ public class ChunkMock implements Chunk
 	public @NotNull PersistentDataContainer getPersistentDataContainer()
 	{
 		return persistentDataContainer;
+	}
+
+	private int getCubicSize()
+	{
+		return (16 * 16) * Math.abs(world.getMaxHeight() - world.getMinHeight()); // (w * w * h)
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/block/BlockMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/BlockMock.java
@@ -44,7 +44,7 @@ public class BlockMock implements Block
 
 	private final MetadataTable metadataTable = new MetadataTable();
 
-	private final @Nullable Location location;
+	private final Location location;
 	private BlockStateMock state;
 	private Material material;
 	private byte data;

--- a/src/test/java/be/seeseemelk/mockbukkit/ChunkSnapshotMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ChunkSnapshotMockTest.java
@@ -137,7 +137,9 @@ class ChunkSnapshotMockTest
 	@Test
 	void getBiome()
 	{
-		world.setBiome(0, 0, 0, Biome.BADLANDS);
+		// Chunk is at world 1, 1. Chunk 0, 0 = world 16, 16
+		world.setBiome(16, 0, 16, Biome.BADLANDS);
+
 		assertEquals(Biome.BADLANDS, chunk.getChunkSnapshot(false, true, false).getBiome(0, 0));
 		assertEquals(Biome.BADLANDS, chunk.getChunkSnapshot(false, true, false).getBiome(0, 0, 0));
 	}
@@ -153,7 +155,8 @@ class ChunkSnapshotMockTest
 	@Test
 	void getBiome_EitherBiome_ReturnsBiomes()
 	{
-		world.setBiome(0, 0, 0, Biome.BADLANDS);
+		// Chunk is at world 1, 1. Chunk 0, 0 = world 16, 16
+		world.setBiome(16, 0, 16, Biome.BADLANDS);
 
 		assertEquals(Biome.BADLANDS, chunk.getChunkSnapshot(false, true, false).getBiome(0, 0, 0));
 		assertEquals(Biome.BADLANDS, chunk.getChunkSnapshot(false, false, true).getBiome(0, 0, 0));

--- a/src/test/java/be/seeseemelk/mockbukkit/ChunkTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ChunkTest.java
@@ -1,8 +1,9 @@
 package be.seeseemelk.mockbukkit;
 
-import org.bukkit.Chunk;
 import org.bukkit.Chunk.LoadLevel;
 import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Zombie;
 import org.junit.jupiter.api.AfterEach;
@@ -61,6 +62,51 @@ class ChunkTest
 	void getWorld_AnyChunkFromWorld_ExactWorldReference()
 	{
 		assertSame(world, world.getChunkAt(0, 0).getWorld());
+	}
+
+	@Test
+	void getBlock_CorrectBlock()
+	{
+		world.getBlockAt(16 + 8, 0, 16 + 6).setType(Material.STONE);
+		ChunkMock chunk = world.getChunkAt(1, 1);
+
+		Material type = chunk.getBlock(8, 0, 6).getType();
+
+		assertEquals(Material.STONE, type);
+	}
+
+	@Test
+	void getBlock_Coordinate_CorrectBlock()
+	{
+		world.getBlockAt(16 + 8, 0, 16 + 6).setType(Material.STONE);
+		ChunkMock chunk = world.getChunkAt(1, 1);
+
+		Material type = chunk.getBlock(new Coordinate(8, 0, 6)).getType();
+
+		assertEquals(Material.STONE, type);
+	}
+
+	@Test
+	void getBlocks_CorrectSize()
+	{
+		ChunkMock chunk = world.getChunkAt(0, 0);
+
+		// w * w * h
+		assertEquals(32768, chunk.getBlocks().size());
+	}
+
+	@Test
+	void getBlocks_CorrectBlocks()
+	{
+		world.getBlockAt(16, 0, 16).setType(Material.STONE);
+		world.getBlockAt(16, 0, 17).setType(Material.STONE_BRICKS);
+		ChunkMock chunk = world.getChunkAt(1, 1);
+
+		Block block1 = chunk.getBlocks().get(0);
+		Block block2 = chunk.getBlocks().get(1);
+
+		assertEquals(Material.STONE, block1.getType());
+		assertEquals(Material.STONE_BRICKS, block2.getType());
 	}
 
 	@Test
@@ -160,4 +206,5 @@ class ChunkTest
 		chunk.load();
 		assertEquals(LoadLevel.ENTITY_TICKING, chunk.getLoadLevel());
 	}
+
 }


### PR DESCRIPTION
# Description
Adds `ChunkMock#getBlocks` which will come in handy later, centralizing the logic for getting all chunk blocks.
It also fixes a bug with getting biome locations where it was getting them from the wrong world location.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
