### PR TITLE
Added mocks for Evoker and Illusioner

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/WorldMock.java
@@ -32,6 +32,7 @@ import be.seeseemelk.mockbukkit.entity.EnderPearlMock;
 import be.seeseemelk.mockbukkit.entity.EndermanMock;
 import be.seeseemelk.mockbukkit.entity.EndermiteMock;
 import be.seeseemelk.mockbukkit.entity.EntityMock;
+import be.seeseemelk.mockbukkit.entity.EvokerMock;
 import be.seeseemelk.mockbukkit.entity.ExperienceOrbMock;
 import be.seeseemelk.mockbukkit.entity.ExplosiveMinecartMock;
 import be.seeseemelk.mockbukkit.entity.FireworkMock;
@@ -45,6 +46,7 @@ import be.seeseemelk.mockbukkit.entity.GoatMock;
 import be.seeseemelk.mockbukkit.entity.GuardianMock;
 import be.seeseemelk.mockbukkit.entity.HopperMinecartMock;
 import be.seeseemelk.mockbukkit.entity.HorseMock;
+import be.seeseemelk.mockbukkit.entity.IllusionerMock;
 import be.seeseemelk.mockbukkit.entity.ItemDisplayMock;
 import be.seeseemelk.mockbukkit.entity.ItemEntityMock;
 import be.seeseemelk.mockbukkit.entity.LargeFireballMock;
@@ -170,6 +172,7 @@ import org.bukkit.entity.Enderman;
 import org.bukkit.entity.Endermite;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Evoker;
 import org.bukkit.entity.ExperienceOrb;
 import org.bukkit.entity.FallingBlock;
 import org.bukkit.entity.Firework;
@@ -184,6 +187,7 @@ import org.bukkit.entity.Golem;
 import org.bukkit.entity.Guardian;
 import org.bukkit.entity.Hanging;
 import org.bukkit.entity.Horse;
+import org.bukkit.entity.Illusioner;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.ItemDisplay;
 import org.bukkit.entity.ItemFrame;
