### PR TITLE
Implement logic for EntityMock, LivingEntityMock, ArmorStandMock, HumanEntityMock and PlayerMock

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ArmorStandMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ArmorStandMock.java
@@ -66,7 +66,8 @@ public class ArmorStandMock extends LivingEntityMock implements ArmorStand
 	@Override
 	protected EntitySubType getSubType()
 	{
-		if (isSmall()) {
+		if (isSmall())
+		{
 			return EntitySubType.SMALL;
 		}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/ArmorStandMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/ArmorStandMock.java
@@ -2,6 +2,7 @@ package be.seeseemelk.mockbukkit.entity;
 
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import be.seeseemelk.mockbukkit.entity.data.EntitySubType;
 import be.seeseemelk.mockbukkit.inventory.ItemStackMock;
 import com.google.common.base.Preconditions;
 import io.papermc.paper.math.Rotations;
@@ -33,6 +34,8 @@ public class ArmorStandMock extends LivingEntityMock implements ArmorStand
 	private boolean isMarker = false;
 	private boolean hasBasePlate = true;
 	private boolean isVisible = true;
+	private boolean isMovable = true;
+	private boolean isTickable = true;
 
 	private @NotNull EulerAngle headPose = EulerAngle.ZERO;
 	private @NotNull EulerAngle bodyPose = EulerAngle.ZERO;
@@ -58,6 +61,16 @@ public class ArmorStandMock extends LivingEntityMock implements ArmorStand
 	public @NotNull EntityType getType()
 	{
 		return EntityType.ARMOR_STAND;
+	}
+
+	@Override
+	protected EntitySubType getSubType()
+	{
+		if (isSmall()) {
+			return EntitySubType.SMALL;
+		}
+
+		return super.getSubType();
 	}
 
 	@Override
@@ -292,29 +305,25 @@ public class ArmorStandMock extends LivingEntityMock implements ArmorStand
 	@Override
 	public boolean canMove()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.isMovable;
 	}
 
 	@Override
-	public void setCanMove(boolean move)
+	public void setCanMove(boolean canMove)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.isMovable = canMove;
 	}
 
 	@Override
 	public boolean canTick()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.isTickable;
 	}
 
 	@Override
 	public void setCanTick(boolean tick)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.isTickable = tick;
 	}
 
 	@Override
@@ -387,85 +396,97 @@ public class ArmorStandMock extends LivingEntityMock implements ArmorStand
 	@Override
 	public @NotNull Rotations getBodyRotations()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return toPaper(getBodyPose());
 	}
 
 	@Override
 	public void setBodyRotations(@NotNull Rotations rotations)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkNotNull(rotations, "Rotations cannot be null");
+		setBodyPose(toBukkit(rotations));
 	}
 
 	@Override
 	public @NotNull Rotations getLeftArmRotations()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return toPaper(getLeftArmPose());
 	}
 
 	@Override
 	public void setLeftArmRotations(@NotNull Rotations rotations)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkNotNull(rotations, "Rotations cannot be null");
+		setLeftArmPose(toBukkit(rotations));
 	}
 
 	@Override
 	public @NotNull Rotations getRightArmRotations()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return toPaper(getRightArmPose());
 	}
 
 	@Override
 	public void setRightArmRotations(@NotNull Rotations rotations)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkNotNull(rotations, "Rotations cannot be null");
+		setRightArmPose(toBukkit(rotations));
 	}
 
 	@Override
 	public @NotNull Rotations getLeftLegRotations()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return toPaper(getLeftLegPose());
 	}
 
 	@Override
 	public void setLeftLegRotations(@NotNull Rotations rotations)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkNotNull(rotations, "Rotations cannot be null");
+		setLeftLegPose(toBukkit(rotations));
 	}
 
 	@Override
 	public @NotNull Rotations getRightLegRotations()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return toPaper(getRightLegPose());
 	}
 
 	@Override
 	public void setRightLegRotations(@NotNull Rotations rotations)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkNotNull(rotations, "Rotations cannot be null");
+		setRightLegPose(toBukkit(rotations));
 	}
 
 	@Override
 	public @NotNull Rotations getHeadRotations()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return toPaper(getHeadPose());
 	}
 
 	@Override
 	public void setHeadRotations(@NotNull Rotations rotations)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkNotNull(rotations, "Rotations cannot be null");
