### PR TITLE
Use the same Java version in the test plugin as used in the root project

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,7 +76,7 @@ tasks {
 	}
 
 	check {
-		 dependsOn(jacocoTestReport)
+		dependsOn(jacocoTestReport)
 	}
 
 	jacocoTestReport {
@@ -105,7 +105,7 @@ sourceSets {
 
 java {
 	toolchain {
-		languageVersion.set(JavaLanguageVersion.of(17))
+		languageVersion.set(JavaLanguageVersion.of(property("java.version").toString().toInt()))
 	}
 }
 
@@ -149,7 +149,7 @@ publishing {
 						name.set("Sebastiaan de Schaetzen")
 						email.set("sebastiaan.de.schaetzen@gmail.com")
 					}
-					developer{
+					developer {
 						id.set("thebusybiscuit")
 						name.set("TheBusyBiscuit")
 					}

--- a/extra/TestPlugin/build.gradle.kts
+++ b/extra/TestPlugin/build.gradle.kts
@@ -9,3 +9,10 @@ repositories {
 dependencies {
 	compileOnly("io.papermc.paper:paper-api:${rootProject.property("paper.api.full-version")}")
 }
+tasks {
+	java {
+		toolchain {
+			languageVersion.set(JavaLanguageVersion.of(rootProject.property("java.version").toString().toInt()))
+		}
+	}
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 paper.api.version=1.20
 paper.api.full-version=1.20.4-R0.1-SNAPSHOT
+java.version=17
 mockbukkit.version=


### PR DESCRIPTION
# Description
I had some tests start failing since the test plugin was getting compiled with Java 19, while the root project uses Java 17.
This adds a common property for what Java version to use and enforces it in both projects.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
