### PR TITLE
Add Support for ItemStack#deserializeBytes & ItemStack#serializeAsBytes and complete ItemMetaSerialization

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
@@ -3,6 +3,8 @@ package be.seeseemelk.mockbukkit;
 import be.seeseemelk.mockbukkit.damage.DamageSourceBuilderMock;
 import be.seeseemelk.mockbukkit.plugin.lifecycle.event.MockLifecycleEventManager;
 import be.seeseemelk.mockbukkit.potion.MockInternalPotionData;
+import be.seeseemelk.mockbukkit.util.io.BukkitObjectInputStreamMock;
+import be.seeseemelk.mockbukkit.util.io.BukkitObjectOutputStreamMock;
 import com.destroystokyo.paper.util.VersionFetcher;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Multimap;
@@ -50,7 +52,11 @@ import org.bukkit.potion.PotionType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -276,15 +282,32 @@ public class MockUnsafeValues implements UnsafeValues
 	@Override
 	public byte[] serializeItem(ItemStack item)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		final ByteArrayOutputStream bao = new ByteArrayOutputStream();
+		try
+		{
+			final ObjectOutputStream oos = new BukkitObjectOutputStreamMock(bao);
+			oos.writeObject(item);
+			return bao.toByteArray();
+		}
+		catch (IOException e)
+		{
+			throw new RuntimeException(e);
+		}
 	}
 
 	@Override
 	public ItemStack deserializeItem(byte[] data)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		final ByteArrayInputStream bai = new ByteArrayInputStream(data);
+		try
+		{
+			final ObjectInputStream ois = new BukkitObjectInputStreamMock(bai);
+			return (ItemStack) ois.readObject();
+		}
+		catch (IOException | ClassNotFoundException e)
+		{
+			throw new RuntimeException(e);
+		}
 	}
 
 	@Override
@@ -561,8 +584,7 @@ public class MockUnsafeValues implements UnsafeValues
 	@Override
 	public Material getMaterial(String material, int version)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return Material.getMaterial(material);
 	}
 
 

