### PR TITLE
Add EndermiteMock

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
@@ -24,6 +24,7 @@ import be.seeseemelk.mockbukkit.entity.EggMock;
 import be.seeseemelk.mockbukkit.entity.ElderGuardianMock;
 import be.seeseemelk.mockbukkit.entity.EnderPearlMock;
 import be.seeseemelk.mockbukkit.entity.EndermanMock;
+import be.seeseemelk.mockbukkit.entity.EndermiteMock;
 import be.seeseemelk.mockbukkit.entity.EntityMock;
 import be.seeseemelk.mockbukkit.entity.ExperienceOrbMock;
 import be.seeseemelk.mockbukkit.entity.ExplosiveMinecartMock;
@@ -134,6 +135,7 @@ import org.bukkit.entity.Egg;
 import org.bukkit.entity.ElderGuardian;
 import org.bukkit.entity.EnderPearl;
 import org.bukkit.entity.Enderman;
+import org.bukkit.entity.Endermite;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.ExperienceOrb;
@@ -1326,6 +1328,10 @@ public class WorldMock implements World
 		else if (clazz == MagmaCube.class)
 		{
 			return new MagmaCubeMock(server, UUID.randomUUID());
+		}
+		else if (clazz == Endermite.class)
+		{
+			return new EndermiteMock(server, UUID.randomUUID());
 		}
 		throw new UnimplementedOperationException();
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EndermiteMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EndermiteMock.java
@@ -1,0 +1,64 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.ServerMock;
+import org.bukkit.entity.Endermite;
+import org.bukkit.entity.EntityType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+public class EndermiteMock extends MonsterMock implements Endermite
+{
+
+	private int life = 0;
+
+	/**
+	 * Constructs a new {@link EndermiteMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
+	public EndermiteMock(@NotNull ServerMock server, @NotNull UUID uuid)
+	{
+		super(server, uuid);
+	}
+
+	/**
+	 * @deprecated No function anymore.
+	 */
+	@Override
+	@Deprecated(since = "1.17")
+	public boolean isPlayerSpawned()
+	{
+		return false;
+	}
+
+	/**
+	 * @deprecated No function anymore.
+	 */
+	@Override
+	@Deprecated(since = "1.17")
+	public void setPlayerSpawned(boolean playerSpawned)
+	{
+		// Nop
+	}
+
+	@Override
+	public void setLifetimeTicks(int ticks)
+	{
+		this.life = ticks;
+	}
+
+	@Override
+	public int getLifetimeTicks()
+	{
+		return this.life;
+	}
+
+	@Override
+	public @NotNull EntityType getType()
+	{
+		return EntityType.ENDERMITE;
+	}
+
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/WorldMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/WorldMockTest.java
@@ -25,6 +25,7 @@ import be.seeseemelk.mockbukkit.entity.EggMock;
 import be.seeseemelk.mockbukkit.entity.ElderGuardianMock;
 import be.seeseemelk.mockbukkit.entity.EnderPearlMock;
 import be.seeseemelk.mockbukkit.entity.EndermanMock;
+import be.seeseemelk.mockbukkit.entity.EndermiteMock;
 import be.seeseemelk.mockbukkit.entity.ExperienceOrbMock;
 import be.seeseemelk.mockbukkit.entity.ExplosiveMinecartMock;
 import be.seeseemelk.mockbukkit.entity.FireballMock;
@@ -1297,7 +1298,8 @@ class WorldMockTest
 				Arguments.of(EntityType.GLOW_SQUID, GlowSquidMock.class),
 				Arguments.of(EntityType.LLAMA_SPIT, LlamaSpitMock.class),
 				Arguments.of(EntityType.DOLPHIN, DolphinMock.class),
-				Arguments.of(EntityType.MAGMA_CUBE, MagmaCubeMock.class)
+				Arguments.of(EntityType.MAGMA_CUBE, MagmaCubeMock.class),
+				Arguments.of(EntityType.ENDERMITE, EndermiteMock.class)
 		);
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/EndermiteMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/EndermiteMockTest.java
@@ -1,0 +1,64 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.MockBukkitExtension;
+import be.seeseemelk.mockbukkit.MockBukkitInject;
+import be.seeseemelk.mockbukkit.ServerMock;
+import org.bukkit.entity.Endermite;
+import org.bukkit.entity.EntityType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockBukkitExtension.class)
+class EndermiteMockTest
+{
+
+	@MockBukkitInject
+	private ServerMock serverMock;
+	private Endermite enderMite;
+
+	@BeforeEach
+	void setUp()
+	{
+		enderMite = new EndermiteMock(serverMock, UUID.randomUUID());
+	}
+
+	@Test
+	void testGetType()
+	{
+		assertEquals(EntityType.ENDERMITE, enderMite.getType());
+	}
+
+	@Test
+	void testIsPlayerSpawned()
+	{
+		Assertions.assertFalse(enderMite.isPlayerSpawned());
+	}
+
+	@Test
+	void testSetPlayerSpawned()
+	{
+		assertDoesNotThrow(() -> enderMite.setPlayerSpawned(true));
+		Assertions.assertFalse(enderMite.isPlayerSpawned());
+	}
+
+	@Test
+	void testGetLifetimeTicksDefault()
+	{
+		assertEquals(0, enderMite.getLifetimeTicks());
+	}
+
+	@Test
+	void testSetLifetimeTicks()
+	{
+		enderMite.setLifetimeTicks(123);
+		assertEquals(123, enderMite.getLifetimeTicks());
+	}
+
+}


### PR DESCRIPTION
# Description
Adds a Mock for the Endermite Entity.
In Paper the Entity gets discarded once it reaches the age of 2400 Ticks, but since we currently don't have a proper ticking system, this behaviour is ignored

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
