### PR TITLE
Implementation of `InventoryViewMock::getItem` and `InventoryViewMock::setItem` (to 4.0 branch)

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryMock.java
@@ -1,5 +1,6 @@
 package org.mockbukkit.mockbukkit.inventory;
 
+import org.mockbukkit.mockbukkit.entity.EntityMock;
 import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -630,6 +631,11 @@ public class InventoryMock implements Inventory
 	@Override
 	public Location getLocation()
 	{
+		if (getHolder() instanceof EntityMock entity)
+		{
+			return entity.getLocation();
+		}
+
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
 	}

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryMock.java
@@ -15,7 +15,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.entity.EntityMock;
-import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryMock.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.entity.EntityMock;
+import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryMock.java
@@ -1,11 +1,11 @@
 package org.mockbukkit.mockbukkit.inventory;
 
-import org.mockbukkit.mockbukkit.entity.EntityMock;
-import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
@@ -13,6 +13,9 @@ import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.entity.EntityMock;
+import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -636,8 +639,18 @@ public class InventoryMock implements Inventory
 			return entity.getLocation();
 		}
 
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		var worlds = Bukkit.getWorlds();
+		World world;
+		if (worlds.isEmpty())
+		{
+			world = MockBukkit.getMock().addSimpleWorld("world");
+		}
+		else
+		{
+			world = worlds.getFirst();
+		}
+
+		return world.getSpawnLocation();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMock.java
@@ -146,32 +146,29 @@ public abstract class InventoryViewMock implements InventoryView
 	@Override
 	public void setItem(int slot, @Nullable ItemStack item)
 	{
-		int topSize = getTopInventory().getSize();
+		ItemStack stack = item == null ? null : item.clone();
+
 		if (slot < 0)
 		{
-			if (item != null)
+			if (stack != null)
 			{
-				Location location = bottomInventory.getLocation(); // should be the player
-				if (location != null)
-				{
-					location.getWorld().dropItemNaturally(location, item);
-					return;
-				}
+				getPlayer().getWorld().dropItemNaturally(getPlayer().getLocation(), stack);
 			}
 
-			throw new IndexOutOfBoundsException(slot);
+			return;
 		}
 
+		int topSize = getTopInventory().getSize();
 		if (slot < topSize)
 		{
-			getTopInventory().setItem(slot, item);
+			getTopInventory().setItem(slot, stack);
 			return;
 		}
 
 		slot -= topSize;
 		if (slot < getBottomInventory().getSize())
 		{
-			getBottomInventory().setItem(slot, item);
+			getBottomInventory().setItem(slot, stack);
 			return;
 		}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMock.java
@@ -145,14 +145,52 @@ public abstract class InventoryViewMock implements InventoryView
 	@Override
 	public void setItem(int slot, @Nullable ItemStack item)
 	{
-		// TODO Auto-generated method stub
+		int topSize = getTopInventory().getSize();
+		if (slot < 0)
+		{
+			// TODO : ???
+			throw new UnimplementedOperationException();
+		}
+
+		if (slot < topSize)
+		{
+			getTopInventory().setItem(slot, item);
+			return;
+		}
+
+		slot -= topSize;
+		if (slot < getBottomInventory().getSize())
+		{
+			getBottomInventory().setItem(slot, item);
+			return;
+		}
+
+		// TODO: ???
 		throw new UnimplementedOperationException();
 	}
 
 	@Override
 	public @Nullable ItemStack getItem(int slot)
 	{
-		// TODO Auto-generated method stub
+		int topSize = getTopInventory().getSize();
+		if (slot < 0)
+		{
+			// TODO : ???
+			throw new UnimplementedOperationException();
+		}
+
+		if (slot < topSize)
+		{
+			return getTopInventory().getItem(slot);
+		}
+
+		slot -= topSize;
+		if (slot < getBottomInventory().getSize())
+		{
+			return getBottomInventory().getItem(slot);
+		}
+
+		// TODO: ???
 		throw new UnimplementedOperationException();
 	}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMock.java
@@ -148,8 +148,14 @@ public abstract class InventoryViewMock implements InventoryView
 		int topSize = getTopInventory().getSize();
 		if (slot < 0)
 		{
-			// TODO : ???
-			throw new UnimplementedOperationException();
+			if (item != null)
+			{
+				// This should throw the item on the ground, but for that we need a location. Which is unimplemented for
+				//   now in 'topInventory'...
+				throw new UnimplementedOperationException();
+			}
+
+			return;
 		}
 
 		if (slot < topSize)
@@ -165,8 +171,7 @@ public abstract class InventoryViewMock implements InventoryView
 			return;
 		}
 
