### PR TITLE
Fix ActivePotionEffect#hasExpired calculation

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/potion/ActivePotionEffect.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/potion/ActivePotionEffect.java
@@ -1,11 +1,10 @@
 package be.seeseemelk.mockbukkit.potion;
 
 import be.seeseemelk.mockbukkit.entity.LivingEntityMock;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.potion.PotionEffect;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.concurrent.TimeUnit;
 
 /**
  * This class represents an active {@link PotionEffect} which was applied to a {@link LivingEntity}.
@@ -17,7 +16,7 @@ public final class ActivePotionEffect
 {
 
 	private final @NotNull PotionEffect effect;
-	private final long timestamp;
+	private final int tickTimestamp;
 
 	/**
 	 * Constructs a new {@link ActivePotionEffect} with the provided {@link PotionEffect}.
@@ -27,7 +26,7 @@ public final class ActivePotionEffect
 	public ActivePotionEffect(@NotNull PotionEffect effect)
 	{
 		this.effect = effect;
-		this.timestamp = System.currentTimeMillis();
+		this.tickTimestamp = Bukkit.getCurrentTick();
 	}
 
 	/**
@@ -37,8 +36,8 @@ public final class ActivePotionEffect
 	 */
 	public boolean hasExpired()
 	{
-		int ticks = effect.getDuration() * 20;
-		return ticks < 1 || timestamp + TimeUnit.SECONDS.toMillis(ticks) < System.currentTimeMillis();
+		int ticks = effect.getDuration();
+		return !effect.isInfinite() && (ticks < 1 || tickTimestamp + ticks < Bukkit.getCurrentTick());
 	}
 
 	/**

--- a/src/test/java/be/seeseemelk/mockbukkit/potion/ActivePotionEffectTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/potion/ActivePotionEffectTest.java
@@ -1,0 +1,60 @@
+package be.seeseemelk.mockbukkit.potion;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ActivePotionEffectTest
+{
+	ServerMock server;
+
+	@BeforeEach
+	void setUp()
+	{
+		server = MockBukkit.mock();
+	}
+
+	@AfterEach
+	void tearDown()
+	{
+		MockBukkit.unmock();
+	}
+
+	@Test
+	void infiniteDuration() {
+		PlayerMock player = server.addPlayer();
+		player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, PotionEffect.INFINITE_DURATION, 0));
+		server.getScheduler().performOneTick();
+		assertFalse(player.getActivePotionEffects().isEmpty());
+	}
+
+	@Test
+	void belowFiniteDuration() {
+		int duration = 3;
+
+		PlayerMock player = server.addPlayer();
+		player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, duration, 0));
+		server.getScheduler().performTicks(duration - 1);
+
+		assertFalse(player.getActivePotionEffects().isEmpty());
+	}
+
+	@Test
+	void aboveFiniteDuration() {
+		int duration = 3;
+
+		PlayerMock player = server.addPlayer();
+		player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, duration, 0));
+		server.getScheduler().performTicks(duration + 1);
+
+		assertTrue(player.getActivePotionEffects().isEmpty());
+	}
+}


### PR DESCRIPTION
# Description
This changes `ActivePotionEffect` to rely on server ticks instead of system time to determine if a potion effect has expired. This also changes `ActivePotionEffect#hasExpired` to always be false when the potion effect is infinite. This fixes #1052.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
