### PR TITLE
Fix equals and implement missing ItemStackMock methods

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMock.java
@@ -1,20 +1,23 @@
 package org.mockbukkit.mockbukkit.inventory;
 
-import org.bukkit.inventory.meta.Damageable;
-import org.mockbukkit.mockbukkit.exception.ItemMetaInitException;
-import org.mockbukkit.mockbukkit.inventory.meta.ItemMetaMock;
 import com.google.common.base.Preconditions;
+import io.papermc.paper.persistence.PersistentDataContainerView;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ItemType;
+import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mockbukkit.mockbukkit.exception.ItemMetaInitException;
+import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
+import org.mockbukkit.mockbukkit.inventory.meta.ItemMetaMock;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Locale;
@@ -98,7 +101,7 @@ public class ItemStackMock extends ItemStack
 		if (type != this.type.asMaterial())
 		{
 			this.type = type.asItemType();
-			if(this.itemMeta == null)
+			if (this.itemMeta == null)
 			{
 				this.itemMeta = findItemMeta(type);
 			}
@@ -106,10 +109,10 @@ public class ItemStackMock extends ItemStack
 			{
 				this.itemMeta = Bukkit.getItemFactory().asMetaFor(this.itemMeta, type);
 			}
-			if(this.durability == 0)
+			if (this.durability == 0)
 			{
 				this.durability = initDurability(this.type);
-				((Damageable)this.itemMeta).resetDamage();
+				((Damageable) this.itemMeta).resetDamage();
 			}
 			else
 			{
@@ -145,7 +148,7 @@ public class ItemStackMock extends ItemStack
 	@Override
 	public boolean setItemMeta(@Nullable ItemMeta itemMeta)
 	{
-		if(itemMeta == null || ItemType.AIR.equals(this.type))
+		if (itemMeta == null || ItemType.AIR.equals(this.type))
 		{
 			this.itemMeta = findItemMeta(getType());
 			this.durability = initDurability(this.type);
@@ -157,13 +160,13 @@ public class ItemStackMock extends ItemStack
 		}
 
 		itemMeta = Bukkit.getItemFactory().asMetaFor(itemMeta, this);
-		if(itemMeta == null) return true;
+		if (itemMeta == null) return true;
 		this.itemMeta = itemMeta;
 
-		if(this.itemMeta instanceof Damageable damageable)
+		if (this.itemMeta instanceof Damageable damageable)
 		{
 			short defaultDurability = initDurability(this.type);
-			if(!damageable.hasDamageValue())
+			if (!damageable.hasDamageValue())
 			{
 				durability = defaultDurability;
 			}
@@ -171,7 +174,7 @@ public class ItemStackMock extends ItemStack
 			{
 				short value = (short) Math.min(Short.MAX_VALUE, damageable.getDamage());
 				setDurability(value);
-				if(durability == defaultDurability)
+				if (durability == defaultDurability)
 				{
 					damageable.resetDamage();
 				}
@@ -201,7 +204,7 @@ public class ItemStackMock extends ItemStack
 	@Override
 	public short getDurability()
 	{
-		if(this.type == ItemType.AIR) return -1;
+		if (this.type == ItemType.AIR) return -1;
 
 		return (short) Math.max(this.durability, 0);
 	}
@@ -211,7 +214,7 @@ public class ItemStackMock extends ItemStack
 	{
 		short oldDurability = this.durability;
 		this.durability = (short) Math.min(Math.max(durability, 0), this.type.getMaxDurability());
-		if((this.itemMeta instanceof Damageable damageable) && this.durability != oldDurability)
+		if ((this.itemMeta instanceof Damageable damageable) && this.durability != oldDurability)
 		{
 			damageable.setDamage(this.durability);
 		}
@@ -222,11 +225,9 @@ public class ItemStackMock extends ItemStack
 	{
 		Preconditions.checkArgument(ench != null, "Enchantment cannot be null");
 
-		final ItemMeta meta = this.getItemMeta();
-		if (meta != null)
+		if (this.itemMeta != null)
 		{
-			meta.addEnchant(ench, level, true);
-			this.setItemMeta(meta);
+			this.itemMeta.addEnchant(ench, level, true);
 		}
 	}
 
@@ -235,7 +236,7 @@ public class ItemStackMock extends ItemStack
 	{
 		Preconditions.checkArgument(ench != null, "Enchantment cannot be null");
 
-		final ItemMeta meta = this.getItemMeta();
+		final ItemMeta meta = this.itemMeta;
 		Preconditions.checkNotNull(meta, "Meta must not be null");
 
 		return meta.getEnchantLevel(ench);
@@ -254,6 +255,61 @@ public class ItemStackMock extends ItemStack
 		if (!(stack instanceof final ItemStackMock bukkit)) return stack.isSimilar(this);
 		if (this == bukkit) return true;
 		return this.type == bukkit.type;
+	}
+
+	@Override
+	public @NotNull PersistentDataContainerView getPersistentDataContainer()
+	{
+		if (this.itemMeta == null)
+		{
+			//TODO
+			throw new UnimplementedOperationException();
+		}
+
+		return itemMeta.getPersistentDataContainer();
+	}
+
+	@Override
+	public @NotNull ItemStack withType(@NotNull Material type)
+	{
+		ItemStackMock item = new ItemStackMock(type, getAmount());
+		if (this.durability != -1) item.setDurability(this.durability);
+		item.setItemMeta(this.itemMeta);
+
+		return item;
+	}
+
+	@Override
+	public boolean containsEnchantment(@NotNull Enchantment ench)
+	{
+		if (this.itemMeta == null) return false;
+
+		return this.itemMeta.getEnchants().containsKey(ench);
+	}
+
+	@Override
+	public int removeEnchantment(@NotNull Enchantment ench)
+	{
+		if (this.itemMeta == null) return 0;
+
+		int level = this.itemMeta.getEnchantLevel(ench);
+		this.itemMeta.removeEnchant(ench);
+		return level;
+	}
+
+	@Override
+	public void removeEnchantments()
+	{
+		if (this.itemMeta == null) return;
+
+		this.itemMeta.removeEnchantments();
+	}
+
+	@Override
+	public int getMaxItemUseDuration(@NotNull LivingEntity entity)
+	{
+		//TODO
+		throw new UnimplementedOperationException();
 	}
 
 	public static ItemStackMock empty()

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMock.java
@@ -145,7 +145,7 @@ public class ItemStackMock extends ItemStack
 	@Override
 	public boolean setItemMeta(@Nullable ItemMeta itemMeta)
 	{
-		if(itemMeta == null)
+		if(itemMeta == null || ItemType.AIR.equals(this.type))
 		{
 			this.itemMeta = findItemMeta(getType());
 			this.durability = initDurability(this.type);

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMock.java
@@ -13,16 +13,19 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ItemType;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mockbukkit.mockbukkit.exception.ItemMetaInitException;
 import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 import org.mockbukkit.mockbukkit.inventory.meta.ItemMetaMock;
+import org.mockbukkit.mockbukkit.persistence.PersistentDataContainerViewMock;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 public class ItemStackMock extends ItemStack
 {
@@ -259,16 +262,29 @@ public class ItemStackMock extends ItemStack
 		return this.type == bukkit.type;
 	}
 
+	private final PersistentDataContainerView pdcView = new PersistentDataContainerViewMock()
+	{
+		@Override
+		public <P, C> @Nullable C get(@NotNull NamespacedKey key, @NotNull PersistentDataType<P, C> type)
+		{
+			if (itemMeta == null) return null;
+
+			return itemMeta.getPersistentDataContainer().get(key, type);
+		}
+
+		@Override
+		public @NotNull Set<NamespacedKey> getKeys()
+		{
+			if (itemMeta == null) return Set.of();
+
+			return itemMeta.getPersistentDataContainer().getKeys();
+		}
+	};
+
 	@Override
 	public @NotNull PersistentDataContainerView getPersistentDataContainer()
 	{
-		if (this.itemMeta == null)
-		{
-			//TODO
-			throw new UnimplementedOperationException();
-		}
-
-		return itemMeta.getPersistentDataContainer();
+		return pdcView;
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMock.java
@@ -29,7 +29,7 @@ public class ItemStackMock extends ItemStack
 
 	private ItemType type = ItemTypeMock.AIR;
 	private int amount = 1;
-	private ItemMeta itemMeta = new ItemMetaMock();
+	private ItemMeta itemMeta;
 	private short durability = -1;
 
 	private static final ItemStackMock EMPTY = new ItemStackMock((Void) null);
@@ -67,6 +67,7 @@ public class ItemStackMock extends ItemStack
 		this.type = ItemTypeMock.AIR;
 		this.durability = initDurability(type);
 		this.amount = 0;
+		this.itemMeta = null;
 	}
 
 	private ItemStackMock(@NotNull ItemType type)
@@ -312,9 +313,9 @@ public class ItemStackMock extends ItemStack
 		throw new UnimplementedOperationException();
 	}
 
-	public static ItemStackMock empty()
+	public static ItemStack empty()
 	{
-		return EMPTY;
+		return EMPTY.clone();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMock.java
@@ -282,7 +282,7 @@ public class ItemStackMock extends ItemStack
 		}
 		if (stack instanceof ItemStackMock bukkit)
 		{
-			return isSimilar(bukkit) && this.amount == bukkit.getAmount() && this.durability == bukkit.durability && Objects.equals(this.getLore(), bukkit.getLore()) && Objects.equals(this.getEnchantments(), bukkit.getEnchantments());
+			return isSimilar(bukkit) && this.amount == bukkit.getAmount() && this.durability == bukkit.durability && Objects.equals(this.itemMeta, bukkit.getItemMeta());
 		}
 		else
 		{

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMock.java
@@ -198,6 +198,8 @@ public class ItemStackMock extends ItemStack
 	@Override
 	public int getMaxStackSize()
 	{
+		if (this.itemMeta == null) return 0;
+
 		return this.itemMeta.hasMaxStackSize() ? this.itemMeta.getMaxStackSize() : this.type.getMaxStackSize();
 	}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMock.java
@@ -50,8 +50,7 @@ public class ItemStackMock extends ItemStack
 		this.type = stack.getType().asItemType();
 		this.amount = stack.getAmount();
 		this.durability = initDurability(this.type);
-
-
+		setItemMeta(stack.getItemMeta());
 	}
 
 	public ItemStackMock(@NotNull Material type, int amount)

--- a/src/main/java/org/mockbukkit/mockbukkit/persistence/PersistentDataContainerViewMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/persistence/PersistentDataContainerViewMock.java
@@ -1,0 +1,67 @@
+package org.mockbukkit.mockbukkit.persistence;
+
+import com.google.common.base.Preconditions;
+import io.papermc.paper.persistence.PersistentDataContainerView;
+import org.bukkit.NamespacedKey;
+import org.bukkit.persistence.PersistentDataAdapterContext;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
+
+import java.io.IOException;
+
+public abstract class PersistentDataContainerViewMock implements PersistentDataContainerView
+{
+
+	private final PersistentDataAdapterContext context = new PersistentDataAdapterContextMock();
+
+	@Override
+	public <T, Z> boolean has(NamespacedKey key, PersistentDataType<T, Z> type)
+	{
+		Preconditions.checkArgument(key != null, "The NamespacedKey key cannot be null");
+		Preconditions.checkArgument(type != null, "The provided type cannot be null");
+
+		final Object value = this.get(key, type);
+		return value != null;
+	}
+
+	@Override
+	public boolean has(NamespacedKey key)
+	{
+		return getKeys().contains(key);
+	}
+
+	@Override
+	public <T, Z> Z getOrDefault(NamespacedKey key, PersistentDataType<T, Z> type, Z defaultValue)
+	{
+		Z value = get(key, type);
+		return value != null ? value : defaultValue;
+	}
+
+	@Override
+	public boolean isEmpty()
+	{
+		return getKeys().isEmpty();
+	}
+
+	@Override
+	public PersistentDataAdapterContext getAdapterContext()
+	{
+		return context;
+	}
+
+	@Override
+	public void copyTo(PersistentDataContainer other, boolean replace)
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public byte[] serializeToBytes() throws IOException
+	{
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/ItemStackMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/ItemStackMockTest.java
@@ -12,6 +12,7 @@ import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -38,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockBukkitExtension.class)
@@ -578,9 +580,35 @@ class ItemStackMockTest
 	void getPersistentDataContainer()
 	{
 		ItemStackMock item = new ItemStackMock(Material.DIAMOND_PICKAXE);
-		PersistentDataContainerView persistentDataContainerView = item.getPersistentDataContainer();
+		PersistentDataContainerView view1 = item.getPersistentDataContainer();
+		PersistentDataContainerView view2 = item.getPersistentDataContainer();
 
-		assertNotNull(persistentDataContainerView);
+		assertSame(view1, view2);
+		assertNotNull(view1);
+		assertTrue(view1.isEmpty());
+
+		NamespacedKey key = NamespacedKey.fromString("key");
+		ItemMeta meta = item.getItemMeta();
+
+		meta.getPersistentDataContainer().set(key, PersistentDataType.STRING, "value");
+		assertTrue(view1.isEmpty());
+
+		item.setItemMeta(meta);
+		assertFalse(view1.isEmpty());
+		assertEquals("value", view1.get(key, PersistentDataType.STRING));
+	}
+
+	@Test
+	void getPersistentDataContainer_Air()
+	{
+		ItemStack item = new ItemStack(Material.AIR);
+		PersistentDataContainerView view1 = item.getPersistentDataContainer();
+		PersistentDataContainerView view2 = item.getPersistentDataContainer();
+
+		assertSame(view1, view2);
+		assertNotNull(view1);
+
+		assertTrue(view1.isEmpty());
 	}
 
 	@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/ItemStackMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/ItemStackMockTest.java
@@ -1,29 +1,31 @@
 package org.mockbukkit.mockbukkit.inventory;
 
-import org.bukkit.Bukkit;
-import org.bukkit.inventory.meta.Damageable;
-import org.mockbukkit.mockbukkit.MockBukkit;
-import org.mockbukkit.mockbukkit.MockBukkitExtension;
-import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
-import org.mockbukkit.mockbukkit.inventory.meta.ArmorMetaMock;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import io.papermc.paper.persistence.PersistentDataContainerView;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
+import org.mockbukkit.mockbukkit.inventory.meta.ArmorMetaMock;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -31,12 +33,12 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @ExtendWith(MockBukkitExtension.class)
 class ItemStackMockTest
@@ -570,6 +572,91 @@ class ItemStackMockTest
 
 		assertFalse(damageable.hasDamage());
 		assertTrue(damageable.hasDamageValue());
+	}
+
+	@Test
+	void getPersistentDataContainer()
+	{
+		ItemStackMock item = new ItemStackMock(Material.DIAMOND_PICKAXE);
+		PersistentDataContainerView persistentDataContainerView = item.getPersistentDataContainer();
+
+		assertNotNull(persistentDataContainerView);
+	}
+
+	@Test
+	void withType()
+	{
+		ItemStackMock item = new ItemStackMock(Material.DIAMOND_PICKAXE);
+		item.setDurability((short) 1);
+		ItemMeta meta = item.getItemMeta();
+		meta.setLore(Collections.singletonList("test"));
+
+		item.setItemMeta(meta);
+		ItemStack other = item.withType(Material.NETHERITE_PICKAXE);
+
+		assertEquals(item.getItemMeta(), other.getItemMeta());
+		assertEquals(Material.NETHERITE_PICKAXE, other.getType());
+		assertEquals(item.getDurability(), other.getDurability());
+	}
+
+	@Test
+	void withType_Air()
+	{
+		ItemStackMock item = new ItemStackMock(Material.DIAMOND_PICKAXE);
+		item.setDurability((short) 1);
+		ItemMeta meta = item.getItemMeta();
+		meta.setLore(Collections.singletonList("test"));
+
+		item.setItemMeta(meta);
+		ItemStack other = item.withType(Material.AIR);
+
+		assertEquals(null, other.getItemMeta());
+		assertEquals(Material.AIR, other.getType());
+	}
+
+	@Test
+	void containsEnchantment()
+	{
+		ItemStackMock item = new ItemStackMock(Material.DIAMOND_PICKAXE);
+
+		assertFalse(item.containsEnchantment(Enchantment.EFFICIENCY));
+		item.addUnsafeEnchantment(Enchantment.EFFICIENCY, 5);
+		assertTrue(item.containsEnchantment(Enchantment.EFFICIENCY));
+
+		assertEquals(5, item.removeEnchantment(Enchantment.EFFICIENCY));
+	}
+
+	@Test
+	void containsEnchantment_Air()
+	{
+		ItemStackMock item = new ItemStackMock(Material.AIR);
+
+		assertFalse(item.containsEnchantment(Enchantment.EFFICIENCY));
+		item.addUnsafeEnchantment(Enchantment.EFFICIENCY, 5);
+		assertFalse(item.containsEnchantment(Enchantment.EFFICIENCY));
+
+		assertEquals(0, item.removeEnchantment(Enchantment.EFFICIENCY));
+	}
+
+	@Test
+	void removeEnchantment_Empty()
+	{
+		ItemStack item = new ItemStack(Material.DIAMOND_PICKAXE);
+
+		assertEquals(0, item.removeEnchantment(Enchantment.EFFICIENCY));
+	}
+
+	@Test
+	void removeEnchantments()
+	{
+		ItemStackMock item = new ItemStackMock(Material.DIAMOND_PICKAXE);
+
+		item.addUnsafeEnchantment(Enchantment.EFFICIENCY, 5);
+		item.addUnsafeEnchantment(Enchantment.UNBREAKING, 3);
+
+		assertEquals(2, item.getEnchantments().size());
+		item.removeEnchantments();
+		assertTrue(item.getEnchantments().isEmpty());
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/persistence/PersistentDataContainerViewMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/persistence/PersistentDataContainerViewMockTest.java
@@ -1,0 +1,116 @@
+package org.mockbukkit.mockbukkit.persistence;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockBukkitExtension.class)
+public class PersistentDataContainerViewMockTest {
+
+    PersistentDataContainerMock parentContainer;
+    PersistentDataContainerViewMock view;
+
+    @BeforeEach
+    void setUp() {
+        parentContainer = new PersistentDataContainerMock();
+
+        view = new PersistentDataContainerViewMock() {
+            @Override
+            public <P, C> @Nullable C get(@NotNull NamespacedKey key, @NotNull PersistentDataType<P, C> type) {
+                return parentContainer.get(key, type);
+            }
+
+            @Override
+            public @NotNull Set<NamespacedKey> getKeys() {
+                return parentContainer.getKeys();
+            }
+        };
+
+    }
+
+    @NotNull
+    @SuppressWarnings("deprecation")
+    private NamespacedKey getRandomKey() {
+        return NamespacedKey.randomKey();
+    }
+
+    @Test
+    void testHas() {
+        NamespacedKey key = getRandomKey();
+        parentContainer.set(key, PersistentDataType.STRING, "value");
+
+        assertTrue(view.has(key));
+        assertTrue(view.has(key, PersistentDataType.STRING));
+
+        assertFalse(view.has(key, PersistentDataType.INTEGER));
+    }
+
+    @Test
+    void testHas_Invalid() {
+        NamespacedKey key = getRandomKey();
+
+        assertFalse(view.has(key));
+        assertFalse(view.has(key, PersistentDataType.STRING));
+    }
+
+    @Test
+    void testGet() {
+        NamespacedKey key = getRandomKey();
+
+        assertNull(view.get(key, PersistentDataType.STRING));
+
+        parentContainer.set(key, PersistentDataType.STRING, "value");
+        assertEquals("value", view.get(key, PersistentDataType.STRING));
+
+        parentContainer.remove(key);
+        assertNull(view.get(key, PersistentDataType.STRING));
+    }
+
+    @Test
+    void testGetOrDefault() {
+        NamespacedKey key = getRandomKey();
+
+        String value = view.getOrDefault(key, PersistentDataType.STRING, "default");
+        assertEquals("default", value);
+
+        parentContainer.set(key, PersistentDataType.STRING, "value");
+        assertEquals("value", view.get(key, PersistentDataType.STRING));
+
+        parentContainer.remove(key);
+        value = view.getOrDefault(key, PersistentDataType.STRING, "default");
+        assertEquals("default", value);
+    }
+
+    @Test
+    void testKeySet() {
+        NamespacedKey key = getRandomKey();
+        parentContainer.set(key, PersistentDataType.STRING, "value");
+
+        assertEquals(parentContainer.getKeys(), view.getKeys());
+    }
+
+    @Test
+    void testIsEmpty() {
+        NamespacedKey key = getRandomKey();
+
+        assertTrue(view.isEmpty());
+
+        parentContainer.set(key, PersistentDataType.STRING, "value");
+        assertFalse(view.isEmpty());
+    }
+
+    @Test
+    void testGetAdapterContext() {
+        assertInstanceOf(PersistentDataAdapterContextMock.class, view.getAdapterContext());
+    }
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/persistence/PersistentDataContainerViewMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/persistence/PersistentDataContainerViewMockTest.java
@@ -14,7 +14,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockBukkitExtension.class)
-public class PersistentDataContainerViewMockTest {
+class PersistentDataContainerViewMockTest {
 
     PersistentDataContainerMock parentContainer;
     PersistentDataContainerViewMock view;

--- a/src/test/java/org/mockbukkit/mockbukkit/persistence/PersistentDataContainerViewMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/persistence/PersistentDataContainerViewMockTest.java
@@ -11,106 +11,123 @@ import org.mockbukkit.mockbukkit.MockBukkitExtension;
 
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockBukkitExtension.class)
-class PersistentDataContainerViewMockTest {
+class PersistentDataContainerViewMockTest
+{
 
-    PersistentDataContainerMock parentContainer;
-    PersistentDataContainerViewMock view;
+	PersistentDataContainerMock parentContainer;
+	PersistentDataContainerViewMock view;
 
-    @BeforeEach
-    void setUp() {
-        parentContainer = new PersistentDataContainerMock();
+	@BeforeEach
+	void setUp()
+	{
+		parentContainer = new PersistentDataContainerMock();
 
-        view = new PersistentDataContainerViewMock() {
-            @Override
-            public <P, C> @Nullable C get(@NotNull NamespacedKey key, @NotNull PersistentDataType<P, C> type) {
-                return parentContainer.get(key, type);
-            }
+		view = new PersistentDataContainerViewMock()
+		{
+			@Override
+			public <P, C> @Nullable C get(@NotNull NamespacedKey key, @NotNull PersistentDataType<P, C> type)
+			{
+				return parentContainer.get(key, type);
+			}
 
-            @Override
-            public @NotNull Set<NamespacedKey> getKeys() {
-                return parentContainer.getKeys();
-            }
-        };
+			@Override
+			public @NotNull Set<NamespacedKey> getKeys()
+			{
+				return parentContainer.getKeys();
+			}
+		};
 
-    }
+	}
 
-    @NotNull
-    @SuppressWarnings("deprecation")
-    private NamespacedKey getRandomKey() {
-        return NamespacedKey.randomKey();
-    }
+	@NotNull
+	@SuppressWarnings("deprecation")
+	private NamespacedKey getRandomKey()
+	{
+		return NamespacedKey.randomKey();
+	}
 
-    @Test
-    void testHas() {
-        NamespacedKey key = getRandomKey();
-        parentContainer.set(key, PersistentDataType.STRING, "value");
+	@Test
+	void testHas()
+	{
+		NamespacedKey key = getRandomKey();
+		parentContainer.set(key, PersistentDataType.STRING, "value");
 
-        assertTrue(view.has(key));
-        assertTrue(view.has(key, PersistentDataType.STRING));
+		assertTrue(view.has(key));
+		assertTrue(view.has(key, PersistentDataType.STRING));
 
-        assertFalse(view.has(key, PersistentDataType.INTEGER));
-    }
+		assertFalse(view.has(key, PersistentDataType.INTEGER));
+	}
 
-    @Test
-    void testHas_Invalid() {
-        NamespacedKey key = getRandomKey();
+	@Test
+	void testHas_Invalid()
+	{
+		NamespacedKey key = getRandomKey();
 
-        assertFalse(view.has(key));
-        assertFalse(view.has(key, PersistentDataType.STRING));
-    }
+		assertFalse(view.has(key));
+		assertFalse(view.has(key, PersistentDataType.STRING));
+	}
 
-    @Test
-    void testGet() {
-        NamespacedKey key = getRandomKey();
+	@Test
+	void testGet()
+	{
+		NamespacedKey key = getRandomKey();
 
-        assertNull(view.get(key, PersistentDataType.STRING));
+		assertNull(view.get(key, PersistentDataType.STRING));
 
-        parentContainer.set(key, PersistentDataType.STRING, "value");
-        assertEquals("value", view.get(key, PersistentDataType.STRING));
+		parentContainer.set(key, PersistentDataType.STRING, "value");
+		assertEquals("value", view.get(key, PersistentDataType.STRING));
 
-        parentContainer.remove(key);
-        assertNull(view.get(key, PersistentDataType.STRING));
-    }
+		parentContainer.remove(key);
+		assertNull(view.get(key, PersistentDataType.STRING));
+	}
 
-    @Test
-    void testGetOrDefault() {
-        NamespacedKey key = getRandomKey();
+	@Test
+	void testGetOrDefault()
+	{
+		NamespacedKey key = getRandomKey();
 
-        String value = view.getOrDefault(key, PersistentDataType.STRING, "default");
-        assertEquals("default", value);
+		String value = view.getOrDefault(key, PersistentDataType.STRING, "default");
+		assertEquals("default", value);
 
-        parentContainer.set(key, PersistentDataType.STRING, "value");
-        assertEquals("value", view.get(key, PersistentDataType.STRING));
+		parentContainer.set(key, PersistentDataType.STRING, "value");
+		assertEquals("value", view.get(key, PersistentDataType.STRING));
 
-        parentContainer.remove(key);
-        value = view.getOrDefault(key, PersistentDataType.STRING, "default");
-        assertEquals("default", value);
-    }
+		parentContainer.remove(key);
+		value = view.getOrDefault(key, PersistentDataType.STRING, "default");
+		assertEquals("default", value);
+	}
 
-    @Test
-    void testKeySet() {
-        NamespacedKey key = getRandomKey();
-        parentContainer.set(key, PersistentDataType.STRING, "value");
+	@Test
+	void testKeySet()
+	{
+		NamespacedKey key = getRandomKey();
+		parentContainer.set(key, PersistentDataType.STRING, "value");
 
-        assertEquals(parentContainer.getKeys(), view.getKeys());
-    }
+		assertEquals(parentContainer.getKeys(), view.getKeys());
+	}
 
-    @Test
-    void testIsEmpty() {
-        NamespacedKey key = getRandomKey();
+	@Test
+	void testIsEmpty()
+	{
+		NamespacedKey key = getRandomKey();
 
-        assertTrue(view.isEmpty());
+		assertTrue(view.isEmpty());
 
-        parentContainer.set(key, PersistentDataType.STRING, "value");
-        assertFalse(view.isEmpty());
-    }
+		parentContainer.set(key, PersistentDataType.STRING, "value");
+		assertFalse(view.isEmpty());
+	}
 
-    @Test
-    void testGetAdapterContext() {
-        assertInstanceOf(PersistentDataAdapterContextMock.class, view.getAdapterContext());
-    }
+	@Test
+	void testGetAdapterContext()
+	{
+		assertInstanceOf(PersistentDataAdapterContextMock.class, view.getAdapterContext());
+	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/persistence/PersistentDataTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/persistence/PersistentDataTest.java
@@ -1,10 +1,8 @@
 package org.mockbukkit.mockbukkit.persistence;
 
-import org.mockbukkit.mockbukkit.MockBukkit;
-import org.mockbukkit.mockbukkit.ServerMock;
-import org.mockbukkit.mockbukkit.entity.PlayerMock;
-import org.mockbukkit.mockbukkit.inventory.meta.ItemMetaMock;
+import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
@@ -12,8 +10,11 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockbukkit.mockbukkit.persistence.PersistentDataAdapterContextMock;
-import org.mockbukkit.mockbukkit.persistence.PersistentDataContainerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.inventory.ItemStackMock;
+import org.mockbukkit.mockbukkit.inventory.meta.ItemMetaMock;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -55,6 +56,9 @@ class PersistentDataTest
 	@Test
 	void testImplementationMocks()
 	{
+		ItemStack item = new ItemStackMock(Material.DIAMOND_PICKAXE);
+		assertTrue(item.getPersistentDataContainer() instanceof PersistentDataContainerViewMock);
+
 		ItemMeta meta = new ItemMetaMock();
 		assertTrue(meta.getPersistentDataContainer() instanceof PersistentDataContainerMock);
 


### PR DESCRIPTION
# Description
Another fix for ItemStackMock
- Fix equals function
- Implement most part or throw exception on method referencing delegated ItemStack. (null on ItemStackMock)
- Also ensure AIR item has not ItemMeta after setItemMeta

Also implemented PersistentDataContainerViewMock as it is required for getPersistentDataContainer in ItemStack

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