-		// TODO: ???
-		throw new UnimplementedOperationException();
+		throw new IndexOutOfBoundsException("Index " + slot + " out of bounds for length " + (topSize + getBottomInventory().getSize()));
 	}
 
 	@Override
@@ -175,8 +180,7 @@ public abstract class InventoryViewMock implements InventoryView
 		int topSize = getTopInventory().getSize();
 		if (slot < 0)
 		{
-			// TODO : ???
-			throw new UnimplementedOperationException();
+			return null;
 		}
 
 		if (slot < topSize)
@@ -190,8 +194,7 @@ public abstract class InventoryViewMock implements InventoryView
 			return getBottomInventory().getItem(slot);
 		}
 
-		// TODO: ???
-		throw new UnimplementedOperationException();
+		throw new IndexOutOfBoundsException("Index " + slot + " out of bounds for length " + (topSize + getBottomInventory().getSize()));
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMock.java
@@ -148,14 +148,9 @@ public abstract class InventoryViewMock implements InventoryView
 		int topSize = getTopInventory().getSize();
 		if (slot < 0)
 		{
-			if (item != null)
-			{
-				// This should throw the item on the ground, but for that we need a location. Which is unimplemented for
-				//   now in 'topInventory'...
-				throw new UnimplementedOperationException();
-			}
-
-			return;
+			// This should throw the item on the ground, but for that we need a location. Which is unimplemented for
+			//   now in 'topInventory'...
+			throw new IndexOutOfBoundsException("Index " + slot + " out of bounds for length " + (topSize + getBottomInventory().getSize()));
 		}
 
 		if (slot < topSize)

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMock.java
@@ -1,5 +1,6 @@
 package org.mockbukkit.mockbukkit.inventory;
 
+import org.bukkit.Location;
 import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 import com.google.common.base.Preconditions;
 import org.bukkit.entity.HumanEntity;
@@ -148,9 +149,17 @@ public abstract class InventoryViewMock implements InventoryView
 		int topSize = getTopInventory().getSize();
 		if (slot < 0)
 		{
-			// This should throw the item on the ground, but for that we need a location. Which is unimplemented for
-			//   now in 'topInventory'...
-			throw new IndexOutOfBoundsException("Index " + slot + " out of bounds for length " + (topSize + getBottomInventory().getSize()));
+			if (item != null)
+			{
+				Location location = bottomInventory.getLocation(); // should be the player
+				if (location != null)
+				{
+					location.getWorld().dropItemNaturally(location, item);
+					return;
+				}
+			}
+
+			throw new IndexOutOfBoundsException(slot);
 		}
 
 		if (slot < topSize)
@@ -166,7 +175,7 @@ public abstract class InventoryViewMock implements InventoryView
 			return;
 		}
 
-		throw new IndexOutOfBoundsException("Index " + slot + " out of bounds for length " + (topSize + getBottomInventory().getSize()));
+		throw new IndexOutOfBoundsException(slot);
 	}
 
 	@Override
@@ -189,7 +198,7 @@ public abstract class InventoryViewMock implements InventoryView
 			return getBottomInventory().getItem(slot);
 		}
 
-		throw new IndexOutOfBoundsException("Index " + slot + " out of bounds for length " + (topSize + getBottomInventory().getSize()));
+		throw new IndexOutOfBoundsException(slot);
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/SimpleInventoryViewMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/SimpleInventoryViewMock.java
@@ -40,20 +40,6 @@ public class SimpleInventoryViewMock extends InventoryViewMock
 	}
 
 	@Override
