### PR TITLE
Plugin class loader fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
 
 	// Dependencies for Unit Tests
 	implementation("org.junit.jupiter:junit-jupiter:5.10.2")
+	implementation("org.junit.platform:junit-platform-launcher:1.10.2")
 
 	// General utilities for the project
 	implementation("net.kyori:adventure-platform-bungeecord:4.3.2")
@@ -73,6 +74,9 @@ tasks {
 	test {
 		dependsOn(project(":extra:TestPlugin").tasks.jar)
 		useJUnitPlatform()
+		options {
+			systemProperty("junit.platform.launcher.interceptors.enabled", "true")
+		}
 	}
 
 	check {

--- a/src/main/java/be/seeseemelk/mockbukkit/MockBukkitLauncherInterceptor.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockBukkitLauncherInterceptor.java
@@ -1,0 +1,41 @@
+package be.seeseemelk.mockbukkit;
+
+import be.seeseemelk.mockbukkit.plugin.MockBukkitClassLoader;
+import org.jetbrains.annotations.ApiStatus;
+import org.junit.platform.launcher.LauncherInterceptor;
+
+@ApiStatus.Internal
+public class MockBukkitLauncherInterceptor implements LauncherInterceptor
+{
+
+	private final MockBukkitClassLoader customClassLoader;
+
+	public MockBukkitLauncherInterceptor()
+	{
+		ClassLoader parent = Thread.currentThread().getContextClassLoader();
+		this.customClassLoader = new MockBukkitClassLoader(parent);
+	}
+
+	@Override
+	public <T> T intercept(LauncherInterceptor.Invocation<T> invocation)
+	{
+		Thread currentThread = Thread.currentThread();
+		ClassLoader originalClassLoader = currentThread.getContextClassLoader();
+		currentThread.setContextClassLoader(customClassLoader);
+		try
+		{
+			return invocation.proceed();
+		}
+		finally
+		{
+			currentThread.setContextClassLoader(originalClassLoader);
+		}
+	}
+
+	@Override
+	public void close()
+	{
+		// Nothing needs to be closed
+	}
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/plugin/MockBukkitClassLoader.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/plugin/MockBukkitClassLoader.java
@@ -13,13 +13,13 @@ public class MockBukkitClassLoader extends ClassLoader
 {
 
 	private final Map<String, MockBukkitPluginClassLoader> classLoaders;
-	private final ClassLoader sysClassLoader;
+	private final ClassLoader bootstrapClassLoader;
 
 	public MockBukkitClassLoader(ClassLoader parent)
 	{
 		super(parent);
 		classLoaders = new HashMap<>();
-		this.sysClassLoader = getSystemClassLoader();
+		this.bootstrapClassLoader = getSystemClassLoader().getParent();
 	}
 
 	@Override
@@ -52,22 +52,13 @@ public class MockBukkitClassLoader extends ClassLoader
 	{
 		try
 		{
-			if (sysClassLoader != null)
-			{
-				return sysClassLoader.loadClass(name);
-			}
+			return bootstrapClassLoader.loadClass(name);
 		}
 		catch (ClassNotFoundException ignored)
 		{
+
 		}
-		try
-		{
-			return findClass(name);
-		}
-		catch (Exception e)
-		{
-			return super.loadClass(name);
-		}
+		return findClass(name);
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/plugin/MockBukkitClassLoader.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/plugin/MockBukkitClassLoader.java
@@ -1,0 +1,104 @@
+package be.seeseemelk.mockbukkit.plugin;
+
+import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+@ApiStatus.Internal
+public class MockBukkitClassLoader extends ClassLoader
+{
+
+	private final Map<String, MockBukkitPluginClassLoader> classLoaders;
+	private final ClassLoader sysClassLoader;
+
+	public MockBukkitClassLoader(ClassLoader parent)
+	{
+		super(parent);
+		classLoaders = new HashMap<>();
+		this.sysClassLoader = getSystemClassLoader();
+	}
+
+	@Override
+	public Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException
+	{
+		synchronized (getClassLoadingLock(name))
+		{
+			// First, check if the class has already been loaded
+			Class<?> c = findLoadedClass(name);
+			if (c == null)
+			{
+				if (classLoaders.containsKey(name))
+				{
+					c = classLoaders.get(name).loadClass(name);
+				}
+				else
+				{
+					c = loadClassWithChildFirstStrategy(name);
+				}
+			}
+			if (resolve)
+			{
+				resolveClass(c);
+			}
+			return c;
+		}
+	}
+
+	private Class<?> loadClassWithChildFirstStrategy(String name) throws ClassNotFoundException
+	{
+		try
+		{
+			if (sysClassLoader != null)
+			{
+				return sysClassLoader.loadClass(name);
+			}
+		}
+		catch (ClassNotFoundException ignored)
+		{
+		}
+		try
+		{
+			return findClass(name);
+		}
+		catch (Exception e)
+		{
+			return super.loadClass(name);
+		}
+	}
+
+	@Override
+	protected Class<?> findClass(String name) throws ClassNotFoundException
+	{
+		byte[] classData = loadClassData(name, getParent());
+		Class<?> aClass = defineClass(name, classData, 0, classData.length);
+		if (aClass.isAssignableFrom(JavaPlugin.class))
+		{
+			MockBukkitPluginClassLoader pluginClassLoader = new MockBukkitPluginClassLoader(getParent());
+			Class<?> pluginClass = pluginClassLoader.loadClass(name);
+			classLoaders.put(name, pluginClassLoader);
+			return pluginClass;
+		}
+		return aClass;
+	}
+
+	static byte[] loadClassData(String name, ClassLoader classLoader) throws ClassNotFoundException
+	{
+		try (InputStream inputStream = classLoader.getResourceAsStream(name.replace('.', '/').concat(".class")))
+		{
+			if (inputStream == null)
+			{
+				throw new IOException("Could not find class: " + name);
+			}
+			return inputStream.readAllBytes();
+		}
+		catch (IOException e)
+		{
+			throw new ClassNotFoundException(e.getMessage());
+		}
+	}
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/plugin/MockBukkitPluginClassLoader.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/plugin/MockBukkitPluginClassLoader.java
@@ -1,0 +1,179 @@
+package be.seeseemelk.mockbukkit.plugin;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import com.destroystokyo.paper.utils.PaperPluginLogger;
+import com.google.common.base.Preconditions;
+import io.papermc.paper.plugin.configuration.PluginMeta;
+import io.papermc.paper.plugin.provider.classloader.ConfiguredPluginClassLoader;
+import io.papermc.paper.plugin.provider.classloader.PluginClassLoaderGroup;
+import org.bukkit.plugin.InvalidDescriptionException;
+import org.bukkit.plugin.PluginDescriptionFile;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Enumeration;
+
+@ApiStatus.Internal
+public class MockBukkitPluginClassLoader extends ClassLoader implements ConfiguredPluginClassLoader
+{
+
+	private PluginDescriptionFile pluginDescriptionFile;
+	private final PluginClassLoaderGroup classLoaderGroup = new MockBukkitPluginClassLoaderGroup();
+
+	public MockBukkitPluginClassLoader(ClassLoader parent)
+	{
+		super(parent);
+	}
+
+	@Override
+	public PluginMeta getConfiguration()
+	{
+		return null;
+	}
+
+	@Override
+	public Class<?> loadClass(@NotNull String name, boolean resolve, boolean checkGlobal, boolean checkLibraries) throws ClassNotFoundException
+	{
+		return loadClass("name");
+	}
+
+	@Override
+	public Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException
+	{
+		synchronized (getClassLoadingLock(name))
+		{
+			Class<?> c = findLoadedClass(name);
+			if (c == null)
+			{
+				c = findClass(name);
+			}
+			if (resolve)
+			{
+				resolveClass(c);
+			}
+			return c;
+		}
+	}
+
+	@Override
+	protected Class<?> findClass(String name) throws ClassNotFoundException
+	{
+		byte[] classData = MockBukkitClassLoader.loadClassData(name, getParent());
+		Class<?> pluginClass = super.defineClass(name, classData, 0, classData.length);
+		if (pluginClass.isAssignableFrom(JavaPlugin.class))
+		{
+			try
+			{
+				this.pluginDescriptionFile = findPluginDescription(pluginClass);
+			}
+			catch (InvalidDescriptionException | IOException e)
+			{
+				throw new RuntimeException(e);
+			}
+		}
+		return pluginClass;
+	}
+
+	private @NotNull PluginDescriptionFile findPluginDescription(@NotNull Class<?> class1)
+			throws IOException, InvalidDescriptionException
+	{
+		Preconditions.checkNotNull(class1, "Class cannot be null");
+		Enumeration<URL> resources = class1.getClassLoader().getResources("plugin.yml");
+		while (resources.hasMoreElements())
+		{
+			URL url = resources.nextElement();
+			PluginDescriptionFile description = new PluginDescriptionFile(url.openStream());
+			String mainClass = description.getMain();
+			if (class1.getName().equals(mainClass))
+				return description;
+		}
+		throw new FileNotFoundException(
+				"Could not find file plugin.yml. Maybe forgot to add the 'main' property?");
+	}
+
+	@Override
+	public void init(JavaPlugin plugin)
+	{
+		ServerMock server = MockBukkit.getMock();
+		if (server == null)
+		{
+			throw new IllegalStateException("Requires mocking to initialize plugin");
+		}
+		String name = pluginDescriptionFile.getName();
+		String version = pluginDescriptionFile.getVersion();
+		try
+		{
+			File dataFolder = createTemporaryDirectory(name + "-" + version, server);
+			File pluginFile = createTemporaryPluginFile(name + "-" + version, server);
+			plugin.init(server, this.pluginDescriptionFile, dataFolder, pluginFile, this, getConfiguration(), PaperPluginLogger.getLogger(getConfiguration()));
+		}
+		catch (IOException e)
+		{
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public @Nullable JavaPlugin getPlugin()
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public @Nullable PluginClassLoaderGroup getGroup()
+	{
+		return classLoaderGroup;
+	}
+
+	@Override
+	public void close() throws IOException
+	{
+		// No resource needs to be closed
+	}
+
+
+	/**
+	 * Tries to create a temporary directory.
+	 *
+	 * @param name The name of the directory to create.
+	 * @return The created temporary directory.
+	 * @throws IOException when the directory could not be created.
+	 */
+	public @NotNull File createTemporaryDirectory(@NotNull String name, ServerMock serverMock) throws IOException
+	{
+		Preconditions.checkNotNull(name, "Name cannot be null");
+		PluginManagerMock pluginManager = serverMock.getPluginManager();
+		File directory = new File(pluginManager.getParentTemporaryDirectory(), name);
+		directory.mkdirs();
+		return directory;
+	}
+
+	/**
+	 * Tries to create a temporary plugin file.
+	 *
+	 * @param name The name of the plugin.
+	 * @return The created temporary file.
+	 * @throws IOException when the file could not be created.
+	 */
+	public @NotNull File createTemporaryPluginFile(@NotNull String name, ServerMock serverMock) throws IOException
+	{
+		Preconditions.checkNotNull(name, "Name cannot be null");
+		PluginManagerMock pluginManager = serverMock.getPluginManager();
+		File pluginFile = new File(pluginManager.getParentTemporaryDirectory(), name + ".jar");
+		if (!pluginFile.exists() && !pluginFile.createNewFile())
+		{
+			throw new IOException("Could not create file " + pluginFile.getAbsolutePath());
+		}
+		return pluginFile;
+	}
+
+}

--- a/src/main/resources/META-INF/services/org.junit.platform.launcher.LauncherInterceptor
+++ b/src/main/resources/META-INF/services/org.junit.platform.launcher.LauncherInterceptor
@@ -1,0 +1,1 @@
+be.seeseemelk.mockbukkit.MockBukkitLauncherInterceptor

--- a/src/test/java/be/seeseemelk/mockbukkit/MockBukkitLauncherInterceptorTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/MockBukkitLauncherInterceptorTest.java
@@ -1,0 +1,25 @@
+package be.seeseemelk.mockbukkit;
+
+import be.seeseemelk.mockbukkit.plugin.MockBukkitClassLoader;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.launcher.LauncherConstants;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class MockBukkitLauncherInterceptorTest
+{
+
+	@Test
+	void modifiedClassLoader()
+	{
+		assertInstanceOf(MockBukkitClassLoader.class, Thread.currentThread().getContextClassLoader());
+	}
+
+	@Test
+	void propertySet()
+	{
+		assertEquals("true", System.getProperty(LauncherConstants.ENABLE_LAUNCHER_INTERCEPTORS));
+	}
+
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/TestPlugin.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/TestPlugin.java
@@ -22,6 +22,9 @@ import java.util.concurrent.CyclicBarrier;
 
 public class TestPlugin extends JavaPlugin implements Listener
 {
+	static {
+		System.out.println("Test plugin loaded");
+	}
 
 	public boolean onEnableExecuted = false;
 	public boolean onDisableExecuted = false;

--- a/src/test/java/be/seeseemelk/mockbukkit/TestPlugin.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/TestPlugin.java
@@ -22,9 +22,6 @@ import java.util.concurrent.CyclicBarrier;
 
 public class TestPlugin extends JavaPlugin implements Listener
 {
-	static {
-		System.out.println("Test plugin loaded");
-	}
 
 	public boolean onEnableExecuted = false;
 	public boolean onDisableExecuted = false;

--- a/src/test/java/be/seeseemelk/mockbukkit/plugin/MockBukkitClassLoaderTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/plugin/MockBukkitClassLoaderTest.java
@@ -5,19 +5,16 @@ import be.seeseemelk.mockbukkit.TestPlugin;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockBukkitExtension.class)
 class MockBukkitClassLoaderTest
 {
 
 	@Test
-	void pluginHasRightClassLoader() throws ClassNotFoundException
+	void pluginHasRightClassLoader()
 	{
-		System.out.println("After class loading");
-		System.out.println(Class.forName("be.seeseemelk.mockbukkit.TestPlugin").getClassLoader());
-		TestPlugin testPlugin = new TestPlugin();
-		assertInstanceOf(MockBukkitPluginClassLoader.class, testPlugin.getClass().getClassLoader());
+		assertEquals(MockBukkitPluginClassLoader.class, TestPlugin.class.getClassLoader().getClass());
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/plugin/MockBukkitClassLoaderTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/plugin/MockBukkitClassLoaderTest.java
@@ -1,0 +1,23 @@
+package be.seeseemelk.mockbukkit.plugin;
+
+import be.seeseemelk.mockbukkit.MockBukkitExtension;
+import be.seeseemelk.mockbukkit.TestPlugin;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+@ExtendWith(MockBukkitExtension.class)
+class MockBukkitClassLoaderTest
+{
+
+	@Test
+	void pluginHasRightClassLoader() throws ClassNotFoundException
+	{
+		System.out.println("After class loading");
+		System.out.println(Class.forName("be.seeseemelk.mockbukkit.TestPlugin").getClassLoader());
+		TestPlugin testPlugin = new TestPlugin();
+		assertInstanceOf(MockBukkitPluginClassLoader.class, testPlugin.getClass().getClassLoader());
+	}
+
+}


### PR DESCRIPTION
# Description
 Found a way to override the class loader used before loading testclasses.
 
 (THIS IS A DRAFT, MERGING THIS WILL PUBLISH AN UNUSABLE RELEASE)

Fixes #755,
Can fix #928

Requires the system property `junit.platform.launcher.interceptors.enabled` to be `true` before running the tests. Can not be done on our end, from what I know
# Checklist
The following items should be checked before the pull request can be merged.
- [ ] Code follows existing style.
- [ ] Unit tests added (if applicable).
