### PR TITLE
Add a builder for MockPlugin

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/MockBukkit.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockBukkit.java
@@ -12,8 +12,6 @@ import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -22,7 +20,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 
@@ -270,10 +267,10 @@ public class MockBukkit
 	 * Loads and enables the Plugin with a specified Config File. It receives the {@code config.yml} as a InputStream
 	 * to load.
 	 *
-	 * @param <T>        The plugin's main class to load.
-	 * @param plugin     The plugin to load for mocking.
+	 * @param <T>          The plugin's main class to load.
+	 * @param plugin       The plugin to load for mocking.
 	 * @param configStream The {@code InputStream} of the {@code config.yml} file to load.
-	 * @param parameters Extra parameters to pass on to the plugin constructor.
+	 * @param parameters   Extra parameters to pass on to the plugin constructor.
 	 * @return An instance of the plugin's main class.
 	 * @apiNote The File name can't be the same as the one the plugin loads by default
 	 */
@@ -290,7 +287,7 @@ public class MockBukkit
 		}
 		catch (IOException | InvalidConfigurationException e)
 		{
-			throw new RuntimeException("Couldn't read config input stream",e);
+			throw new RuntimeException("Couldn't read config input stream", e);
 		}
 		return loadWithConfig(plugin, config, parameters);
 	}
