### PR TITLE
Translation keys for remaining keyed mocks

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/damage/DamageTypeMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/damage/DamageTypeMock.java
@@ -1,6 +1,5 @@
 package be.seeseemelk.mockbukkit.damage;
 
-import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;
 import org.bukkit.NamespacedKey;
@@ -10,6 +9,7 @@ import org.bukkit.damage.DamageEffect;
 import org.bukkit.damage.DamageScaling;
 import org.bukkit.damage.DamageType;
 import org.bukkit.damage.DeathMessageType;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 public class DamageTypeMock implements DamageType
@@ -21,23 +21,15 @@ public class DamageTypeMock implements DamageType
 	static final String DAMAGE_SCALING = "damageScaling";
 	static final String KEY = "key";
 
-	/**
-	 * Create a {@link DamageTypeMock} from a {@link JsonObject}.
-	 * <p>
-	 * Example:
-	 * <pre>
-	 * {
-	 *       "key": "minecraft:in_fire",
-	 *       "damageScaling": "WHEN_CAUSED_BY_LIVING_NON_PLAYER",
-	 *       "sound": "minecraft:entity.player.hurt_on_fire",
-	 *       "deathMessageType": "DEFAULT",
-	 *       "exhaustion": 0.1
-	 * }
-	 * </pre>
-	 *
-	 * @param data The json data.
-	 * @return The damage type created from the JSON
-	 */
+
+	private final DamageScaling damageScaling;
+	private final DamageEffectMock damageEffect;
+	private final NamespacedKey key;
+	private final DeathMessageType deathMessageType;
+	private final float exhaustion;
+	private final String translationKey;
+
+	@ApiStatus.Internal
 	public static DamageTypeMock from(JsonObject data)
 	{
 		Preconditions.checkArgument(data != null, "JsonObject can't be null");
@@ -60,18 +52,12 @@ public class DamageTypeMock implements DamageType
 		Sound sound = Registry.SOUNDS.get(NamespacedKey.fromString(soundValue));
 		DamageEffectMock damageEffect = new DamageEffectMock(sound);
 		DeathMessageType deathMessageType = DeathMessageType.valueOf(deathMessageTypeValue);
-
-		// Create object
-		return new DamageTypeMock(damageScaling, damageEffect, key, deathMessageType, exhaustion);
+		String translationKey = data.get("translationKey").getAsString();
+		return new DamageTypeMock(damageScaling, damageEffect, key, deathMessageType, exhaustion, translationKey);
 	}
 
-	private final DamageScaling damageScaling;
-	private final DamageEffectMock damageEffect;
-	private final NamespacedKey key;
-	private final DeathMessageType deathMessageType;
-	private final float exhaustion;
-
-	public DamageTypeMock(@NotNull DamageScaling damageScaling, @NotNull DamageEffectMock damageEffect, @NotNull NamespacedKey key, @NotNull DeathMessageType deathMessageType, float exhaustion)
+	@ApiStatus.Internal
+	public DamageTypeMock(@NotNull DamageScaling damageScaling, @NotNull DamageEffectMock damageEffect, @NotNull NamespacedKey key, @NotNull DeathMessageType deathMessageType, float exhaustion, String translationKey)
 	{
 		Preconditions.checkArgument(damageScaling != null, "DamageScaling cannot be null");
 		Preconditions.checkArgument(damageEffect != null, "DamageEffectMock cannot be null");
@@ -83,11 +69,9 @@ public class DamageTypeMock implements DamageType
 		this.key = key;
 		this.deathMessageType = deathMessageType;
 		this.exhaustion = exhaustion;
+		this.translationKey = translationKey;
 	}
 
-	/**
-	 * @deprecated Will be replaced with {{@link #from(JsonObject)}}.
-	 */
 	@Deprecated(forRemoval = true)
 	public DamageTypeMock(JsonObject data)
 	{
@@ -97,12 +81,13 @@ public class DamageTypeMock implements DamageType
 		this.key = NamespacedKey.fromString(data.get("key").getAsString());
 		this.deathMessageType = DeathMessageType.valueOf(data.get("deathMessageType").getAsString());
 		this.exhaustion = data.get("exhaustion").getAsFloat();
+		this.translationKey = data.get("translationKey").getAsString();
 	}
 
 	@Override
 	public @NotNull String getTranslationKey()
 	{
-		throw new UnimplementedOperationException();
+		return translationKey;
 	}
 
 	@Override

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimMaterialMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimMaterialMock.java
@@ -1,6 +1,5 @@
 package be.seeseemelk.mockbukkit.inventory.meta.trim;
 
