### PR TITLE
feat(world): Implement RespawnAnchor API

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
@@ -2571,8 +2571,7 @@ public class WorldMock implements World
 	@ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 	public boolean doesRespawnAnchorWork()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return isRespawnAnchorWorks();
 	}
 
 	@Override
@@ -2960,8 +2959,7 @@ public class WorldMock implements World
 	@Override
 	public boolean isRespawnAnchorWorks()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return environment == Environment.NETHER;
 	}
 
 	@Override

--- a/src/test/java/be/seeseemelk/mockbukkit/WorldMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/WorldMockTest.java
@@ -2053,4 +2053,37 @@ class WorldMockTest
 		assertEquals(10, world.getTicksPerMonsterSpawns());
 	}
 
+	@Test
+	void testIsRespawnAnchorWorks()
+	{
+		WorldMock world = new WorldMock(Material.DIRT, 3);
+		world.setEnvironment(World.Environment.NETHER);
+		assertTrue(world.isRespawnAnchorWorks());
+	}
+
+	@Test
+	void testIsRespawnAnchorWorksFalse()
+	{
+		WorldMock world = new WorldMock(Material.DIRT, 3);
+		assertFalse(world.isRespawnAnchorWorks());
+		world.setEnvironment(World.Environment.THE_END);
+		assertFalse(world.isRespawnAnchorWorks());
+	}
+
+	@Test
+	void testDoesRespawnAnchorWork()
+	{
+		WorldMock world = new WorldMock(Material.DIRT, 3);
+		world.setEnvironment(World.Environment.NETHER);
+		assertTrue(world.doesRespawnAnchorWork());
+	}
+
+	@Test
+	void testDoesRespawnAnchorWorkFalse()
+	{
+		WorldMock world = new WorldMock(Material.DIRT, 3);
+		assertFalse(world.doesRespawnAnchorWork());
+		world.setEnvironment(World.Environment.THE_END);
+		assertFalse(world.doesRespawnAnchorWork());
+	}
 }


### PR DESCRIPTION
# Description
Implements both `isRespawnAnchorWorks()` and `doesRespawnAnchorWork()`. Ideally this would be registry backed, so it would stay in sync with potential new World Types, but since thats not something we have at the moment, this is the best we got.

# Checklist 
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
