### PR TITLE
fix BlockMock.setType(Material type, boolean applyPhysics) doing nothing

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/block/BlockMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/BlockMock.java
@@ -261,7 +261,7 @@ public class BlockMock implements Block
 	@Override
 	public void setType(@NotNull Material type, boolean applyPhysics)
 	{
-		setType(material);
+		setType(type);
 	}
 
 	@Override


### PR DESCRIPTION
Method argument was ignored at all
