### PR TITLE
fix(player): Throw UnsupportedOperationException when calling remove()

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/entity/PlayerMock.java
@@ -3382,6 +3382,12 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	}
 
 	@Override
+	public void remove()
+	{
+		throw new UnsupportedOperationException("Players can't be removed with this method, use kick() instead");
+	}
+
+	@Override
 	public Player.@NotNull Spigot spigot()
 	{
 		return playerSpigotMock;

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -2652,4 +2652,10 @@ class PlayerMockTest
 
 	}
 
+	@Test
+	void testRemove()
+	{
+		assertThrows(UnsupportedOperationException.class, () -> player.remove());
+	}
+
 }


### PR DESCRIPTION
Players can only be removed with kick()

# Description
According to [this commit](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/7580463199b892e909a7d9904d4482eebc63d643#src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java), removing Players with the `Player#remove()` Method throws an `UnsupportedOperationException`. This PR overrides this Method to throw this exact Exception

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
