### PR TITLE
fix playerlist hasplayedbefore

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/MockPlayerList.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockPlayerList.java
@@ -4,16 +4,13 @@ import be.seeseemelk.mockbukkit.ban.MockIpBanList;
 import be.seeseemelk.mockbukkit.ban.MockProfileBanList;
 import be.seeseemelk.mockbukkit.entity.OfflinePlayerMock;
 import be.seeseemelk.mockbukkit.entity.PlayerMock;
-import com.destroystokyo.paper.profile.PlayerProfile;
 import com.google.common.base.Preconditions;
-import org.bukkit.BanList;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.net.InetAddress;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -109,6 +106,7 @@ public class MockPlayerList
 	{
 		this.lastSeen.put(player.getUniqueId(), System.currentTimeMillis());
 		this.onlinePlayers.remove(player);
+		this.hasPlayedBefore.put(player.getUniqueId(), true);
 	}
 
 	/**
@@ -157,6 +155,7 @@ public class MockPlayerList
 	{
 		Preconditions.checkArgument(firstPlayed > 0, "First played time must be non-negative");
 		this.firstPlayed.put(uuid, firstPlayed);
+		this.hasPlayedBefore.put(uuid, true);
 	}
 
 	/**
@@ -187,6 +186,7 @@ public class MockPlayerList
 	{
 		Preconditions.checkArgument(lastSeen > 0, "Last seen time must be non-negative");
 		this.lastSeen.put(uuid, lastSeen);
+		this.hasPlayedBefore.put(uuid, true);
 	}
 
 	/**
@@ -211,6 +211,7 @@ public class MockPlayerList
 	{
 		Preconditions.checkArgument(lastLogin > 0, "Last login time must be non-negative");
 		this.lastLogins.put(uuid, lastLogin);
+		this.hasPlayedBefore.put(uuid, true);
 	}
 
 	/**

--- a/src/test/java/be/seeseemelk/mockbukkit/MockPlayerListTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/MockPlayerListTest.java
@@ -54,20 +54,24 @@ class MockPlayerListTest
 	void addPlayer_SetsFirstPlayed()
 	{
 		PlayerMock player = server.addPlayer();
+		assertFalse(playerList.hasPlayedBefore(player.getUniqueId()));
 
 		playerList.addPlayer(player);
 
 		assertNotEquals(0, playerList.getFirstPlayed(player.getUniqueId()));
+		assertTrue(playerList.hasPlayedBefore(player.getUniqueId()));
 	}
 
 	@Test
 	void addPlayer_SetsLastLogin()
 	{
 		PlayerMock player = server.addPlayer();
+		assertFalse(playerList.hasPlayedBefore(player.getUniqueId()));
 
 		playerList.addPlayer(player);
 
 		assertNotEquals(0, playerList.getLastLogin(player.getUniqueId()));
+		assertTrue(playerList.hasPlayedBefore(player.getUniqueId()));
 	}
 
 	@Test
@@ -94,10 +98,12 @@ class MockPlayerListTest
 	void disconnect_SetsLastSeen()
 	{
 		PlayerMock player = server.addPlayer();
+		assertFalse(playerList.hasPlayedBefore(player.getUniqueId()));
 
 		playerList.disconnectPlayer(player);
 
 		assertNotEquals(0, playerList.getLastSeen(player.getUniqueId()));
+		assertTrue(playerList.hasPlayedBefore(player.getUniqueId()));
 	}
 
 	@Test
@@ -203,10 +209,12 @@ class MockPlayerListTest
 	void setFirstPlayed()
 	{
 		UUID uuid = UUID.randomUUID();
+		assertFalse(playerList.hasPlayedBefore(uuid));
 
 		playerList.setFirstPlayed(uuid, 10L);
 
 		assertEquals(10, playerList.getFirstPlayed(uuid));
+		assertTrue(playerList.hasPlayedBefore(uuid));
 	}
 
 	@Test
@@ -221,10 +229,12 @@ class MockPlayerListTest
 	void setLastSeen()
 	{
 		UUID uuid = UUID.randomUUID();
+		assertFalse(playerList.hasPlayedBefore(uuid));
 
 		playerList.setLastSeen(uuid, 10L);
 
 		assertEquals(10, playerList.getLastSeen(uuid));
+		assertTrue(playerList.hasPlayedBefore(uuid));
 	}
 
 	@Test
@@ -250,10 +260,12 @@ class MockPlayerListTest
 	void setLastLogin()
 	{
 		UUID uuid = UUID.randomUUID();
+		assertFalse(playerList.hasPlayedBefore(uuid));
 
 		playerList.setLastLogin(uuid, 10L);
 
 		assertEquals(10, playerList.getLastLogin(uuid));
+		assertTrue(playerList.hasPlayedBefore(uuid));
 	}
 
 	@Test


### PR DESCRIPTION
# Description
<!-- State the changes of the pull request below. -->
This PR fixes the playerlist hasplayedbefore.
When setting setlastseen hasplayedbefore would never be set.
This would always return false.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