-	public void setItem(int slot, @Nullable ItemStack item)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public @Nullable ItemStack getItem(int slot)
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
 	public void setCursor(@Nullable ItemStack item)
 	{
 		this.getPlayer().setItemOnCursor(item);

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryMockTest.java
@@ -1,6 +1,8 @@
 package org.mockbukkit.mockbukkit.inventory;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.World;
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.ServerMock;
 import org.bukkit.Material;
@@ -651,23 +653,36 @@ class InventoryMockTest
 	@Test
 	void getLocation_WithEntityHolder()
 	{
-		// Setup
 		Player player = server.addPlayer();
 		Location expectedLocation = new Location(player.getWorld(), 10, 20, 30);
 		player.teleport(expectedLocation);
 
-		// Test
+		inventory = new InventoryMock(player, InventoryType.CHEST);
 		Location location = inventory.getLocation();
 
-		// Verify
 		assertNotNull(location);
 		assertEquals(expectedLocation, location);
 	}
 
 	@Test
-	void getLocation()
+	void getLocation_WithoutEntityHolder_WithNoWorldCreatedYet()
 	{
-		assertThrows(UnimplementedOperationException.class, inventory::getLocation);
+		Location location = inventory.getLocation();
+
+		assertNotNull(location);
+		assertEquals(Bukkit.getWorlds().getFirst().getSpawnLocation(), location);
+	}
+
+	@Test
+	void getLocation_WithoutEntityHolder_WithWorldCreated()
+	{
+		World world = server.addSimpleWorld("world");
+		world.setSpawnLocation(1, 2, 3);
+
+		Location location = inventory.getLocation();
+
+		assertNotNull(location);
+		assertEquals(new Location(world, 1, 2, 3), location);
 	}
 
 	@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryMockTest.java
@@ -1,5 +1,6 @@
 package org.mockbukkit.mockbukkit.inventory;
 
+import org.bukkit.Location;
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.ServerMock;
 import org.bukkit.Material;
@@ -10,6 +11,9 @@ import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.block.state.BlockStateMock;
+import org.mockbukkit.mockbukkit.entity.EntityMock;
+import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -644,4 +648,36 @@ class InventoryMockTest
 		assertEquals(1, inventory.getNumberOfItems(emerald));
 	}
 
+	@Test
+	void getLocation_WithEntityHolder()
+	{
+		// Setup
+		Player player = server.addPlayer();
+		Location expectedLocation = new Location(player.getWorld(), 10, 20, 30);
+		player.teleport(expectedLocation);
+
+		// Test
+		Location location = inventory.getLocation();
+
+		// Verify
+		assertNotNull(location);
+		assertEquals(expectedLocation, location);
+	}
+
+	@Test
+	void getLocation()
+	{
+		assertThrows(UnimplementedOperationException.class, inventory::getLocation);
+	}
+
+	@Test
+	void getLocation_WithNonEntityHolder()
+	{
+		Player player = server.addPlayer();
+		final Location expectedLocation = new Location(player.getWorld(), 10, 20, 30);
+		player.teleport(expectedLocation);
+		InventoryMock inventory = new InventoryMock(player, InventoryType.PLAYER);
+
+		assertEquals(expectedLocation, inventory.getLocation());
+	}
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryMockTest.java
@@ -676,7 +676,7 @@ class InventoryMockTest
 		Player player = server.addPlayer();
 		final Location expectedLocation = new Location(player.getWorld(), 10, 20, 30);
 		player.teleport(expectedLocation);
-		InventoryMock inventory = new InventoryMock(player, InventoryType.PLAYER);
+		inventory = new InventoryMock(player, InventoryType.PLAYER);
 
 		assertEquals(expectedLocation, inventory.getLocation());
 	}

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMockTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -167,6 +168,10 @@ class InventoryViewMockTest
 		view.setItem(0, sword);
 
 		assertEquals(sword, chest.getItem(0));
+
+		// Ensure it is copied
+		sword.setAmount(2);
+		assertNotEquals(sword, chest.getItem(0));
 	}
 
 	@Test
@@ -179,6 +184,10 @@ class InventoryViewMockTest
 		view.setItem(9, sword);
 
 		assertEquals(sword, player.getInventory().getItem(0));
+
+		// Ensure it is copied
+		sword.setAmount(2);
+		assertNotEquals(sword, player.getInventory().getItem(0));
 	}
 
 	@Test
