### PR TITLE
Add sign side implementation

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/SignMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/SignMock.java
@@ -287,7 +287,7 @@ public class SignMock extends TileStateMock implements Sign
 		}
 
 		@Override
-		public void setColor(DyeColor color)
+		public void setColor(@NotNull DyeColor color)
 		{
 			Preconditions.checkNotNull(color, "Color cannot be null!");
 			this.color = color;

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/SignMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/SignMock.java
@@ -26,8 +26,8 @@ import java.util.List;
  */
 public class SignMock extends TileStateMock implements Sign
 {
-	private final SignSideImpl front;
-	private final SignSideImpl back;
+	private final SignSideMock front;
+	private final SignSideMock back;
 
 	/**
 	 * Constructs a new {@link SignMock} for the provided {@link Material}.
@@ -39,8 +39,8 @@ public class SignMock extends TileStateMock implements Sign
 	{
 		super(material);
 		checkType(material, Tag.SIGNS);
-		this.front = new SignSideImpl();
-		this.back = new SignSideImpl();
+		this.front = new SignSideMock();
+		this.back = new SignSideMock();
 	}
 
 	/**
@@ -53,8 +53,8 @@ public class SignMock extends TileStateMock implements Sign
 	{
 		super(block);
 		checkType(block, Tag.SIGNS);
-		this.front = new SignSideImpl();
-		this.back = new SignSideImpl();
+		this.front = new SignSideMock();
+		this.back = new SignSideMock();
 	}
 
 	/**
@@ -65,8 +65,8 @@ public class SignMock extends TileStateMock implements Sign
 	protected SignMock(@NotNull SignMock state)
 	{
 		super(state);
-		this.front = new SignSideImpl(state.front);
-		this.back = new SignSideImpl(state.back);
+		this.front = new SignSideMock(state.front);
+		this.back = new SignSideMock(state.back);
 	}
 
 	@Override
@@ -198,18 +198,18 @@ public class SignMock extends TileStateMock implements Sign
 		return new SignMock(this);
 	}
 
-	private static class SignSideImpl implements SignSide {
+	private static class SignSideMock implements SignSide {
 
 		private final Component[] lines;
 		private boolean glowing = false;
 		private DyeColor color = DyeColor.BLACK;
 
-		private SignSideImpl() {
+		private SignSideMock() {
 			this.lines = new Component[4];
 			Arrays.fill(lines, Component.empty());
 		}
 
-		private SignSideImpl(SignSide signSide) {
+		private SignSideMock(SignSide signSide) {
 			this.lines = signSide.lines().toArray(new Component[0]);
 			this.glowing = signSide.isGlowingText();
 			this.color = signSide.getColor();

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/SignMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/SignMock.java
@@ -16,7 +16,7 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -26,10 +26,8 @@ import java.util.List;
  */
 public class SignMock extends TileStateMock implements Sign
 {
-
-	private final String[] lines = { "", "", "", "" };
-	private @NotNull DyeColor color = DyeColor.BLACK;
-	private boolean glowing = false;
+	private final SignSideImpl front;
+	private final SignSideImpl back;
 
 	/**
 	 * Constructs a new {@link SignMock} for the provided {@link Material}.
@@ -41,6 +39,8 @@ public class SignMock extends TileStateMock implements Sign
 	{
 		super(material);
 		checkType(material, Tag.SIGNS);
+		this.front = new SignSideImpl();
+		this.back = new SignSideImpl();
 	}
 
 	/**
@@ -53,6 +53,8 @@ public class SignMock extends TileStateMock implements Sign
 	{
 		super(block);
 		checkType(block, Tag.SIGNS);
+		this.front = new SignSideImpl();
+		this.back = new SignSideImpl();
 	}
 
 	/**
@@ -63,39 +65,26 @@ public class SignMock extends TileStateMock implements Sign
 	protected SignMock(@NotNull SignMock state)
 	{
 		super(state);
-
-		for (int i = 0; i < 4; i++)
-		{
-			this.lines[i] = state.getLine(i);
-		}
-		this.color = state.getColor();
-		this.glowing = state.isGlowingText();
+		this.front = new SignSideImpl(state.front);
+		this.back = new SignSideImpl(state.back);
 	}
 
 	@Override
 	public @NotNull List<Component> lines()
 	{
-		List<Component> components = new ArrayList<>();
-
-		for (String line : this.lines)
-		{
-			components.add(LegacyComponentSerializer.legacySection().deserialize(line));
-		}
-
-		return components;
+		return front.lines();
 	}
 
 	@Override
 	public @NotNull Component line(int index) throws IndexOutOfBoundsException
 	{
-		return LegacyComponentSerializer.legacySection().deserialize(getLine(index));
+		return front.line(index);
 	}
 
 	@Override
 	public void line(int index, @NotNull Component line) throws IndexOutOfBoundsException
 	{
-		Preconditions.checkNotNull(line, "Line cannot be null!");
-		this.lines[index] = LegacyComponentSerializer.legacySection().serialize(line);
+		front.line(index, line);
 	}
 
 	@Override
@@ -103,28 +92,21 @@ public class SignMock extends TileStateMock implements Sign
 	@Deprecated(since = "1.16")
 	public String @NotNull [] getLines()
 	{
-		String[] text = new String[4];
-
-		for (int i = 0; i < 4; i++)
-		{
-			text[i] = getLine(i);
-		}
-
-		return text;
+		return front.getLines();
 	}
 
 	@Override
 	@Deprecated(since = "1.16")
 	public @NotNull String getLine(int index) throws IndexOutOfBoundsException
 	{
-		return this.lines[index];
+		return front.getLine(index);
 	}
 
 	@Override
 	@Deprecated(since = "1.16")
-	public void setLine(int index, @NotNull String line) throws IndexOutOfBoundsException
+	public void setLine(int index, String line) throws IndexOutOfBoundsException
 	{
-		this.lines[index] = line != null ? line : "";
+		front.setLine(index, line);
 	}
 
 	@Override
@@ -144,26 +126,25 @@ public class SignMock extends TileStateMock implements Sign
 	@Override
 	public boolean isGlowingText()
 	{
-		return this.glowing;
+		return front.isGlowingText();
 	}
 
 	@Override
 	public void setGlowingText(boolean glowing)
 	{
-		this.glowing = glowing;
+		front.setGlowingText(glowing);
 	}
 
 	@Override
 	public @NotNull DyeColor getColor()
 	{
-		return this.color;
+		return front.getColor();
 	}
 
 	@Override
 	public void setColor(@NotNull DyeColor color)
 	{
-		Preconditions.checkNotNull(color, "Color can not be null!");
-		this.color = color;
+		front.setColor(color);
 	}
 
 	@Override
@@ -183,8 +164,11 @@ public class SignMock extends TileStateMock implements Sign
 	@Override
 	public @NotNull SignSide getSide(@NotNull Side side)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return switch (side)
+		{
+			case FRONT -> front;
+			case BACK -> back;
+        };
 	}
 
 	@Override
@@ -214,4 +198,99 @@ public class SignMock extends TileStateMock implements Sign
 		return new SignMock(this);
 	}
 
+	private static class SignSideImpl implements SignSide {
+
+		private final Component[] lines;
+		private boolean glowing = false;
+		private DyeColor color = DyeColor.BLACK;
+
+		private SignSideImpl() {
+			this.lines = new Component[4];
+			Arrays.fill(lines, Component.empty());
+		}
+
+		private SignSideImpl(SignSide signSide) {
+			this.lines = signSide.lines().toArray(new Component[0]);
+			this.glowing = signSide.isGlowingText();
+			this.color = signSide.getColor();
+		}
+
+		@Override
+		public @NotNull List<Component> lines()
+		{
+			return List.of(lines);
+		}
+
+		@Override
+		public @NotNull Component line(int index) throws IndexOutOfBoundsException
+		{
+			if (index < 0 || index >= lines.length)
+				throw new IndexOutOfBoundsException("Index out of bounds: " + index);
+			return lines[index];
+		}
+
+		@Override
+		public void line(int index, @NotNull Component line) throws IndexOutOfBoundsException
+		{
+			Preconditions.checkNotNull(line, "Line cannot be null!");
+			if (index < 0 || index >= lines.length)
+				throw new IndexOutOfBoundsException("Index out of bounds: " + index);
+			lines[index] = line;
+		}
+
+		@Override
+		public @NotNull String[] getLines()
+		{
+			return Arrays.stream(lines)
+					.map(LegacyComponentSerializer.legacySection()::serialize)
+					.toArray(String[]::new);
+		}
+
+		@Override
+		public @NotNull String getLine(int index) throws IndexOutOfBoundsException
+		{
+			if (index < 0 || index >= lines.length)
+				throw new IndexOutOfBoundsException("Index out of bounds: " + index);
+			return LegacyComponentSerializer.legacySection().serialize(lines[index]);
+		}
+
+		// Please note: NullableProblems is suppressed because the method signature requires a non-null String but
+		// the implementation allows null values to be set.
+		@Override
+		public void setLine(int index, @SuppressWarnings("NullableProblems") String line) throws IndexOutOfBoundsException
+		{
+			if (index < 0 || index >= lines.length)
+				throw new IndexOutOfBoundsException("Index out of bounds: " + index);
+			if (line == null) {
+				lines[index] = Component.empty();
+			} else {
+				lines[index] = LegacyComponentSerializer.legacySection().deserialize(line);
+			}
+		}
+
+		@Override
+		public boolean isGlowingText()
+		{
+			return glowing;
+		}
+
+		@Override
+		public void setGlowingText(boolean glowing)
+		{
+			this.glowing = glowing;
+		}
+
+		@Override
+		public @NotNull DyeColor getColor()
+		{
+			return color;
+		}
+
+		@Override
+		public void setColor(DyeColor color)
+		{
+			Preconditions.checkNotNull(color, "Color cannot be null!");
+			this.color = color;
+		}
+	}
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/block/state/SignMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/state/SignMockTest.java
@@ -10,6 +10,7 @@ import org.bukkit.DyeColor;
 import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.block.sign.Side;
+import org.bukkit.block.sign.SignSide;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -212,10 +213,9 @@ class SignMockTest
 	@ParameterizedTest
 	@EnumSource(Side.class)
 	void testSetInvalidLineNumber(Side side) {
-		assertThrows(IndexOutOfBoundsException.class, () ->
-				sign.getSide(side).line(-1, Component.text("Hello")));
-		assertThrows(IndexOutOfBoundsException.class, () ->
-				sign.getSide(side).line(4, Component.text("Hello")));
+		SignSide signSide = sign.getSide(side);
+		assertThrows(IndexOutOfBoundsException.class, () -> signSide.line(-1, Component.text("Hello")));
+		assertThrows(IndexOutOfBoundsException.class, () -> signSide.line(4, Component.text("Hello")));
 	}
 
 	@ParameterizedTest

--- a/src/test/java/be/seeseemelk/mockbukkit/block/state/SignMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/state/SignMockTest.java
@@ -214,8 +214,9 @@ class SignMockTest
 	@EnumSource(Side.class)
 	void testSetInvalidLineNumber(Side side) {
 		SignSide signSide = sign.getSide(side);
-		assertThrows(IndexOutOfBoundsException.class, () -> signSide.line(-1, Component.text("Hello")));
-		assertThrows(IndexOutOfBoundsException.class, () -> signSide.line(4, Component.text("Hello")));
+		Component text = Component.text("Hello");
+		assertThrows(IndexOutOfBoundsException.class, () -> signSide.line(-1, text));
+		assertThrows(IndexOutOfBoundsException.class, () -> signSide.line(4, text));
 	}
 
 	@ParameterizedTest

--- a/src/test/java/be/seeseemelk/mockbukkit/block/state/SignMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/block/state/SignMockTest.java
@@ -4,15 +4,27 @@ import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.WorldMock;
 import be.seeseemelk.mockbukkit.block.BlockMock;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
 import org.bukkit.Tag;
+import org.bukkit.block.sign.Side;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -31,6 +43,7 @@ class SignMockTest
 	@BeforeEach
 	void setUp()
 	{
+		MockBukkit.mock();
 		this.world = new WorldMock();
 		this.block = world.getBlockAt(0, 10, 0);
 		this.block.setType(Material.OAK_SIGN);
@@ -167,4 +180,123 @@ class SignMockTest
 		assertTrue(sign.isGlowingText());
 	}
 
+	@ParameterizedTest
+	@MethodSource("sidesAndLineNumbers")
+	void setNumberedLineAsStringOnSide(Side side, int line) {
+		String text = "Hello §aWorld";
+		sign.getSide(side).setLine(line, text);
+		assertEquals(text, sign.getSide(side).getLine(line));
+		for (int i = 0; i < 4; i++) {
+			if (i != line) {
+				assertEquals("", sign.getSide(side).getLine(i));
+			}
+		}
+	}
+
+	@ParameterizedTest
+	@MethodSource("sidesAndLineNumbers")
+	void setNumberedLineAsComponentOnSide(Side side, int line) {
+		Component component = Component.join(JoinConfiguration.spaces(),
+				Component.text("Hello"), Component.text("World", NamedTextColor.GREEN));
+		sign.getSide(side).line(line, component);
+		assertEquals(component, sign.getSide(side).line(line));
+		assertEquals("Hello §aWorld", sign.getSide(side).getLine(line));
+		for (int i = 0; i < 4; i++) {
+			if (i != line) {
+				assertEquals(Component.empty(), sign.getSide(side).line(i));
+				assertEquals("", sign.getSide(side).getLine(i));
+			}
+		}
+	}
+
+	@ParameterizedTest
+	@EnumSource(Side.class)
+	void testSetInvalidLineNumber(Side side) {
+		assertThrows(IndexOutOfBoundsException.class, () ->
+				sign.getSide(side).line(-1, Component.text("Hello")));
+		assertThrows(IndexOutOfBoundsException.class, () ->
+				sign.getSide(side).line(4, Component.text("Hello")));
+	}
+
+	@ParameterizedTest
+	@EnumSource(Side.class)
+	void testGetLinesAsComponents(Side side) {
+		assertEquals(List.of(
+				Component.empty(),
+				Component.empty(),
+				Component.empty(),
+				Component.empty()
+		), sign.getSide(side).lines());
+
+		sign.getSide(side).line(0, Component.text("Line 1"));
+		sign.getSide(side).line(1, Component.text("Line 2"));
+		sign.getSide(side).line(2, Component.text("Line 3"));
+		sign.getSide(side).line(3, Component.text("Line 4"));
+
+		assertEquals(List.of(
+				Component.text("Line 1"),
+				Component.text("Line 2"),
+				Component.text("Line 3"),
+				Component.text("Line 4")
+		), sign.getSide(side).lines());
+	}
+
+	@ParameterizedTest
+	@EnumSource(Side.class)
+	void testGetLinesAsStrings(Side side) {
+		assertArrayEquals(new String[] {
+				"",
+				"",
+				"",
+				""
+		}, sign.getSide(side).getLines());
+
+		sign.getSide(side).line(0, Component.text("Line 1"));
+		sign.getSide(side).line(1, Component.text("Line 2"));
+		sign.getSide(side).line(2, Component.text("Line 3"));
+		sign.getSide(side).line(3, Component.text("Line 4"));
+
+		assertArrayEquals(new String[] {
+				"Line 1",
+				"Line 2",
+				"Line 3",
+				"Line 4"
+		}, sign.getSide(side).getLines());
+	}
+
+	@ParameterizedTest
+	@EnumSource(Side.class)
+	void testSetGlowingOnSide(Side side) {
+		sign.getSide(side).setGlowingText(true);
+		assertTrue(sign.getSide(side).isGlowingText());
+
+		for (Side otherSide : Side.values()) {
+			if (otherSide != side) {
+				assertFalse(sign.getSide(otherSide).isGlowingText());
+			}
+		}
+	}
+
+	@ParameterizedTest
+	@EnumSource(Side.class)
+	void testSetColorOnSide(Side side) {
+		sign.getSide(side).setColor(DyeColor.BLUE);
+		assertEquals(DyeColor.BLUE, sign.getSide(side).getColor());
+
+		for (Side otherSide : Side.values()) {
+			if (otherSide != side) {
+				assertEquals(DyeColor.BLACK, sign.getSide(otherSide).getColor());
+			}
+		}
+	}
+
+	static List<Arguments> sidesAndLineNumbers() {
+		List<Arguments> result = new LinkedList<>();
+		for (Side side : Side.values()) {
+			for (int i = 0; i < 4; i++) {
+				result.add(Arguments.of(side, i));
+			}
+		}
+		return result;
+	}
 }


### PR DESCRIPTION
# Description
This PR implements `org.bukkit.block.Sign#getSide(..)` on the SignMock.

The existing and deprecated methods on `Sign` have been changed to use the front side of a sign. I've added parameterized tests to test both sides of a sign and kept the existing unit tests against Sign.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
