### PR TITLE
doc(README): remove typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ development of MockBukkit.
 
 ### Using MockBukkit
 
-A plugin can be loaded in this initialiser block.
+A plugin can be loaded in this initializer block.
 
 ```java
 private ServerMock server;


### PR DESCRIPTION
## Description:

This Pull Request fixes a typographical error in the README.md file.


## Changes Made:

 - Corrected "initialiser" to "initializer" in the README.md file.

## Additional Information:

This fix is not related to any existing issue. It's a minor typo that I noticed while reviewing the README.

Thank you for considering this contribution.