### PR TITLE
Fix ItemMetaMock get enchants

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -1,5 +1,7 @@
 package org.mockbukkit.mockbukkit.inventory.meta;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 import org.mockbukkit.mockbukkit.exception.ItemMetaInitException;
 import org.mockbukkit.mockbukkit.persistence.PersistentDataContainerMock;
@@ -40,7 +42,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -701,7 +703,9 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	@Override
 	public @NotNull Map<Enchantment, Integer> getEnchants()
 	{
-		return Collections.unmodifiableMap(enchants);
+		return enchants != null ? ImmutableSortedMap.copyOf(enchants,
+				Comparator.comparing(o -> o.getKey().toString())
+				) : ImmutableMap.of();
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/meta/ItemMetaMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/meta/ItemMetaMockTest.java
@@ -41,6 +41,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -49,7 +50,9 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
@@ -462,6 +465,28 @@ class ItemMetaMockTest
 		Map<Enchantment, Integer> actual = meta.getEnchants();
 		assertEquals(1, actual.size());
 		assertEquals(3, actual.get(Enchantment.UNBREAKING));
+	}
+
+	@Test
+	void getEnchants_IsSorted(){
+		meta.addEnchant(Enchantment.UNBREAKING, 3, true);
+		Map<Enchantment, Integer> actual = meta.getEnchants();
+
+		assertInstanceOf(SortedMap.class, actual);
+	}
+
+	@Test
+	void getEnchants_IsCopy(){
+		Map<Enchantment, Integer> actual1 = meta.getEnchants();
+		Map<Enchantment, Integer> actual2 = meta.getEnchants();
+
+		assertNotSame(actual1, actual2);
+		assertEquals(actual1, actual2);
+
+		meta.addEnchant(Enchantment.UNBREAKING, 3, true);
+		Map<Enchantment, Integer> actual3 = meta.getEnchants();
+
+		assertNotEquals(actual1, actual3);
 	}
 
 	@Test


### PR DESCRIPTION
# Description
Fix getEnchants not providing a sorted copy of the enchantment map

Only "issue" is I did not add unit test to check sorted map comparator as I don't really have an idea how should I implement this.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