-import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;
 import net.kyori.adventure.text.Component;
@@ -15,26 +14,26 @@ public class TrimMaterialMock implements TrimMaterial
 
 	private final NamespacedKey key;
 	private final Component description;
+	private final String translationKey;
 
-	/**
-	 * @param key         The namespaced key representing this trim material
-	 * @param description The description of this trim material
-	 */
-	public TrimMaterialMock(NamespacedKey key, Component description)
+
+	@ApiStatus.Internal
+	public TrimMaterialMock(NamespacedKey key, Component description, String translationKey)
 	{
 		this.key = key;
 		this.description = description;
+		this.translationKey = translationKey;
 	}
 
 	/**
 	 * @param data Json data
-	 * @deprecated Use {@link #TrimMaterialMock(NamespacedKey, Component)} instead
 	 */
 	@Deprecated(forRemoval = true)
 	public TrimMaterialMock(JsonObject data)
 	{
 		this.key = NamespacedKey.fromString(data.get("key").getAsString());
 		this.description = GsonComponentSerializer.gson().deserializeFromTree(data.get("description"));
+		this.translationKey = data.get("translationKey").getAsString();
 	}
 
 	@Override
@@ -46,7 +45,7 @@ public class TrimMaterialMock implements TrimMaterial
 	@Override
 	public @NotNull String getTranslationKey()
 	{
-		throw new UnimplementedOperationException();
+		return this.translationKey;
 	}
 
 	@Override
@@ -62,7 +61,8 @@ public class TrimMaterialMock implements TrimMaterial
 		Preconditions.checkArgument(data.has("key"), "Missing json key");
 		NamespacedKey key = NamespacedKey.fromString(data.get("key").getAsString());
 		Component description = GsonComponentSerializer.gson().deserializeFromTree(data.get("description"));
-		return new TrimMaterialMock(key, description);
+		String translationKey = data.get("translationKey").getAsString();
+		return new TrimMaterialMock(key, description, translationKey);
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimPatternMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimPatternMock.java
@@ -1,6 +1,5 @@
 package be.seeseemelk.mockbukkit.inventory.meta.trim;
 
-import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;
 import net.kyori.adventure.text.Component;
@@ -15,25 +14,26 @@ public class TrimPatternMock implements TrimPattern
 
 	private final NamespacedKey key;
 	private final Component description;
+	private final String translationKey;
 
-	/**
-	 * @param key The namespaced key representing this pattern
-	 */
-	public TrimPatternMock(NamespacedKey key, Component description)
+	
+	@ApiStatus.Internal
+	public TrimPatternMock(NamespacedKey key, Component description, String translationKey)
 	{
 		this.key = key;
 		this.description = description;
+		this.translationKey = translationKey;
 	}
 
 	/**
 	 * @param data Json data
-	 * @deprecated Use {@link #TrimPatternMock(NamespacedKey, Component)} instead
 	 */
 	@Deprecated(forRemoval = true)
 	public TrimPatternMock(JsonObject data)
 	{
 		this.key = NamespacedKey.fromString(data.get("key").getAsString());
 		this.description = GsonComponentSerializer.gson().deserializeFromTree(data.get("description"));
+		this.translationKey = data.get("translationKey").getAsString();
 	}
 
 	@Override
@@ -45,7 +45,7 @@ public class TrimPatternMock implements TrimPattern
 	@Override
 	public @NotNull String getTranslationKey()
 	{
-		throw new UnimplementedOperationException();
+		return this.translationKey;
 	}
 
 	@Override
@@ -61,7 +61,8 @@ public class TrimPatternMock implements TrimPattern
 		Preconditions.checkArgument(data.has("key"), "Missing json key");
 		NamespacedKey key = NamespacedKey.fromString(data.get("key").getAsString());
 		Component description = GsonComponentSerializer.gson().deserializeFromTree(data.get("description"));