+		setHeadPose(toBukkit(rotations));
+	}
+
+	private static EulerAngle toBukkit(Rotations rotation)
+	{
+		return new EulerAngle(
+				Math.toRadians(rotation.x()),
+				Math.toRadians(rotation.y()),
+				Math.toRadians(rotation.z())
+		);
+	}
+
+	private static Rotations toPaper(EulerAngle eulerAngle)
+	{
+		return Rotations.ofDegrees(
+			Math.toDegrees(eulerAngle.getX()),
+			Math.toDegrees(eulerAngle.getY()),
+			Math.toDegrees(eulerAngle.getZ())
+		);
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EntityMock.java
@@ -52,6 +52,7 @@ import org.bukkit.permissions.PermissionAttachmentInfo;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.util.BoundingBox;
+import org.bukkit.util.NumberConversions;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -96,6 +97,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	private @Nullable Component customName = null;
 	private boolean customNameVisible = false;
 	private boolean invulnerable;
+	private boolean sneaking = false;
 	private boolean invisible;
 	private boolean noPhysics;
 	private boolean persistent = true;
@@ -111,6 +113,9 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	private boolean visualFire;
 	private boolean silent;
 	private boolean gravity = true;
+
+	private Pose pose = Pose.STANDING;
+	private boolean isFixedPose = false;
 
 	private final EntityData entityData;
 	private CreatureSpawnEvent.SpawnReason spawnReason = CreatureSpawnEvent.SpawnReason.CUSTOM;
@@ -599,6 +604,12 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	public double getHeight()
 	{
 		return entityData.getHeight(this.getSubType(), this.getEntityState());
+	}
+
+	protected double getHeight(@NotNull EntityState state)
+	{
+		Preconditions.checkNotNull(state, "State cannot be null");
+		return entityData.getHeight(this.getSubType(), state);
 	}
 
 	@Override
@@ -1172,8 +1183,14 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	@Override
 	public void setRotation(float yaw, float pitch)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		NumberConversions.checkFinite(pitch, "pitch not finite");
+		NumberConversions.checkFinite(yaw, "yaw not finite");
+
+		yaw = Location.normalizeYaw(yaw);
+		pitch = Location.normalizePitch(pitch);
+
+		location.setYaw(yaw);
+		location.setPitch(pitch);
 	}
 
 	@Override
@@ -1205,8 +1222,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	@Override
 	public @NotNull Pose getPose()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.pose;
 	}
 
 	@Override
@@ -1404,15 +1420,13 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	@Override
 	public boolean isSneaking()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.sneaking;
 	}
 
 	@Override
 	public void setSneaking(boolean sneak)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.sneaking = sneak;
 	}
 
 	@Override
@@ -1432,15 +1446,15 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	@Override
 	public void setPose(@NotNull Pose pose, boolean fixed)
 	{
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException();
+		Preconditions.checkNotNull(pose, "Pose cannot be null");
+		this.pose = pose;
+		this.isFixedPose = fixed;
 	}
 
 	@Override
 	public boolean hasFixedPose()
 	{
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException();
+		return this.isFixedPose;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/HumanEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/HumanEntityMock.java
@@ -61,8 +61,8 @@ public abstract class HumanEntityMock extends LivingEntityMock implements HumanE
 	protected int expLevel = 0;
 	private float saturation = 5.0F;
 	private int foodLevel = 20;
-	private boolean sleeping;
 	protected boolean blocking;
+	private int sleepTicks = 0;
 
 	/**
 	 * Constructs a new {@link HumanEntityMock} on the provided {@link ServerMock} with a specified {@link UUID}.
@@ -339,31 +339,18 @@ public abstract class HumanEntityMock extends LivingEntityMock implements HumanE
 	@Override
 	public boolean isDeeplySleeping()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return isSleeping() && getSleepTicks() > 100;
 	}
 
-	@Override
-	public boolean isSleeping()
+	public void setSleepTicks(int sleepTicks)
 	{
-		return this.sleeping;
-	}
-
-	/**
-	 * Set whether this entity is slumbering.
-	 *
-	 * @param sleeping If this entity is slumbering
-	 */
-	public void setSleeping(boolean sleeping)
-	{
-		this.sleeping = sleeping;
+		this.sleepTicks = sleepTicks;
 	}
 
 	@Override
 	public int getSleepTicks()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.sleepTicks;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -376,26 +376,31 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		throw new UnimplementedOperationException();
 	}
 
