### PR TITLE
Adds Ender Crystal Mock

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
@@ -27,6 +27,7 @@ import be.seeseemelk.mockbukkit.entity.DragonFireballMock;
 import be.seeseemelk.mockbukkit.entity.DrownedMock;
 import be.seeseemelk.mockbukkit.entity.EggMock;
 import be.seeseemelk.mockbukkit.entity.ElderGuardianMock;
+import be.seeseemelk.mockbukkit.entity.EnderCrystalMock;
 import be.seeseemelk.mockbukkit.entity.EnderPearlMock;
 import be.seeseemelk.mockbukkit.entity.EndermanMock;
 import be.seeseemelk.mockbukkit.entity.EndermiteMock;
@@ -159,6 +160,7 @@ import org.bukkit.entity.DragonFireball;
 import org.bukkit.entity.Drowned;
 import org.bukkit.entity.Egg;
 import org.bukkit.entity.ElderGuardian;
+import org.bukkit.entity.EnderCrystal;
 import org.bukkit.entity.EnderPearl;
 import org.bukkit.entity.Enderman;
 import org.bukkit.entity.Endermite;
@@ -1459,6 +1461,9 @@ public class WorldMock implements World
 		else if (clazz == Marker.class)
 		{
 			return new MarkerMock(server, UUID.randomUUID());
+		} else if (clazz == EnderCrystal.class)
+		{
+			return new EnderCrystalMock(server, UUID.randomUUID());
 		}
 		throw new UnimplementedOperationException();
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EnderCrystalMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EnderCrystalMock.java
@@ -1,0 +1,64 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.ServerMock;
+import org.bukkit.Location;
+import org.bukkit.entity.EnderCrystal;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+/**
+ * Mock implementation of a {@link EnderCrystal}.
+ *
+ * @see EntityMock
+ */
+public class EnderCrystalMock extends EntityMock implements EnderCrystal
+{
+
+	private boolean showBottom = false;
+
+	private Location beamTarget = null;
+
+	/**
+	 * Constructs a new EntityMock on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
+	protected EnderCrystalMock(@NotNull ServerMock server, @NotNull UUID uuid)
+	{
+		super(server, uuid);
+	}
+
+	@Override
+	public boolean isShowingBottom()
+	{
+		return this.showBottom;
+	}
+
+	@Override
+	public void setShowingBottom(boolean showing)
+	{
+		this.showBottom = showing;
+	}
+
+	@Override
+	public @Nullable Location getBeamTarget()
+	{
+		return this.beamTarget;
+	}
+
+	@Override
+	public void setBeamTarget(@Nullable Location location)
+	{
+		if (location == null) {
+			this.beamTarget = null;
+		} else if (location.getWorld() != this.getWorld()) {
+			throw new IllegalArgumentException("Cannot set beam target location to different world");
+		} else {
+			this.beamTarget = location.toBlockLocation();
+		}
+	}
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EnderCrystalMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EnderCrystalMock.java
@@ -26,7 +26,7 @@ public class EnderCrystalMock extends EntityMock implements EnderCrystal
 	 * @param server The server to create the entity on.
 	 * @param uuid   The UUID of the entity.
 	 */
-	protected EnderCrystalMock(@NotNull ServerMock server, @NotNull UUID uuid)
+	public EnderCrystalMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);
 	}

--- a/src/test/java/be/seeseemelk/mockbukkit/WorldMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/WorldMockTest.java
@@ -26,6 +26,7 @@ import be.seeseemelk.mockbukkit.entity.DonkeyMock;
 import be.seeseemelk.mockbukkit.entity.DragonFireballMock;
 import be.seeseemelk.mockbukkit.entity.EggMock;
 import be.seeseemelk.mockbukkit.entity.ElderGuardianMock;
+import be.seeseemelk.mockbukkit.entity.EnderCrystalMock;
 import be.seeseemelk.mockbukkit.entity.EnderPearlMock;
 import be.seeseemelk.mockbukkit.entity.EndermanMock;
 import be.seeseemelk.mockbukkit.entity.EndermiteMock;
@@ -1332,7 +1333,8 @@ class WorldMockTest
 				Arguments.of(EntityType.TRIDENT, Trident.class),
 				Arguments.of(EntityType.SPECTRAL_ARROW, SpectralArrow.class),
 				Arguments.of(EntityType.ARROW, Arrow.class),
