### PR TITLE
fix(workflow): update tag message to include commit ID and PR number

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.BUILD_TOKEN }}
-      
+
       - name: Get merged pull request
         uses: actions-ecosystem/action-get-merged-pull-request@v1.0.1
         if: ${{ github.event_name == 'push' }}
@@ -43,9 +43,18 @@ jobs:
           current_version: ${{ steps.get-latest-tag.outputs.tag }}
           level: ${{ steps.release-label.outputs.level }}
 
+      - name: Get commit ID for the new tag
+        id: get-commit-id
+        run: echo "commit_id=$(git rev-parse HEAD)" >> $GITHUB_ENV
+
+      - name: Extract PR number from commit message
+        id: extract-pr
+        run: echo "pr_number=$(git log -1 --pretty=%B | grep -oP '(?<=#)\d+')" >> $GITHUB_ENV
+
       - name: Push tag
         uses: actions-ecosystem/action-push-tag@v1
         if: ${{ steps.bump-semver.outputs.new_version != null }}
         with:
           tag: ${{ steps.bump-semver.outputs.new_version }}
-          message: '${{ steps.bump-semver.outputs.new_version }}: PR #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}'
+          message: '${{ steps.bump-semver.outputs.new_version }}: PR #${{ env.pr_number }} - Commit ID: ${{ env.commit_id }}'
+

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -43,18 +43,10 @@ jobs:
           current_version: ${{ steps.get-latest-tag.outputs.tag }}
           level: ${{ steps.release-label.outputs.level }}
 
-      - name: Get commit ID for the new tag
-        id: get-commit-id
-        run: echo "commit_id=$(git rev-parse HEAD)" >> $GITHUB_ENV
-
-      - name: Extract PR number from commit message
-        id: extract-pr
-        run: echo "pr_number=$(git log -1 --pretty=%B | grep -oP '(?<=#)\d+')" >> $GITHUB_ENV
-
       - name: Push tag
         uses: actions-ecosystem/action-push-tag@v1
         if: ${{ steps.bump-semver.outputs.new_version != null }}
         with:
           tag: ${{ steps.bump-semver.outputs.new_version }}
-          message: '${{ steps.bump-semver.outputs.new_version }}: PR #${{ env.pr_number }} - Commit ID: ${{ env.commit_id }}'
+          message: '${{ steps.bump-semver.outputs.new_version }}: PR #${{ steps.pr.outputs.number }} - Commit ID: ${{ github.sha }}'
 


### PR DESCRIPTION
# Description
This PR fixes PR Number parsing for tags

> [!WARNING]  
> This relies on having the PR number as part of the commit message e.g. `fizz buzz (#123)`. Changing the format of these commit messages breaks this workflow and requires adaptations to be made to accomodate the new format

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
