### PR TITLE
BlockMock | Light level, LightFromSky and LightFromBlocks

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/block/BlockMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/BlockMock.java
@@ -30,6 +30,7 @@ import org.bukkit.util.Vector;
 import org.bukkit.util.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
 
 import java.util.Collection;
 import java.util.List;
@@ -49,6 +50,10 @@ public class BlockMock implements Block
 	private Material material;
 	private byte data;
 	private BlockData blockData;
+
+	private byte lightLevel = 0;
+	private byte lightFromSky = 15;
+	private byte lightFromBlocks = 0;
 
 	/**
 	 * Creates a basic block made of air.
@@ -171,22 +176,49 @@ public class BlockMock implements Block
 	@Override
 	public byte getLightLevel()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return lightLevel;
+	}
+
+	/**
+	 * Sets the light level for this block.
+	 *
+	 * @param lightLevel Value between 0 and 15.
+	 */
+	public void setLightLevel(@Range(from=0, to=15) byte lightLevel)
+	{
+		this.lightLevel = lightLevel;
 	}
 
 	@Override
 	public byte getLightFromSky()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return lightFromSky;
+	}
+
+	/**
+	 * Sets the light level received from sky.
+	 *
+	 * @param lightFromSky Value between 0 and 15.
+	 */
+	public void setLightFromSky(@Range(from=0, to=15) byte lightFromSky)
+	{
+		this.lightFromSky = lightFromSky;
 	}
 
 	@Override
 	public byte getLightFromBlocks()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return lightFromBlocks;
