### PR TITLE
Change domain name to publish to

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <a href="https://search.maven.org/search?q=MockBukkit">
         <img alt="Maven Central" src="https://img.shields.io/maven-central/v/org.mockbukkit.mockbukkit/mockbukkit-v1.21?color=1bcc94&logo=apache-maven" />
     </a>
-    <a href="https://javadoc.io/doc/org.mockbukkit.mockbukkit/MockBukkit-v1.21">
+    <a href="https://javadoc.io/doc/org.mockbukkit.mockbukkit/mockbukkit-v1.21">
         <img alt="Javadocs" src="https://javadoc.io/badge2/org.mockbukkit.mockbukkit/mockbukkit-v1.21/javadoc.svg" />
     </a>
     <a href="https://sonarcloud.io/project/issues?resolved=false&types=CODE_SMELL&id=MockBukkit_MockBukkit">

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
         <img alt="Documentation Status" src="https://readthedocs.org/projects/mockbukkit/badge/?version=v1.21" />
     </a>
     <a href="https://search.maven.org/search?q=MockBukkit">
-        <img alt="Maven Central" src="https://img.shields.io/maven-central/v/org.mockbukkit.mockbukkit/MockBukkit-v1.21?color=1bcc94&logo=apache-maven" />
+        <img alt="Maven Central" src="https://img.shields.io/maven-central/v/org.mockbukkit.mockbukkit/mockbukkit-v1.21?color=1bcc94&logo=apache-maven" />
     </a>
     <a href="https://javadoc.io/doc/com.github.seeseemelk/MockBukkit-v1.21">
-        <img alt="Javadocs" src="https://javadoc.io/badge2/com.github.seeseemelk/MockBukkit-v1.21/javadoc.svg" />
+        <img alt="Javadocs" src="https://javadoc.io/badge2/com.github.seeseemelk/mockbukkit-v1.21/javadoc.svg" />
     </a>
     <a href="https://sonarcloud.io/project/issues?resolved=false&types=CODE_SMELL&id=MockBukkit_MockBukkit">
         <img alt="Code Smells" src="https://sonarcloud.io/api/project_badges/measure?project=MockBukkit_MockBukkit&metric=code_smells">
@@ -51,7 +51,7 @@ MockBukkit can easily be included in your project using either Maven or gradle.
 > [!TIP]
 > Currently, the newest version available is
 >
