### PR TITLE
Constructors for keyed classes

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/GameEventMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/GameEventMock.java
@@ -1,8 +1,11 @@
 package be.seeseemelk.mockbukkit;
 
+import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;
 import org.bukkit.GameEvent;
+import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 public class GameEventMock extends GameEvent
@@ -10,6 +13,19 @@ public class GameEventMock extends GameEvent
 
 	private final NamespacedKey key;
 
+	/**
+	 * @param key A namespaced key
+	 */
+	public GameEventMock(NamespacedKey key)
+	{
+		this.key = key;
+	}
+
+	/**
+	 * @param data Json data
+	 * @deprecated Use {@link #GameEventMock(NamespacedKey)} instead.
+	 */
+	@Deprecated(forRemoval = true)
 	public GameEventMock(JsonObject data)
 	{
 		this.key = NamespacedKey.fromString(data.get("key").getAsString());
@@ -19,6 +35,15 @@ public class GameEventMock extends GameEvent
 	public @NotNull NamespacedKey getKey()
 	{
 		return key;
+	}
+
+	@ApiStatus.Internal
+	public static GameEventMock from(JsonObject data)
+	{
+		Preconditions.checkNotNull(data);
+		Preconditions.checkArgument(data.has("key"), "Missing json key");
+		NamespacedKey key = NamespacedKey.fromString(data.get("key").getAsString());
+		return new GameEventMock(key);
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/MusicInstrumentMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MusicInstrumentMock.java
@@ -1,8 +1,10 @@
 package be.seeseemelk.mockbukkit;
 
+import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;
 import org.bukkit.MusicInstrument;
 import org.bukkit.NamespacedKey;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 public class MusicInstrumentMock extends MusicInstrument
@@ -10,6 +12,19 @@ public class MusicInstrumentMock extends MusicInstrument
 
 	private final NamespacedKey key;
 
+	/**
+	 * @param key The namespaced key representing this music instrument
+	 */
+	MusicInstrumentMock(NamespacedKey key)
+	{
+		this.key = key;
+	}
+
+	/**
+	 * @param data Json data
+	 * @deprecated Use {@link #MusicInstrumentMock(NamespacedKey)} instead
+	 */
+	@Deprecated(forRemoval = true)
 	MusicInstrumentMock(JsonObject data)
 	{
 		this.key = NamespacedKey.fromString(data.get("key").getAsString());
@@ -19,6 +34,15 @@ public class MusicInstrumentMock extends MusicInstrument
 	public @NotNull NamespacedKey getKey()
 	{
 		return key;
+	}
+
+	@ApiStatus.Internal
+	public static MusicInstrumentMock from(JsonObject data)
+	{
+		Preconditions.checkNotNull(data);
+		Preconditions.checkArgument(data.has("key"), "Missing json key");
+		NamespacedKey key = NamespacedKey.fromString(data.get("key").getAsString());
+		return new MusicInstrumentMock(key);
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/RegistryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/RegistryMock.java
@@ -86,35 +86,35 @@ public class RegistryMock<T extends Keyed> implements Registry<T>
 	{
 		if (tClass == Structure.class)
 		{
-			return StructureMock::new;
+			return StructureMock::from;
 		}
 		else if (tClass == StructureType.class)
 		{
-			return StructureTypeMock::new;
+			return StructureTypeMock::from;
 		}
 		else if (tClass == TrimMaterial.class)
 		{
-			return TrimMaterialMock::new;
+			return TrimMaterialMock::from;
 		}
 		else if (tClass == TrimPattern.class)
 		{
-			return TrimPatternMock::new;
+			return TrimPatternMock::from;
 		}
 		else if (tClass == MusicInstrument.class)
 		{
-			return MusicInstrumentMock::new;
+			return MusicInstrumentMock::from;
 		}
 		else if (tClass == GameEvent.class)
 		{
-			return GameEventMock::new;
+			return GameEventMock::from;
 		}
 		else if (tClass == Enchantment.class)
 		{
-			return EnchantmentMock::new;
+			return EnchantmentMock::from;
 		}
 		else if (tClass == PotionEffectType.class)
 		{
-			return MockPotionEffectType::new;
+			return MockPotionEffectType::from;
 		}
 		else if (tClass == DamageType.class)
 		{

--- a/src/main/java/be/seeseemelk/mockbukkit/enchantments/EnchantmentMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/enchantments/EnchantmentMock.java
@@ -14,9 +14,11 @@ import org.bukkit.enchantments.EnchantmentTarget;
 import org.bukkit.entity.EntityCategory;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -43,6 +45,49 @@ public class EnchantmentMock extends Enchantment
 	private int startLevel;
 	private EnchantmentTarget itemTarget;
 
+	/**
+	 * @param key             The key representing this enchantment
+	 * @param target          the item targets of this enchantment
+	 * @param treasure        Whether this enchantment can be found in a treasure
+	 * @param cursed          Whether this enchantment is a curse
+	 * @param maxLevel        The max level of this enchantment
+	 * @param startLevel      The min level of this enchantment
+	 * @param name            The name of the enchantment
+	 * @param displayNames    The display name of the enchantment dependent on level
+	 * @param minModifiedCost The minimal modified cost for this enchantment dependent on level
+	 * @param maxModifiedCost The maximal modified cost for this enchantment dependent on level
+	 * @param tradeable       Whether this enchantment can be obtained from trades
+	 * @param discoverable    Whether this enchantment is in a loot table
+	 * @param rarity          The rarity of this enchantment
+	 * @param conflicts       Namespaced-keys of enchantments that are conflicting with this enchantment
+	 */
+	public EnchantmentMock(NamespacedKey key, EnchantmentTarget target, boolean treasure, boolean cursed, int maxLevel,
+						   int startLevel, String name, Component[] displayNames, int[] minModifiedCost,
+						   int[] maxModifiedCost, boolean tradeable, boolean discoverable, EnchantmentRarity rarity,
+						   Set<NamespacedKey> conflicts)
+	{
+		this.key = key;
+		this.itemTarget = target;
+		this.treasure = treasure;
+		this.cursed = cursed;
+		this.maxLevel = maxLevel;
+		this.startLevel = startLevel;
+		this.name = name;
+		this.displayNames = displayNames;
+		this.minModifiedCosts = minModifiedCost;
+		this.maxModifiedCosts = maxModifiedCost;
+		this.tradeable = tradeable;
+		this.discoverable = discoverable;
+		this.rarity = rarity;
+		this.conflicts = conflicts;
+	}
+
+	/**
+	 * @param data Json data
+	 * @deprecated Use {@link #EnchantmentMock(NamespacedKey, EnchantmentTarget, boolean, boolean, int, int, String, Component[], int[], int[], boolean, boolean, EnchantmentRarity, Set)}
+	 * instead.
+	 */
+	@Deprecated(forRemoval = true)
 	public EnchantmentMock(JsonObject data)
 	{
 		this.key = NamespacedKey.fromString(data.get("key").getAsString());
@@ -60,53 +105,6 @@ public class EnchantmentMock extends Enchantment
 		String rarityString = data.get("rarity").getAsString();
 		this.rarity = EnchantmentRarity.valueOf(rarityString);
 		this.conflicts = getConflicts(data.get("conflicts").getAsJsonArray());
-	}
-
-	private Set<NamespacedKey> getConflicts(JsonArray conflicts)
-	{
-		Set<NamespacedKey> output = new HashSet<>();
-		for (JsonElement conflict : conflicts)
-		{
-			output.add(NamespacedKey.fromString(conflict.getAsString()));
-		}
-		return output;
-	}
-
-	private Component[] getDisplayNames(JsonArray displayNamesData, int maxLevel)
-	{
-		Component[] output = new Component[maxLevel];
-		for (JsonElement element : displayNamesData)
-		{
-			JsonObject displayNameData = element.getAsJsonObject();
-			int level = displayNameData.get(LEVEL).getAsInt();
-			GsonComponentSerializer gsonComponentSerializer = GsonComponentSerializer.builder().build();
-			output[level - 1] = gsonComponentSerializer.deserializeFromTree(displayNameData.get("text"));
-		}
-		return output;
-	}
-
-	private int[] getMinModifiedCosts(JsonArray minModifiedCosts, int maxLevel)
-	{
-		int[] output = new int[maxLevel];
-		for (JsonElement element : minModifiedCosts)
-		{
-			JsonObject minModifiedCost = element.getAsJsonObject();
-			int level = minModifiedCost.get(LEVEL).getAsInt();
-			output[level - 1] = minModifiedCost.get(COST).getAsInt();
-		}
-		return output;
-	}
-
-	private int[] getMaxModifiedCosts(JsonArray maxModifiedCosts, int maxLevel)
-	{
-		int[] output = new int[maxLevel];
-		for (JsonElement element : maxModifiedCosts)
-		{
-			JsonObject maxModifiedCost = element.getAsJsonObject();
-			int level = maxModifiedCost.get(LEVEL).getAsInt();
-			output[level - 1] = maxModifiedCost.get(COST).getAsInt();
-		}
-		return output;
 	}
 
 	@Override
@@ -276,6 +274,82 @@ public class EnchantmentMock extends Enchantment
 	public @NotNull NamespacedKey getKey()
 	{
 		return this.key;
+	}
+
+	@ApiStatus.Internal
+	public static EnchantmentMock from(JsonObject data)
+	{
+		Preconditions.checkNotNull(data);
+		List<String> expectedArguments = List.of("key", "itemTarget", "treasure", "cursed", "maxLevel", "startLevel",
+				"name", "displayNames", "minModifiedCosts", "maxModifiedCosts", "tradeable", "discoverable", "rarity",
+				"conflicts");
+		expectedArguments.forEach(expectedKey ->
+				Preconditions.checkArgument(data.has(expectedKey), "Missing json key: " + expectedKey));
+
+		NamespacedKey key = NamespacedKey.fromString(data.get("key").getAsString());
+		EnchantmentTarget itemTarget = EnchantmentTarget.valueOf(data.get("itemTarget").getAsString());
+		boolean treasure = data.get("treasure").getAsBoolean();
+		boolean cursed = data.get("cursed").getAsBoolean();
+		int maxLevel = data.get("maxLevel").getAsInt();
+		int startLevel = data.get("startLevel").getAsInt();
+		String name = data.get("name").getAsString();
+		Component[] displayNames = getDisplayNames(data.get("displayNames").getAsJsonArray(), maxLevel);
+		int[] minModifiedCosts = getMinModifiedCosts(data.get("minModifiedCosts").getAsJsonArray(), maxLevel);
+		int[] maxModifiedCosts = getMaxModifiedCosts(data.get("maxModifiedCosts").getAsJsonArray(), maxLevel);
+		boolean tradeable = data.get("tradeable").getAsBoolean();
+		boolean discoverable = data.get("discoverable").getAsBoolean();
+		String rarityString = data.get("rarity").getAsString();
+		EnchantmentRarity rarity = EnchantmentRarity.valueOf(rarityString);
+		Set<NamespacedKey> conflicts = getConflicts(data.get("conflicts").getAsJsonArray());
+		return new EnchantmentMock(key, itemTarget, treasure, cursed, maxLevel, startLevel, name, displayNames, minModifiedCosts,
+				maxModifiedCosts, tradeable, discoverable, rarity, conflicts);
+	}
+
+	private static Set<NamespacedKey> getConflicts(JsonArray conflicts)
+	{
+		Set<NamespacedKey> output = new HashSet<>();
+		for (JsonElement conflict : conflicts)
+		{
+			output.add(NamespacedKey.fromString(conflict.getAsString()));
+		}
+		return output;
+	}
+
+	private static Component[] getDisplayNames(JsonArray displayNamesData, int maxLevel)
+	{
+		Component[] output = new Component[maxLevel];
+		for (JsonElement element : displayNamesData)
+		{
+			JsonObject displayNameData = element.getAsJsonObject();
+			int level = displayNameData.get(LEVEL).getAsInt();
+			GsonComponentSerializer gsonComponentSerializer = GsonComponentSerializer.builder().build();
+			output[level - 1] = gsonComponentSerializer.deserializeFromTree(displayNameData.get("text"));
+		}
+		return output;
+	}
+
+	private static int[] getMinModifiedCosts(JsonArray minModifiedCosts, int maxLevel)
+	{
+		int[] output = new int[maxLevel];
+		for (JsonElement element : minModifiedCosts)
+		{
+			JsonObject minModifiedCost = element.getAsJsonObject();
+			int level = minModifiedCost.get(LEVEL).getAsInt();
+			output[level - 1] = minModifiedCost.get(COST).getAsInt();
+		}
+		return output;
+	}
+
+	private static int[] getMaxModifiedCosts(JsonArray maxModifiedCosts, int maxLevel)
+	{
+		int[] output = new int[maxLevel];
+		for (JsonElement element : maxModifiedCosts)
+		{
+			JsonObject maxModifiedCost = element.getAsJsonObject();
+			int level = maxModifiedCost.get(LEVEL).getAsInt();
+			output[level - 1] = maxModifiedCost.get(COST).getAsInt();
+		}
+		return output;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/enchantments/EnchantmentMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/enchantments/EnchantmentMock.java
@@ -276,6 +276,13 @@ public class EnchantmentMock extends Enchantment
 		return this.key;
 	}
 
+	@Override
+	public @NotNull String getTranslationKey()
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
 	@ApiStatus.Internal
 	public static EnchantmentMock from(JsonObject data)
 	{
@@ -350,13 +357,6 @@ public class EnchantmentMock extends Enchantment
 			output[level - 1] = maxModifiedCost.get(COST).getAsInt();
 		}
 		return output;
-	}
-
-	@Override
-	public @NotNull String getTranslationKey()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/generator/structure/StructureMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/generator/structure/StructureMock.java
@@ -7,6 +7,7 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.generator.structure.Structure;
 import org.bukkit.generator.structure.StructureType;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 public class StructureMock extends Structure
@@ -15,10 +16,37 @@ public class StructureMock extends Structure
 	private final NamespacedKey key;
 	private final StructureType type;
 
+	/**
+	 * @param key  The namespaced key representing this structure
+	 * @param type The type of structure
+	 */
+	public StructureMock(NamespacedKey key, StructureType type)
+	{
+		this.key = key;
+		this.type = type;
+	}
+
+	/**
+	 * @param data Json data
+	 * @deprecated Will use {@link #StructureMock(NamespacedKey, StructureType)} instead.
+	 */
+	@Deprecated(forRemoval = true)
 	public StructureMock(JsonObject data)
 	{
+		Preconditions.checkNotNull(data);
 		this.key = NamespacedKey.fromString(data.get("key").getAsString());
 		this.type = Registry.STRUCTURE_TYPE.get(Preconditions.checkNotNull(NamespacedKey.fromString(data.get("type").getAsString())));
+	}
+
+	@ApiStatus.Internal
+	public static StructureMock from(JsonObject data)
+	{
+		Preconditions.checkNotNull(data);
+		Preconditions.checkArgument(data.has("key"), "Missing json key");
+		Preconditions.checkArgument(data.has("type"), "Missing json key");
+		NamespacedKey key = NamespacedKey.fromString(data.get("key").getAsString());
+		StructureType type = Registry.STRUCTURE_TYPE.get(Preconditions.checkNotNull(NamespacedKey.fromString(data.get("type").getAsString())));
+		return new StructureMock(key, type);
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/generator/structure/StructureTypeMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/generator/structure/StructureTypeMock.java
@@ -1,8 +1,10 @@
 package be.seeseemelk.mockbukkit.generator.structure;
 
+import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;
 import org.bukkit.NamespacedKey;
 import org.bukkit.generator.structure.StructureType;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 public class StructureTypeMock extends StructureType
@@ -10,6 +12,19 @@ public class StructureTypeMock extends StructureType
 
 	private final NamespacedKey key;
 
+	/**
+	 * @param key The namespaced key representing this structure type
+	 */
+	public StructureTypeMock(NamespacedKey key)
+	{
+		this.key = key;
+	}
+
+	/**
+	 * @param data Json data
+	 * @deprecated Use {@link #StructureTypeMock(NamespacedKey)} instead
+	 */
+	@Deprecated(forRemoval = true)
 	public StructureTypeMock(JsonObject data)
 	{
 		this.key = NamespacedKey.fromString(data.get("key").getAsString());
@@ -19,6 +34,15 @@ public class StructureTypeMock extends StructureType
 	public @NotNull NamespacedKey getKey()
 	{
 		return key;
+	}
+
+	@ApiStatus.Internal
+	public static StructureTypeMock from(JsonObject data)
+	{
+		Preconditions.checkNotNull(data);
+		Preconditions.checkArgument(data.has("key"), "Missing json key");
+		NamespacedKey key = NamespacedKey.fromString(data.get("key").getAsString());
+		return new StructureTypeMock(key);
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimMaterialMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimMaterialMock.java
@@ -1,11 +1,13 @@
 package be.seeseemelk.mockbukkit.inventory.meta.trim;
 
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.meta.trim.TrimMaterial;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 public class TrimMaterialMock implements TrimMaterial
@@ -14,6 +16,20 @@ public class TrimMaterialMock implements TrimMaterial
 	private final NamespacedKey key;
 	private final Component description;
 
+	/**
+	 * @param key The namespaced key representing this trim material
+	 * @param description The description of this trim material
+	 */
+	public TrimMaterialMock(NamespacedKey key, Component description){
+		this.key = key;
+		this.description = description;
+	}
+
+	/**
+	 * @param data Json data
+	 * @deprecated Use {@link #TrimMaterialMock(NamespacedKey,Component)} instead
+	 */
+	@Deprecated(forRemoval = true)
 	public TrimMaterialMock(JsonObject data)
 	{
 		this.key = NamespacedKey.fromString(data.get("key").getAsString());
@@ -36,6 +52,16 @@ public class TrimMaterialMock implements TrimMaterial
 	public @NotNull NamespacedKey getKey()
 	{
 		return key;
+	}
+
+	@ApiStatus.Internal
+	public static TrimMaterialMock from(JsonObject data)
+	{
+		Preconditions.checkNotNull(data);
+		Preconditions.checkArgument(data.has("key"), "Missing json key");
+		NamespacedKey key = NamespacedKey.fromString(data.get("key").getAsString());
+		Component description = GsonComponentSerializer.gson().deserializeFromTree(data.get("description"));
+		return new TrimMaterialMock(key,description);
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimMaterialMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimMaterialMock.java
@@ -1,5 +1,6 @@
 package be.seeseemelk.mockbukkit.inventory.meta.trim;
 
+import com.google.common.base.Preconditions;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimPatternMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimPatternMock.java
@@ -1,11 +1,13 @@
 package be.seeseemelk.mockbukkit.inventory.meta.trim;
 
+import com.google.common.base.Preconditions;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import com.google.gson.JsonObject;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.meta.trim.TrimPattern;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 public class TrimPatternMock implements TrimPattern
@@ -14,6 +16,20 @@ public class TrimPatternMock implements TrimPattern
 	private final NamespacedKey key;
 	private final Component description;
 
+	/**
+	 * @param key The namespaced key representing this pattern
+	 */
+	public TrimPatternMock(NamespacedKey key, Component description)
+	{
+		this.key = key;
+		this.description = description;
+	}
+
+	/**
+	 * @param data Json data
+	 * @deprecated Use {@link #TrimPatternMock(NamespacedKey, Component)} instead
+	 */
+	@Deprecated(forRemoval = true)
 	public TrimPatternMock(JsonObject data)
 	{
 		this.key = NamespacedKey.fromString(data.get("key").getAsString());
@@ -36,6 +52,16 @@ public class TrimPatternMock implements TrimPattern
 	public @NotNull NamespacedKey getKey()
 	{
 		return key;
+	}
+
+	@ApiStatus.Internal
+	public static TrimPatternMock from(JsonObject data)
+	{
+		Preconditions.checkNotNull(data);
+		Preconditions.checkArgument(data.has("key"), "Missing json key");
+		NamespacedKey key = NamespacedKey.fromString(data.get("key").getAsString());
+		Component description = GsonComponentSerializer.gson().deserializeFromTree(data.get("description"));
+		return new TrimPatternMock(key,description);
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/potion/MockPotionEffectType.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/potion/MockPotionEffectType.java
@@ -219,16 +219,4 @@ public class MockPotionEffectType extends PotionEffectType
 		throw new UnimplementedOperationException();
 	}
 
-	@ApiStatus.Internal
-	public static Keyed from(JsonObject data)
-	{
-		NamespacedKey key = NamespacedKey.fromString(data.get("key").getAsString());
-		int id = data.get("id").getAsInt();
-		String name = data.get("name").getAsString();
-		boolean instant = data.get("instant").getAsBoolean();
-		Color color = Color.fromRGB(data.get("rgb").getAsInt());
-		Category category = Category.valueOf(data.get("category").getAsString());
-		return new MockPotionEffectType(key, id, name, instant, color, category);
-	}
-
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/potion/MockPotionEffectType.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/potion/MockPotionEffectType.java
@@ -219,4 +219,16 @@ public class MockPotionEffectType extends PotionEffectType
 		throw new UnimplementedOperationException();
 	}
 
+	@ApiStatus.Internal
+	public static Keyed from(JsonObject data)
+	{
+		NamespacedKey key = NamespacedKey.fromString(data.get("key").getAsString());
+		int id = data.get("id").getAsInt();
+		String name = data.get("name").getAsString();
+		boolean instant = data.get("instant").getAsBoolean();
+		Color color = Color.fromRGB(data.get("rgb").getAsInt());
+		Category category = Category.valueOf(data.get("category").getAsString());
+		return new MockPotionEffectType(key, id, name, instant, color, category);
+	}
+
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/potion/MockPotionEffectType.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/potion/MockPotionEffectType.java
@@ -5,11 +5,13 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonObject;
 import org.bukkit.Color;
+import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.EnumMap;
@@ -33,7 +35,15 @@ public class MockPotionEffectType extends PotionEffectType
 	private final Category category;
 
 
-	public MockPotionEffectType(@NotNull NamespacedKey key, int id, String name, boolean instant, Color color, Category category)
+	/**
+	 * @param key      The namespaced key representing this effect
+	 * @param id       The magic number representing this effect
+	 * @param name     The name of this effect
+	 * @param instant  Whether the effect is instant or not
+	 * @param color    The color of the effect
+	 * @param category The category of the effect
+	 */
+	public MockPotionEffectType(@NotNull NamespacedKey key, int id, @NotNull String name, boolean instant, @NotNull Color color, @NotNull Category category)
 	{
 		super();
 
@@ -43,7 +53,7 @@ public class MockPotionEffectType extends PotionEffectType
 		this.instant = instant;
 		this.color = Preconditions.checkNotNull(color);
 		this.attributeModifiers = new EnumMap<>(Attribute.class);
-		this.category = category;
+		this.category = Preconditions.checkNotNull(category);
 	}
 
 	/**
@@ -60,6 +70,11 @@ public class MockPotionEffectType extends PotionEffectType
 		this(key, id, name, instant, color, Category.NEUTRAL);
 	}
 
+	/**
+	 * @param data Json data
+	 * @deprecated Use {@link #MockPotionEffectType(NamespacedKey, int, String, boolean, Color, Category)} instead.
+	 */
+	@Deprecated(forRemoval = true)
 	public MockPotionEffectType(JsonObject data)
 	{
 		this(NamespacedKey.fromString(data.get("key").getAsString()),
@@ -183,6 +198,18 @@ public class MockPotionEffectType extends PotionEffectType
 	{
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
+	}
+
+	@ApiStatus.Internal
+	public static Keyed from(JsonObject data)
+	{
+		NamespacedKey key = NamespacedKey.fromString(data.get("key").getAsString());
+		int id = data.get("id").getAsInt();
+		String name = data.get("name").getAsString();
+		boolean instant = data.get("instant").getAsBoolean();
+		Color color = Color.fromRGB(data.get("rgb").getAsInt());
+		Category category = Category.valueOf(data.get("category").getAsString());
+		return new MockPotionEffectType(key, id, name, instant, color, category);
 	}
 
 	@Override

--- a/src/test/java/be/seeseemelk/mockbukkit/GameEventMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/GameEventMockTest.java
@@ -1,0 +1,38 @@
+package be.seeseemelk.mockbukkit;
+
+import com.google.gson.JsonObject;
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockBukkitExtension.class)
+class GameEventMockTest
+{
+
+	private NamespacedKey key;
+	private GameEventMock gameEvent;
+
+	@BeforeEach
+	void setUp()
+	{
+		this.key = new NamespacedKey("mock_bukkit", "custom_game_event");
+		this.gameEvent = new GameEventMock(key);
+	}
+
+	@Test
+	void getKey()
+	{
+		assertEquals(key, gameEvent.getKey());
+	}
+
+	@Test
+	void from()
+	{
+		JsonObject invalid = new JsonObject();
+		assertThrows(IllegalArgumentException.class, () -> GameEventMock.from(invalid));
+	}
+
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/MusicInstrumentMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/MusicInstrumentMockTest.java
@@ -1,0 +1,39 @@
+package be.seeseemelk.mockbukkit;
+
+import com.google.gson.JsonObject;
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockBukkitExtension.class)
+class MusicInstrumentMockTest
+{
+
+	private NamespacedKey key;
+	private MusicInstrumentMock musicInstrument;
+
+	@BeforeEach
+	void setUp()
+	{
+		this.key = new NamespacedKey("mock_bukkit", "custom_music_instrument");
+		this.musicInstrument = new MusicInstrumentMock(key);
+	}
+
+	@Test
+	void getKey()
+	{
+		assertEquals(key, musicInstrument.getKey());
+	}
+
+	@Test
+	void from()
+	{
+		JsonObject invalid = new JsonObject();
+		assertThrows(IllegalArgumentException.class, () -> MusicInstrumentMock.from(invalid));
+	}
+
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/enchantments/EnchantmentMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/enchantments/EnchantmentMockTest.java
@@ -1,0 +1,189 @@
+package be.seeseemelk.mockbukkit.enchantments;
+
+import be.seeseemelk.mockbukkit.MockBukkitExtension;
+import com.google.gson.JsonObject;
+import io.papermc.paper.enchantments.EnchantmentRarity;
+import net.kyori.adventure.text.Component;
+import org.bukkit.NamespacedKey;
+import org.bukkit.enchantments.EnchantmentTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockBukkitExtension.class)
+class EnchantmentMockTest
+{
+
+	private final static String NAMESPACE = "mock_bukkit";
+	private NamespacedKey key;
+	private EnchantmentTarget target;
+	private int maxLevel;
+	private int minLevel;
+	private String name;
+	private Component[] displayNames;
+	private int[] minModifiedCost;
+	private int[] maxModifiedCost;
+	private EnchantmentRarity rarity;
+	private EnchantmentMock enchantment;
+
+	public static Stream<Integer> getAvailableLevels()
+	{
+		return Stream.of(1, 2);
+	}
+
+	@BeforeEach
+	void setUp()
+	{
+		this.key = new NamespacedKey(NAMESPACE, "custom_enchantment");
+		this.target = EnchantmentTarget.ARMOR_FEET;
+		this.maxLevel = 2;
+		this.minLevel = 1;
+		this.name = "Custom enchantment";
+		this.displayNames = new Component[]{ Component.text("Level 1"), Component.text("Level 2") };
+		this.minModifiedCost = new int[]{ 1, 2 };
+		this.maxModifiedCost = new int[]{ 20, 25 };
+		this.rarity = EnchantmentRarity.RARE;
+		this.enchantment = new EnchantmentMock(key, target, true, true, maxLevel, minLevel, name, displayNames, minModifiedCost,
+				maxModifiedCost, true, true, rarity, Set.of(key));
+	}
+
+	@ParameterizedTest
+	@MethodSource("getAvailableLevels")
+	void displayName(int level)
+	{
+		assertEquals(displayNames[level - 1], enchantment.displayName(level));
+	}
+
+	@Test
+	void isTradeable()
+	{
+		assertTrue(enchantment.isTradeable());
+	}
+
+	@Test
+	void isDiscoverable()
+	{
+		assertTrue(enchantment.isDiscoverable());
+	}
+
+	@ParameterizedTest
+	@MethodSource("getAvailableLevels")
+	void getMaxModifiedCost(int level)
+	{
+		assertEquals(maxModifiedCost[level - 1], enchantment.getMaxModifiedCost(level));
+	}
+
+	@ParameterizedTest
+	@MethodSource("getAvailableLevels")
+	void getMinModifiedCost(int level)
+	{
+		assertEquals(minModifiedCost[level - 1], enchantment.getMinModifiedCost(level));
+	}
+
+	@Test
+	void getRarity()
+	{
+		assertEquals(rarity, enchantment.getRarity());
+	}
+
+	@Test
+	void getName()
+	{
+		assertEquals(name, enchantment.getName());
+	}
+
+	@Test
+	void getMaxLevel()
+	{
+		assertEquals(maxLevel, enchantment.getMaxLevel());
+	}
+
+	@Test
+	void setMaxLevel()
+	{
+		enchantment.setMaxLevel(20);
+		assertEquals(20, enchantment.getMaxLevel());
+	}
+
+	@Test
+	void getStartLevel()
+	{
+		assertEquals(minLevel, enchantment.getStartLevel());
+	}
+
+	@Test
+	void setStartLevel()
+	{
+		enchantment.setStartLevel(20);
+		assertEquals(20, enchantment.getStartLevel());
+	}
+
+	@Test
+	void getItemTarget()
+	{
+		assertEquals(target, enchantment.getItemTarget());
+	}
+
+	@Test
+	void setItemTarget()
+	{
+		enchantment.setItemTarget(EnchantmentTarget.CROSSBOW);
+		assertEquals(EnchantmentTarget.CROSSBOW, enchantment.getItemTarget());
+	}
+
+	@Test
+	void isTreasure()
+	{
+		assertTrue(enchantment.isTreasure());
+	}
+
+	@Test
+	void setTreasure()
+	{
+		enchantment.setTreasure(false);
+		assertFalse(enchantment.isTreasure());
+	}
+
+	@Test
+	void isCursed()
+	{
+		assertTrue(enchantment.isCursed());
+	}
+
+	@Test
+	void setCursed()
+	{
+		enchantment.setCursed(false);
+		assertFalse(enchantment.isCursed());
+	}
+
+	@Test
+	void conflictsWith()
+	{
+		assertTrue(enchantment.conflictsWith(enchantment));
+	}
+
+	@Test
+	void getKey()
+	{
+		assertEquals(key, enchantment.getKey());
+	}
+
+	@Test
+	void from_invalid()
+	{
+		JsonObject invalid = new JsonObject();
+		assertThrows(IllegalArgumentException.class, () -> EnchantmentMock.from(invalid));
+	}
+
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/generator/structure/StructureMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/generator/structure/StructureMockTest.java
@@ -1,0 +1,53 @@
+package be.seeseemelk.mockbukkit.generator.structure;
+
+import be.seeseemelk.mockbukkit.MockBukkitExtension;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockBukkitExtension.class)
+class StructureMockTest
+{
+
+
+	private StructureMock structure;
+	private StructureTypeMock structureType;
+	private static final String NAME_SPACE = "mock_bukkit";
+	private NamespacedKey key;
+
+	@BeforeEach
+	void setUp()
+	{
+		this.structureType = new StructureTypeMock(new NamespacedKey(NAME_SPACE, "custom_structure_type"));
+		this.key = new NamespacedKey(NAME_SPACE, "custom_structure");
+		this.structure = new StructureMock(key, structureType);
+	}
+
+	@Test
+	void from_invalid()
+	{
+		// technically already tests valid keys for this
+		JsonObject invalid = new JsonObject();
+		invalid.add("invalidKey", new JsonPrimitive("key"));
+		assertThrows(IllegalArgumentException.class, () -> StructureMock.from(invalid));
+	}
+
+	@Test
+	void getStructureType()
+	{
+		assertEquals(structureType, structure.getStructureType());
+	}
+
+	@Test
+	void getKey()
+	{
+		assertEquals(key, structure.getKey());
+	}
+
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/generator/structure/StructureTypeMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/generator/structure/StructureTypeMockTest.java
@@ -1,0 +1,40 @@
+package be.seeseemelk.mockbukkit.generator.structure;
+
+import be.seeseemelk.mockbukkit.MockBukkitExtension;
+import com.google.gson.JsonObject;
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockBukkitExtension.class)
+class StructureTypeMockTest
+{
+
+
+	private NamespacedKey key;
+	private StructureTypeMock structureType;
+
+	@BeforeEach
+	void setUp()
+	{
+		this.key = new NamespacedKey("mock_bukkit", "custom_structure_type");
+		this.structureType = new StructureTypeMock(key);
+	}
+
+	@Test
+	void getKey()
+	{
+		assertEquals(key, structureType.getKey());
+	}
+
+	@Test
+	void from()
+	{
+		JsonObject invalid = new JsonObject();
+		assertThrows(IllegalArgumentException.class, () -> StructureTypeMock.from(invalid));
+	}
+
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimMaterialMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimMaterialMockTest.java
@@ -1,6 +1,7 @@
 package be.seeseemelk.mockbukkit.inventory.meta.trim;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
+import com.google.gson.JsonObject;
 import org.bukkit.inventory.meta.trim.TrimMaterial;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +34,13 @@ class TrimMaterialMockTest
 	void getKey()
 	{
 		assertNotNull(TrimMaterial.QUARTZ.getKey());
+	}
+
+	@Test
+	void from_invalid()
+	{
+		JsonObject invalid = new JsonObject();
+		assertThrows(IllegalArgumentException.class, () -> TrimMaterialMock.from(invalid));
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimPatternMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimPatternMockTest.java
@@ -1,6 +1,7 @@
 package be.seeseemelk.mockbukkit.inventory.meta.trim;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
+import com.google.gson.JsonObject;
 import org.bukkit.inventory.meta.trim.TrimPattern;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +34,13 @@ class TrimPatternMockTest
 	void getKey()
 	{
 		assertNotNull(TrimPattern.SHAPER.getKey());
+	}
+
+	@Test
+	void from_invalid()
+	{
+		JsonObject invalid = new JsonObject();
+		assertThrows(IllegalArgumentException.class, () -> TrimPatternMock.from(invalid));
 	}
 
 }


### PR DESCRIPTION
# Description
1. Adds reasonable constructors for these items.
2. Depricates the all constructors with gson objects inside them; this has now been replaced with a .from method instead
3. Adds tests to all these keyed classes, which previously had not been the case

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
