### PR TITLE
Fix data races in scheduler, plugin manager and player list

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/ban/IpBanListMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/ban/IpBanListMock.java
@@ -18,27 +18,27 @@ import java.util.Set;
 public class IpBanListMock implements org.bukkit.ban.IpBanList
 {
 
+	// Accesses to this field must be done while synchronizing on IpBanListMock.this
 	private final Map<String, BanEntry<InetAddress>> bans = new HashMap<>();
 	private static final String TARGET_CANNOT_BE_NULL = "Target cannot be null";
 
 	@Override
 	@Deprecated(since = "1.20")
-	public @Nullable BanEntry<InetAddress> getBanEntry(@NotNull String target)
+	public synchronized @Nullable BanEntry<InetAddress> getBanEntry(@NotNull String target)
 	{
 		Preconditions.checkNotNull(target, TARGET_CANNOT_BE_NULL);
 		return bans.getOrDefault(target, null);
 	}
 
 	@Override
-	public @Nullable BanEntry<InetAddress> getBanEntry(@NotNull InetAddress target)
+	public synchronized @Nullable BanEntry<InetAddress> getBanEntry(@NotNull InetAddress target)
 	{
 		Preconditions.checkNotNull(target, TARGET_CANNOT_BE_NULL);
 		return bans.getOrDefault(InetAddresses.toAddrString(target), null);
 	}
 
 	@Override
-
-	public @Nullable BanEntry<InetAddress> addBan(@NotNull String target, @Nullable String reason, @Nullable Date expires, @Nullable String source)
+	public synchronized @Nullable BanEntry<InetAddress> addBan(@NotNull String target, @Nullable String reason, @Nullable Date expires, @Nullable String source)
 	{
 		Preconditions.checkNotNull(target, TARGET_CANNOT_BE_NULL);
 		BanEntry<InetAddress> entry = new IpBanEntryMock(
@@ -53,20 +53,20 @@ public class IpBanListMock implements org.bukkit.ban.IpBanList
 	}
 
 	@Override
-	public @Nullable BanEntry<InetAddress> addBan(@NotNull InetAddress target, @Nullable String reason, @Nullable Date expires, @Nullable String source)
+	public synchronized @Nullable BanEntry<InetAddress> addBan(@NotNull InetAddress target, @Nullable String reason, @Nullable Date expires, @Nullable String source)
 	{
 		return addBan(InetAddresses.toAddrString(target), reason, expires, source);
 	}
 
 	@Override
-	public @Nullable BanEntry<InetAddress> addBan(@NotNull InetAddress target, @Nullable String reason, @Nullable Instant expires, @Nullable String source)
+	public synchronized @Nullable BanEntry<InetAddress> addBan(@NotNull InetAddress target, @Nullable String reason, @Nullable Instant expires, @Nullable String source)
 	{
 		Date date = expires != null ? Date.from(expires) : null;
 		return this.addBan(target, reason, date, source);
 	}
 
 	@Override
-	public @Nullable BanEntry<InetAddress> addBan(@NotNull InetAddress target, @Nullable String reason, @Nullable Duration duration, @Nullable String source)
+	public synchronized @Nullable BanEntry<InetAddress> addBan(@NotNull InetAddress target, @Nullable String reason, @Nullable Duration duration, @Nullable String source)
 	{
 		Instant instant = duration != null ? Instant.now().plus(duration) : null;
 		return this.addBan(target, reason, instant, source);
@@ -75,7 +75,7 @@ public class IpBanListMock implements org.bukkit.ban.IpBanList
 	@Override
 	@Deprecated(since = "1.20")
 	@SuppressWarnings("rawtypes")
-	public @NotNull Set<BanEntry> getBanEntries()
+	public synchronized @NotNull Set<BanEntry> getBanEntries()
 	{
 		ImmutableSet.Builder<BanEntry> builder = ImmutableSet.builder();
 		for (String target : bans.keySet())
@@ -90,7 +90,7 @@ public class IpBanListMock implements org.bukkit.ban.IpBanList
 	}
 
 	@Override
-	public @NotNull Set<BanEntry<InetAddress>> getEntries()
+	public synchronized @NotNull Set<BanEntry<InetAddress>> getEntries()
 	{
 		ImmutableSet.Builder<BanEntry<InetAddress>> builder = ImmutableSet.builder();
 		for (String target : bans.keySet())
@@ -105,26 +105,26 @@ public class IpBanListMock implements org.bukkit.ban.IpBanList
 	}
 
 	@Override
-	public boolean isBanned(@NotNull InetAddress target)
+	public synchronized boolean isBanned(@NotNull InetAddress target)
 	{
 		return this.bans.values().stream().anyMatch(banEntry -> banEntry.getBanTarget().equals(target));
 	}
 
 	@Override
-	public boolean isBanned(@NotNull String target)
+	public synchronized boolean isBanned(@NotNull String target)
 	{
 		return this.bans.values().stream().anyMatch(banEntry -> InetAddresses.toAddrString(banEntry.getBanTarget()).equals(target));
 	}
 
 	@Override
-	public void pardon(@NotNull InetAddress target)
+	public synchronized void pardon(@NotNull InetAddress target)
 	{
 		Preconditions.checkNotNull(target, TARGET_CANNOT_BE_NULL);
 		this.pardon(InetAddresses.toAddrString(target));
 	}
 
 	@Override
-	public void pardon(@NotNull String target)
+	public synchronized void pardon(@NotNull String target)
 	{
 		Preconditions.checkNotNull(target, TARGET_CANNOT_BE_NULL);
 		this.bans.remove(target);

--- a/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
@@ -78,7 +78,6 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	private final List<PluginCommand> commands = new ArrayList<>();
 	private final List<Event> events = new ArrayList<>();
 	private File parentTemporaryDirectory;
-	private final @NotNull Map<String, List<Listener>> listeners = new HashMap<>();
 
 	/**
 	 * Constructs a new {@link PluginManagerMock} for the provided {@link ServerMock}.
@@ -776,23 +775,9 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 		{
 			throw new IllegalPluginAccessException("Plugin attempted to register " + listener + " while not enabled");
 		}
-		addListener(listener, plugin);
 		for (Map.Entry<Class<? extends Event>, Set<RegisteredListener>> entry : plugin.getPluginLoader().createRegisteredListeners(listener, plugin).entrySet())
 		{
 			getEventListeners(getRegistrationClass(entry.getKey())).registerAll(entry.getValue());
-		}
-
-	}
-
-	private void addListener(@NotNull Listener listener, @NotNull Plugin plugin)
-	{
-		Preconditions.checkNotNull(listener, "Listener cannot be null");
-		Preconditions.checkNotNull(plugin, "Listener cannot be null");
-		List<Listener> l = listeners.getOrDefault(plugin.getName(), new ArrayList<>());
-		if (!l.contains(listener))
-		{
-			l.add(listener);
-			listeners.put(plugin.getName(), l);
 		}
 	}
 
@@ -804,18 +789,7 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	public void unregisterPluginEvents(@NotNull Plugin plugin)
 	{
 		Preconditions.checkNotNull(plugin, "Listener cannot be null");
-		List<Listener> listListener = listeners.get(plugin.getName());
-		if (listListener != null)
-		{
-			for (Listener l : listListener)
-			{
-				for (Map.Entry<Class<? extends Event>, Set<RegisteredListener>> entry : plugin.getPluginLoader().createRegisteredListeners(l, plugin).entrySet())
-				{
-					getEventListeners(getRegistrationClass(entry.getKey())).unregister(plugin);
-				}
-			}
-		}
-
+		HandlerList.unregisterAll(plugin);
 	}
 
 	@Override
@@ -838,7 +812,6 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 		{
 			throw new IllegalPluginAccessException("Plugin attempted to register " + event + " while not enabled");
 		}
-		addListener(listener, plugin);
 		getEventListeners(event).register(new RegisteredListener(listener, executor, priority, plugin, ignoreCancelled));
 	}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
@@ -49,13 +49,14 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.jar.JarFile;
@@ -74,10 +75,13 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	private static final Pattern VALID_PLUGIN_NAMES = Pattern.compile("^[A-Za-z0-9_.-]+$");
 
 	private final @NotNull ServerMock server;
+
+	// These fields must be accessed only while synchronizing on PluginManagerMock.this
 	private final List<Plugin> plugins = new ArrayList<>();
 	private final List<PluginCommand> commands = new ArrayList<>();
-	private final List<Event> events = new ArrayList<>();
-	private File parentTemporaryDirectory;
+
+	private final List<Event> events = new CopyOnWriteArrayList<>(); // CopyOnWriteArrayList is necessary to return a Stream in getFiredEvents()
+	private final AtomicReference<File> parentTemporaryDirectory = new AtomicReference<>(); // Initialized once in getParentTemporaryDirectory() and read-only afterwards
 
 	/**
 	 * Constructs a new {@link PluginManagerMock} for the provided {@link ServerMock}.
@@ -97,6 +101,7 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	 */
 	public void unload()
 	{
+		File parentTemporaryDirectory = this.parentTemporaryDirectory.get();
 		if (parentTemporaryDirectory == null)
 			return;
 
@@ -238,7 +243,7 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	}
 
 	@Override
-	public Plugin getPlugin(@NotNull String name)
+	public synchronized Plugin getPlugin(@NotNull String name)
 	{
 		Preconditions.checkNotNull(name, "Name cannot be null");
 		for (Plugin plugin : plugins)
@@ -252,7 +257,7 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	}
 
 	@Override
-	public Plugin @NotNull [] getPlugins()
+	public synchronized Plugin @NotNull [] getPlugins()
 	{
 		return plugins.toArray(new Plugin[0]);
 	}
@@ -262,9 +267,9 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	 *
 	 * @return A collection of all available commands.
 	 */
-	public @NotNull Collection<PluginCommand> getCommands()
+	public synchronized @NotNull Collection<PluginCommand> getCommands()
 	{
-		return Collections.unmodifiableList(commands);
+		return List.copyOf(commands);
 	}
 
 	/**
@@ -334,10 +339,19 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	 */
 	public @NotNull File getParentTemporaryDirectory() throws IOException
 	{
+		File parentTemporaryDirectory = this.parentTemporaryDirectory.get();
 		if (parentTemporaryDirectory == null)
 		{
 			Random random = ThreadLocalRandom.current();
-			parentTemporaryDirectory = Files.createTempDirectory("MockBukkit-" + random.nextInt(0, Integer.MAX_VALUE)).toFile();
+			File tmpDir = Files.createTempDirectory("MockBukkit-" + random.nextInt(0, Integer.MAX_VALUE)).toFile();
+			File prev = this.parentTemporaryDirectory.compareAndExchange(null, tmpDir);
+			if (prev != null)
+			{
+				// Another thread set parentTemporaryDirectory. Prev is the correct tmp directory
+				Files.delete(tmpDir.toPath());
+				return prev;
+			}
+			return tmpDir;
 		}
 		return parentTemporaryDirectory;
 	}
@@ -383,8 +397,11 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	public void registerLoadedPlugin(@NotNull Plugin plugin)
 	{
 		Preconditions.checkNotNull(plugin, "Plugin cannot be null");
-		addCommandsFrom(plugin);
-		plugins.add(plugin);
+		synchronized (this)
+		{
+			addCommandsFrom(plugin);
+			plugins.add(plugin);
+		}
 		plugin.onLoad();
 	}
 
@@ -651,7 +668,7 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	 *
 	 * @param plugin The plugin from which to read commands.
 	 */
-	protected void addCommandsFrom(@NotNull Plugin plugin)
+	protected synchronized void addCommandsFrom(@NotNull Plugin plugin)
 	{
 		Preconditions.checkNotNull(plugin, "Plugin cannot be null");
 		Map<String, Map<String, Object>> pluginCommands = plugin.getDescription().getCommands();
@@ -678,33 +695,18 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	public boolean isPluginEnabled(@NotNull String name)
 	{
 		Preconditions.checkNotNull(name, "Name cannot be null");
-		boolean result = false;
-
-		for (Plugin mockedPlugin : plugins)
-		{
-			if (mockedPlugin.getName().equals(name))
-			{
-				result = mockedPlugin.isEnabled();
-			}
-		}
-
-		return result;
+		Plugin plugin = getPlugin(name);
+		return plugin != null && plugin.isEnabled();
 	}
 
 	@Override
-	public boolean isPluginEnabled(@Nullable Plugin plugin)
+	public synchronized boolean isPluginEnabled(@Nullable Plugin plugin)
 	{
-		boolean result = false;
-
-		for (Plugin mockedPlugin : plugins)
+		if (plugin != null && plugins.contains(plugin))
 		{
-			if (mockedPlugin.equals(plugin))
-			{
-				result = plugin.isEnabled();
-			}
+			return plugin.isEnabled();
 		}
-
-		return result;
+		return false;
 	}
 
 	@Override
@@ -745,7 +747,7 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	@Override
 	public void disablePlugins()
 	{
-		for (Plugin plugin : plugins)
+		for (Plugin plugin : getPlugins())
 			disablePlugin(plugin);
 	}
 
@@ -753,7 +755,10 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	public void clearPlugins()
 	{
 		disablePlugins();
-		plugins.clear();
+		synchronized (this)
+		{
+			plugins.clear();
+		}
 	}
 
 	/**

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/RepeatingTask.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/RepeatingTask.java
@@ -2,6 +2,7 @@ package org.mockbukkit.mockbukkit.scheduler;
 
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitTask;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Consumer;
@@ -59,7 +60,8 @@ public class RepeatingTask extends ScheduledTask
 	/**
 	 * Updates the scheduled tick for the next run.
 	 */
-	public void updateScheduledTick()
+	@ApiStatus.Internal
+	protected void updateScheduledTick()
 	{
 		setScheduledTick(getScheduledTick() + period);
 	}

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/ScheduledTask.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/ScheduledTask.java
@@ -83,7 +83,6 @@ public class ScheduledTask implements BukkitTask, BukkitWorker
 		this.running = false;
 	}
 
-
 	/**
 	 * @return Whether the task is running.
 	 */
@@ -99,11 +98,10 @@ public class ScheduledTask implements BukkitTask, BukkitWorker
 	 * @param running Whether the task is running.
 	 */
 	@ApiStatus.Internal
-	public void setRunning(boolean running)
+	protected void setRunning(boolean running)
 	{
 		this.running = running;
 	}
-
 
 	/**
 	 * Get the tick at which the task is scheduled to run at.
@@ -120,6 +118,7 @@ public class ScheduledTask implements BukkitTask, BukkitWorker
 	 *
 	 * @param scheduledTick The tick at which the task is scheduled to run at.
 	 */
+	@ApiStatus.Internal
 	protected void setScheduledTick(long scheduledTick)
 	{
 		this.scheduledTick = scheduledTick;

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/ScheduledTask.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/ScheduledTask.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CancellationException;
@@ -22,14 +23,14 @@ public class ScheduledTask implements BukkitTask, BukkitWorker
 	private final int id;
 	private final Plugin plugin;
 	private final boolean isSync;
-	private boolean isCancelled = false;
-	private long scheduledTick;
-	private boolean running;
+	private volatile boolean isCancelled = false;
+	private volatile long scheduledTick;
+	private volatile boolean running;
 	private final @Nullable Runnable runnable;
 	private final @Nullable Consumer<? super BukkitTask> consumer;
-	private final List<Runnable> cancelListeners = new LinkedList<>();
-	private Thread thread;
-	private boolean submitted = false;
+	private final List<Runnable> cancelListeners = Collections.synchronizedList(new LinkedList<>());
+	private volatile Thread thread;
+	private volatile boolean submitted = false;
 
 	/**
 	 * Constructs a new {@link ScheduledTask} with the provided parameters.


### PR DESCRIPTION
# Description
This fixes data races and race conditions in the scheduler, plugin manager and player list.

As discussed on Discord, this also makes internal-only methods in `ScheduledTask` and `RepeatingTask` classes `protected` and `@ApiStatus.Internal`.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (not really applicable here I think).
