### PR TITLE
Fix Material#getKey usage

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/BlockDataMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/BlockDataMock.java
@@ -85,7 +85,7 @@ public class BlockDataMock implements BlockData
 	protected static void checkMaterial(@NotNull Material material)
 	{
 		Preconditions.checkNotNull(material, NULL_MATERIAL_EXCEPTION_MESSAGE);
-		Preconditions.checkState(material.isBlock(), "Can't create a block from " + material.getKey());
+		Preconditions.checkState(material.isBlock(), "Can't create a block from " + material);
 	}
 
 	/**
@@ -95,7 +95,7 @@ public class BlockDataMock implements BlockData
 	 */
 	protected void checkProperty(String property)
 	{
-		Preconditions.checkState(BlockDataMockRegistry.getInstance().isValidStateForBlockWithMaterial(getMaterial(), property), property + " is not a valid property for " + getMaterial().getKey());
+		Preconditions.checkState(BlockDataMockRegistry.getInstance().isValidStateForBlockWithMaterial(getMaterial(), property), property + " is not a valid property for " + getMaterial());
 	}
 	// endregion
 


### PR DESCRIPTION
# Description
Material#getKey doesn't work for legacy materials and throws an exception for messages

# Checklist
The following items should be checked before the pull request can be merged.
- [ ] Code follows existing style.
- [ ] Unit tests added (if applicable).
