### PR TITLE
Removed concurrency from test longRunningTask_Throws_RunTimeException

### DIFF
--- a/src/test/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/scheduler/BukkitSchedulerMockTest.java
@@ -287,12 +287,16 @@ class BukkitSchedulerMockTest
 	}
 
 	@Test
-	void longRunningTask_Throws_RunTimeException()
+	void longRunningTask_Throws_RunTimeException() throws InterruptedException
 	{
 		assertEquals(0, scheduler.getNumberOfQueuedAsyncTasks());
+
+		final CountDownLatch countDownLatch = new CountDownLatch(1);
 		final AtomicBoolean alive = new AtomicBoolean(true);
+
 		testTask = scheduler.runTaskAsynchronously(null, () ->
 		{
+			countDownLatch.countDown();
 			while (alive.get())
 			{
 				if (testTask.isCancelled())
@@ -311,6 +315,8 @@ class BukkitSchedulerMockTest
 				}
 			}
 		});
+		countDownLatch.await(1, TimeUnit.SECONDS);
+
 		assertTrue(alive.get());
 		assertEquals(1, scheduler.getActiveRunningCount());
 		scheduler.performTicks(10);


### PR DESCRIPTION
# Description
The test had concurrency issue, resulting in some failures as reported in https://github.com/MockBukkit/MockBukkit/issues/1134.

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [N/A] Unit tests added (if applicable).

# Fixes
- https://github.com/MockBukkit/MockBukkit/issues/1134