@@ -187,10 +196,6 @@ class InventoryViewMockTest
 		Player player = server.addPlayer();
 		InventoryMock chest = new ChestInventoryMock(null, 9);
 		view = new PlayerInventoryViewMock(player, chest);
-
-		assertThrows(
-				IndexOutOfBoundsException.class,
-				() -> view.setItem(-1, null));
 
 		// Verify no items were dropped (since item was null) [ there can be only 1: the player ]
 		assertEquals(List.of(player), player.getWorld().getEntities());
@@ -209,7 +214,11 @@ class InventoryViewMockTest
 		List<Entity> entities = player.getWorld().getEntities().stream().filter(p -> !(p instanceof Player)).toList();
 		assertEquals(1, entities.size());
 		assertInstanceOf(ItemEntityMock.class, entities.getFirst());
+
 		assertEquals(sword, ((ItemEntityMock) entities.getFirst()).getItemStack());
+
+		sword.setAmount(2);
+		assertNotEquals(sword, ((ItemEntityMock) entities.getFirst()).getItemStack());
 	}
 
 	@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMockTest.java
@@ -3,8 +3,10 @@ package org.mockbukkit.mockbukkit.inventory;
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.ServerMock;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -104,4 +106,52 @@ class InventoryViewMockTest
 		view.setTitle("Test");
 		assertEquals("Test", view.getTitle());
     }
+
+	@Test
+	void getItemFromTopInventory()
+	{
+		ItemStack sword = ItemStack.of(Material.IRON_SWORD);
+		Player player = server.addPlayer();
+		InventoryMock chest = new SimpleInventoryMock();
+		chest.setItem(0, sword);
+		InventoryViewMock view = new PlayerInventoryViewMock(player, chest);
+
+		assertEquals(sword, view.getItem(0));
+	}
+
+	@Test
+	void getItemFromBottomInventory()
+	{
+		ItemStack sword = ItemStack.of(Material.IRON_SWORD);
+		Player player = server.addPlayer();
+		player.getInventory().setItem(0, sword);
+		InventoryMock chest = new SimpleInventoryMock();
+		InventoryViewMock view = new PlayerInventoryViewMock(player, chest);
+
+		assertEquals(sword, view.getItem(9));
+	}
+
+	@Test
+	void setItemInTopInventory()
+	{
+		ItemStack sword = ItemStack.of(Material.IRON_SWORD);
+		Player player = server.addPlayer();
+		InventoryMock chest = new SimpleInventoryMock();
+		InventoryViewMock view = new PlayerInventoryViewMock(player, chest);
+		view.setItem(0, sword);
+
+		assertEquals(sword, chest.getItem(0));
+	}
+
+	@Test
+	void setItemInBottomInventory()
+	{
+		ItemStack sword = ItemStack.of(Material.IRON_SWORD);
+		Player player = server.addPlayer();
+		InventoryMock chest = new SimpleInventoryMock();
+		InventoryViewMock view = new PlayerInventoryViewMock(player, chest);
+		view.setItem(9, sword);
+
+		assertEquals(sword, player.getInventory().getItem(0));
+	}
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMockTest.java
@@ -112,7 +112,7 @@ class InventoryViewMockTest
 	{
 		ItemStack sword = ItemStack.of(Material.IRON_SWORD);
 		Player player = server.addPlayer();
-		InventoryMock chest = new SimpleInventoryMock();
+		InventoryMock chest = new ChestInventoryMock(null, 9);
 		chest.setItem(0, sword);
 		view = new PlayerInventoryViewMock(player, chest);
 
@@ -125,7 +125,7 @@ class InventoryViewMockTest
 		ItemStack sword = ItemStack.of(Material.IRON_SWORD);
 		Player player = server.addPlayer();
 		player.getInventory().setItem(0, sword);
-		InventoryMock chest = new SimpleInventoryMock();
+		InventoryMock chest = new ChestInventoryMock(null, 9);
 		view = new PlayerInventoryViewMock(player, chest);
 
 		assertEquals(sword, view.getItem(9));
@@ -136,7 +136,7 @@ class InventoryViewMockTest
 	{
 		ItemStack sword = ItemStack.of(Material.IRON_SWORD);
 		Player player = server.addPlayer();
-		InventoryMock chest = new SimpleInventoryMock();
+		InventoryMock chest = new ChestInventoryMock(null, 9);
 		view = new PlayerInventoryViewMock(player, chest);
 		view.setItem(0, sword);
 
@@ -148,7 +148,7 @@ class InventoryViewMockTest
 	{
 		ItemStack sword = ItemStack.of(Material.IRON_SWORD);
 		Player player = server.addPlayer();
-		InventoryMock chest = new SimpleInventoryMock();
+		InventoryMock chest = new ChestInventoryMock(null, 9);
 		view = new PlayerInventoryViewMock(player, chest);
 		view.setItem(9, sword);
 

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMockTest.java
@@ -1,23 +1,22 @@
 package org.mockbukkit.mockbukkit.inventory;
 
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Item;
-import org.mockbukkit.mockbukkit.MockBukkit;
-import org.mockbukkit.mockbukkit.ServerMock;
-import org.mockbukkit.mockbukkit.entity.PlayerMock;
 import org.bukkit.Material;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.ItemEntityMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -99,20 +98,20 @@ class InventoryViewMockTest
 		assertEquals(InventoryType.CREATIVE, view.getType());
 	}
 
-    @Test
-    void getOriginalTitle()
+	@Test
+	void getOriginalTitle()
 	{
 		view.setTitle("Test");
 		view.setTitle("Foobar");
 		assertEquals("Inventory", view.getOriginalTitle());
-    }
+	}
 
-    @Test
-    void setTitle()
+	@Test
+	void setTitle()
 	{
 		view.setTitle("Test");
 		assertEquals("Test", view.getTitle());
-    }
+	}
 
 	@Test
 	void getItemFromTopInventory()
