### PR TITLE
Add GetEntityCount and GetMoonPhase in WorldMock

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
@@ -634,8 +634,7 @@ public class WorldMock implements World
 	@Override
 	public @NotNull MoonPhase getMoonPhase()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return MoonPhase.getPhase(getFullTime() / 24000L);
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
@@ -589,8 +589,13 @@ public class WorldMock implements World
 	@Override
 	public int getEntityCount()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		int ret = 0;
+		for (Entity entity : getEntities()) {
+			if (isChunkLoaded(entity.getChunk())) {
+				++ret;
+			}
+		}
+		return ret;
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
@@ -3,6 +3,7 @@ package org.mockbukkit.mockbukkit.world;
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
 import io.papermc.paper.event.world.WorldGameRuleChangeEvent;
+import io.papermc.paper.world.MoonPhase;
 import org.bukkit.Chunk;
 import org.bukkit.ChunkSnapshot;
 import org.bukkit.Difficulty;
@@ -46,6 +47,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.MockBukkitExtension;
@@ -2388,6 +2390,35 @@ class WorldMockTest
 
 		zombie.remove();
 		assertEquals(0, world.getEntityCount());
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+		"FULL_MOON, 0",
+		"FULL_MOON, 23999",
+		"WANING_GIBBOUS, 24000",
+		"WANING_GIBBOUS, 47999",
+		"LAST_QUARTER, 48000",
+		"LAST_QUARTER, 71999",
+		"WANING_CRESCENT, 72000",
+		"WANING_CRESCENT, 95999",
+		"NEW_MOON, 96000",
+		"NEW_MOON, 119999",
+		"WAXING_CRESCENT, 120000",
+		"WAXING_CRESCENT, 143999",
+		"FIRST_QUARTER, 144000",
+		"FIRST_QUARTER, 167999",
+		"WAXING_GIBBOUS, 168000",
+		"WAXING_GIBBOUS, 191999",
+		"FULL_MOON, 192000",
+	})
+	void getMoonPhase(MoonPhase expected, long time)
+	{
+		WorldMock world = new WorldMock(Material.DIRT, 3);
+
+		world.setFullTime(time);
+
+		assertEquals(expected, world.getMoonPhase());
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
@@ -41,6 +41,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.util.BoundingBox;
 import org.bukkit.util.Consumer;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -2368,6 +2369,25 @@ class WorldMockTest
 
 		world.setEnvironment(World.Environment.THE_END);
 		assertEquals(256, world.getLogicalHeight());
+	}
+
+	@Test
+	void getEntityCount()
+	{
+		WorldMock world = new WorldMock(Material.DIRT, 3);
+		assertEquals(0, world.getEntityCount());
+
+		Entity zombie = world.spawnEntity(new Location(world, 0, 5, 0), EntityType.ZOMBIE);
+		assertEquals(1, world.getEntityCount());
+
+		Entity wolf = world.spawnEntity(new Location(world, 5, 5, 5), EntityType.WOLF);
+		assertEquals(2, world.getEntityCount());
+
+		wolf.remove();
+		assertEquals(1, world.getEntityCount());
+
+		zombie.remove();
+		assertEquals(0, world.getEntityCount());
 	}
 
 }


### PR DESCRIPTION
# Description
Implement method GetEntityCount and GetMoonPhase in World mock.

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
