### PR TITLE
Added mocks for Illager and Pillager

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
@@ -61,6 +61,7 @@ import be.seeseemelk.mockbukkit.entity.PandaMock;
 import be.seeseemelk.mockbukkit.entity.ParrotMock;
 import be.seeseemelk.mockbukkit.entity.PigMock;
 import be.seeseemelk.mockbukkit.entity.PigZombieMock;
+import be.seeseemelk.mockbukkit.entity.PillagerMock;
 import be.seeseemelk.mockbukkit.entity.PolarBearMock;
 import be.seeseemelk.mockbukkit.entity.PoweredMinecartMock;
 import be.seeseemelk.mockbukkit.entity.PufferFishMock;
@@ -199,6 +200,7 @@ import org.bukkit.entity.Panda;
 import org.bukkit.entity.Parrot;
 import org.bukkit.entity.Pig;
 import org.bukkit.entity.PigZombie;
+import org.bukkit.entity.Pillager;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.PolarBear;
 import org.bukkit.entity.Projectile;
@@ -1464,6 +1466,9 @@ public class WorldMock implements World
 		} else if (clazz == EnderCrystal.class)
 		{
 			return new EnderCrystalMock(server, UUID.randomUUID());
+		} else if (clazz == Pillager.class)
+		{
+			return new PillagerMock(server, UUID.randomUUID());
 		}
 		throw new UnimplementedOperationException();
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/IllagerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/IllagerMock.java
@@ -1,0 +1,28 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.ServerMock;
+import org.bukkit.entity.Illager;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+/**
+ * Mock implementation of a {@link Illager}.
+ *
+ * @see RaiderMock
+ */
+public abstract class IllagerMock extends RaiderMock implements Illager
+{
+
+	/**
+	 * Constructs a new {@link RaiderMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
+	protected IllagerMock(@NotNull ServerMock server, @NotNull UUID uuid)
+	{
+		super(server, uuid);
+	}
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/IllagerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/IllagerMock.java
@@ -15,7 +15,7 @@ public abstract class IllagerMock extends RaiderMock implements Illager
 {
 
 	/**
-	 * Constructs a new {@link RaiderMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 * Constructs a new {@link IllagerMock} on the provided {@link ServerMock} with a specified {@link UUID}.
 	 *
 	 * @param server The server to create the entity on.
 	 * @param uuid   The UUID of the entity.

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PillagerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PillagerMock.java
@@ -3,6 +3,7 @@ package be.seeseemelk.mockbukkit.entity;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.inventory.InventoryMock;
 import org.bukkit.Sound;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Pillager;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
@@ -41,6 +42,12 @@ public class PillagerMock extends IllagerMock implements Pillager, MockRangedEnt
 	public @NotNull Inventory getInventory()
 	{
 		return this.inventory;
+	}
+
+	@Override
+	public @NotNull EntityType getType()
+	{
+		return EntityType.PILLAGER;
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PillagerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PillagerMock.java
@@ -1,0 +1,46 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.inventory.InventoryMock;
+import org.bukkit.Sound;
+import org.bukkit.entity.Pillager;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.Inventory;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+/**
+ * Mock implementation of a {@link Pillager}.
+ *
+ * @see IllagerMock
+ */
+public class PillagerMock extends IllagerMock implements Pillager, MockRangedEntity<PillagerMock>
+{
+
+	private final Inventory inventory = new InventoryMock(this, 5, InventoryType.CHEST);
+
+	/**
+	 * Constructs a new {@link RaiderMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
+	protected PillagerMock(@NotNull ServerMock server, @NotNull UUID uuid)
+	{
+		super(server, uuid);
+	}
+
+	@Override
+	public @NotNull Sound getCelebrationSound()
+	{
+		return Sound.ENTITY_PILLAGER_CELEBRATE;
+	}
+
+	@Override
+	public @NotNull Inventory getInventory()
+	{
+		return this.inventory;
+	}
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PillagerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PillagerMock.java
@@ -2,11 +2,14 @@ package be.seeseemelk.mockbukkit.entity;
 
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.inventory.InventoryMock;
+import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Pillager;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
@@ -30,6 +33,14 @@ public class PillagerMock extends IllagerMock implements Pillager, MockRangedEnt
 	public PillagerMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);
+	}
+
+	@Override
+	public void finalizeSpawn()
+	{
+		super.finalizeSpawn();
+
+		inventory.setItem(EquipmentSlot.HAND.ordinal(), ItemStack.of(Material.CROSSBOW));
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PillagerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PillagerMock.java
@@ -21,7 +21,7 @@ public class PillagerMock extends IllagerMock implements Pillager, MockRangedEnt
 	private final Inventory inventory = new InventoryMock(this, 5, InventoryType.CHEST);
 
 	/**
-	 * Constructs a new {@link RaiderMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 * Constructs a new {@link PillagerMock} on the provided {@link ServerMock} with a specified {@link UUID}.
 	 *
 	 * @param server The server to create the entity on.
 	 * @param uuid   The UUID of the entity.

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PillagerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PillagerMock.java
@@ -26,7 +26,7 @@ public class PillagerMock extends IllagerMock implements Pillager, MockRangedEnt
 	 * @param server The server to create the entity on.
 	 * @param uuid   The UUID of the entity.
 	 */
-	protected PillagerMock(@NotNull ServerMock server, @NotNull UUID uuid)
+	public PillagerMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/ChestInventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/ChestInventoryMock.java
@@ -1,5 +1,6 @@
 package be.seeseemelk.mockbukkit.inventory;
 
+import com.google.common.base.Preconditions;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
@@ -24,6 +25,8 @@ public class ChestInventoryMock extends InventoryMock
 	public ChestInventoryMock(InventoryHolder holder, int size)
 	{
 		super(holder, size, InventoryType.CHEST);
+		Preconditions.checkArgument(9 <= size && size <= 54 && size % 9 == 0,
+				"Size for custom inventory must be a multiple of 9 between 9 and 54 slots (got " + size + ")");
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/InventoryMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/InventoryMock.java
@@ -49,8 +49,7 @@ public class InventoryMock implements Inventory
 	 */
 	public InventoryMock(@Nullable InventoryHolder holder, int size, @NotNull InventoryType type)
 	{
-		Preconditions.checkArgument(2 == size || (9 <= size && size <= 54 && size % 9 == 0),
-				"Size for custom inventory must be two or a multiple of 9 between 9 and 54 slots (got " + size + ")");
+		Preconditions.checkArgument(size > 0, "Inventory size has to be > 0");
 		Preconditions.checkNotNull(type, "The InventoryType must not be null!");
 
 		this.holder = holder;

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -12,6 +12,7 @@ import be.seeseemelk.mockbukkit.inventory.BarrelInventoryMock;
 import be.seeseemelk.mockbukkit.inventory.BeaconInventoryMock;
 import be.seeseemelk.mockbukkit.inventory.BrewerInventoryMock;
 import be.seeseemelk.mockbukkit.inventory.CartographyInventoryMock;
+import be.seeseemelk.mockbukkit.inventory.ChestInventoryMock;
 import be.seeseemelk.mockbukkit.inventory.DispenserInventoryMock;
 import be.seeseemelk.mockbukkit.inventory.DropperInventoryMock;
 import be.seeseemelk.mockbukkit.inventory.EnchantingInventoryMock;
@@ -90,7 +91,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.spigotmc.event.player.PlayerSpawnLocationEvent;
 
 import javax.imageio.ImageIO;
-import java.awt.Graphics2D;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -1313,6 +1314,18 @@ class ServerMockTest
 	}
 
 	@Test
+	void testCreateChestInventory()
+	{
+		assertInstanceOf(ChestInventoryMock.class, server.createInventory(null, InventoryType.CHEST, "", 9));
+	}
+
+	@Test
+	void testCreateChestInventory_GivenInvalidSize()
+	{
+		assertThrows(IllegalArgumentException.class, () -> server.createInventory(null, InventoryType.CHEST, "", 10));
+	}
+
+	@Test
 	void testCreatePlayerInventory()
 	{
 		PlayerMock playerMock = server.addPlayer();
@@ -1719,14 +1732,14 @@ class ServerMockTest
 	}
 
 	@Test
-	void testGetTags_blockRegistry() 
+	void testGetTags_blockRegistry()
 	{
 		Iterable<Tag<Material>> blockTags = server.getTags(Tag.REGISTRY_BLOCKS, Material.class);
 		assertTrue(blockTags.iterator().hasNext());
 	}
 
 	@Test
-	void testGetTags_itemRegistry() 
+	void testGetTags_itemRegistry()
 	{
 		Iterable<Tag<Material>> itemTags = server.getTags(Tag.REGISTRY_ITEMS, Material.class);
 		assertTrue(itemTags.iterator().hasNext());

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -91,7 +91,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.spigotmc.event.player.PlayerSpawnLocationEvent;
 
 import javax.imageio.ImageIO;
-import java.awt.*;
+import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.File;

--- a/src/test/java/be/seeseemelk/mockbukkit/WorldMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/WorldMockTest.java
@@ -58,6 +58,7 @@ import be.seeseemelk.mockbukkit.entity.PandaMock;
 import be.seeseemelk.mockbukkit.entity.ParrotMock;
 import be.seeseemelk.mockbukkit.entity.PigMock;
 import be.seeseemelk.mockbukkit.entity.PigZombieMock;
+import be.seeseemelk.mockbukkit.entity.PillagerMock;
 import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import be.seeseemelk.mockbukkit.entity.PolarBearMock;
 import be.seeseemelk.mockbukkit.entity.PoweredMinecartMock;
@@ -1334,7 +1335,8 @@ class WorldMockTest
 				Arguments.of(EntityType.SPECTRAL_ARROW, SpectralArrow.class),
 				Arguments.of(EntityType.ARROW, Arrow.class),
 				Arguments.of(EntityType.MARKER, MarkerMock.class),
-				Arguments.of(EntityType.END_CRYSTAL, EnderCrystalMock.class)
+				Arguments.of(EntityType.END_CRYSTAL, EnderCrystalMock.class),
+				Arguments.of(EntityType.PILLAGER, PillagerMock.class)
 		);
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PillagerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PillagerMockTest.java
@@ -1,0 +1,52 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import org.bukkit.Sound;
+import org.bukkit.inventory.Inventory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class PillagerMockTest
+{
+
+	private ServerMock server;
+	private PillagerMock pillager;
+
+	@BeforeEach
+	void setUp()
+	{
+		server = MockBukkit.mock();
+		pillager = new PillagerMock(server, UUID.randomUUID());
+	}
+
+	@AfterEach
+	void tearDown()
+	{
+		MockBukkit.unmock();
+	}
+
+	@Test
+	void getCelebrationSound()
+	{
+		assertEquals(Sound.ENTITY_PILLAGER_CELEBRATE, pillager.getCelebrationSound());
+	}
+
+	@Test
+	void getInventory()
+	{
+		Inventory inventory = pillager.getInventory();
+
+		assertNotNull(inventory);
+		assertEquals(5, inventory.getSize());
+		assertSame(inventory, pillager.getInventory());
+	}
+
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PillagerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PillagerMockTest.java
@@ -2,9 +2,12 @@ package be.seeseemelk.mockbukkit.entity;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
+import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,6 +16,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 class PillagerMockTest
@@ -60,6 +64,20 @@ class PillagerMockTest
 	void getEyeHeight_GivenDefaultPosition()
 	{
 		assertEquals(1.6575, pillager.getEyeHeight());
+	}
+
+	@Test
+	void finalizeSpawn_ShouldEquipCrossBowInMainHand() {
+
+		ItemStack crossbow = pillager.getInventory().getItem(EquipmentSlot.HAND.ordinal());
+		assertNull(crossbow);
+
+		pillager.finalizeSpawn();
+
+		crossbow = pillager.getInventory().getItem(EquipmentSlot.HAND.ordinal());
+		assertNotNull(crossbow);
+		assertEquals(1, crossbow.getAmount());
+		assertEquals(Material.CROSSBOW, crossbow.getType());
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PillagerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PillagerMockTest.java
@@ -3,6 +3,7 @@ package be.seeseemelk.mockbukkit.entity;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import org.bukkit.Sound;
+import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.Inventory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +48,18 @@ class PillagerMockTest
 		assertNotNull(inventory);
 		assertEquals(5, inventory.getSize());
 		assertSame(inventory, pillager.getInventory());
+	}
+
+	@Test
+	void getType()
+	{
+		assertEquals(EntityType.PILLAGER, pillager.getType());
+	}
+
+	@Test
+	void getEyeHeight_GivenDefaultPosition()
+	{
+		assertEquals(1.6575, pillager.getEyeHeight());
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/ChestInventoryMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/ChestInventoryMockTest.java
@@ -2,15 +2,20 @@ package be.seeseemelk.mockbukkit.inventory;
 
 import be.seeseemelk.mockbukkit.MockBukkitExtension;
 import org.bukkit.Material;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Arrays;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockBukkitExtension.class)
@@ -23,6 +28,34 @@ class ChestInventoryMockTest
 	void setUp()
 	{
 		this.inventory = new ChestInventoryMock(null, 9);
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = { 9, 18, 27, 36, 45, 54 })
+	void constructor_SetsSize(int size)
+	{
+		assertEquals(size, new ChestInventoryMock(null, size).getSize());
+	}
+
+	@Test
+	void constructor_SetsSizeTooSmall()
+	{
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new ChestInventoryMock(null, -1));
+		assertEquals("Inventory size has to be > 0", e.getMessage());
+	}
+
+	@Test
+	void constructor_SetsSizeTooBig()
+	{
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new ChestInventoryMock(null, 63));
+		assertEquals("Size for custom inventory must be a multiple of 9 between 9 and 54 slots (got 63)", e.getMessage());
+	}
+
+	@Test
+	void constructor_SetsSizeTooNotDivisibleByNine()
+	{
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new ChestInventoryMock(null, 10));
+		assertEquals("Size for custom inventory must be a multiple of 9 between 9 and 54 slots (got 10)", e.getMessage());
 	}
 
 	@Test

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/InventoryMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/InventoryMockTest.java
@@ -61,18 +61,6 @@ class InventoryMockTest
 	}
 
 	@Test
-	void constructor_SetsSizeTooBig()
-	{
-		assertThrows(IllegalArgumentException.class, () -> new SimpleInventoryMock(null, 63, InventoryType.CHEST));
-	}
-
-	@Test
-	void constructor_SetsSizeTooNotDivisibleByNine()
-	{
-		assertThrows(IllegalArgumentException.class, () -> new SimpleInventoryMock(null, 10, InventoryType.CHEST));
-	}
-
-	@Test
 	void constructor_SetsSizeTwoParamConstructor()
 	{
 		assertEquals(10, new SimpleInventoryMock(null, InventoryType.WORKBENCH).getSize());


### PR DESCRIPTION
# Description
Implemented mocks for [Illager](https://jd.papermc.io/paper/1.21.1/org/bukkit/entity/Illager.html) and [Pillager](https://jd.papermc.io/paper/1.21.1/org/bukkit/entity/Pillager.html).

A small refactor in InventoryMock was required, to support this change. In Paper, the Inventory does not have a restriction in sizes, only in CraftServer.
To resolve this, the validation was moved to ChestInventory.

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [X] Unit tests added (if applicable).

# Relates
- https://github.com/MockBukkit/MockBukkit/issues/825