--- a/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
@@ -298,6 +298,8 @@ public class MockUnsafeValues implements UnsafeValues
 	@Override
 	public ItemStack deserializeItem(byte[] data)
 	{
+		Preconditions.checkNotNull(data, "null cannot be deserialized");
+		Preconditions.checkArgument(data.length > 0, "cannot deserialize nothing");
 		final ByteArrayInputStream bai = new ByteArrayInputStream(data);
 		try
 		{

--- a/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockUnsafeValues.java
@@ -282,6 +282,8 @@ public class MockUnsafeValues implements UnsafeValues
 	@Override
 	public byte[] serializeItem(ItemStack item)
 	{
+		Preconditions.checkNotNull(item, "null cannot be serialized");
+		Preconditions.checkArgument(item.getType() != Material.AIR, "air cannot be serialized");
 		final ByteArrayOutputStream bao = new ByteArrayOutputStream();
 		try
 		{

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/ItemFactoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/ItemFactoryMock.java
@@ -208,8 +208,7 @@ public class ItemFactoryMock implements ItemFactory
 	@Override
 	public @NotNull ItemStack ensureServerConversions(@NotNull ItemStack item)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return item;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ArmorStandMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ArmorStandMetaMock.java
@@ -120,7 +120,9 @@ public class ArmorStandMetaMock extends ItemMetaMock implements ArmorStandMeta
 	public boolean equals(Object obj)
 	{
 		if (!(obj instanceof ArmorStandMeta meta))
+		{
 			return false;
+		}
 		return super.equals(obj) &&
 				this.isInvisible() == meta.isInvisible() &&
 				this.hasNoBasePlate() == meta.hasNoBasePlate() &&

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ArmorStandMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ArmorStandMetaMock.java
@@ -155,8 +155,8 @@ public class ArmorStandMetaMock extends ItemMetaMock implements ArmorStandMeta
 		serialMock.deserializeInternal(args);
 		serialMock.invisible = (boolean) args.get("invisible");
 		serialMock.marker = (boolean) args.get("marker");
-		serialMock.noBasePlate = (boolean) args.get("noBasePlate");
-		serialMock.showArms = (boolean) args.get("showArms");
+		serialMock.noBasePlate = (boolean) args.get("no-base-plate");
+		serialMock.showArms = (boolean) args.get("show-arms");
 		serialMock.small = (boolean) args.get("small");
 		return serialMock;
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ArmorStandMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ArmorStandMetaMock.java
@@ -178,4 +178,10 @@ public class ArmorStandMetaMock extends ItemMetaMock implements ArmorStandMeta
 		serialized.put("small", this.small);
 		return serialized;
 	}
+
+	@Override
+	protected String getTypeName()
+	{
+		return "ARMOR_STAND";
+	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ArmorStandMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ArmorStandMetaMock.java
@@ -3,6 +3,8 @@ package be.seeseemelk.mockbukkit.inventory.meta;
 import com.destroystokyo.paper.inventory.meta.ArmorStandMeta;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Map;
+
 /**
  * Mock implementation of an {@link ArmorStandMeta}.
  *
@@ -141,4 +143,39 @@ public class ArmorStandMetaMock extends ItemMetaMock implements ArmorStandMeta
 		return clone;
 	}
 
+	/**
+	 * Required method for Bukkit deserialization.
+	 *
+	 * @param args A serialized ArmorStandMetaMock object in a Map&lt;String, Object&gt; format.
+	 * @return A new instance of the ArmorStandMetaMock class.
+	 */
+	public static @NotNull ArmorStandMetaMock deserialize(@NotNull Map<String, Object> args)
+	{
+		ArmorStandMetaMock serialMock = new ArmorStandMetaMock();
+		serialMock.deserializeInternal(args);
+		serialMock.invisible = (boolean) args.get("invisible");
+		serialMock.marker = (boolean) args.get("marker");
+		serialMock.noBasePlate = (boolean) args.get("noBasePlate");
+		serialMock.showArms = (boolean) args.get("showArms");
+		serialMock.small = (boolean) args.get("small");
+		return serialMock;
+	}
+
+	/**
+	 * Serializes the properties of an ArmorStandMetaMock to a HashMap.
+	 * Unimplemented properties are not present in the map.
+	 *
+	 * @return A HashMap of String, Object pairs representing the ArmorStandMetaMock.
+	 */
+	@Override
+	public @NotNull Map<String, Object> serialize()
+	{
+		final Map<String, Object> serialized = super.serialize();
+		serialized.put("invisible", this.invisible);
+		serialized.put("marker", this.marker);
+		serialized.put("noBasePlate", this.noBasePlate);
+		serialized.put("showArms", this.showArms);
+		serialized.put("small", this.small);
+		return serialized;
+	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ArmorStandMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ArmorStandMetaMock.java
@@ -184,4 +184,5 @@ public class ArmorStandMetaMock extends ItemMetaMock implements ArmorStandMeta
 	{
 		return "ARMOR_STAND";
 	}
+
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ArmorStandMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ArmorStandMetaMock.java
@@ -173,8 +173,8 @@ public class ArmorStandMetaMock extends ItemMetaMock implements ArmorStandMeta
 		final Map<String, Object> serialized = super.serialize();
 		serialized.put("invisible", this.invisible);
 		serialized.put("marker", this.marker);
-		serialized.put("noBasePlate", this.noBasePlate);
-		serialized.put("showArms", this.showArms);
+		serialized.put("no-base-plate", this.noBasePlate);
+		serialized.put("show-arms", this.showArms);
 		serialized.put("small", this.small);
 		return serialized;
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/AxolotlBucketMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/AxolotlBucketMetaMock.java
@@ -113,4 +113,10 @@ public class AxolotlBucketMetaMock extends ItemMetaMock implements AxolotlBucket
 		return serialized;
 	}
 
+	@Override
+	protected String getTypeName()
+	{
+		return "AXOLOTL_BUCKET";
+	}
+
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/AxolotlBucketMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/AxolotlBucketMetaMock.java
@@ -4,6 +4,8 @@ import org.bukkit.entity.Axolotl;
 import org.bukkit.inventory.meta.AxolotlBucketMeta;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Map;
+
 /**
  * Mock implementation of an {@link AxolotlBucketMeta}.
  *
@@ -81,6 +83,34 @@ public class AxolotlBucketMetaMock extends ItemMetaMock implements AxolotlBucket
 		clone.variant = this.variant;
 
 		return clone;
+	}
+
+	/**
+	 * Required method for Bukkit deserialization.
+	 *
+	 * @param args A serialized AxolotlBucketMetaMock object in a Map&lt;String, Object&gt; format.
+	 * @return A new instance of the AxolotlBucketMetaMock class.
+	 */
+	public static @NotNull AxolotlBucketMetaMock deserialize(@NotNull Map<String, Object> args)
+	{
+		AxolotlBucketMetaMock serialMock = new AxolotlBucketMetaMock();
+		serialMock.deserializeInternal(args);
+		serialMock.variant = (Axolotl.Variant) args.get("variant");
+		return serialMock;
+	}
+
+	/**
+	 * Serializes the properties of an AxolotlBucketMetaMock to a HashMap.
+	 * Unimplemented properties are not present in the map.
+	 *
+	 * @return A HashMap of String, Object pairs representing the AxolotlBucketMetaMock.
+	 */
+	@Override
+	public @NotNull Map<String, Object> serialize()
+	{
+		final Map<String, Object> serialized = super.serialize();
+		serialized.put("variant", this.variant);
+		return serialized;
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/AxolotlBucketMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/AxolotlBucketMetaMock.java
@@ -71,7 +71,9 @@ public class AxolotlBucketMetaMock extends ItemMetaMock implements AxolotlBucket
 	public boolean equals(Object obj)
 	{
 		if (!(obj instanceof AxolotlBucketMeta meta))
+		{
 			return false;
+		}
 		return super.equals(obj) && this.variant == meta.getVariant();
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BannerMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BannerMetaMock.java
@@ -112,7 +112,9 @@ public class BannerMetaMock extends ItemMetaMock implements BannerMeta
 	public boolean equals(Object obj)
 	{
 		if (!(obj instanceof BannerMeta meta))
+		{
 			return false;
+		}
 		return super.equals(obj) && this.baseColor == meta.getBaseColor() && this.patterns.equals(meta.getPatterns());
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BannerMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BannerMetaMock.java
@@ -158,4 +158,10 @@ public class BannerMetaMock extends ItemMetaMock implements BannerMeta
 		return serialized;
 	}
 
+	@Override
+	protected String getTypeName()
+	{
+		return "BANNER";
+	}
+
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BannerMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BannerMetaMock.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Mock implementation of an {@link BannerMeta}.
@@ -124,6 +125,37 @@ public class BannerMetaMock extends ItemMetaMock implements BannerMeta
 		clone.patterns = new ArrayList<>(this.patterns);
 
 		return clone;
+	}
+
+	/**
+	 * Required method for Bukkit deserialization.
+	 *
+	 * @param args A serialized BannerMetaMock object in a Map&lt;String, Object&gt; format.
+	 * @return A new instance of the BannerMetaMock class.
+	 */
+	@SuppressWarnings("unchecked")
+	public static @NotNull BannerMetaMock deserialize(@NotNull Map<String, Object> args)
+	{
+		BannerMetaMock serialMock = new BannerMetaMock();
+		serialMock.deserializeInternal(args);
+		serialMock.setBaseColor((DyeColor) args.get("base-color"));
+		serialMock.setPatterns(((List<Map<String, Object>>) args.get("patterns")).stream().map(Pattern::new).toList());
+		return serialMock;
+	}
+
+	/**
+	 * Serializes the properties of an BannerMetaMock to a HashMap.
+	 * Unimplemented properties are not present in the map.
+	 *
+	 * @return A HashMap of String, Object pairs representing the BannerMetaMock.
+	 */
+	@Override
+	public @NotNull Map<String, Object> serialize()
+	{
+		final Map<String, Object> serialized = super.serialize();
+		serialized.put("base-color", this.baseColor);
+		serialized.put("patterns", this.patterns.stream().map(Pattern::serialize).toList());
+		return serialized;
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BookMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BookMetaMock.java
@@ -66,11 +66,17 @@ public class BookMetaMock extends ItemMetaMock implements BookMeta
 	public boolean equals(Object obj)
 	{
 		if (this == obj)
+		{
 			return true;
+		}
 		if (!super.equals(obj))
+		{
 			return false;
+		}
 		if (!(obj instanceof BookMetaMock other))
+		{
 			return false;
+		}
 		return Objects.equals(author, other.author) && Objects.equals(pages, other.pages)
 				&& Objects.equals(title, other.title) && Objects.equals(generation, other.generation);
 	}
@@ -225,9 +231,13 @@ public class BookMetaMock extends ItemMetaMock implements BookMeta
 		{
 			String newText;
 			if (text != null)
+			{
 				newText = text.length() > 32767 ? text.substring(0, 32767) : text;
+			}
 			else
+			{
 				newText = "";
+			}
 			this.pages.set(page - 1, newText);
 		}
 	}
@@ -348,12 +358,18 @@ public class BookMetaMock extends ItemMetaMock implements BookMeta
 	{
 		final Map<String, Object> serialized = super.serialize();
 		if (this.title != null)
+		{
 			serialized.put("title", this.title);
+		}
 		if (this.author != null)
+		{
 			serialized.put("author", this.author);
+		}
 		serialized.put("pages", this.pages);
 		if (this.generation != null)
+		{
 			serialized.put("generation", this.generation);
+		}
 		return serialized;
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BookMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BookMetaMock.java
@@ -357,4 +357,10 @@ public class BookMetaMock extends ItemMetaMock implements BookMeta
 		return serialized;
 	}
 
+	@Override
+	protected String getTypeName()
+	{
+		return "BOOK";
+	}
+
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BookMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BookMetaMock.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -315,6 +316,45 @@ public class BookMetaMock extends ItemMetaMock implements BookMeta
 	{
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
+	}
+
+	/**
+	 * Required method for Bukkit deserialization.
+	 *
+	 * @param args A serialized BookMetaMock object in a Map&lt;String, Object&gt; format.
+	 * @return A new instance of the BookMetaMock class.
+	 */
+	@SuppressWarnings("unchecked")
+	public static @NotNull BookMetaMock deserialize(@NotNull Map<String, Object> args)
+	{
+		BookMetaMock serialMock = new BookMetaMock();
+		serialMock.deserializeInternal(args);
+		serialMock.title = (String) args.get("title");
+		serialMock.author = (String) args.get("author");
+		serialMock.pages = (List<String>) args.get("pages");
+		serialMock.generation = (Generation) args.get("generation");
+
+		return serialMock;
+	}
+
+	/**
+	 * Serializes the properties of an BookMetaMock to a HashMap.
+	 * Unimplemented properties are not present in the map.
+	 *
+	 * @return A HashMap of String, Object pairs representing the BookMetaMock.
+	 */
+	@Override
+	public @NotNull Map<String, Object> serialize()
+	{
+		final Map<String, Object> serialized = super.serialize();
+		if (this.title != null)
+			serialized.put("title", this.title);
+		if (this.author != null)
+			serialized.put("author", this.author);
+		serialized.put("pages", this.pages);
+		if (this.generation != null)
+			serialized.put("generation", this.generation);
+		return serialized;
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BundleMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BundleMetaMock.java
@@ -132,4 +132,11 @@ public class BundleMetaMock extends ItemMetaMock implements BundleMeta
 		serialized.put("items", this.items);
 		return serialized;
 	}
+
+	@Override
+	protected String getTypeName()
+	{
+		return "BUNDLE";
+	}
+
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BundleMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BundleMetaMock.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Mock implementation of a {@link BundleMeta}.
@@ -103,4 +104,32 @@ public class BundleMetaMock extends ItemMetaMock implements BundleMeta
 		return clone;
 	}
 
+	/**
+	 * Required method for Bukkit deserialization.
+	 *
+	 * @param args A serialized BundleMetaMock object in a Map&lt;String, Object&gt; format.
+	 * @return A new instance of the BundleMetaMock class.
+	 */
+	@SuppressWarnings("unchecked")
+	public static @NotNull BundleMetaMock deserialize(@NotNull Map<String, Object> args)
+	{
+		BundleMetaMock serialMock = new BundleMetaMock();
+		serialMock.deserializeInternal(args);
+		serialMock.items = args.get("items") == null ? new ArrayList<>() : (List<ItemStack>) args.get("items");
+		return serialMock;
+	}
+
+	/**
+	 * Serializes the properties of an BundleMetaMock to a HashMap.
+	 * Unimplemented properties are not present in the map.
+	 *
+	 * @return A HashMap of String, Object pairs representing the BundleMetaMock.
+	 */
+	@Override
+	public @NotNull Map<String, Object> serialize()
+	{
+		final Map<String, Object> serialized = super.serialize();
+		serialized.put("items", this.items);
+		return serialized;
+	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BundleMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/BundleMetaMock.java
@@ -92,7 +92,9 @@ public class BundleMetaMock extends ItemMetaMock implements BundleMeta
 	public boolean equals(Object obj)
 	{
 		if (!(obj instanceof BundleMeta meta))
+		{
 			return false;
+		}
 		return super.equals(obj) && this.getItems().equals(meta.getItems());
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/CompassMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/CompassMetaMock.java
@@ -86,7 +86,9 @@ public class CompassMetaMock extends ItemMetaMock implements CompassMeta
 	public boolean equals(Object obj)
 	{
 		if (!(obj instanceof CompassMeta meta))
+		{
 			return false;
+		}
 		return super.equals(obj) && Objects.equals(this.lodestone, meta.getLodestone()) && this.tracked == meta.isLodestoneTracked();
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/CompassMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/CompassMetaMock.java
@@ -131,4 +131,11 @@ public class CompassMetaMock extends ItemMetaMock implements CompassMeta
 		serialized.put("tracked", this.tracked);
 		return serialized;
 	}
+
+	@Override
+	protected String getTypeName()
+	{
+		return "COMPASS";
+	}
+
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/CompassMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/CompassMetaMock.java
@@ -6,6 +6,7 @@ import org.bukkit.inventory.meta.CompassMeta;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -98,4 +99,36 @@ public class CompassMetaMock extends ItemMetaMock implements CompassMeta
 		return clone;
 	}
 
+	/**
+	 * Required method for Bukkit deserialization.
+	 *
+	 * @param args A serialized CompassMetaMock object in a Map&lt;String, Object&gt; format.
+	 * @return A new instance of the CompassMetaMock class.
+	 */
+	public static @NotNull CompassMetaMock deserialize(@NotNull Map<String, Object> args)
+	{
+		CompassMetaMock serialMock = new CompassMetaMock();
+		serialMock.deserializeInternal(args);
+		serialMock.lodestone = (Location) args.get("lodestone");
+		serialMock.tracked = (boolean) args.get("tracked");
+		return serialMock;
+	}
+
+	/**
+	 * Serializes the properties of an CompassMetaMock to a HashMap.
+	 * Unimplemented properties are not present in the map.
+	 *
+	 * @return A HashMap of String, Object pairs representing the CompassMetaMock.
+	 */
+	@Override
+	public @NotNull Map<String, Object> serialize()
+	{
+		final Map<String, Object> serialized = super.serialize();
+		if (this.lodestone != null)
+		{
+			serialized.put("lodestone", this.lodestone);
+		}
+		serialized.put("tracked", this.tracked);
+		return serialized;
+	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/CrossbowMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/CrossbowMetaMock.java
@@ -97,7 +97,9 @@ public class CrossbowMetaMock extends ItemMetaMock implements CrossbowMeta
 	public boolean equals(Object obj)
 	{
 		if (!(obj instanceof CrossbowMeta meta))
+		{
 			return false;
+		}
 		return super.equals(obj) && Objects.equals(this.getChargedProjectiles(), meta.getChargedProjectiles());
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/CrossbowMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/CrossbowMetaMock.java
@@ -122,7 +122,7 @@ public class CrossbowMetaMock extends ItemMetaMock implements CrossbowMeta
 	{
 		CrossbowMetaMock serialMock = new CrossbowMetaMock();
 		serialMock.deserializeInternal(args);
-		serialMock.setChargedProjectiles((List<ItemStack>) args.get("projectiles"));
+		serialMock.projectiles = (List<ItemStack>) args.get("projectiles");
 		return serialMock;
 	}
 
@@ -138,5 +138,11 @@ public class CrossbowMetaMock extends ItemMetaMock implements CrossbowMeta
 		final Map<String, Object> serialized = super.serialize();
 		serialized.put("projectiles", this.projectiles);
 		return serialized;
+	}
+
+	@Override
+	protected String getTypeName()
+	{
+		return "CROSSBOW";
 	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/CrossbowMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/CrossbowMetaMock.java
@@ -145,4 +145,5 @@ public class CrossbowMetaMock extends ItemMetaMock implements CrossbowMeta
 	{
 		return "CROSSBOW";
 	}
+
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/CrossbowMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/CrossbowMetaMock.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -41,10 +42,9 @@ public class CrossbowMetaMock extends ItemMetaMock implements CrossbowMeta
 	{
 		super(meta);
 
-		if (meta.hasChargedProjectiles())
-		{
-			this.projectiles = new ArrayList<>(meta.getChargedProjectiles());
-		}
+		this.projectiles = meta.hasChargedProjectiles() ?
+				new ArrayList<>(meta.getChargedProjectiles()) :
+				new ArrayList<>();
 	}
 
 	@Override
@@ -111,4 +111,32 @@ public class CrossbowMetaMock extends ItemMetaMock implements CrossbowMeta
 		return clone;
 	}
 
+	/**
+	 * Required method for Bukkit deserialization.
+	 *
+	 * @param args A serialized CrossbowMetaMock object in a Map&lt;String, Object&gt; format.
+	 * @return A new instance of the CrossbowMetaMock class.
+	 */
+	@SuppressWarnings("unchecked")
+	public static @NotNull CrossbowMetaMock deserialize(@NotNull Map<String, Object> args)
+	{
+		CrossbowMetaMock serialMock = new CrossbowMetaMock();
+		serialMock.deserializeInternal(args);
+		serialMock.setChargedProjectiles((List<ItemStack>) args.get("projectiles"));
+		return serialMock;
+	}
+
+	/**
+	 * Serializes the properties of an CrossbowMetaMock to a HashMap.
+	 * Unimplemented properties are not present in the map.
+	 *
+	 * @return A HashMap of String, Object pairs representing the CrossbowMetaMock.
+	 */
+	@Override
+	public @NotNull Map<String, Object> serialize()
+	{
+		final Map<String, Object> serialized = super.serialize();
+		serialized.put("projectiles", this.projectiles);
+		return serialized;
+	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/EnchantedBookMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/EnchantedBookMetaMock.java
@@ -171,11 +171,13 @@ public class EnchantedBookMetaMock extends ItemMetaMock implements EnchantmentSt
 		return serialized;
 	}
 
-	private static String getEnchantmentKey(Enchantment enchantment) {
+	private static String getEnchantmentKey(Enchantment enchantment)
+	{
 		return enchantment.getKey().getKey();
 	}
 
-	private static Enchantment getEnchantment(String key) {
+	private static Enchantment getEnchantment(String key)
+	{
 		NamespacedKey namespacedKey = NamespacedKey.minecraft(key);
 		return Registry.ENCHANTMENT.get(namespacedKey);
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/EnchantedBookMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/EnchantedBookMetaMock.java
@@ -179,4 +179,11 @@ public class EnchantedBookMetaMock extends ItemMetaMock implements EnchantmentSt
 		NamespacedKey namespacedKey = NamespacedKey.minecraft(key);
 		return Registry.ENCHANTMENT.get(namespacedKey);
 	}
+
+	@Override
+	protected String getTypeName()
+	{
+		return "ENCHANTED";
+	}
+
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/EnchantedBookMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/EnchantedBookMetaMock.java
@@ -1,6 +1,8 @@
 package be.seeseemelk.mockbukkit.inventory.meta;
 
 import com.google.common.collect.ImmutableMap;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.jetbrains.annotations.NotNull;
@@ -135,4 +137,46 @@ public class EnchantedBookMetaMock extends ItemMetaMock implements EnchantmentSt
 		return storedEnchantments.remove(ench) != null;
 	}
 
+	/**
+	 * Required method for Bukkit deserialization.
+	 *
+	 * @param args A serialized EnchantedBookMetaMock object in a Map&lt;String, Object&gt; format.
+	 * @return A new instance of the EnchantedBookMetaMock class.
+	 */
+	public static @NotNull EnchantedBookMetaMock deserialize(@NotNull Map<String, Object> args)
+	{
+		EnchantedBookMetaMock serialMock = new EnchantedBookMetaMock();
+		serialMock.deserializeInternal(args);
+		if (args.containsKey("storedEnchantments"))
+		{
+			//noinspection unchecked
+			serialMock.storedEnchantments = ((Map<String, Integer>) args.get("storedEnchantments")).entrySet().stream()
+					.collect(ImmutableMap.toImmutableMap(entry -> getEnchantment(entry.getKey()), Map.Entry::getValue));
+		}
+		return serialMock;
+	}
+
+	/**
+	 * Serializes the properties of an EnchantedBookMetaMock to a HashMap.
+	 * Unimplemented properties are not present in the map.
+	 *
+	 * @return A HashMap of String, Object pairs representing the EnchantedBookMetaMock.
+	 */
+	@Override
+	public @NotNull Map<String, Object> serialize()
+	{
+		final Map<String, Object> serialized = super.serialize();
+		serialized.put("storedEnchantments", this.storedEnchantments.entrySet().stream()
+				.collect(ImmutableMap.toImmutableMap(entry -> getEnchantmentKey(entry.getKey()), Map.Entry::getValue)));
+		return serialized;
+	}
+
+	private static String getEnchantmentKey(Enchantment enchantment) {
+		return enchantment.getKey().getKey();
+	}
+
+	private static Enchantment getEnchantment(String key) {
+		NamespacedKey namespacedKey = NamespacedKey.minecraft(key);
+		return Registry.ENCHANTMENT.get(namespacedKey);
+	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/EnchantedBookMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/EnchantedBookMetaMock.java
@@ -147,10 +147,10 @@ public class EnchantedBookMetaMock extends ItemMetaMock implements EnchantmentSt
 	{
 		EnchantedBookMetaMock serialMock = new EnchantedBookMetaMock();
 		serialMock.deserializeInternal(args);
-		if (args.containsKey("storedEnchantments"))
+		if (args.containsKey("stored-enchantments"))
 		{
 			//noinspection unchecked
-			serialMock.storedEnchantments = ((Map<String, Integer>) args.get("storedEnchantments")).entrySet().stream()
+			serialMock.storedEnchantments = ((Map<String, Integer>) args.get("stored-enchantments")).entrySet().stream()
 					.collect(ImmutableMap.toImmutableMap(entry -> getEnchantment(entry.getKey()), Map.Entry::getValue));
 		}
 		return serialMock;
@@ -166,7 +166,7 @@ public class EnchantedBookMetaMock extends ItemMetaMock implements EnchantmentSt
 	public @NotNull Map<String, Object> serialize()
 	{
 		final Map<String, Object> serialized = super.serialize();
-		serialized.put("storedEnchantments", this.storedEnchantments.entrySet().stream()
+		serialized.put("stored-enchantments", this.storedEnchantments.entrySet().stream()
 				.collect(ImmutableMap.toImmutableMap(entry -> getEnchantmentKey(entry.getKey()), Map.Entry::getValue)));
 		return serialized;
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/FireworkEffectMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/FireworkEffectMetaMock.java
@@ -5,6 +5,7 @@ import org.bukkit.inventory.meta.FireworkEffectMeta;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -88,6 +89,37 @@ public class FireworkEffectMetaMock extends ItemMetaMock implements FireworkEffe
 	public @Nullable FireworkEffect getEffect()
 	{
 		return effect;
+	}
+
+	/**
+	 * Required method for Bukkit deserialization.
+	 *
+	 * @param args A serialized FireworkEffectMetaMock object in a Map&lt;String, Object&gt; format.
+	 * @return A new instance of the FireworkEffectMetaMock class.
+	 */
+	@SuppressWarnings("unchecked")
+	public static @NotNull FireworkEffectMetaMock deserialize(@NotNull Map<String, Object> args)
+	{
+		FireworkEffectMetaMock serialMock = new FireworkEffectMetaMock();
+		serialMock.deserializeInternal(args);
+		if (args.containsKey("effect"))
+			serialMock.effect = (FireworkEffect) FireworkEffect.deserialize((Map<String, Object>) args.get("effect"));
+		return serialMock;
+	}
+
+	/**
+	 * Serializes the properties of an FireworkEffectMetaMock to a HashMap.
+	 * Unimplemented properties are not present in the map.
+	 *
+	 * @return A HashMap of String, Object pairs representing the FireworkEffectMetaMock.
+	 */
+	@Override
+	public @NotNull Map<String, Object> serialize()
+	{
+		final Map<String, Object> serialized = super.serialize();
+		if (effect != null)
+			serialized.put("effect", effect.serialize());
+		return serialized;
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/FireworkEffectMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/FireworkEffectMetaMock.java
@@ -43,7 +43,7 @@ public class FireworkEffectMetaMock extends ItemMetaMock implements FireworkEffe
 	{
 		final int prime = 31;
 		int result = super.hashCode();
-		return prime * result + effect.hashCode();
+		return prime * result + (effect != null ? effect.hashCode() : 0);
 	}
 
 	@Override
@@ -120,6 +120,12 @@ public class FireworkEffectMetaMock extends ItemMetaMock implements FireworkEffe
 		if (effect != null)
 			serialized.put("effect", effect.serialize());
 		return serialized;
+	}
+
+	@Override
+	protected String getTypeName()
+	{
+		return "FIREWORK_EFFECT";
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/FireworkEffectMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/FireworkEffectMetaMock.java
@@ -103,7 +103,9 @@ public class FireworkEffectMetaMock extends ItemMetaMock implements FireworkEffe
 		FireworkEffectMetaMock serialMock = new FireworkEffectMetaMock();
 		serialMock.deserializeInternal(args);
 		if (args.containsKey("effect"))
+		{
 			serialMock.effect = (FireworkEffect) FireworkEffect.deserialize((Map<String, Object>) args.get("effect"));
+		}
 		return serialMock;
 	}
 
@@ -118,7 +120,9 @@ public class FireworkEffectMetaMock extends ItemMetaMock implements FireworkEffe
 	{
 		final Map<String, Object> serialized = super.serialize();
 		if (effect != null)
+		{
 			serialized.put("effect", effect.serialize());
+		}
 		return serialized;
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/FireworkMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/FireworkMetaMock.java
@@ -183,4 +183,10 @@ public class FireworkMetaMock extends ItemMetaMock implements FireworkMeta
 		return serialized;
 	}
 
+	@Override
+	protected String getTypeName()
+	{
+		return "FIREWORK";
+	}
+
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/FireworkMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/FireworkMetaMock.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Mock implementation of an {@link FireworkMeta}.
@@ -149,6 +150,37 @@ public class FireworkMetaMock extends ItemMetaMock implements FireworkMeta
 		}
 
 		this.power = power;
+	}
+
+	/**
+	 * Required method for Bukkit deserialization.
+	 *
+	 * @param args A serialized FireworkMetaMock object in a Map&lt;String, Object&gt; format.
+	 * @return A new instance of the FireworkMetaMock class.
+	 */
+	@SuppressWarnings("unchecked")
+	public static @NotNull FireworkMetaMock deserialize(@NotNull Map<String, Object> args)
+	{
+		FireworkMetaMock serialMock = new FireworkMetaMock();
+		serialMock.deserializeInternal(args);
+		serialMock.addEffects(((List<?>) args.get("effects")).stream()
+				.map(e -> (FireworkEffect) FireworkEffect.deserialize((Map<String, Object>) e))
+				.toList());
+		return serialMock;
+	}
+
+	/**
+	 * Serializes the properties of an FireworkMetaMock to a HashMap.
+	 * Unimplemented properties are not present in the map.
+	 *
+	 * @return A HashMap of String, Object pairs representing the FireworkMetaMock.
+	 */
+	@Override
+	public @NotNull Map<String, Object> serialize()
+	{
+		final Map<String, Object> serialized = super.serialize();
+		serialized.put("effects", effects.stream().map(FireworkEffect::serialize).toList());
+		return serialized;
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -558,7 +558,9 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 		{
 			map.put("enchants", this.enchants.entrySet().stream()
 					.collect(Collectors.toMap(entry -> entry.getKey().getKey().value(), Map.Entry::getValue)));
-		} else {
+		}
+		else
+		{
 			map.put("enchants", new HashMap<String, Integer>());
 		}
 
@@ -612,7 +614,8 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 
 	@SuppressWarnings("unchecked")
 	@ApiStatus.Internal
-	protected void deserializeInternal(@NotNull Map<String, Object> args) {
+	protected void deserializeInternal(@NotNull Map<String, Object> args)
+	{
 		displayName = (String) args.get("display-name");
 		lore = (List<String>) args.get("lore");
 		localizedName = (String) args.get("loc-name");
@@ -986,4 +989,5 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	{
 		return "UNSPECIFIC";
 	}
+
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -126,7 +126,9 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	static boolean checkConflictingEnchants(@Nullable Map<Enchantment, Integer> enchantments, @NotNull Enchantment ench)
 	{
 		if (enchantments == null || enchantments.isEmpty())
+		{
 			return false;
+		}
 
 		Iterator<Enchantment> var2 = enchantments.keySet().iterator();
 
@@ -134,7 +136,9 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 		do
 		{
 			if (!var2.hasNext())
+			{
 				return false;
+			}
 			enchant = var2.next();
 		}
 		while (!enchant.conflictsWith(ench));
@@ -193,9 +197,13 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	private boolean isLoreEquals(@NotNull ItemMeta meta)
 	{
 		if (lore == null)
+		{
 			return !meta.hasLore();
+		}
 		else if (!meta.hasLore())
+		{
 			return false;
+		}
 
 		List<Component> otherLore = meta.lore();
 		if (lore.size() == otherLore.size())
@@ -203,7 +211,9 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 			for (int i = 0; i < lore.size(); i++)
 			{
 				if (!GsonComponentSerializer.gson().deserialize(lore.get(i)).equals(otherLore.get(i)))
+				{
 					return false;
+				}
 			}
 			return true;
 		}
@@ -223,9 +233,13 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 		if (displayName != null)
 		{
 			if (meta.hasDisplayName())
+			{
 				return GsonComponentSerializer.gson().deserialize(displayName).equals(meta.displayName());
+			}
 			else
+			{
 				return false;
+			}
 		}
 		else
 		{
@@ -494,7 +508,9 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 		for (int i = 0; i < this.lore.size(); i++)
 		{
 			if (GsonComponentSerializer.gson().deserialize(this.lore.get(i)).equals(lines.get(i)))
+			{
 				continue;
+			}
 			throw new AssertionError(String.format("Line %d should be '%s' but was '%s'", i, lines.get(i), this.lore.get(i)));
 		}
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -590,6 +590,7 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 		*/
 
 		map.put("PublicBukkitValues", this.persistentDataContainer.serialize());
+		map.put("meta-type", getTypeName());
 
 		// Return map
 		return map;
@@ -980,4 +981,9 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 		toUpdate.addAll(beingSet.stream().map(Material::getKey).collect(java.util.stream.Collectors.toSet()));
 	}
 
+	@ApiStatus.Internal
+	protected String getTypeName()
+	{
+		return "UNSPECIFIC";
+	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -27,6 +27,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.Repairable;
 import org.bukkit.inventory.meta.tags.CustomItemTagContainer;
 import org.bukkit.persistence.PersistentDataContainer;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -592,27 +593,32 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	 * @param args A serialized ItemMetaMock object in a Map&lt;String, Object&gt; format.
 	 * @return A new instance of the ItemMetaMock class.
 	 */
-	@SuppressWarnings("unchecked")
 	public static @NotNull ItemMetaMock deserialize(@NotNull Map<String, Object> args)
 	{
 		ItemMetaMock serialMock = new ItemMetaMock();
 
-		serialMock.displayName = (String) args.get("display-name");
-		serialMock.lore = (List<String>) args.get("lore");
-		serialMock.localizedName = (String) args.get("loc-name");
-		serialMock.enchants = (Map<Enchantment, Integer>) args.get("enchants");
-		serialMock.hideFlags = (Set<ItemFlag>) args.get("ItemFlags");
-		serialMock.unbreakable = (boolean) args.get("Unbreakable");
-		serialMock.setAttributeModifiers((Multimap<Attribute, AttributeModifier>) args.get("AttributeModifiers"));
-		// customTagContainer is also unimplemented in mock.
-		serialMock.customModelData = (Integer) args.get("custom-model-data");
-		Map<String, Object> map = (Map<String, Object>) args.get("PublicBukkitValues");
-		serialMock.persistentDataContainer = PersistentDataContainerMock.deserialize(map);
-		serialMock.damage = (int) args.get("Damage");
-		serialMock.repairCost = (int) args.get("repair-cost");
-		serialMock.destroyableKeys = (Set<Namespaced>) args.get("destroyable-keys");
-		serialMock.placeableKeys = (Set<Namespaced>) args.get("placeable-keys");
+		serialMock.deserializeInternal(args);
 		return serialMock;
+	}
+
+	@SuppressWarnings("unchecked")
+	@ApiStatus.Internal
+	protected void deserializeInternal(@NotNull Map<String, Object> args) {
+		displayName = (String) args.get("display-name");
+		lore = (List<String>) args.get("lore");
+		localizedName = (String) args.get("loc-name");
+		enchants = (Map<Enchantment, Integer>) args.get("enchants");
+		hideFlags = (Set<ItemFlag>) args.get("ItemFlags");
+		unbreakable = (boolean) args.get("Unbreakable");
+		setAttributeModifiers((Multimap<Attribute, AttributeModifier>) args.get("AttributeModifiers"));
+		// customTagContainer is also unimplemented in mock.
+		customModelData = (Integer) args.get("custom-model-data");
+		Map<String, Object> map = (Map<String, Object>) args.get("PublicBukkitValues");
+		persistentDataContainer = PersistentDataContainerMock.deserialize(map);
+		damage = (int) args.get("Damage");
+		repairCost = (int) args.get("repair-cost");
+		destroyableKeys = (Set<Namespaced>) args.get("destroyable-keys");
+		placeableKeys = (Set<Namespaced>) args.get("placeable-keys");
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -17,6 +17,8 @@ import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.md_5.bungee.api.chat.BaseComponent;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.enchantments.Enchantment;
@@ -552,7 +554,13 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 			map.put("custom-model-data", this.customModelData);
 		}
 
-		map.put("enchants", this.enchants);
+		if (this.enchants != null)
+		{
+			map.put("enchants", this.enchants.entrySet().stream()
+					.collect(Collectors.toMap(entry -> entry.getKey().getKey().value(), Map.Entry::getValue)));
+		} else {
+			map.put("enchants", new HashMap<String, Integer>());
+		}
 
 		if (hasAttributeModifiers())
 		{
@@ -607,7 +615,17 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 		displayName = (String) args.get("display-name");
 		lore = (List<String>) args.get("lore");
 		localizedName = (String) args.get("loc-name");
-		enchants = (Map<Enchantment, Integer>) args.get("enchants");
+
+		enchants = new HashMap<>();
+		for (Map.Entry<String, Integer> entry : ((Map<String, Integer>) args.get("enchants")).entrySet())
+		{
+			Enchantment enchantment = Registry.ENCHANTMENT.get(NamespacedKey.minecraft(entry.getKey()));
+			if (enchantment != null)
+			{
+				enchants.put(enchantment, entry.getValue());
+			}
+		}
+
 		hideFlags = (Set<ItemFlag>) args.get("ItemFlags");
 		unbreakable = (boolean) args.get("Unbreakable");
 		setAttributeModifiers((Multimap<Attribute, AttributeModifier>) args.get("AttributeModifiers"));

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/KnowledgeBookMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/KnowledgeBookMetaMock.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -112,4 +113,36 @@ public class KnowledgeBookMetaMock extends ItemMetaMock implements KnowledgeBook
 		this.addRecipe(recipes.toArray(new NamespacedKey[0]));
 	}
 
+	/**
+	 * Required method for Bukkit deserialization.
+	 *
+	 * @param args A serialized KnowledgeBookMetaMock object in a Map&lt;String, Object&gt; format.
+	 * @return A new instance of the KnowledgeBookMetaMock class.
+	 */
+	@SuppressWarnings("unchecked")
+	public static @NotNull KnowledgeBookMetaMock deserialize(@NotNull Map<String, Object> args)
+	{
+		KnowledgeBookMetaMock serialMock = new KnowledgeBookMetaMock();
+		serialMock.deserializeInternal(args);
+		if (args.containsKey("recipes"))
+		{
+			serialMock.addRecipe(((List<String>) args.get("recipes")).stream().map(NamespacedKey::fromString).toArray(NamespacedKey[]::new));
+		}
+
+		return serialMock;
+	}
+
+	/**
+	 * Serializes the properties of an KnowledgeBookMetaMock to a HashMap.
+	 * Unimplemented properties are not present in the map.
+	 *
+	 * @return A HashMap of String, Object pairs representing the KnowledgeBookMetaMock.
+	 */
+	@Override
+	public @NotNull Map<String, Object> serialize()
+	{
+		final Map<String, Object> serialized = super.serialize();
+		serialized.put("recipes", recipes.stream().map(NamespacedKey::toString).toList());
+		return serialized;
+	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/KnowledgeBookMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/KnowledgeBookMetaMock.java
@@ -145,4 +145,11 @@ public class KnowledgeBookMetaMock extends ItemMetaMock implements KnowledgeBook
 		serialized.put("recipes", recipes.stream().map(NamespacedKey::toString).toList());
 		return serialized;
 	}
+
+	@Override
+	protected String getTypeName()
+	{
+		return "KNOWLEDGE_BOOK";
+	}
+
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/LeatherArmorMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/LeatherArmorMetaMock.java
@@ -6,6 +6,7 @@ import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -83,6 +84,34 @@ public class LeatherArmorMetaMock extends ItemMetaMock implements LeatherArmorMe
 	public void setColor(@Nullable Color color)
 	{
 		this.color = color == null ? Bukkit.getItemFactory().getDefaultLeatherColor() : color;
+	}
+
+	/**
+	 * Required method for Bukkit deserialization.
+	 *
+	 * @param args A serialized LeatherArmorMetaMock object in a Map&lt;String, Object&gt; format.
+	 * @return A new instance of the LeatherArmorMetaMock class.
+	 */
+	public static @NotNull LeatherArmorMetaMock deserialize(@NotNull Map<String, Object> args)
+	{
+		LeatherArmorMetaMock serialMock = new LeatherArmorMetaMock();
+		serialMock.deserializeInternal(args);
+		serialMock.color = Color.fromARGB((int) args.get("color"));
+		return serialMock;
+	}
+
+	/**
+	 * Serializes the properties of an LeatherArmorMetaMock to a HashMap.
+	 * Unimplemented properties are not present in the map.
+	 *
+	 * @return A HashMap of String, Object pairs representing the LeatherArmorMetaMock.
+	 */
+	@Override
+	public @NotNull Map<String, Object> serialize()
+	{
+		final Map<String, Object> serialized = super.serialize();
+		serialized.put("color", color.asARGB());
+		return serialized;
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/LeatherArmorMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/LeatherArmorMetaMock.java
@@ -114,4 +114,10 @@ public class LeatherArmorMetaMock extends ItemMetaMock implements LeatherArmorMe
 		return serialized;
 	}
 
+	@Override
+	protected String getTypeName()
+	{
+		return "LEATHER_ARMOR";
+	}
+
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/MapMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/MapMetaMock.java
@@ -200,7 +200,8 @@ public class MapMetaMock extends ItemMetaMock implements MapMeta
 		serialMock.deserializeInternal(args);
 		serialMock.mapId = (Integer) args.get("map-id");
 		serialMock.mapView = (MapView) args.get("map-view");
-		if (args.containsKey("color")) {
+		if (args.containsKey("color"))
+		{
 			serialMock.color = Color.fromARGB((int) args.get("color"));
 		}
 		serialMock.scaling = (byte) args.get("scaling");
@@ -239,4 +240,5 @@ public class MapMetaMock extends ItemMetaMock implements MapMeta
 	{
 		return "MAP";
 	}
+
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/MapMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/MapMetaMock.java
@@ -7,6 +7,7 @@ import org.bukkit.map.MapView;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -187,4 +188,49 @@ public class MapMetaMock extends ItemMetaMock implements MapMeta
 		return clone;
 	}
 
+	/**
+	 * Required method for Bukkit deserialization.
+	 *
+	 * @param args A serialized MapMetaMock object in a Map&lt;String, Object&gt; format.
+	 * @return A new instance of the MapMetaMock class.
+	 */
+	public static @NotNull MapMetaMock deserialize(@NotNull Map<String, Object> args)
+	{
+		MapMetaMock serialMock = new MapMetaMock();
+		serialMock.deserializeInternal(args);
+		serialMock.mapId = (Integer) args.get("map-id");
+		serialMock.mapView = (MapView) args.get("map-view");
+		if (args.containsKey("color")) {
+			serialMock.color = Color.fromARGB((int) args.get("color"));
+		}
+		serialMock.scaling = (byte) args.get("scaling");
+		return serialMock;
+	}
+
+	/**
+	 * Serializes the properties of an MapMetaMock to a HashMap.
+	 * Unimplemented properties are not present in the map.
+	 *
+	 * @return A HashMap of String, Object pairs representing the MapMetaMock.
+	 */
+	@Override
+	public @NotNull Map<String, Object> serialize()
+	{
+		final Map<String, Object> serialized = super.serialize();
+		if (this.mapId != null)
+		{
+			serialized.put("map-id", this.mapId);
+		}
+		if (this.mapView != null)
+		{
+			serialized.put("map-view", this.mapView);
+		}
+		if (this.color != null)
+		{
+			serialized.put("color", this.color.asARGB());
+		}
+		serialized.put("scaling", this.scaling);
+
+		return serialized;
+	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/MapMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/MapMetaMock.java
@@ -168,7 +168,9 @@ public class MapMetaMock extends ItemMetaMock implements MapMeta
 	public boolean equals(Object obj)
 	{
 		if (!(obj instanceof MapMeta meta))
+		{
 			return false;
+		}
 		if (!super.equals(obj) ||
 				((this.hasMapId() || meta.hasMapId()) && !Objects.equals(this.mapId, meta.getMapId())) ||
 				!Objects.equals(this.mapView, meta.getMapView()) ||

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/MapMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/MapMetaMock.java
@@ -233,4 +233,10 @@ public class MapMetaMock extends ItemMetaMock implements MapMeta
 
 		return serialized;
 	}
+
+	@Override
+	protected String getTypeName()
+	{
+		return "MAP";
+	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/PotionMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/PotionMetaMock.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -228,6 +229,36 @@ public class PotionMetaMock extends ItemMetaMock implements PotionMeta
 	{
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
+	}
+
+	/**
+	 * Required method for Bukkit deserialization.
+	 *
+	 * @param args A serialized PotionMetaMock object in a Map&lt;String, Object&gt; format.
+	 * @return A new instance of the PotionMetaMock class.
+	 */
+	@SuppressWarnings("unchecked")
+	public static @NotNull PotionMetaMock deserialize(@NotNull Map<String, Object> args)
+	{
+		PotionMetaMock serialMock = new PotionMetaMock();
+		serialMock.deserializeInternal(args);
+		serialMock.effects = ((List<Map<String, Object>>) args.get("effects")).stream()
+				.map(PotionEffect::new).toList();
+		return serialMock;
+	}
+
+	/**
+	 * Serializes the properties of an PotionMetaMock to a HashMap.
+	 * Unimplemented properties are not present in the map.
+	 *
+	 * @return A HashMap of String, Object pairs representing the PotionMetaMock.
+	 */
+	@Override
+	public @NotNull Map<String, Object> serialize()
+	{
+		final Map<String, Object> serialized = super.serialize();
+		serialized.put("effects", this.effects.stream().map(PotionEffect::serialize).toList());
+		return serialized;
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/PotionMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/PotionMetaMock.java
@@ -261,4 +261,10 @@ public class PotionMetaMock extends ItemMetaMock implements PotionMeta
 		return serialized;
 	}
 
+	@Override
+	protected String getTypeName()
+	{
+		return "POTION";
+	}
+
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SkullMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SkullMetaMock.java
@@ -236,4 +236,10 @@ public class SkullMetaMock extends ItemMetaMock implements SkullMeta
 		return serialized;
 	}
 
+	@Override
+	protected String getTypeName()
+	{
+		return "SKULL";
+	}
+
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SkullMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SkullMetaMock.java
@@ -232,7 +232,9 @@ public class SkullMetaMock extends ItemMetaMock implements SkullMeta
 	{
 		final Map<String, Object> serialized = super.serialize();
 		if (playerProfile != null)
+		{
 			serialized.put("player-profile", playerProfile);
+		}
 		return serialized;
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SkullMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SkullMetaMock.java
@@ -12,6 +12,7 @@ import org.bukkit.profile.PlayerProfile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -83,7 +84,7 @@ public class SkullMetaMock extends ItemMetaMock implements SkullMeta
 			return false;
 		}
 
-		return Objects.equals(playerProfile.getName(), other.getOwningPlayer().getName());
+		return playerProfile == other.getOwningPlayer() || Objects.equals(playerProfile.getName(), other.getOwningPlayer().getName());
 	}
 
 	@Override
@@ -203,6 +204,36 @@ public class SkullMetaMock extends ItemMetaMock implements SkullMeta
 	{
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
+	}
+
+
+	/**
+	 * Required method for Bukkit deserialization.
+	 *
+	 * @param args A serialized SkullMetaMock object in a Map&lt;String, Object&gt; format.
+	 * @return A new instance of the SkullMetaMock class.
+	 */
+	public static @NotNull SkullMetaMock deserialize(@NotNull Map<String, Object> args)
+	{
+		SkullMetaMock serialMock = new SkullMetaMock();
+		serialMock.deserializeInternal(args);
+		serialMock.playerProfile = (com.destroystokyo.paper.profile.PlayerProfile) args.get("player-profile");
+		return serialMock;
+	}
+
+	/**
+	 * Serializes the properties of an SkullMetaMock to a HashMap.
+	 * Unimplemented properties are not present in the map.
+	 *
+	 * @return A HashMap of String, Object pairs representing the SkullMetaMock.
+	 */
+	@Override
+	public @NotNull Map<String, Object> serialize()
+	{
+		final Map<String, Object> serialized = super.serialize();
+		if (playerProfile != null)
+			serialized.put("player-profile", playerProfile);
+		return serialized;
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SpawnEggMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SpawnEggMetaMock.java
@@ -7,6 +7,8 @@ import org.bukkit.inventory.meta.SpawnEggMeta;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Map;
+
 /**
  * Mock implementation of an {@link SpawnEggMeta}.
  *
@@ -91,4 +93,16 @@ public class SpawnEggMetaMock extends ItemMetaMock implements SpawnEggMeta
 		return (SpawnEggMetaMock) super.clone();
 	}
 
+	/**
+	 * Required method for Bukkit deserialization.
+	 *
+	 * @param args A serialized SpawnEggMetaMock object in a Map&lt;String, Object&gt; format.
+	 * @return A new instance of the SpawnEggMetaMock class.
+	 */
+	public static @NotNull SpawnEggMetaMock deserialize(@NotNull Map<String, Object> args)
+	{
+		SpawnEggMetaMock serialMock = new SpawnEggMetaMock();
+		serialMock.deserializeInternal(args);
+		return serialMock;
+	}
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SpawnEggMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SpawnEggMetaMock.java
@@ -105,4 +105,11 @@ public class SpawnEggMetaMock extends ItemMetaMock implements SpawnEggMeta
 		serialMock.deserializeInternal(args);
 		return serialMock;
 	}
+
+	@Override
+	protected String getTypeName()
+	{
+		return "SPAWN_EGG";
+	}
+
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SuspiciousStewMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SuspiciousStewMetaMock.java
@@ -188,4 +188,10 @@ public class SuspiciousStewMetaMock extends ItemMetaMock implements SuspiciousSt
 		return serialized;
 	}
 
+	@Override
+	protected String getTypeName()
+	{
+		return "SUSPICIOUS_STEW";
+	}
+
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SuspiciousStewMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SuspiciousStewMetaMock.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Mock implementation of a {@link SuspiciousStewMeta}.
@@ -155,6 +156,36 @@ public class SuspiciousStewMetaMock extends ItemMetaMock implements SuspiciousSt
 		}
 
 		return -1;
+	}
+
+	/**
+	 * Required method for Bukkit deserialization.
+	 *
+	 * @param args A serialized SuspiciousStewMetaMock object in a Map&lt;String, Object&gt; format.
+	 * @return A new instance of the SuspiciousStewMetaMock class.
+	 */
+	@SuppressWarnings("unchecked")
+	public static @NotNull SuspiciousStewMetaMock deserialize(@NotNull Map<String, Object> args)
+	{
+		SuspiciousStewMetaMock serialMock = new SuspiciousStewMetaMock();
+		serialMock.deserializeInternal(args);
+		serialMock.effects = ((List<Map<String, Object>>) args.get("effects")).stream()
+				.map(PotionEffect::new).toList();
+		return serialMock;
+	}
+
+	/**
+	 * Serializes the properties of an SuspiciousStewMetaMock to a HashMap.
+	 * Unimplemented properties are not present in the map.
+	 *
+	 * @return A HashMap of String, Object pairs representing the SuspiciousStewMetaMock.
+	 */
+	@Override
+	public @NotNull Map<String, Object> serialize()
+	{
+		final Map<String, Object> serialized = super.serialize();
+		serialized.put("effects", this.effects.stream().map(PotionEffect::serialize).toList());
+		return serialized;
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SuspiciousStewMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/SuspiciousStewMetaMock.java
@@ -55,7 +55,9 @@ public class SuspiciousStewMetaMock extends ItemMetaMock implements SuspiciousSt
 	public boolean equals(Object obj)
 	{
 		if (!(obj instanceof SuspiciousStewMetaMock meta))
+		{
 			return false;
+		}
 		return this.effects.equals(meta.effects);
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/TropicalFishBucketMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/TropicalFishBucketMetaMock.java
@@ -176,4 +176,10 @@ public class TropicalFishBucketMetaMock extends ItemMetaMock implements Tropical
 		return serialized;
 	}
 
+	@Override
+	protected String getTypeName()
+	{
+		return "TROPICAL_FISH_BUCKET";
+	}
+
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/TropicalFishBucketMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/TropicalFishBucketMetaMock.java
@@ -6,6 +6,8 @@ import org.bukkit.entity.TropicalFish;
 import org.bukkit.inventory.meta.TropicalFishBucketMeta;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Map;
+
 /**
  * Mock implementation of an {@link TropicalFishBucketMeta}.
  *
@@ -34,6 +36,11 @@ public class TropicalFishBucketMetaMock extends ItemMetaMock implements Tropical
 	public TropicalFishBucketMetaMock(@NotNull TropicalFishBucketMeta meta)
 	{
 		super(meta);
+
+		if (meta instanceof TropicalFishBucketMetaMock mock)
+		{
+			mock.checkVars();
+		}
 
 		this.patternColor = meta.getPatternColor();
 		this.bodyColor = meta.getBodyColor();
@@ -134,6 +141,39 @@ public class TropicalFishBucketMetaMock extends ItemMetaMock implements Tropical
 		clone.bodyColor = this.bodyColor;
 		clone.pattern = this.pattern;
 		return clone;
+	}
+
+	/**
+	 * Required method for Bukkit deserialization.
+	 *
+	 * @param args A serialized TropicalFishBucketMetaMock object in a Map&lt;String, Object&gt; format.
+	 * @return A new instance of the TropicalFishBucketMetaMock class.
+	 */
+	public static @NotNull TropicalFishBucketMetaMock deserialize(@NotNull Map<String, Object> args)
+	{
+		TropicalFishBucketMetaMock serialMock = new TropicalFishBucketMetaMock();
+		serialMock.deserializeInternal(args);
+		serialMock.bodyColor = (DyeColor) args.get("body-color");
+		serialMock.patternColor = (DyeColor) args.get("pattern-color");
+		serialMock.pattern = (TropicalFish.Pattern) args.get("pattern");
+		return serialMock;
+	}
+
+	/**
+	 * Serializes the properties of an TropicalFishBucketMetaMock to a HashMap.
+	 * Unimplemented properties are not present in the map.
+	 *
+	 * @return A HashMap of String, Object pairs representing the TropicalFishBucketMetaMock.
+	 */
+	@Override
+	public @NotNull Map<String, Object> serialize()
+	{
+		final Map<String, Object> serialized = super.serialize();
+		checkVars();
+		serialized.put("body-color", bodyColor);
+		serialized.put("pattern-color", patternColor);
+		serialized.put("pattern", pattern);
+		return serialized;
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/TropicalFishBucketMetaMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/TropicalFishBucketMetaMock.java
@@ -129,7 +129,9 @@ public class TropicalFishBucketMetaMock extends ItemMetaMock implements Tropical
 	public boolean equals(Object obj)
 	{
 		if (!(obj instanceof TropicalFishBucketMeta meta))
+		{
 			return false;
+		}
 		return super.equals(obj) && patternColor == meta.getPatternColor() && bodyColor == meta.getBodyColor() && pattern == meta.getPattern();
 	}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimMaterialMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimMaterialMock.java
@@ -1,6 +1,5 @@
 package be.seeseemelk.mockbukkit.inventory.meta.trim;
 
-import com.google.common.base.Preconditions;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimMaterialMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimMaterialMock.java
@@ -17,17 +17,18 @@ public class TrimMaterialMock implements TrimMaterial
 	private final Component description;
 
 	/**
-	 * @param key The namespaced key representing this trim material
+	 * @param key         The namespaced key representing this trim material
 	 * @param description The description of this trim material
 	 */
-	public TrimMaterialMock(NamespacedKey key, Component description){
+	public TrimMaterialMock(NamespacedKey key, Component description)
+	{
 		this.key = key;
 		this.description = description;
 	}
 
 	/**
 	 * @param data Json data
-	 * @deprecated Use {@link #TrimMaterialMock(NamespacedKey,Component)} instead
+	 * @deprecated Use {@link #TrimMaterialMock(NamespacedKey, Component)} instead
 	 */
 	@Deprecated(forRemoval = true)
 	public TrimMaterialMock(JsonObject data)
@@ -61,7 +62,7 @@ public class TrimMaterialMock implements TrimMaterial
 		Preconditions.checkArgument(data.has("key"), "Missing json key");
 		NamespacedKey key = NamespacedKey.fromString(data.get("key").getAsString());
 		Component description = GsonComponentSerializer.gson().deserializeFromTree(data.get("description"));
-		return new TrimMaterialMock(key,description);
+		return new TrimMaterialMock(key, description);
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimPatternMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimPatternMock.java
@@ -61,7 +61,7 @@ public class TrimPatternMock implements TrimPattern
 		Preconditions.checkArgument(data.has("key"), "Missing json key");
 		NamespacedKey key = NamespacedKey.fromString(data.get("key").getAsString());
 		Component description = GsonComponentSerializer.gson().deserializeFromTree(data.get("description"));
-		return new TrimPatternMock(key,description);
+		return new TrimPatternMock(key, description);
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimPatternMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimPatternMock.java
@@ -1,7 +1,7 @@
 package be.seeseemelk.mockbukkit.inventory.meta.trim;
 
-import com.google.common.base.Preconditions;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;

--- a/src/main/java/be/seeseemelk/mockbukkit/util/io/BukkitObjectInputStreamMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/util/io/BukkitObjectInputStreamMock.java
@@ -1,0 +1,64 @@
+package be.seeseemelk.mockbukkit.util.io;
+
+import be.seeseemelk.mockbukkit.inventory.meta.ItemMetaMock;
+import be.seeseemelk.mockbukkit.inventory.meta.LeatherArmorMetaMock;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+
+public class BukkitObjectInputStreamMock extends ObjectInputStream {
+
+	public BukkitObjectInputStreamMock(InputStream in) throws IOException
+	{
+		super(in);
+		this.enableResolveObject(true);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	protected Object resolveObject(Object obj) throws IOException
+	{
+		if (obj instanceof LinkedHashMap<?, ?> map)
+		{
+
+			if (map.containsKey("v") && map.containsKey("type"))
+			{
+				return deserializeItemStack((Map<String, Object>) map);
+			}
+		}
+
+		return super.resolveObject(obj);
+	}
+
+
+	@ApiStatus.Internal
+	@SuppressWarnings("unchecked")
+	private static ItemStack deserializeItemStack(Map<String, Object> map)
+	{
+		ItemStack itemStack = ItemStack.deserialize(map);
+		if (map.containsKey("meta"))
+		{
+			final Class<? extends ItemMeta> aClass = itemStack.getItemMeta().getClass();
+			try
+			{
+				final Method method = aClass.getDeclaredMethod("deserialize", Map.class);
+				final Map<String, Object> serializedMeta = (Map<String, Object>) map.get("meta");
+				ItemMeta meta = (ItemMeta) method.invoke(null, serializedMeta);
+				itemStack.setItemMeta(meta);
+			} catch (ReflectiveOperationException e) {
+				Logger.getLogger("BukkitObjectInputStreamMock").log(Level.WARNING, "Failed to deserialize ItemMeta for " + aClass.getName(), e);
+			}
+		}
+		return itemStack;
+	}
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/util/io/BukkitObjectOutputStreamMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/util/io/BukkitObjectOutputStreamMock.java
@@ -1,0 +1,39 @@
+package be.seeseemelk.mockbukkit.util.io;
+
+import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.util.Map;
+
+
+public class BukkitObjectOutputStreamMock extends ObjectOutputStream
+{
+
+	public BukkitObjectOutputStreamMock(OutputStream out) throws IOException
+	{
+		super(out);
+		this.enableReplaceObject(true);
+	}
+
+	@Override
+	protected Object replaceObject(Object obj) throws IOException
+	{
+
+		if (obj instanceof ConfigurationSerializable configurationSerializable)
+		{
+			if (!(obj instanceof ItemStack || obj instanceof ItemMeta))
+			{
+				throw new UnimplementedOperationException("Serializing ConfigurationSerializable is not yet implemented for " + obj.getClass().getName());
+			}
+			final Map<String, Object> serialize = configurationSerializable.serialize();
+			return super.replaceObject(serialize);
+		}
+		return super.replaceObject(obj);
+	}
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/util/io/BukkitObjectOutputStreamMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/util/io/BukkitObjectOutputStreamMock.java
@@ -1,6 +1,7 @@
 package be.seeseemelk.mockbukkit.util.io;
 
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import org.bukkit.Location;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -26,7 +27,7 @@ public class BukkitObjectOutputStreamMock extends ObjectOutputStream
 
 		if (obj instanceof ConfigurationSerializable configurationSerializable)
 		{
-			if (!(obj instanceof ItemStack || obj instanceof ItemMeta))
+			if (!(obj instanceof ItemStack || obj instanceof ItemMeta || obj instanceof Location))
 			{
 				throw new UnimplementedOperationException("Serializing ConfigurationSerializable is not yet implemented for " + obj.getClass().getName());
 			}

--- a/src/test/java/be/seeseemelk/mockbukkit/UnsafeValuesTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/UnsafeValuesTest.java
@@ -100,7 +100,9 @@ class UnsafeValuesTest
 		for (Material material : Material.values())
 		{
 			if (material.isLegacy() || material.isAir())
+			{
 				continue;
+			}
 			ItemStack item = new ItemStack(material);
 			items.add(item);
 		}

--- a/src/test/java/be/seeseemelk/mockbukkit/UnsafeValuesTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/UnsafeValuesTest.java
@@ -3,6 +3,7 @@ package be.seeseemelk.mockbukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BundleMeta;
 import org.bukkit.material.MaterialData;
 import org.bukkit.plugin.InvalidDescriptionException;
 import org.bukkit.plugin.InvalidPluginException;
@@ -15,6 +16,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.StringReader;
+import java.util.List;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -72,6 +75,30 @@ class UnsafeValuesTest
 		}
 
 		assertTrue(mockUnsafeValues.isSupportedApiVersion(currentVersion));
+	}
+
+	@Test
+	void serializeItemTest() {
+		for (Material material : Material.values()) {
+			if (material.isLegacy())
+				continue;
+			ItemStack item = new ItemStack(material);
+			item.editMeta(meta -> {
+				meta.setDisplayName("Test");
+				meta.setLore(List.of("Test1", "Test2"));
+				meta.setUnbreakable(true);
+			});
+
+			item.editMeta(meta -> {
+				if (meta instanceof BundleMeta bundleMeta)
+				{
+					bundleMeta.addItem(item.clone());
+				}
+			});
+			byte[] serialized = mockUnsafeValues.serializeItem(item);
+			ItemStack deserialized = mockUnsafeValues.deserializeItem(serialized);
+			assertEquals(item, deserialized);
+		}
 	}
 
 	@Test

--- a/src/test/java/be/seeseemelk/mockbukkit/UnsafeValuesTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/UnsafeValuesTest.java
@@ -117,7 +117,8 @@ class UnsafeValuesTest
 		assertEquals(expected, actual, "ItemStacks are not equal, metas: \n" + expected.getItemMeta() + "\n" + actual.getItemMeta());
 	}
 
-	private void populateItemMeta(ItemStack item) {
+	private void populateItemMeta(ItemStack item)
+	{
 		item.editMeta(meta ->
 		{
 			meta.setDisplayName("Test");
@@ -148,7 +149,8 @@ class UnsafeValuesTest
 				arrow.editMeta(itemMeta -> {});
 				crossbowMeta.addChargedProjectile(arrow);
 			}
-			if (meta instanceof EnchantmentStorageMeta storageMeta) {
+			if (meta instanceof EnchantmentStorageMeta storageMeta)
+			{
 				storageMeta.addStoredEnchant(Enchantment.DAMAGE_ALL, 1, true);
 			}
 		});

--- a/src/test/java/be/seeseemelk/mockbukkit/UnsafeValuesTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/UnsafeValuesTest.java
@@ -14,6 +14,7 @@ import org.bukkit.inventory.meta.BannerMeta;
 import org.bukkit.inventory.meta.BundleMeta;
 import org.bukkit.inventory.meta.CompassMeta;
 import org.bukkit.inventory.meta.CrossbowMeta;
+import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.bukkit.material.MaterialData;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
@@ -146,6 +147,9 @@ class UnsafeValuesTest
 				ItemStack arrow = new ItemStack(Material.ARROW);
 				arrow.editMeta(itemMeta -> {});
 				crossbowMeta.addChargedProjectile(arrow);
+			}
+			if (meta instanceof EnchantmentStorageMeta storageMeta) {
+				storageMeta.addStoredEnchant(Enchantment.DAMAGE_ALL, 1, true);
 			}
 		});
 	}

--- a/src/test/java/be/seeseemelk/mockbukkit/UnsafeValuesTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/UnsafeValuesTest.java
@@ -13,6 +13,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BannerMeta;
 import org.bukkit.inventory.meta.BundleMeta;
 import org.bukkit.inventory.meta.CompassMeta;
+import org.bukkit.inventory.meta.CrossbowMeta;
 import org.bukkit.material.MaterialData;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
@@ -112,7 +113,7 @@ class UnsafeValuesTest
 		populateItemMeta(expected);
 		byte[] serialized = mockUnsafeValues.serializeItem(expected);
 		ItemStack actual = mockUnsafeValues.deserializeItem(serialized);
-		assertEquals(expected, actual, "ItemStacks are not equal, metas: \n" + expected.getItemMeta().getEnchants() + "\n" + actual.getItemMeta().getEnchants());
+		assertEquals(expected, actual, "ItemStacks are not equal, metas: \n" + expected.getItemMeta() + "\n" + actual.getItemMeta());
 	}
 
 	private void populateItemMeta(ItemStack item) {
@@ -139,6 +140,12 @@ class UnsafeValuesTest
 			{
 				compassMeta.setLodestone(new Location(Bukkit.getWorlds().get(0), 1, 2, 3));
 				compassMeta.setLodestoneTracked(true);
+			}
+			if (meta instanceof CrossbowMeta crossbowMeta)
+			{
+				ItemStack arrow = new ItemStack(Material.ARROW);
+				arrow.editMeta(itemMeta -> {});
+				crossbowMeta.addChargedProjectile(arrow);
 			}
 		});
 	}


### PR DESCRIPTION
Fixes #1013 
# Description
<!-- State the changes of the pull request below. -->
Completed Serialization for all Metas that where not fully serialized.
Add Support for ItemStack#deserializeBytes via BukkitObjectInputStreamMock
Add Support for ItemStack#serializeAsBytes via BukkitObjectOutputStreamMock

There where also a change in metas that where required beaucse the some clones failed

ItemFactoryMock#ensureServerConversions needed to be implemented so the deserialization can work.

Also I would apricote if someone can improve upon the UntiTest so that all metas will be fully tested.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