@@ -438,7 +435,7 @@ public class MockBukkit
 	 */
 	public static @NotNull MockPlugin createMockPlugin()
 	{
-		return createMockPlugin("MockPlugin");
+		return MockPlugin.builder().build();
 	}
 
 	/**
@@ -450,7 +447,7 @@ public class MockBukkit
 	 */
 	public static @NotNull MockPlugin createMockPlugin(@NotNull String pluginName)
 	{
-		return createMockPlugin(pluginName, "1.0.0");
+		return MockPlugin.builder().withPluginName(pluginName).build();
 	}
 
 	/**
@@ -463,11 +460,7 @@ public class MockBukkit
 	 */
 	public static @NotNull MockPlugin createMockPlugin(@NotNull String pluginName, @NotNull String pluginVersion)
 	{
-		ensureMocking();
-		PluginDescriptionFile description = new PluginDescriptionFile(pluginName, pluginVersion, MockPlugin.class.getName());
-		JavaPlugin instance = mock.getPluginManager().loadPlugin(MockPlugin.class, description, new Object[0]);
-		mock.getPluginManager().enablePlugin(instance);
-		return (MockPlugin) instance;
+		return MockPlugin.builder().withPluginName(pluginName).withPluginVersion(pluginVersion).build();
 	}
 
 	/**

--- a/src/main/java/be/seeseemelk/mockbukkit/MockBukkit.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockBukkit.java
@@ -435,7 +435,7 @@ public class MockBukkit
 	 */
 	public static @NotNull MockPlugin createMockPlugin()
 	{
-		return MockPlugin.builder().build();
+		return createMockPlugin("MockPlugin");
 	}
 
 	/**
@@ -447,7 +447,7 @@ public class MockBukkit
 	 */
 	public static @NotNull MockPlugin createMockPlugin(@NotNull String pluginName)
 	{
-		return MockPlugin.builder().withPluginName(pluginName).build();
+		return createMockPlugin(pluginName, "1.0.0");
 	}
 
 	/**
@@ -460,7 +460,11 @@ public class MockBukkit
 	 */
 	public static @NotNull MockPlugin createMockPlugin(@NotNull String pluginName, @NotNull String pluginVersion)
 	{
-		return MockPlugin.builder().withPluginName(pluginName).withPluginVersion(pluginVersion).build();
+		ensureMocking();
+		PluginDescriptionFile description = new PluginDescriptionFile(pluginName, pluginVersion, MockPlugin.class.getName());
+		JavaPlugin instance = mock.getPluginManager().loadPlugin(MockPlugin.class, description, new Object[0]);
+		mock.getPluginManager().enablePlugin(instance);
+		return (MockPlugin) instance;
 	}
 
 	/**

--- a/src/main/java/be/seeseemelk/mockbukkit/MockPlugin.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockPlugin.java
@@ -1,5 +1,6 @@
 package be.seeseemelk.mockbukkit;
 
+import com.google.common.base.Preconditions;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.java.JavaPluginLoader;
@@ -53,32 +54,34 @@ public class MockPlugin extends JavaPlugin
 		{
 		}
 
-		public Builder withOnLoad(Runnable onLoad)
+		public Builder withOnLoad(@NotNull Runnable onLoad)
 		{
 			this.onLoad = Optional.of(onLoad);
 			return this;
 		}
 
-		public Builder withOnEnable(Runnable onEnable)
+		public Builder withOnEnable(@NotNull Runnable onEnable)
 		{
 			this.onEnable = Optional.of(onEnable);
 			return this;
 		}
 
-		public Builder withOnDisable(Runnable onDisable)
+		public Builder withOnDisable(@NotNull Runnable onDisable)
 		{
 			this.onDisable = Optional.of(onDisable);
 			return this;
 		}
 
-		public Builder withPluginName(String name)
+		public Builder withPluginName(@NotNull String name)
 		{
+			Preconditions.checkNotNull(name);
 			this.pluginName = name;
 			return this;
 		}
 
-		public Builder withPluginVersion(String version)
+		public Builder withPluginVersion(@NotNull String version)
 		{
+			Preconditions.checkNotNull(version);
 			this.pluginVersion = version;
 			return this;
 		}

--- a/src/main/java/be/seeseemelk/mockbukkit/MockPlugin.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockPlugin.java
@@ -127,43 +127,41 @@ public class MockPlugin extends JavaPlugin
 			return (MockPlugin) instance;
 		}
 
-		@ApiStatus.Internal
-		public static class InternalMockPlugin extends MockPlugin
-		{
-
-			private final Optional<Runnable> onEnable;
-			private final Optional<Runnable> onDisable;
-			private final Optional<Runnable> onLoad;
-
-			public InternalMockPlugin(Optional<Runnable> onEnable, Optional<Runnable> onDisable, Optional<Runnable> onLoad)
-			{
-				this.onEnable = onEnable;
-				this.onDisable = onDisable;
-				this.onLoad = onLoad;
-			}
-
-			@Override
-			public void onEnable()
-			{
-				onEnable.ifPresent(Runnable::run);
-			}
-
-			@Override
-			public void onDisable()
-			{
-				onDisable.ifPresent(Runnable::run);
-			}
-
-			@Override
-			public void onLoad()
-			{
-				onLoad.ifPresent(Runnable::run);
-			}
-
-		}
-
-
 	}
 
+	@ApiStatus.Internal
+	public static class InternalMockPlugin extends MockPlugin
+	{
+
+		private final Optional<Runnable> onEnable;
+		private final Optional<Runnable> onDisable;
+		private final Optional<Runnable> onLoad;
+
+		public InternalMockPlugin(Optional<Runnable> onEnable, Optional<Runnable> onDisable, Optional<Runnable> onLoad)
+		{
+			this.onEnable = onEnable;
+			this.onDisable = onDisable;
+			this.onLoad = onLoad;
+		}
+
+		@Override
+		public void onEnable()
+		{
+			onEnable.ifPresent(Runnable::run);
+		}
+
+		@Override
+		public void onDisable()
+		{
+			onDisable.ifPresent(Runnable::run);
+		}
+
+		@Override
+		public void onLoad()
+		{
+			onLoad.ifPresent(Runnable::run);
+		}
+
+	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/MockPlugin.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/MockPlugin.java
@@ -36,6 +36,11 @@ public class MockPlugin extends JavaPlugin
 		super(loader, description, dataFolder, file);
 	}
 
+	/**
+	 * Create a builder for mock plugins, allows for on enable, on disable code execution and so on
+	 *
+	 * @return A builder for mock plugin
+	 */
 	public static Builder builder()
 	{
 		return new Builder();
@@ -54,24 +59,40 @@ public class MockPlugin extends JavaPlugin
 		{
 		}
 
+		/**
+		 * @param onLoad What to run on load
+		 * @return This builder
+		 */
 		public Builder withOnLoad(@NotNull Runnable onLoad)
 		{
 			this.onLoad = Optional.of(onLoad);
 			return this;
 		}
 
+		/**
+		 * @param onEnable What to run on enable
+		 * @return This builder
+		 */
 		public Builder withOnEnable(@NotNull Runnable onEnable)
 		{
 			this.onEnable = Optional.of(onEnable);
 			return this;
 		}
 
+		/**
+		 * @param onDisable What to run on disable
+		 * @return This builder
+		 */
 		public Builder withOnDisable(@NotNull Runnable onDisable)
 		{
 			this.onDisable = Optional.of(onDisable);
 			return this;
 		}
 
+		/**
+		 * @param name The name of the plugin to build
+		 * @return This builder
+		 */
 		public Builder withPluginName(@NotNull String name)
 		{
 			Preconditions.checkNotNull(name);
@@ -79,6 +100,10 @@ public class MockPlugin extends JavaPlugin
 			return this;
 		}
 
+		/**
+		 * @param version The version of the blugin to build
+		 * @return This builder
+		 */
 		public Builder withPluginVersion(@NotNull String version)
 		{
 			Preconditions.checkNotNull(version);
@@ -86,51 +111,57 @@ public class MockPlugin extends JavaPlugin
 			return this;
 		}
 
+		/**
+		 * Build and initiate a new MockPlugin instance
+		 *
+		 * @return A mock plugin instance
+		 */
 		public MockPlugin build()
 		{
 			MockBukkit.ensureMocking();
 
 			PluginDescriptionFile description = new PluginDescriptionFile(pluginName, pluginVersion, InternalMockPlugin.class.getName());
 			ServerMock mock = MockBukkit.getMock();
-			JavaPlugin instance = mock.getPluginManager().loadPlugin(InternalMockPlugin.class, description, new Object[]{onEnable, onDisable, onLoad});
+			JavaPlugin instance = mock.getPluginManager().loadPlugin(InternalMockPlugin.class, description, new Object[]{ onEnable, onDisable, onLoad });
 			mock.getPluginManager().enablePlugin(instance);
 			return (MockPlugin) instance;
 		}
 
-	}
-
-	@ApiStatus.Internal
-	public static class InternalMockPlugin extends MockPlugin
-	{
-
-		private final Optional<Runnable> onEnable;
-		private final Optional<Runnable> onDisable;
-		private final Optional<Runnable> onLoad;
-
-		public InternalMockPlugin(Optional<Runnable> onEnable, Optional<Runnable> onDisable, Optional<Runnable> onLoad)
+		@ApiStatus.Internal
+		public static class InternalMockPlugin extends MockPlugin
 		{
-			this.onEnable = onEnable;
-			this.onDisable = onDisable;
-			this.onLoad = onLoad;
+
+			private final Optional<Runnable> onEnable;
+			private final Optional<Runnable> onDisable;
+			private final Optional<Runnable> onLoad;
+
+			public InternalMockPlugin(Optional<Runnable> onEnable, Optional<Runnable> onDisable, Optional<Runnable> onLoad)
+			{
+				this.onEnable = onEnable;
+				this.onDisable = onDisable;
+				this.onLoad = onLoad;
+			}
+
+			@Override
+			public void onEnable()
+			{
+				onEnable.ifPresent(Runnable::run);
+			}
+
+			@Override
+			public void onDisable()
+			{
+				onDisable.ifPresent(Runnable::run);
+			}
+
+			@Override
+			public void onLoad()
+			{
+				onLoad.ifPresent(Runnable::run);
+			}
+
 		}
 
-		@Override
-		public void onEnable()
-		{
-			onEnable.ifPresent(Runnable::run);
-		}
-
-		@Override
-		public void onDisable()
-		{
-			onDisable.ifPresent(Runnable::run);
-		}
-
-		@Override
-		public void onLoad()
-		{
-			onLoad.ifPresent(Runnable::run);
-		}
 
 	}
 