@@ -1484,6 +1488,12 @@ public class WorldMock implements World
 		} else if (clazz == Vindicator.class)
 		{
 			return new VindicatorMock(server, UUID.randomUUID());
+		} else if (clazz == Evoker.class)
+		{
+			return new EvokerMock(server, UUID.randomUUID());
+		} else if (clazz == Illusioner.class)
+		{
+			return new IllusionerMock(server, UUID.randomUUID());
 		}
 		throw new UnimplementedOperationException();
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EvokerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EvokerMock.java
@@ -1,0 +1,104 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.ServerMock;
+import org.bukkit.Sound;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Evoker;
+import org.bukkit.entity.Sheep;
+import org.bukkit.entity.Spellcaster;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+/**
+ * Mock implementation of a {@link Evoker}.
+ *
+ * @see SpellcasterMock
+ */
+public class EvokerMock extends SpellcasterMock implements Evoker
+{
+	private Sheep wololoTarget;
+
+	/**
+	 * Constructs a new {@link EvokerMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
+	protected EvokerMock(@NotNull ServerMock server, @NotNull UUID uuid)
+	{
+		super(server, uuid);
+	}
+
+	@NotNull
+	@Override
+	public Evoker.Spell getCurrentSpell()
+	{
+		return toEvokerSpell(getSpell());
+	}
+
+	@Override
+	public void setCurrentSpell(@Nullable Evoker.Spell spell)
+	{
+		setSpell(toSpellcasterSpell(spell));
+	}
+
+	@Override
+	public @Nullable Sheep getWololoTarget()
+	{
+		return this.wololoTarget;
+	}
+
+	@Override
+	public void setWololoTarget(@Nullable Sheep sheep)
+	{
+		this.wololoTarget = sheep;
+	}
+
+	@Override
+	public @NotNull Sound getCelebrationSound()
+	{
+		return Sound.ENTITY_EVOKER_CELEBRATE;
+	}
+
+	@Override
+	public @NotNull EntityType getType()
+	{
+		return EntityType.EVOKER;
+	}
+
+	/**
+	 * Convert a {@link Evoker.Spell} into a {@link Spellcaster.Spell}.
+	 *
+	 * @param spell The spell to be converted.
+	 *
+	 * @return The converted spell.
+	 */
+	@NotNull
+	private static Spellcaster.Spell toSpellcasterSpell(@Nullable Evoker.Spell spell) {
+
+		if (spell == null) {
+			return Spellcaster.Spell.NONE;
+		}
+
+		return Spellcaster.Spell.values()[spell.ordinal()];
+	}
+
+	/**
+	 * Convert a {@link Spellcaster.Spell} into a {@link Evoker.Spell}.
+	 *
+	 * @param spell The spell to be converted.
+	 *
+	 * @return The converted spell.
+	 */
+	@NotNull
+	private static Evoker.Spell toEvokerSpell(@Nullable Spellcaster.Spell spell) {
+		if (spell == null) {
+			return Evoker.Spell.NONE;
+		}
+
+		return Evoker.Spell.values()[spell.ordinal()];
+	}
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/EvokerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/EvokerMock.java
@@ -26,7 +26,7 @@ public class EvokerMock extends SpellcasterMock implements Evoker
 	 * @param server The server to create the entity on.
 	 * @param uuid   The UUID of the entity.
 	 */
-	protected EvokerMock(@NotNull ServerMock server, @NotNull UUID uuid)
+	public EvokerMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/IllusionerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/IllusionerMock.java
@@ -1,0 +1,42 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.ServerMock;
+import org.bukkit.Sound;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Illusioner;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+/**
+ * Mock implementation of a {@link Illusioner}.
+ *
+ * @see SpellcasterMock
+ */
+public class IllusionerMock extends SpellcasterMock implements Illusioner, MockRangedEntity<IllusionerMock>
+{
+
+	/**
+	 * Constructs a new {@link IllusionerMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
+	protected IllusionerMock(@NotNull ServerMock server, @NotNull UUID uuid)
+	{
+		super(server, uuid);
+	}
+
+	@Override
+	public @NotNull Sound getCelebrationSound()
+	{
+		return Sound.ENTITY_ILLUSIONER_AMBIENT;
+	}
+
+	@Override
+	public @NotNull EntityType getType()
+	{
+		return EntityType.ILLUSIONER;
+	}
+
+}

--- a/src/main/java/be/seeseemelk/mockbukkit/entity/IllusionerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/IllusionerMock.java
@@ -22,7 +22,7 @@ public class IllusionerMock extends SpellcasterMock implements Illusioner, MockR
 	 * @param server The server to create the entity on.
 	 * @param uuid   The UUID of the entity.
 	 */
-	protected IllusionerMock(@NotNull ServerMock server, @NotNull UUID uuid)
+	public IllusionerMock(@NotNull ServerMock server, @NotNull UUID uuid)
 	{
 		super(server, uuid);
 	}

--- a/src/test/java/be/seeseemelk/mockbukkit/WorldMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/WorldMockTest.java
@@ -30,6 +30,7 @@ import be.seeseemelk.mockbukkit.entity.EnderCrystalMock;
 import be.seeseemelk.mockbukkit.entity.EnderPearlMock;
 import be.seeseemelk.mockbukkit.entity.EndermanMock;
 import be.seeseemelk.mockbukkit.entity.EndermiteMock;
+import be.seeseemelk.mockbukkit.entity.EvokerMock;
 import be.seeseemelk.mockbukkit.entity.ExperienceOrbMock;
 import be.seeseemelk.mockbukkit.entity.ExplosiveMinecartMock;
 import be.seeseemelk.mockbukkit.entity.FireballMock;
@@ -44,6 +45,7 @@ import be.seeseemelk.mockbukkit.entity.GoatMock;
 import be.seeseemelk.mockbukkit.entity.GuardianMock;
 import be.seeseemelk.mockbukkit.entity.HopperMinecartMock;
 import be.seeseemelk.mockbukkit.entity.HorseMock;
+import be.seeseemelk.mockbukkit.entity.IllusionerMock;
 import be.seeseemelk.mockbukkit.entity.ItemDisplayMock;
 import be.seeseemelk.mockbukkit.entity.ItemEntityMock;
 import be.seeseemelk.mockbukkit.entity.LeashHitchMock;
@@ -1343,7 +1345,9 @@ class WorldMockTest
 				Arguments.of(EntityType.PILLAGER, PillagerMock.class),
 				Arguments.of(EntityType.WITCH, WitchMock.class),
 				Arguments.of(EntityType.RAVAGER, RavagerMock.class),
-				Arguments.of(EntityType.VINDICATOR, VindicatorMock.class)
+				Arguments.of(EntityType.VINDICATOR, VindicatorMock.class),
+				Arguments.of(EntityType.EVOKER, EvokerMock.class),
+				Arguments.of(EntityType.ILLUSIONER, IllusionerMock.class)
 		);
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/EvokerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/EvokerMockTest.java
@@ -1,0 +1,107 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import org.bukkit.Sound;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Evoker;
+import org.bukkit.entity.Sheep;
+import org.bukkit.entity.Spellcaster;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EvokerMockTest
+{
+
+	private ServerMock server;
+	private EvokerMock evoker;
+
+	@BeforeEach
+	void setUp()
+	{
+		server = MockBukkit.mock();
+		evoker = new EvokerMock(server, UUID.randomUUID());
+	}
+
+	@AfterEach
+	void tearDown()
+	{
+		MockBukkit.unmock();
+	}
+
+	@Test
+	void getCurrentSpell_GivenDefaultValue()
+	{
+		assertEquals(Evoker.Spell.NONE, evoker.getCurrentSpell());
+		assertEquals(Spellcaster.Spell.NONE, evoker.getSpell());
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"NONE, NONE",
+			"SUMMON, SUMMON_VEX",
+			"FANGS, FANGS",
+			"WOLOLO, WOLOLO",
+			"DISAPPEAR, DISAPPEAR",
+			"BLINDNESS, BLINDNESS"
+	})
+	void getCurrentSpell_GivenValidValues(Evoker.Spell evokerSpell, Spellcaster.Spell spellcasterSpell)
+	{
+		evoker.setCurrentSpell(evokerSpell);
+		assertEquals(evokerSpell, evoker.getCurrentSpell());
+		assertEquals(spellcasterSpell, evoker.getSpell());
+	}
+
+	@Test
+	void setSpell_GivenNullValue()
+	{
+		evoker.setCurrentSpell(null);
+		assertEquals(Evoker.Spell.NONE, evoker.getCurrentSpell());
+		assertEquals(Spellcaster.Spell.NONE, evoker.getSpell());
+	}
+
+	@Test
+	void getWololoTarget_GivenDefaultValue()
+	{
+		assertNull(evoker.getWololoTarget());
+	}
+
+	@Test
+	void getWololoTarget_GivenChangedValue()
+	{
+		Sheep sheep = new SheepMock(server, UUID.randomUUID());
+		evoker.setWololoTarget(sheep);
+
+		Sheep actual = evoker.getWololoTarget();
+
+		assertEquals(sheep, actual);
+		assertSame(sheep, actual);
+	}
+
+	@Test
+	void getCelebrationSound()
+	{
+		assertEquals(Sound.ENTITY_EVOKER_CELEBRATE, evoker.getCelebrationSound());
+	}
+
+	@Test
+	void getEyeHeight_GivenDefaultValue()
+	{
+		assertEquals(1.6575D, evoker.getEyeHeight());
+	}
+
+	@Test
+	void getType()
+	{
+		assertEquals(EntityType.EVOKER, evoker.getType());
+	}
+
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/IllusionerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/IllusionerMockTest.java
@@ -1,0 +1,52 @@
+package be.seeseemelk.mockbukkit.entity;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import org.bukkit.Sound;
+import org.bukkit.entity.EntityType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class IllusionerMockTest
+{
+
+	private ServerMock server;
+	private IllusionerMock illusioner;
+
+	@BeforeEach
+	void setUp()
+	{
+		server = MockBukkit.mock();
+		illusioner = new IllusionerMock(server, UUID.randomUUID());
+	}
+
+	@AfterEach
+	void tearDown()
+	{
+		MockBukkit.unmock();
+	}
+
+	@Test
+	void getCelebrationSound()
+	{
+		assertEquals(Sound.ENTITY_ILLUSIONER_AMBIENT, illusioner.getCelebrationSound());
+	}
+
+	@Test
+	void getEyeHeight_GivenDefaultValue()
+	{
+		assertEquals(1.6575D, illusioner.getEyeHeight());
+	}
+
+	@Test
+	void getType()
+	{
+		assertEquals(EntityType.ILLUSIONER, illusioner.getType());
+	}
+
+}


### PR DESCRIPTION
# Description
Implemented mocks for [Evoker](https://jd.papermc.io/paper/1.21.1/org/bukkit/entity/Evoker.html) and [Illusioner](https://jd.papermc.io/paper/1.21.1/org/bukkit/entity/Illusioner.html).

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [X] Unit tests added (if applicable).

# Relates
- https://github.com/MockBukkit/MockBukkit/issues/825