-				Arguments.of(EntityType.MARKER, MarkerMock.class)
+				Arguments.of(EntityType.MARKER, MarkerMock.class),
+				Arguments.of(EntityType.END_CRYSTAL, EnderCrystalMock.class)
 		);
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/EnderCrystalMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/EnderCrystalMockTest.java
@@ -40,25 +40,29 @@ class EnderCrystalMockTest
 	}
 
 	@Test
-	void isShowingBottom_GivenDefaultValue() {
+	void isShowingBottom_GivenDefaultValue()
+	{
 		assertFalse(crystal.isShowingBottom());
 	}
 
 	@ParameterizedTest
 	@ValueSource(booleans = {true, false})
-	void isShowingBottom_GivenUpdateInValue(boolean expectedValue) {
+	void isShowingBottom_GivenUpdateInValue(boolean expectedValue)
+	{
 		crystal.setShowingBottom(expectedValue);
 		boolean actual = crystal.isShowingBottom();
 		assertEquals(expectedValue, actual);
 	}
 
 	@Test
-	void getBeamTarget_GivenDefaultValue() {
+	void getBeamTarget_GivenDefaultValue()
+	{
 		assertNull(crystal.getBeamTarget());
 	}
 
 	@Test
-	void getBeamTarget_GivenLocationInTheSameWorld() {
+	void getBeamTarget_GivenLocationInTheSameWorld()
+	{
 
 		World world = new WorldMock();
 		Location entityLocation = new Location(world, 0, 0, 0);
@@ -78,7 +82,8 @@ class EnderCrystalMockTest
 	}
 
 	@Test
-	void setBeamTarget_GivenLocationInDifferentWorld() {
+	void setBeamTarget_GivenLocationInDifferentWorld()
+	{
 
 		World worldA = new WorldMock();
 		Location entityLocation = new Location(worldA, 0, 0, 0);

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/EnderCrystalMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/EnderCrystalMockTest.java
@@ -1,0 +1,95 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.WorldMock;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class EnderCrystalMockTest
+{
+
+	private ServerMock server;
+	private EnderCrystalMock crystal;
+
+	@BeforeEach
+	void setUp()
+	{
+		server = MockBukkit.mock();
+		crystal = new EnderCrystalMock(server, UUID.randomUUID());
+	}
+
+	@AfterEach
+	void tearDown()
+	{
+		MockBukkit.unmock();
+	}
+
+	@Test
+	void isShowingBottom_GivenDefaultValue() {
+		assertFalse(crystal.isShowingBottom());
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	void isShowingBottom_GivenUpdateInValue(boolean expectedValue) {
+		crystal.setShowingBottom(expectedValue);
+		boolean actual = crystal.isShowingBottom();
+		assertEquals(expectedValue, actual);
+	}
+
+	@Test
+	void getBeamTarget_GivenDefaultValue() {
+		assertNull(crystal.getBeamTarget());
+	}
+
+	@Test
+	void getBeamTarget_GivenLocationInTheSameWorld() {
+
+		World world = new WorldMock();
+		Location entityLocation = new Location(world, 0, 0, 0);
+		crystal.setLocation(entityLocation);
+
+		Location target = new Location(world, 10.25, 5, 23.75);
+		crystal.setBeamTarget(target);
+
+		@Nullable Location actual = crystal.getBeamTarget();
+		assertNotNull(actual);
+		assertEquals(10, actual.getX());
+		assertEquals(5, actual.getY());
+		assertEquals(23, actual.getZ());
+
+		crystal.setBeamTarget(null);
+		assertNull(crystal.getBeamTarget());
+	}
+
+	@Test
+	void setBeamTarget_GivenLocationInDifferentWorld() {
+
+		World worldA = new WorldMock();
+		Location entityLocation = new Location(worldA, 0, 0, 0);
+		crystal.setLocation(entityLocation);
+
+		World worldB = new WorldMock();
+		Location target = new Location(worldB, 0, 0, 0);
+
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> crystal.setBeamTarget(target));
+
+		assertEquals("Cannot set beam target location to different world", e.getMessage());
+	}
+
+}


### PR DESCRIPTION
# Description
Just as described in the title, this PR's add the logic for the ender crystal mock, based on Paper implementation.

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [X] Unit tests added (if applicable).

# Relates
- https://github.com/MockBukkit/MockBukkit/issues/825
