### PR TITLE
More verbose error message.

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
@@ -623,7 +623,7 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 			command.setUsage((String) value);
 			break;
 		default:
-			throw new UnsupportedOperationException("Unknown section " + name + " with value '" + value + "'. Are you sure this is allowed here? (Reference guide: https://www.spigotmc.org/wiki/plugin-yml/#commands)");
+			throw new UnsupportedOperationException("Unknown section " + name + " with value '" + value + "'. Are you sure this is allowed here? (Reference guide: https://docs.papermc.io/paper/dev/plugin-yml#commands)");
 		}
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/plugin/PluginManagerMock.java
@@ -623,7 +623,7 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 			command.setUsage((String) value);
 			break;
 		default:
-			throw new UnsupportedOperationException("Unknown section " + value);
+			throw new UnsupportedOperationException("Unknown section " + name + " with value '" + value + "'. Are you sure this is allowed here? (Reference guide: https://www.spigotmc.org/wiki/plugin-yml/#commands)");
 		}
 	}
 


### PR DESCRIPTION
# Description
Adding a more verbose error message.

## context:
I had an issue where I had `default: true` in my commands. This is safely ignored by spigot/paper, however it wasn't by mockbukkit (good!). However, it took me about 20 minutes to figure out why. I'm hoping this extended error message gives people a better starting point where to look for their mistake.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