+	}
+
+	/**
+	 * Sets the light level received from other blocks.
+	 *
+	 * @param lightFromBlocks Value between 0 and 15.
+	 */
+	public void setLightFromBlocks(@Range(from=0, to=15) byte lightFromBlocks)
+	{
+		this.lightFromBlocks = lightFromBlocks;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/block/BlockMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/BlockMock.java
@@ -190,9 +190,7 @@ public class BlockMock implements Block
 	 */
 	public void setLightFromSky(byte lightFromSky)
 	{
-		if (lightFromSky < 0 || lightFromSky > 15) {
-			throw new IllegalArgumentException("Light level should be between 0 and 15.");
-		}
+		Preconditions.checkArgument(lightFromSky >= 0 && lightFromSky <= 15, "Light level should be between 0 and 15.");
 
 		this.lightFromSky = lightFromSky;
 	}
@@ -210,9 +208,7 @@ public class BlockMock implements Block
 	 */
 	public void setLightFromBlocks(byte lightFromBlocks)
 	{
-		if (lightFromBlocks < 0 || lightFromBlocks > 15) {
-			throw new IllegalArgumentException("Light level should be between 0 and 15.");
-		}
+		Preconditions.checkArgument(lightFromBlocks >= 0 && lightFromBlocks <= 15, "Light level should be between 0 and 15.");
 
 		this.lightFromBlocks = lightFromBlocks;
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/block/BlockMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/BlockMock.java
@@ -30,7 +30,6 @@ import org.bukkit.util.Vector;
 import org.bukkit.util.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.Range;
 
 import java.util.Collection;
 import java.util.List;
@@ -51,7 +50,6 @@ public class BlockMock implements Block
 	private byte data;
 	private BlockData blockData;
 
-	private byte lightLevel = 0;
 	private byte lightFromSky = 15;
 	private byte lightFromBlocks = 0;
 
@@ -176,17 +174,7 @@ public class BlockMock implements Block
 	@Override
 	public byte getLightLevel()
 	{
-		return lightLevel;
-	}
-
-	/**
-	 * Sets the light level for this block.
-	 *
-	 * @param lightLevel Value between 0 and 15.
-	 */
-	public void setLightLevel(@Range(from=0, to=15) byte lightLevel)
-	{
-		this.lightLevel = lightLevel;
+		return (byte) Math.max(getLightFromSky(), getLightFromBlocks());
 	}
 
 	@Override
@@ -200,8 +188,12 @@ public class BlockMock implements Block
 	 *
 	 * @param lightFromSky Value between 0 and 15.
 	 */
-	public void setLightFromSky(@Range(from=0, to=15) byte lightFromSky)
+	public void setLightFromSky(byte lightFromSky)
 	{
+		if (lightFromSky < 0 || lightFromSky > 15) {
+			throw new IllegalArgumentException("Light level should be between 0 and 15.");
+		}
+
 		this.lightFromSky = lightFromSky;
 	}
 
@@ -216,8 +208,12 @@ public class BlockMock implements Block
 	 *
 	 * @param lightFromBlocks Value between 0 and 15.
 	 */
-	public void setLightFromBlocks(@Range(from=0, to=15) byte lightFromBlocks)
+	public void setLightFromBlocks(byte lightFromBlocks)
 	{
+		if (lightFromBlocks < 0 || lightFromBlocks > 15) {
+			throw new IllegalArgumentException("Light level should be between 0 and 15.");
+		}
+
 		this.lightFromBlocks = lightFromBlocks;
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/block/BlockMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/BlockMockTest.java
@@ -4,7 +4,6 @@ import be.seeseemelk.mockbukkit.ChunkCoordinate;
 import be.seeseemelk.mockbukkit.ChunkMock;
 import be.seeseemelk.mockbukkit.Coordinate;
 import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.WorldMock;
 import be.seeseemelk.mockbukkit.block.data.BlockDataMock;
 import org.bukkit.Location;
@@ -100,6 +99,27 @@ class BlockMockTest
 	{
 		block.setType(Material.JUNGLE_TRAPDOOR);
 		assertInstanceOf(TrapDoor.class, block.getBlockData());
+	}
+
+	@Test
+	void getLightLevel() {
+		assertEquals(0, block.getLightLevel());
+		block.setLightLevel((byte) 15);
+		assertEquals(15, block.getLightLevel());
+	}
+
+	@Test
+	void getLightFromSky() {
+		assertEquals(15, block.getLightFromSky());
+		block.setLightFromSky((byte) 0);
+		assertEquals(0, block.getLightFromSky());
+	}
+
+	@Test
+	void getLightFromBlocks() {
+		assertEquals(0, block.getLightFromBlocks());
+		block.setLightFromBlocks((byte) 15);
+		assertEquals(15, block.getLightFromBlocks());
 	}
 
 	@Test

--- a/src/test/java/be/seeseemelk/mockbukkit/block/BlockMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/BlockMockTest.java
@@ -18,7 +18,10 @@ import org.bukkit.block.data.type.TrapDoor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -103,8 +106,11 @@ class BlockMockTest
 
 	@Test
 	void getLightLevel() {
-		assertEquals(0, block.getLightLevel());
-		block.setLightLevel((byte) 15);
+		block.setLightFromSky((byte) 15);
+		assertEquals(15, block.getLightLevel());
+		block.setLightFromSky((byte) 5);
+		assertEquals(5, block.getLightLevel());
+		block.setLightFromBlocks((byte) 15);
 		assertEquals(15, block.getLightLevel());
 	}
 
@@ -115,11 +121,39 @@ class BlockMockTest
 		assertEquals(0, block.getLightFromSky());
 	}
 
+	@ParameterizedTest
+	@ValueSource(bytes = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 })
+	void setLightFromSky_GivenValidValues(byte lightLevel) {
+		assertDoesNotThrow(() -> block.setLightFromSky(lightLevel));
+	}
+
+	@ParameterizedTest
+	@ValueSource(bytes = { -1, 16 })
+	void setLightFromSky_GivenInvalidValues(byte invalidLightLevel) {
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> block.setLightFromSky(invalidLightLevel));
+
+		assertEquals("Light level should be between 0 and 15.", e.getMessage());
+	}
+
 	@Test
 	void getLightFromBlocks() {
 		assertEquals(0, block.getLightFromBlocks());
 		block.setLightFromBlocks((byte) 15);
 		assertEquals(15, block.getLightFromBlocks());
+	}
+
+	@ParameterizedTest
+	@ValueSource(bytes = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 })
+	void setLightFromBlocks_GivenValidValues(byte lightLevel) {
+		assertDoesNotThrow(() -> block.setLightFromBlocks(lightLevel));
+	}
+
+	@ParameterizedTest
+	@ValueSource(bytes = { -1, 16 })
+	void setLightFromBlocks_GivenInvalidValues(byte invalidLightLevel) {
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> block.setLightFromBlocks(invalidLightLevel));
+
+		assertEquals("Light level should be between 0 and 15.", e.getMessage());
 	}
 
 	@Test


### PR DESCRIPTION
# Description
Implement getters and setters for BlockMock to resolve issue https://github.com/MockBukkit/MockBukkit/issues/953.

I did not include any hard restriction on the values, so end-users can decide what values suites well. But this includes a soft-warning with the annotation `@Range(from=0, to=15)` to notify the user's that they providing values outside of default Paper values.

See: https://jd.papermc.io/paper/1.20/org/bukkit/block/Block.html#getLightLevel()

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
