### PR TITLE
Remove `minecraft:` string from translation key in enchantment mock

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/enchantments/EnchantmentMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/enchantments/EnchantmentMock.java
@@ -45,7 +45,7 @@ public class EnchantmentMock extends Enchantment
 	private final int[] minModifiedCosts;
 	private int maxLevel;
 	private int startLevel;
-	private final NamespacedKey translationKey;
+	private final String translationKey;
 	private final int anvilCost;
 
 	/**
@@ -66,7 +66,7 @@ public class EnchantmentMock extends Enchantment
 	public EnchantmentMock(NamespacedKey key, boolean treasure, boolean cursed, int maxLevel,
 						   int startLevel, String name, Component[] displayNames, int[] minModifiedCost,
 						   int[] maxModifiedCost, boolean tradeable, boolean discoverable,
-						   Set<NamespacedKey> conflicts, Set<NamespacedKey> enchantables, NamespacedKey translationKey,
+						   Set<NamespacedKey> conflicts, Set<NamespacedKey> enchantables, String translationKey,
 						   int anvilCost)
 	{
 		this.key = key;
@@ -108,7 +108,7 @@ public class EnchantmentMock extends Enchantment
 		this.discoverable = data.get("discoverable").getAsBoolean();
 		this.conflicts = getConflicts(data.get("conflicts").getAsJsonArray());
 		this.enchantables = getEnchantables(data.get("enchantable").getAsJsonArray());
-		this.translationKey = NamespacedKey.fromString(data.get("translationKey").getAsString());
+		this.translationKey = data.get("translationKey").getAsString();
 		this.anvilCost = data.get("anvilCost").getAsInt();
 	}
 
@@ -191,7 +191,7 @@ public class EnchantmentMock extends Enchantment
 	// be a translatable component which is not guaranteed.
 	public @NotNull String translationKey()
 	{
-		return translationKey.toString();
+		return translationKey;
 	}
 
 	@Override
@@ -338,7 +338,7 @@ public class EnchantmentMock extends Enchantment
 		boolean discoverable = data.get("discoverable").getAsBoolean();
 		Set<NamespacedKey> conflicts = getConflicts(data.get("conflicts").getAsJsonArray());
 		Set<NamespacedKey> enchantables = getEnchantables(data.get("enchantables").getAsJsonArray());
-		NamespacedKey translationKey = NamespacedKey.fromString(data.get("translationKey").getAsString());
+		String translationKey = data.get("translationKey").getAsString();
 		int anvilCost = data.get("anvilCost").getAsInt();
 		return new EnchantmentMock(key, treasure, cursed, maxLevel, startLevel, name, displayNames, minModifiedCosts,
 				maxModifiedCosts, tradeable, discoverable, conflicts, enchantables, translationKey, anvilCost);

--- a/src/main/java/be/seeseemelk/mockbukkit/enchantments/EnchantmentMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/enchantments/EnchantmentMock.java
@@ -89,7 +89,7 @@ public class EnchantmentMock extends Enchantment
 	/**
 	 * @param data Json data
 	 * @deprecated Use {@link #EnchantmentMock(NamespacedKey, boolean, boolean, int, int, String, Component[], int[],
-	 * int[], boolean, boolean, Set, Set, NamespacedKey, int)}
+	 * int[], boolean, boolean, Set, Set, String, int)}
 	 * instead.
 	 */
 	@Deprecated(forRemoval = true)

--- a/src/test/java/be/seeseemelk/mockbukkit/enchantments/EnchantmentMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/enchantments/EnchantmentMockTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -37,7 +36,7 @@ class EnchantmentMockTest
 	private int[] maxModifiedCost;
 	private EnchantmentMock enchantment;
 	private Set<NamespacedKey> enchantables;
-	private NamespacedKey translationKey;
+	private String translationKey;
 	private int anvilCost;
 
 	public static Stream<Integer> getAvailableLevels()
@@ -56,7 +55,7 @@ class EnchantmentMockTest
 		this.minModifiedCost = new int[]{ 1, 2 };
 		this.maxModifiedCost = new int[]{ 20, 25 };
 		this.enchantables = Set.of(NamespacedKey.minecraft("trident"));
-		this.translationKey = new NamespacedKey(NAMESPACE, "translation_key");
+		this.translationKey = "translation_key";
 		this.anvilCost = 3;
 		this.enchantment = new EnchantmentMock(key, true, true, maxLevel, minLevel, name, displayNames, minModifiedCost,
 				maxModifiedCost, true, true, Set.of(key), enchantables, translationKey, anvilCost);
@@ -189,13 +188,13 @@ class EnchantmentMockTest
 	@Test
 	void testTranslationKey()
 	{
-		assertEquals(translationKey.toString(), enchantment.getTranslationKey());
+		assertEquals(translationKey, enchantment.translationKey());
 	}
 
 	@Test
 	void testGetTranslationKey()
 	{
-		assertEquals(translationKey.toString(), enchantment.getTranslationKey());
+		assertEquals(translationKey, enchantment.getTranslationKey());
 	}
 
 	@Test


### PR DESCRIPTION
# Description
Patches the changes in pr #1087 related to translation keys

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
