### PR TITLE
Fix isSimilar

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/ItemStackMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/ItemStackMock.java
@@ -195,7 +195,7 @@ public class ItemStackMock extends ItemStack
 	public boolean isSimilar(@org.jetbrains.annotations.Nullable ItemStack stack)
 	{
 		if (stack == null) return false;
-		if (!(stack instanceof final ItemStackMock bukkit)) return false;
+		if (!(stack instanceof final ItemStackMock bukkit)) return stack.isSimilar(this);
 		if (this == bukkit) return true;
 		return this.type == bukkit.type;
 	}

--- a/src/test/java/be/seeseemelk/mockbukkit/inventory/ItemStackMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/inventory/ItemStackMockTest.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @ExtendWith(MockBukkitExtension.class)
 class ItemStackMockTest
@@ -73,6 +74,29 @@ class ItemStackMockTest
 			assertTrue(expected.has("throws"), "No exception should be thrown");
 			assertEquals(expected.get("throws").getAsString(), e.getClass().getName());
 		}
+	}
+
+	@Test
+	void isSimilar_different() {
+		var a = new ItemStack(Material.SAND);
+		var b = new ItemStack(Material.DIAMOND);
+
+		assertFalse(a.isSimilar(b));
+	}
+
+	@Test
+	void isSimilar_similar() {
+		ItemStack a = new ItemStack(Material.SAND);
+		ItemStack b = new ItemStack(Material.SAND);
+
+		assertTrue(a.isSimilar(b));
+	}
+
+	@Test
+	void isSimilar_null() {
+		ItemStack a = new ItemStack(Material.SAND);
+
+		assertFalse(a.isSimilar(null));
 	}
 
 	@Test


### PR DESCRIPTION
# Description
<!-- State the changes of the pull request below. -->
Fixes isSimilar not working properly, for example this will fail:

```java
var a = new ItemStack(Material.SAND);
var b = new ItemStack(Material.SAND);

Assertions.assertTrue(a.isSimilar(b));
```

@Thorinwasher also helped in this in the discord (ty man)

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