@@ -205,12 +204,12 @@ class InventoryViewMockTest
 		InventoryMock chest = new ChestInventoryMock(null, 9);
 		view = new PlayerInventoryViewMock(player, chest);
 
-		// see comment in setItem for more information
-		assertThrows(
-				IndexOutOfBoundsException.class,
-				() -> view.setItem(-1, sword));
+		view.setItem(-1, sword);
 
-		assertEquals(List.of(player), player.getWorld().getEntities());
+		List<Entity> entities = player.getWorld().getEntities().stream().filter(p -> !(p instanceof Player)).toList();
+		assertEquals(1, entities.size());
+		assertInstanceOf(ItemEntityMock.class, entities.getFirst());
+		assertEquals(sword, ((ItemEntityMock) entities.getFirst()).getItemStack());
 	}
 
 	@Test
@@ -223,4 +222,5 @@ class InventoryViewMockTest
 
 		assertThrows(IndexOutOfBoundsException.class, () -> view.setItem(100, sword));
 	}
+
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMockTest.java
@@ -1,5 +1,7 @@
 package org.mockbukkit.mockbukkit.inventory;
 
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.ServerMock;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
@@ -10,10 +12,15 @@ import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class InventoryViewMockTest
 {
@@ -120,6 +127,26 @@ class InventoryViewMockTest
 	}
 
 	@Test