-		return new TrimPatternMock(key, description);
+		String translationKey = data.get("translationKey").getAsString();
+		return new TrimPatternMock(key, description, translationKey);
 	}
 
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/damage/DamageSourceMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/damage/DamageSourceMockTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class DamageSourceMockTest
 {
 
-	private final Location damageLocation = new Location(new WorldMock(), 0,0,0);
+	private final Location damageLocation = new Location(new WorldMock(), 0, 0, 0);
 
 	private ServerMock serverMock;
 	private DamageType damageType;
@@ -161,7 +161,7 @@ class DamageSourceMockTest
 	{
 
 		DamageEffectMock damageEffect = new DamageEffectMock(Sound.ENTITY_ZOMBIE_HURT);
-		DamageTypeMock neverDamage = new DamageTypeMock(DamageScaling.NEVER, damageEffect, NamespacedKey.fromString(NamespacedKey.MINECRAFT), DeathMessageType.DEFAULT, 0.1F);
+		DamageTypeMock neverDamage = new DamageTypeMock(DamageScaling.NEVER, damageEffect, NamespacedKey.fromString(NamespacedKey.MINECRAFT), DeathMessageType.DEFAULT, 0.1F, "test");
 		DamageSourceMock damageSource = new DamageSourceMock(neverDamage, causingEntity, causingEntity, damageLocation);
 
 		boolean actual = damageSource.scalesWithDifficulty();

--- a/src/test/java/be/seeseemelk/mockbukkit/damage/DamageTypeMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/damage/DamageTypeMockTest.java
@@ -28,6 +28,7 @@ class DamageTypeMockTest
 		json.addProperty(DamageTypeMock.DAMAGE_SCALING, expectedDamageType.damageScaling());
 		json.addProperty(DamageTypeMock.KEY, expectedDamageType.key());
 		json.addProperty(DamageTypeMock.SOUND, expectedDamageType.sound());
+		json.addProperty("translationKey", "mockbukkit.placeholder");
 
 		DamageTypeMock actual = DamageTypeMock.from(json);
 

--- a/src/test/java/be/seeseemelk/mockbukkit/damage/DamageTypeMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/damage/DamageTypeMockTest.java
@@ -2,6 +2,8 @@ package be.seeseemelk.mockbukkit.damage;
 
 import be.seeseemelk.mockbukkit.MockBukkitExtension;
 import com.google.gson.JsonObject;
+import org.bukkit.damage.DamageType;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -14,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ExtendWith(MockBukkitExtension.class)
 class DamageTypeMockTest
 {
+
 	@ParameterizedTest
 	@MethodSource("getMinecraftDamageTypes")
 	void from_GivenMinecraftExamples(ExpectedDamageType expectedDamageType)
@@ -37,6 +40,13 @@ class DamageTypeMockTest
 
 	record ExpectedDamageType(String key, String damageScaling, String sound, String deathMessageType, float exhaustion)
 	{
+
+	}
+
+	@Test
+	void translationKey()
+	{
+		assertEquals("arrow", DamageType.ARROW.getTranslationKey());
 	}
 
 	/**
@@ -47,50 +57,50 @@ class DamageTypeMockTest
 	public static Stream<Arguments> getMinecraftDamageTypes()
 	{
 		return Stream.of(
-			Arguments.of(new ExpectedDamageType("minecraft:in_fire","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt_on_fire", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:lightning_bolt","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:on_fire","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt_on_fire", "DEFAULT", 0.0F)),
-			Arguments.of(new ExpectedDamageType("minecraft:lava","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt_on_fire", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:hot_floor","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt_on_fire", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:in_wall","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
-			Arguments.of(new ExpectedDamageType("minecraft:cramming","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
-			Arguments.of(new ExpectedDamageType("minecraft:drown","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt_drown", "DEFAULT", 0.0F)),
-			Arguments.of(new ExpectedDamageType("minecraft:starve","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
-			Arguments.of(new ExpectedDamageType("minecraft:cactus","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:fall","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "FALL_VARIANTS", 0.0F)),
-			Arguments.of(new ExpectedDamageType("minecraft:fly_into_wall","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
-			Arguments.of(new ExpectedDamageType("minecraft:out_of_world","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
-			Arguments.of(new ExpectedDamageType("minecraft:generic","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
-			Arguments.of(new ExpectedDamageType("minecraft:magic","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
-			Arguments.of(new ExpectedDamageType("minecraft:wither","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
-			Arguments.of(new ExpectedDamageType("minecraft:dragon_breath","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
-			Arguments.of(new ExpectedDamageType("minecraft:dry_out","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:sweet_berry_bush","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt_sweet_berry_bush", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:freeze","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt_freeze", "DEFAULT", 0.0F)),
-			Arguments.of(new ExpectedDamageType("minecraft:stalagmite","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
-			Arguments.of(new ExpectedDamageType("minecraft:falling_block","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:falling_anvil","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:falling_stalactite","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:sting","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:mob_attack","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:mob_attack_no_aggro","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:player_attack","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:arrow","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:trident","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:mob_projectile","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:fireworks","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:fireball","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt_on_fire", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:unattributed_fireball","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt_on_fire", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:wither_skull","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:thrown","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:indirect_magic","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
-			Arguments.of(new ExpectedDamageType("minecraft:thorns","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:enchant.thorns.hit", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:explosion","ALWAYS","minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:player_explosion","ALWAYS","minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:sonic_boom","ALWAYS","minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
-			Arguments.of(new ExpectedDamageType("minecraft:bad_respawn_point","ALWAYS","minecraft:entity.player.hurt", "INTENTIONAL_GAME_DESIGN", 0.1F)),
-			Arguments.of(new ExpectedDamageType("minecraft:outside_border","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
-			Arguments.of(new ExpectedDamageType("minecraft:generic_kill","WHEN_CAUSED_BY_LIVING_NON_PLAYER","minecraft:entity.player.hurt", "DEFAULT", 0.0F))
+				Arguments.of(new ExpectedDamageType("minecraft:in_fire", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt_on_fire", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:lightning_bolt", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:on_fire", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt_on_fire", "DEFAULT", 0.0F)),
+				Arguments.of(new ExpectedDamageType("minecraft:lava", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt_on_fire", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:hot_floor", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt_on_fire", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:in_wall", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
+				Arguments.of(new ExpectedDamageType("minecraft:cramming", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
+				Arguments.of(new ExpectedDamageType("minecraft:drown", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt_drown", "DEFAULT", 0.0F)),
+				Arguments.of(new ExpectedDamageType("minecraft:starve", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
+				Arguments.of(new ExpectedDamageType("minecraft:cactus", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:fall", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "FALL_VARIANTS", 0.0F)),
+				Arguments.of(new ExpectedDamageType("minecraft:fly_into_wall", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
+				Arguments.of(new ExpectedDamageType("minecraft:out_of_world", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
+				Arguments.of(new ExpectedDamageType("minecraft:generic", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
+				Arguments.of(new ExpectedDamageType("minecraft:magic", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
+				Arguments.of(new ExpectedDamageType("minecraft:wither", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
+				Arguments.of(new ExpectedDamageType("minecraft:dragon_breath", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
+				Arguments.of(new ExpectedDamageType("minecraft:dry_out", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:sweet_berry_bush", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt_sweet_berry_bush", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:freeze", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt_freeze", "DEFAULT", 0.0F)),
+				Arguments.of(new ExpectedDamageType("minecraft:stalagmite", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
+				Arguments.of(new ExpectedDamageType("minecraft:falling_block", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:falling_anvil", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:falling_stalactite", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:sting", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:mob_attack", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:mob_attack_no_aggro", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:player_attack", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:arrow", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:trident", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:mob_projectile", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:fireworks", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:fireball", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt_on_fire", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:unattributed_fireball", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt_on_fire", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:wither_skull", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:thrown", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:indirect_magic", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
+				Arguments.of(new ExpectedDamageType("minecraft:thorns", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:enchant.thorns.hit", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:explosion", "ALWAYS", "minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:player_explosion", "ALWAYS", "minecraft:entity.player.hurt", "DEFAULT", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:sonic_boom", "ALWAYS", "minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
+				Arguments.of(new ExpectedDamageType("minecraft:bad_respawn_point", "ALWAYS", "minecraft:entity.player.hurt", "INTENTIONAL_GAME_DESIGN", 0.1F)),
+				Arguments.of(new ExpectedDamageType("minecraft:outside_border", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.0F)),
+				Arguments.of(new ExpectedDamageType("minecraft:generic_kill", "WHEN_CAUSED_BY_LIVING_NON_PLAYER", "minecraft:entity.player.hurt", "DEFAULT", 0.0F))
 		);
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimMaterialMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimMaterialMockTest.java
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TrimMaterialMockTest
 {
@@ -34,6 +36,12 @@ class TrimMaterialMockTest
 	void getKey()
 	{
 		assertNotNull(TrimMaterial.QUARTZ.getKey());
+	}
+
+	@Test
+	void translationKey()
+	{
+		assertEquals("trim_material.minecraft.amethyst", TrimMaterial.AMETHYST.getTranslationKey());
 	}
 
 	@Test

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimPatternMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/meta/trim/TrimPatternMockTest.java
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TrimPatternMockTest
 {
@@ -34,6 +36,12 @@ class TrimPatternMockTest
 	void getKey()
 	{
 		assertNotNull(TrimPattern.SHAPER.getKey());
+	}
+
+	@Test
+	void translationKey()
+	{
+		assertEquals("trim_pattern.minecraft.eye", TrimPattern.EYE.getTranslationKey());
 	}
 
 	@Test


### PR DESCRIPTION
# Description
Adds translation keys for the remaining keyed classes (except for PotionEffectTypeMock, which has this done in a separate pr).

Also removed some comments and made the constructors @ApiStatus.Internal, as they seem to change all the time 

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