--- a/src/test/java/be/seeseemelk/mockbukkit/MockPluginTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/MockPluginTest.java
@@ -5,16 +5,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockBukkitExtension.class)
 class MockPluginTest
 {
+
 	@MockBukkitInject
 	ServerMock serverMock;
 
 	@Test
-	void onEnable_triggers(){
+	void onEnable_triggers()
+	{
 		AtomicBoolean trigger = new AtomicBoolean(false);
 		MockPlugin.Builder builder = MockPlugin.builder().withOnEnable(() -> trigger.set(true));
 		assertFalse(trigger.get());
@@ -23,7 +26,8 @@ class MockPluginTest
 	}
 
 	@Test
-	void onLoad_triggers(){
+	void onLoad_triggers()
+	{
 		AtomicBoolean trigger = new AtomicBoolean(false);
 		MockPlugin.Builder builder = MockPlugin.builder().withOnLoad(() -> trigger.set(true));
 		assertFalse(trigger.get());
@@ -32,7 +36,8 @@ class MockPluginTest
 	}
 
 	@Test
-	void onDisable_triggers(){
+	void onDisable_triggers()
+	{
 		AtomicBoolean trigger = new AtomicBoolean(false);
 		MockPlugin.Builder builder = MockPlugin.builder().withOnDisable(() -> trigger.set(true));
 		assertFalse(trigger.get());
@@ -41,4 +46,5 @@ class MockPluginTest
 		serverMock.getPluginManager().disablePlugins();
 		assertTrue(trigger.get());
 	}
+
 }

--- a/src/test/java/be/seeseemelk/mockbukkit/MockPluginTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/MockPluginTest.java
@@ -1,0 +1,44 @@
+package be.seeseemelk.mockbukkit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockBukkitExtension.class)
+class MockPluginTest
+{
+	@MockBukkitInject
+	ServerMock serverMock;
+
+	@Test
+	void onEnable_triggers(){
+		AtomicBoolean trigger = new AtomicBoolean(false);
+		MockPlugin.Builder builder = MockPlugin.builder().withOnEnable(() -> trigger.set(true));
+		assertFalse(trigger.get());
+		builder.build();
+		assertTrue(trigger.get());
+	}
+
+	@Test
+	void onLoad_triggers(){
+		AtomicBoolean trigger = new AtomicBoolean(false);
+		MockPlugin.Builder builder = MockPlugin.builder().withOnLoad(() -> trigger.set(true));
+		assertFalse(trigger.get());
+		builder.build();
+		assertTrue(trigger.get());
+	}
+
+	@Test
+	void onDisable_triggers(){
+		AtomicBoolean trigger = new AtomicBoolean(false);
+		MockPlugin.Builder builder = MockPlugin.builder().withOnDisable(() -> trigger.set(true));
+		assertFalse(trigger.get());
+		builder.build();
+		assertFalse(trigger.get());
+		serverMock.getPluginManager().disablePlugins();
+		assertTrue(trigger.get());
+	}
+}


### PR DESCRIPTION
# Description
I thought, maybe it could possibly be good to add custom onEnable / onDisable / onLoad functionality for the mock plugin. It's at least useful internally. Something like this would be necessary for pull request #1106 as something would need to execute before the plugin is fully enabled (although yeah, you could just make a new plugin for every individual test, but that's not ideal). Please just tell me if this a bad idea, and I will just close this and make a custom class instead.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