-> [![ALTERNATE-TEXT](https://img.shields.io/maven-central/v/com.github.seeseemelk/MockBukkit-v1.21?color=1bcc94&logo=apache-maven)](https://search.maven.org/search?q=MockBukkit)
+> [![ALTERNATE-TEXT](https://img.shields.io/maven-central/v/com.github.seeseemelk/mockbukkit-v1.21?color=1bcc94&logo=apache-maven)](https://search.maven.org/search?q=MockBukkit)
 
 
 > Note: The Breaking Changes intended for 3.0 were already made in 2.145.1. Due to an Error it didn't get properly tagged
@@ -70,7 +70,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.mockbukkit.mockbukkit:MockBukkit-v1.21:[version]'
+    testImplementation 'org.mockbukkit.mockbukkit:mockbukkit-v1.21:[version]'
 }
 ```
 
@@ -114,7 +114,7 @@ MockBukkit can easily be included in Maven using the default Maven Central and P
 <dependencies>
   <dependency>
     <groupId>org.mockbukkit.mockbukkit</groupId>
-    <artifactId>MockBukkit-v1.21</artifactId>
+    <artifactId>mockbukkit-v1.21</artifactId>
     <version>[version]</version>
     <scope>test</scope>
   </dependency>
@@ -191,7 +191,7 @@ This is useful when the plugin you are testing may be looking at other loaded pl
 The following piece of code creates a placeholder plugin that extends JavaPlugin.
 
 ```java
-MockPlugin plugin = MockBukkit.createMockPlugin()
+MockPlugin plugin = MockBukkit.createMockPlugin();
 ```
 
 ### Mock Players

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
         <img alt="Documentation Status" src="https://readthedocs.org/projects/mockbukkit/badge/?version=v1.21" />
     </a>
     <a href="https://search.maven.org/search?q=MockBukkit">
-        <img alt="Maven Central" src="https://img.shields.io/maven-central/v/com.github.seeseemelk/MockBukkit-v1.21?color=1bcc94&logo=apache-maven" />
+        <img alt="Maven Central" src="https://img.shields.io/maven-central/v/org.mockbukkit.mockbukkit/MockBukkit-v1.21?color=1bcc94&logo=apache-maven" />
     </a>
     <a href="https://javadoc.io/doc/com.github.seeseemelk/MockBukkit-v1.21">
         <img alt="Javadocs" src="https://javadoc.io/badge2/com.github.seeseemelk/MockBukkit-v1.21/javadoc.svg" />
@@ -70,7 +70,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'com.github.seeseemelk:MockBukkit-v1.21:[version]'
+    testImplementation 'org.mockbukkit.mockbukkit:MockBukkit-v1.21:[version]'
 }
 ```
 
@@ -113,7 +113,7 @@ MockBukkit can easily be included in Maven using the default Maven Central and P
 
 <dependencies>
   <dependency>
-    <groupId>com.github.seeseemelk</groupId>
+    <groupId>org.mockbukkit.mockbukkit</groupId>
     <artifactId>MockBukkit-v1.21</artifactId>
     <version>[version]</version>
     <scope>test</scope>

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
     <a href="https://search.maven.org/search?q=MockBukkit">
         <img alt="Maven Central" src="https://img.shields.io/maven-central/v/org.mockbukkit.mockbukkit/mockbukkit-v1.21?color=1bcc94&logo=apache-maven" />
     </a>
-    <a href="https://javadoc.io/doc/com.github.seeseemelk/MockBukkit-v1.21">
-        <img alt="Javadocs" src="https://javadoc.io/badge2/com.github.seeseemelk/mockbukkit-v1.21/javadoc.svg" />
+    <a href="https://javadoc.io/doc/org.mockbukkit.mockbukkit/MockBukkit-v1.21">
+        <img alt="Javadocs" src="https://javadoc.io/badge2/org.mockbukkit.mockbukkit/mockbukkit-v1.21/javadoc.svg" />
     </a>
     <a href="https://sonarcloud.io/project/issues?resolved=false&types=CODE_SMELL&id=MockBukkit_MockBukkit">
         <img alt="Code Smells" src="https://sonarcloud.io/api/project_badges/measure?project=MockBukkit_MockBukkit&metric=code_smells">
@@ -51,7 +51,7 @@ MockBukkit can easily be included in your project using either Maven or gradle.
 > [!TIP]
 > Currently, the newest version available is
 >
-> [![ALTERNATE-TEXT](https://img.shields.io/maven-central/v/com.github.seeseemelk/mockbukkit-v1.21?color=1bcc94&logo=apache-maven)](https://search.maven.org/search?q=MockBukkit)
+> [![ALTERNATE-TEXT](https://img.shields.io/maven-central/v/org.mockbukkit.mockbukkit/mockbukkit-v1.21?color=1bcc94&logo=apache-maven)](https://search.maven.org/search?q=MockBukkit)
 
 
 > Note: The Breaking Changes intended for 3.0 were already made in 2.145.1. Due to an Error it didn't get properly tagged

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 	id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
 }
 
-group = "com.github.seeseemelk"
+group = "org.mockbukkit.mockbukkit"
 version = this.getFullVersion()
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -139,7 +139,7 @@ nexusPublishing {
 publishing {
 	publications {
 		create<MavenPublication>("maven") {
-			artifactId = "MockBukkit-v${property("paper.api.version")}"
+			artifactId = "mockbukkit-v${property("paper.api.version")}"
 			from(components.getByName("java"))
 			pom {
 				name.set("MockBukkit-v${property("paper.api.version")}")


### PR DESCRIPTION
# Description
I saw that we have not changed the domain name to publish Mockbukkit to, this pr should fix that.

Domain name is now `org.mockbukkit.mockbukkit` instead of `com.github.seeseemelk`

# Checklist
The following items should be checked before the pull request can be merged.
- [n/a] Code follows existing style.
- [n/a] Unit tests added (if applicable).