-	protected double getEyeHeight(EntityState pose) {
+	protected double getEyeHeight(EntityState pose)
+	{
 		return getHeight(pose) * 0.85D;
 	}
 
 	@Override
 	public double getEyeHeight(boolean ignorePose)
 	{
-		if (ignorePose) {
+		if (ignorePose)
+		{
 			return getEyeHeight(EntityState.DEFAULT);
 		}
 
-		if (isSleeping()) {
+		if (isSleeping())
+		{
 			return getEyeHeight(EntityState.SLEEPING);
 		}
 
-		if (isSneaking()) {
+		if (isSneaking())
+		{
 			return getEyeHeight(EntityState.SNEAKING);
 		}
 
-		if (isSwimming()) {
+		if (isSwimming())
+		{
 			return getEyeHeight(EntityState.SWIMMING);
 		}
 

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/LivingEntityMock.java
@@ -5,6 +5,7 @@ import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.attribute.AttributeInstanceMock;
 import be.seeseemelk.mockbukkit.attribute.AttributesMock;
+import be.seeseemelk.mockbukkit.entity.data.EntityState;
 import be.seeseemelk.mockbukkit.inventory.EntityEquipmentMock;
 import be.seeseemelk.mockbukkit.potion.ActivePotionEffect;
 import com.destroystokyo.paper.block.TargetBlockInfo;
@@ -98,6 +99,8 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	private boolean collidable = true;
 	private boolean ai = true;
 	private boolean swimming;
+	private boolean sleeping;
+	private boolean climbing;
 	private double absorptionAmount;
 	private int arrowCooldown;
 	private int arrowsInBody;
@@ -332,13 +335,6 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	}
 
 	@Override
-	public double getEyeHeight()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
 	public void startUsingItem(@NotNull EquipmentSlot hand)
 	{
 		// TODO Auto-generated method stub
@@ -380,11 +376,36 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		throw new UnimplementedOperationException();
 	}
 
+	protected double getEyeHeight(EntityState pose) {
+		return getHeight(pose) * 0.85D;
+	}
+
 	@Override
 	public double getEyeHeight(boolean ignorePose)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		if (ignorePose) {
+			return getEyeHeight(EntityState.DEFAULT);
+		}
+
+		if (isSleeping()) {
+			return getEyeHeight(EntityState.SLEEPING);
+		}
+
+		if (isSneaking()) {
+			return getEyeHeight(EntityState.SNEAKING);
+		}
+
+		if (isSwimming()) {
+			return getEyeHeight(EntityState.SWIMMING);
+		}
+
+		return getEyeHeight(EntityState.DEFAULT);
+	}
+
+	@Override
+	public double getEyeHeight()
+	{
+		return getEyeHeight(false);
 	}
 
 
@@ -863,18 +884,36 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		throw new UnimplementedOperationException();
 	}
 
+	/**
+	 * Set whether this entity is slumbering.
+	 *
+	 * @param sleeping If this entity is slumbering
+	 */
+	public void setSleeping(boolean sleeping)
+	{
+		this.sleeping = sleeping;
+	}
+
 	@Override
 	public boolean isSleeping()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.sleeping;
+	}
+
+	/**
+	 * Set whether this entity is climbing.
+	 *
+	 * @param climbing If this entity is climbing
+	 */
+	public void setClimbing(boolean climbing)
+	{
+		this.climbing = climbing;
 	}
 
 	@Override
 	public boolean isClimbing()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.climbing;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -176,7 +176,6 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	private int expTotal = 0;
 	private float exp = 0;
 	private int expCooldown = 0;
-	private boolean sneaking = false;
 	private boolean sprinting = false;
 	private boolean allowFlight = false;
 	private boolean flying = false;
@@ -759,20 +758,6 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	}
 
 	@Override
-	public double getEyeHeight()
-	{
-		return getEyeHeight(false);
-	}
-
-	@Override
-	public double getEyeHeight(boolean ignorePose)
-	{
-		if (isSneaking() && !ignorePose)
-			return 1.54D;
-		return 1.62D;
-	}
-
-	@Override
 	public int getNoDamageTicks()
 	{
 		// TODO Auto-generated method stub
@@ -1146,18 +1131,6 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 		throw new UnimplementedOperationException();
 	}
 
-	@Override
-	public boolean isSneaking()
-	{
-		return sneaking;
-	}
-
-	@Override
-	public void setSneaking(boolean sneaking)
-	{
-		this.sneaking = sneaking;
-	}
-
 	/**
 	 * Simulates sneaking.
 	 *
@@ -1170,7 +1143,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 		Bukkit.getPluginManager().callEvent(event);
 		if (!event.isCancelled())
 		{
-			this.sneaking = event.isSneaking();
+			setSneaking(event.isSneaking());
 		}
 		return event;
 	}

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/ArmorStandMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/ArmorStandMockTest.java
@@ -3,7 +3,9 @@ package be.seeseemelk.mockbukkit.entity;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.WorldMock;
+import be.seeseemelk.mockbukkit.entity.data.EntitySubType;
 import be.seeseemelk.mockbukkit.inventory.ItemStackMock;
+import io.papermc.paper.math.Rotations;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -27,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ArmorStandMockTest
 {
+	private static final double ACCEPTABLE_ERROR_DELTA = 0.0000000001;
 
 	private ServerMock server;
 	private World world;
@@ -391,6 +394,251 @@ class ArmorStandMockTest
 	void testIsSlotDisabledNullThrows()
 	{
 		assertThrows(NullPointerException.class, () -> armorStand.isSlotDisabled(null));
+	}
+
+	@Test
+	void getHeight_GivenNormalArmorStand()
+	{
+		assertEquals(1.975D, armorStand.getHeight());
+	}
+
+	@Test
+	void getHeight_GivenSmallArmorStand()
+	{
+		armorStand.setSmall(true);
+		assertEquals(0.9875D, armorStand.getHeight());
+	}
+
+	@Test
+	void getEyeHeight_GivenNormalArmorStand()
+	{
+		assertEquals(1.67875D, armorStand.getEyeHeight());
+	}
+
+	@Test
+	void getEyeHeight_GivenSmallArmorStand()
+	{
+		armorStand.setSmall(true);
+		assertEquals(0.839375D, armorStand.getEyeHeight());
+	}
+
+	@Test
+	void getSubType_GivenNormalArmorStand()
+	{
+		EntitySubType actual = armorStand.getSubType();
+		assertEquals(EntitySubType.DEFAULT, actual);
+	}
+
+	@Test
+	void getSubType_GivenSmallArmorStand()
+	{
+		armorStand.setSmall(true);
+		EntitySubType actual = armorStand.getSubType();
+		assertEquals(EntitySubType.SMALL, actual);
+	}
+
+	@Test
+	void getBodyRotations_GivenDefaultValue()
+	{
+		Rotations actual = armorStand.getBodyRotations();
+		assertEquals(0.0, actual.x());
+		assertEquals(0.0, actual.y());
+		assertEquals(0.0, actual.z());
+
+		EulerAngle actualPose = armorStand.getBodyPose();
+		assertEquals(0.0, actualPose.getX(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0.0, actualPose.getY(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0.0, actualPose.getZ(), ACCEPTABLE_ERROR_DELTA);
+	}
+
+	@Test
+	void getBodyRotations_GivenNewRotation()
+	{
+		armorStand.setBodyRotations(Rotations.ofDegrees(45, 0, 30));
+		Rotations actual = armorStand.getBodyRotations();
+		assertEquals(45, actual.x(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0, actual.y(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(30, actual.z(), ACCEPTABLE_ERROR_DELTA);
+
+		EulerAngle actualPose = armorStand.getBodyPose();
+		assertEquals(0.7853981633974483, actualPose.getX(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0.0, actualPose.getY(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0.5235987755982988, actualPose.getZ(), ACCEPTABLE_ERROR_DELTA);
+	}
+
+	@Test
+	void getLeftArmRotations_GivenDefaultValue()
+	{
+		Rotations actual = armorStand.getLeftArmRotations();
+		assertEquals(-10.0, actual.x());
+		assertEquals(0.0, actual.y());
+		assertEquals(-10.0, actual.z());
+
+		EulerAngle actualPose = armorStand.getLeftArmPose();
+		assertEquals(-0.17453292519943295, actualPose.getX(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0.0, actualPose.getY(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(-0.17453292519943295, actualPose.getZ(), ACCEPTABLE_ERROR_DELTA);
+	}
+
+	@Test
+	void getLeftArmRotations_GivenNewRotation()
+	{
+		armorStand.setLeftArmRotations(Rotations.ofDegrees(45, 0, 30));
+		Rotations actual = armorStand.getLeftArmRotations();
+		assertEquals(45, actual.x(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0, actual.y(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(30, actual.z(), ACCEPTABLE_ERROR_DELTA);
+
+		EulerAngle actualPose = armorStand.getLeftArmPose();
+		assertEquals(0.7853981633974483, actualPose.getX(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0.0, actualPose.getY(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0.5235987755982988, actualPose.getZ(), ACCEPTABLE_ERROR_DELTA);
+	}
+
+	@Test
+	void getRightArmRotations_GivenDefaultValue()
+	{
+		Rotations actual = armorStand.getRightArmRotations();
+		assertEquals(-14.999999999999998, actual.x());
+		assertEquals(0.0, actual.y());
+		assertEquals(10.0, actual.z());
+
+		EulerAngle actualPose = armorStand.getRightArmPose();
+		assertEquals(-0.2617993877991494, actualPose.getX(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0.0, actualPose.getY(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0.17453292519943295, actualPose.getZ(), ACCEPTABLE_ERROR_DELTA);
+	}
+
+	@Test
+	void getRightArmRotations_GivenNewRotation()
+	{
+		armorStand.setRightArmRotations(Rotations.ofDegrees(45, 0, 30));
+		Rotations actual = armorStand.getRightArmRotations();
+		assertEquals(45, actual.x(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0, actual.y(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(30, actual.z(), ACCEPTABLE_ERROR_DELTA);
+
+		EulerAngle actualPose = armorStand.getRightArmPose();
+		assertEquals(0.7853981633974483, actualPose.getX(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0.0, actualPose.getY(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0.5235987755982988, actualPose.getZ(), ACCEPTABLE_ERROR_DELTA);
+	}
+
+	@Test
+	void getLeftLegRotations_GivenDefaultValue()
+	{
+		Rotations actual = armorStand.getLeftLegRotations();
+		assertEquals(-1, actual.x());
+		assertEquals(0, actual.y());
+		assertEquals(-1, actual.z());
+
+		EulerAngle actualPose = armorStand.getLeftLegPose();
+		assertEquals(-0.017453292519943295, actualPose.getX(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0.0, actualPose.getY(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(-0.017453292519943295, actualPose.getZ(), ACCEPTABLE_ERROR_DELTA);
+	}
+
+	@Test
+	void getLeftLegRotations_GivenNewRotation()
+	{
+		armorStand.setLeftLegRotations(Rotations.ofDegrees(45, 0, 30));
+		Rotations actual = armorStand.getLeftLegRotations();
+		assertEquals(45, actual.x(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0, actual.y(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(30, actual.z(), ACCEPTABLE_ERROR_DELTA);
+
+		EulerAngle actualPose = armorStand.getLeftLegPose();
+		assertEquals(0.7853981633974483, actualPose.getX(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0.0, actualPose.getY(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0.5235987755982988, actualPose.getZ(), ACCEPTABLE_ERROR_DELTA);
+	}
+
+	@Test
+	void getRightLegRotations_GivenDefaultValue()
+	{
+		Rotations actual = armorStand.getRightLegRotations();
+		assertEquals(1, actual.x());
+		assertEquals(0, actual.y());
+		assertEquals(1, actual.z());
+
+		EulerAngle actualPose = armorStand.getRightLegPose();
+		assertEquals(0.017453292519943295, actualPose.getX(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0.0, actualPose.getY(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0.017453292519943295, actualPose.getZ(), ACCEPTABLE_ERROR_DELTA);
+	}
+
+	@Test
+	void getRightLegRotations_GivenNewRotation()
+	{
+		armorStand.setRightLegRotations(Rotations.ofDegrees(45, 0, 30));
+		Rotations actual = armorStand.getRightLegRotations();
+		assertEquals(45, actual.x(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0, actual.y(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(30, actual.z(), ACCEPTABLE_ERROR_DELTA);
+
+		EulerAngle actualPose = armorStand.getRightLegPose();
+		assertEquals(0.7853981633974483, actualPose.getX(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0.0, actualPose.getY(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0.5235987755982988, actualPose.getZ(), ACCEPTABLE_ERROR_DELTA);
+	}
+
+	@Test
+	void getHeadRotations_GivenDefaultValue()
+	{
+		Rotations actual = armorStand.getHeadRotations();
+		assertEquals(0, actual.x());
+		assertEquals(0, actual.y());
+		assertEquals(0, actual.z());
+
+		EulerAngle actualPose = armorStand.getHeadPose();
+		assertEquals(0.0, actualPose.getX(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0.0, actualPose.getY(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0.0, actualPose.getZ(), ACCEPTABLE_ERROR_DELTA);
+	}
+
+	@Test
+	void getHeadRotations_GivenNewRotation()
+	{
+		armorStand.setHeadRotations(Rotations.ofDegrees(45, 0, 30));
+		Rotations actual = armorStand.getHeadRotations();
+		assertEquals(45, actual.x(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0, actual.y(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(30, actual.z(), ACCEPTABLE_ERROR_DELTA);
+
+		EulerAngle actualPose = armorStand.getHeadPose();
+		assertEquals(0.7853981633974483, actualPose.getX(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0.0, actualPose.getY(), ACCEPTABLE_ERROR_DELTA);
+		assertEquals(0.5235987755982988, actualPose.getZ(), ACCEPTABLE_ERROR_DELTA);
+	}
+
+	@Test
+	void canMove_GivenDefaultValue()
+	{
+		boolean actual = armorStand.canMove();
+		assertTrue(actual);
+	}
+
+	@Test
+	void canMove_GivenChangedValue()
+	{
+		armorStand.setCanMove(false);
+		boolean actual = armorStand.canMove();
+		assertFalse(actual);
+	}
+
+	@Test
+	void canTick_GivenDefaultValue()
+	{
+		boolean actual = armorStand.canTick();
+		assertTrue(actual);
+	}
+
+	@Test
+	void canTick_GivenChangedValue()
+	{
+		armorStand.setCanTick(false);
+		boolean actual = armorStand.canTick();
+		assertFalse(actual);
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
@@ -19,6 +19,7 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Mob;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Pose;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.CreatureSpawnEvent;
@@ -37,6 +38,8 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.List;
 import java.util.UUID;
@@ -1181,6 +1184,76 @@ class EntityMockTest
 	{
 		entity.setSpawnReason(CreatureSpawnEvent.SpawnReason.NATURAL);
 		assertEquals(CreatureSpawnEvent.SpawnReason.NATURAL, entity.getEntitySpawnReason());
+	}
+
+	@Test
+	void isSneaking_GivenDefaultValue()
+	{
+		boolean actual = entity.isSneaking();
+		assertFalse(actual);
+	}
+
+	@Test
+	void isSneaking_GivenSetSneakingWithTrue()
+	{
+		entity.setSneaking(true);
+		boolean actual = entity.isSneaking();
+		assertTrue(actual);
+	}
+
+	@Test
+	void getPose_GivenDefaultPose() {
+		Pose actual = entity.getPose();
+		assertEquals(Pose.STANDING, actual);
+	}
+
+	@ParameterizedTest
+	@EnumSource(Pose.class)
+	void getPose_GivenValidPoses(Pose expectedPose) {
+		entity.setPose(expectedPose);
+		Pose actual = entity.getPose();
+		assertEquals(expectedPose, actual);
+	}
+
+	@Test
+	void hasFixedPose_GivenDefaultPose() {
+		boolean actual = entity.hasFixedPose();
+		assertFalse(actual);
+	}
+
+	@Test
+	void hasFixedPose_GivenFixedPose() {
+		entity.setPose(Pose.STANDING, true);
+		boolean actual = entity.hasFixedPose();
+		assertTrue(actual);
+	}
+
+	@Test
+	void setRotation_GivenInfiniteYaw() {
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> entity.setRotation(Float.POSITIVE_INFINITY, 0));
+		assertEquals("yaw not finite", e.getMessage());
+	}
+
+	@Test
+	void setRotation_GivenInfinitePitch() {
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> entity.setRotation(0, Float.POSITIVE_INFINITY));
+		assertEquals("pitch not finite", e.getMessage());
+	}
+
+	@Test
+	void setRotation_GivenDefaultRotation() {
+		Location actual = entity.getLocation();
+		assertEquals(0.0F, actual.getYaw());
+		assertEquals(0.0F, actual.getPitch());
+	}
+
+	@Test
+	void setRotation_GivenNewRotation() {
+		entity.setRotation(45.0F, 270F);
+
+		Location actual = entity.getLocation();
+		assertEquals(45.0F, actual.getYaw());
+		assertEquals(90.0F, actual.getPitch());
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/EntityMockTest.java
@@ -1202,53 +1202,61 @@ class EntityMockTest
 	}
 
 	@Test
-	void getPose_GivenDefaultPose() {
+	void getPose_GivenDefaultPose()
+	{
 		Pose actual = entity.getPose();
 		assertEquals(Pose.STANDING, actual);
 	}
 
 	@ParameterizedTest
 	@EnumSource(Pose.class)
-	void getPose_GivenValidPoses(Pose expectedPose) {
+	void getPose_GivenValidPoses(Pose expectedPose)
+	{
 		entity.setPose(expectedPose);
 		Pose actual = entity.getPose();
 		assertEquals(expectedPose, actual);
 	}
 
 	@Test
-	void hasFixedPose_GivenDefaultPose() {
+	void hasFixedPose_GivenDefaultPose()
+	{
 		boolean actual = entity.hasFixedPose();
 		assertFalse(actual);
 	}
 
 	@Test
-	void hasFixedPose_GivenFixedPose() {
+	void hasFixedPose_GivenFixedPose()
+	{
 		entity.setPose(Pose.STANDING, true);
 		boolean actual = entity.hasFixedPose();
 		assertTrue(actual);
 	}
 
 	@Test
-	void setRotation_GivenInfiniteYaw() {
+	void setRotation_GivenInfiniteYaw()
+	{
 		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> entity.setRotation(Float.POSITIVE_INFINITY, 0));
 		assertEquals("yaw not finite", e.getMessage());
 	}
 
 	@Test
-	void setRotation_GivenInfinitePitch() {
+	void setRotation_GivenInfinitePitch()
+	{
 		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> entity.setRotation(0, Float.POSITIVE_INFINITY));
 		assertEquals("pitch not finite", e.getMessage());
 	}
 
 	@Test
-	void setRotation_GivenDefaultRotation() {
+	void setRotation_GivenDefaultRotation()
+	{
 		Location actual = entity.getLocation();
 		assertEquals(0.0F, actual.getYaw());
 		assertEquals(0.0F, actual.getPitch());
 	}
 
 	@Test
-	void setRotation_GivenNewRotation() {
+	void setRotation_GivenNewRotation()
+	{
 		entity.setRotation(45.0F, 270F);
 
 		Location actual = entity.getLocation();

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/HumanEntityMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/HumanEntityMockTest.java
@@ -21,6 +21,8 @@ import org.bukkit.inventory.InventoryView;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -302,6 +304,58 @@ class HumanEntityMockTest
 		human.setBlocking(true);
 		human.getInventory().setItemInOffHand(new ItemStackMock(Material.AIR));
 		assertFalse(human.isBlocking());
+	}
+
+	@Test
+	void getSleepTicks_GivenDefaultValue()
+	{
+		int actual = human.getSleepTicks();
+		assertEquals(0, actual);
+	}
+
+	@Test
+	void getSleepTicks_GivenPossibleValue()
+	{
+		human.setSleepTicks(100);
+		int actual = human.getSleepTicks();
+		assertEquals(100, actual);
+	}
+
+	@Test
+	void isDeeplySleeping_GivenDefaultValue()
+	{
+		boolean actual = human.isDeeplySleeping();
+		assertFalse(actual);
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100})
+	void isDeeplySleeping_GivenNonDeepSleepLevelIsSleeping(int sleepTicks)
+	{
+		human.setSleeping(true);
+		human.setSleepTicks(sleepTicks);
+		boolean actual = human.isDeeplySleeping();
+		assertFalse(actual);
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {101, 110, 120, 130, 140, 150})
+	void isDeeplySleeping_GivenDeepSleepLevelAndIsSleeping(int sleepTicks)
+	{
+		human.setSleeping(true);
+		human.setSleepTicks(sleepTicks);
+		boolean actual = human.isDeeplySleeping();
+		assertTrue(actual);
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 101, 110, 120, 130, 140, 150})
+	void isDeeplySleeping_GivenIsNotSleeping(int sleepTicks)
+	{
+		human.setSleeping(false);
+		human.setSleepTicks(sleepTicks);
+		boolean actual = human.isDeeplySleeping();
+		assertFalse(actual);
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/LivingEntityMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/LivingEntityMockTest.java
@@ -208,4 +208,34 @@ class LivingEntityMockTest
 		}
 	}
 
+	@Test
+	void isSleeping_GivenDefaultValue()
+	{
+		boolean actual = livingEntity.isSleeping();
+		assertFalse(actual);
+	}
+
+	@Test
+	void isSleeping_GivenSleepingAsTrue()
+	{
+		livingEntity.setSleeping(true);
+		boolean actual = livingEntity.isSleeping();
+		assertTrue(actual);
+	}
+
+	@Test
+	void isClimbing_GivenDefaultValue()
+	{
+		boolean actual = livingEntity.isClimbing();
+		assertFalse(actual);
+	}
+
+	@Test
+	void isClimbing_GivenSleepingAsTrue()
+	{
+		livingEntity.setClimbing(true);
+		boolean actual = livingEntity.isClimbing();
+		assertTrue(actual);
+	}
+
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -828,6 +828,60 @@ class PlayerMockTest
 	}
 
 	@Test
+	void getHeight_WhileStanding()
+	{
+		assertEquals(1.8D, player.getHeight());
+	}
+
+	@Test
+	void getHeight_WhileSneaking()
+	{
+		player.setSneaking(true);
+		assertEquals(1.5D, player.getHeight());
+	}
+
+	@Test
+	void getHeight_WhileSleeping()
+	{
+		player.setSleeping(true);
+		assertEquals(0.2D, player.getHeight());
+	}
+
+	@Test
+	void getHeight_WhileSwimming()
+	{
+		player.setSwimming(true);
+		assertEquals(0.6D, player.getHeight());
+	}
+
+	@Test
+	void getEyeHeight_WhileStanding()
+	{
+		assertEquals(1.53D, player.getEyeHeight());
+	}
+
+	@Test
+	void getEyeHeight_WhileSneaking()
+	{
+		player.setSneaking(true);
+		assertEquals(1.275D, player.getEyeHeight());
+	}
+
+	@Test
+	void getEyeHeight_WhileSleeping()
+	{
+		player.setSleeping(true);
+		assertEquals(0.17D, player.getEyeHeight());
+	}
+
+	@Test
+	void getEyeHeight_WhileSwimming()
+	{
+		player.setSwimming(true);
+		assertEquals(0.51D, player.getEyeHeight());
+	}
+
+	@Test
 	void getPlayer_SneakingEyeHeight()
 	{
 		player.setSneaking(true);


### PR DESCRIPTION
# Description
This PR implements logic for the classes EntityMock, LivingEntityMock, ArmorStandMock, HumanEntityMock and PlayerMock.
Initially it was started with the intention to update only ArmorStandMock, but since it has functions in command with EntityMock and LivingEntityMock it was required to also update them. 

The classes HumanEntityMock and PlayerMock was done a cleanup do remove redudant function that are now present in the LivingEntityMock or EntityMock.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added.

Same as https://github.com/MockBukkit/MockBukkit/pull/1041 but now for v1.21