### PR TITLE
Fix unloadWorld returning false when WorldUnloadEvent is not cancelled

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/ServerMock.java
@@ -1520,7 +1520,7 @@ public 	class ServerMock extends Server.Spigot implements Server
 		{
 			return false;
 		}
-		if (new WorldUnloadEvent(worldMock).callEvent())
+		if (!new WorldUnloadEvent(worldMock).callEvent())
 		{
 			return false;
 		}

--- a/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/ServerMockTest.java
@@ -132,7 +132,7 @@ class ServerMockTest
 	}
 
 	@Test
-	void createWorld_WorldCreator()
+	void createWorld_WorldCreator_unloadWorld()
 	{
 		WorldCreator worldCreator = new WorldCreator("test")
 				.seed(12345)
@@ -145,6 +145,10 @@ class ServerMockTest
 		assertEquals(12345, world.getSeed());
 		assertEquals(WorldType.FLAT, world.getWorldType());
 		assertEquals(World.Environment.NORMAL, world.getEnvironment());
+
+		assertTrue(server.unloadWorld("test", false));
+		assertEquals(0, server.getWorlds().size());
+		assertNull(server.getWorld("test"));
 	}
 
 	@Test


### PR DESCRIPTION
# Description
<!-- State the changes of the pull request below. -->
A boolean mishap when checking if WorldUnloadEvent is cancelled during server#unloadWorld

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
