### PR TITLE
Fix isAction check returning true in other people's CI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -172,14 +172,14 @@ fun isFork(): Boolean {
 }
 
 fun isAction(): Boolean {
-	return System.getenv("CI") != null
+	return System.getenv("GITHUB_ACTIONS") == "true" && System.getenv("GITHUB_REPOSITORY") == "MockBukkit/MockBukkit"
 }
 
 fun getFullVersion(): String {
-	return if (!isAction()) {
-		"dev-${run("git", "rev-parse", "--verify", "--short", "HEAD")}"
-	} else {
+	return if (isAction()) {
 		property("mockbukkit.version") as String
+	} else {
+		"dev-${run("git", "rev-parse", "--verify", "--short", "HEAD")}"
 	}
 }
 


### PR DESCRIPTION
# Description
Closes https://github.com/MockBukkit/MockBukkit/issues/939.

Instead of simply checking if the `CI` env var is set, we now check that `GITHUB_ACTIONS` is true to ensure we're running in an action, and we check the `GITHUB_REPOSITORY` to ensure it's our repo we're running in.

The relevant GitHub docs can be found here:
https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
