### PR TITLE
Update user token again

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,7 @@ jobs:
 
           ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository \
             -Pmockbukkit.version=$(echo ${{ github.ref_name }} | sed -e 's:v::') \
-            -PossrhUsername=nkmPKqn2 \
+            -PossrhUsername=Iu0XBMzI \
             -PossrhPassword=$OSSRH_PASSWORD \
             -Psigning.secretKeyRingFile=private.gpg \
             -Psigning.keyId=${{ secrets.PRIV_KEY_ID }} \


### PR DESCRIPTION
# Description
The first user token could not be used for whatever reason, resulting in a 403.
I regenerated the token, now it works locally, so it should work here too.