+	void getItemWrongIndex_1()
+	{
+		Player player = server.addPlayer();
+		InventoryMock chest = new ChestInventoryMock(null, 9);
+		view = new PlayerInventoryViewMock(player, chest);
+
+		assertNull(view.getItem(-1));
+	}
+
+	@Test
+	void getItemWrongIndex100()
+	{
+		Player player = server.addPlayer();
+		InventoryMock chest = new ChestInventoryMock(null, 9);
+		view = new PlayerInventoryViewMock(player, chest);
+
+		assertThrows(IndexOutOfBoundsException.class, () -> view.getItem(100));
+	}
+
+	@Test
 	void getItemFromBottomInventory()
 	{
 		ItemStack sword = ItemStack.of(Material.IRON_SWORD);
@@ -153,5 +180,43 @@ class InventoryViewMockTest
 		view.setItem(9, sword);
 
 		assertEquals(sword, player.getInventory().getItem(0));
+	}
+
+	@Test
+	void setItemNegativeSlot_WithNullItem()
+	{
+		Player player = server.addPlayer();
+		InventoryMock chest = new ChestInventoryMock(null, 9);
+		view = new PlayerInventoryViewMock(player, chest);
+
+		view.setItem(-1, null);
+
+		// Verify no items were dropped (since item was null) [ there can be only 1: the player ]
+		assertEquals(List.of(player), player.getWorld().getEntities());
+	}
+
+	@Test
+	void setItemNegativeSlot_WithValidItem()
+	{
+		ItemStack sword = ItemStack.of(Material.IRON_SWORD);
+		Player player = server.addPlayer();
+		InventoryMock chest = new ChestInventoryMock(null, 9);
+		view = new PlayerInventoryViewMock(player, chest);
+
+		// see comment in setItem for more information
+		assertThrows(
+				UnimplementedOperationException.class,
+				() -> view.setItem(-1, sword));
+	}
+
+	@Test
+	void setItemWrongIndex100()
+	{
+		ItemStack sword = ItemStack.of(Material.IRON_SWORD);
+		Player player = server.addPlayer();
+		InventoryMock chest = new ChestInventoryMock(null, 9);
+		view = new PlayerInventoryViewMock(player, chest);
+
+		assertThrows(IndexOutOfBoundsException.class, () -> view.setItem(100, sword));
 	}
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMockTest.java
@@ -114,7 +114,7 @@ class InventoryViewMockTest
 		Player player = server.addPlayer();
 		InventoryMock chest = new SimpleInventoryMock();
 		chest.setItem(0, sword);
-		InventoryViewMock view = new PlayerInventoryViewMock(player, chest);
+		view = new PlayerInventoryViewMock(player, chest);
 
 		assertEquals(sword, view.getItem(0));
 	}
@@ -126,7 +126,7 @@ class InventoryViewMockTest
 		Player player = server.addPlayer();
 		player.getInventory().setItem(0, sword);
 		InventoryMock chest = new SimpleInventoryMock();
-		InventoryViewMock view = new PlayerInventoryViewMock(player, chest);
+		view = new PlayerInventoryViewMock(player, chest);
 
 		assertEquals(sword, view.getItem(9));
 	}
@@ -137,7 +137,7 @@ class InventoryViewMockTest
 		ItemStack sword = ItemStack.of(Material.IRON_SWORD);
 		Player player = server.addPlayer();
 		InventoryMock chest = new SimpleInventoryMock();
-		InventoryViewMock view = new PlayerInventoryViewMock(player, chest);
+		view = new PlayerInventoryViewMock(player, chest);
 		view.setItem(0, sword);
 
 		assertEquals(sword, chest.getItem(0));
@@ -149,7 +149,7 @@ class InventoryViewMockTest
 		ItemStack sword = ItemStack.of(Material.IRON_SWORD);
 		Player player = server.addPlayer();
 		InventoryMock chest = new SimpleInventoryMock();
-		InventoryViewMock view = new PlayerInventoryViewMock(player, chest);
+		view = new PlayerInventoryViewMock(player, chest);
 		view.setItem(9, sword);
 
 		assertEquals(sword, player.getInventory().getItem(0));

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMockTest.java
@@ -189,7 +189,9 @@ class InventoryViewMockTest
 		InventoryMock chest = new ChestInventoryMock(null, 9);
 		view = new PlayerInventoryViewMock(player, chest);
 
-		view.setItem(-1, null);
+		assertThrows(
+				IndexOutOfBoundsException.class,
+				() -> view.setItem(-1, null));
 
 		// Verify no items were dropped (since item was null) [ there can be only 1: the player ]
 		assertEquals(List.of(player), player.getWorld().getEntities());
@@ -205,8 +207,10 @@ class InventoryViewMockTest
 
 		// see comment in setItem for more information
 		assertThrows(
-				UnimplementedOperationException.class,
+				IndexOutOfBoundsException.class,
 				() -> view.setItem(-1, sword));
+
+		assertEquals(List.of(player), player.getWorld().getEntities());
 	}
 
 	@Test


### PR DESCRIPTION
# Description
As @Thorinwasher mentioned, seems like 4.0 is now the main branch. So pushing my changes to there to.
Closing this would deprecate #1177 (and vice versa)

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
