### PR TITLE
Improve power in FireworkMetaMock

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/FireworkMetaMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/FireworkMetaMock.java
@@ -11,6 +11,7 @@ import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Mock implementation of an {@link FireworkMeta}.
@@ -21,7 +22,7 @@ public class FireworkMetaMock extends ItemMetaMock implements FireworkMeta
 {
 
 	private @NotNull List<FireworkEffect> effects = new ArrayList<>();
-	private int power = 0;
+	private Integer power;
 
 	/**
 	 * Constructs a new {@link FireworkMetaMock}.
@@ -42,17 +43,21 @@ public class FireworkMetaMock extends ItemMetaMock implements FireworkMeta
 
 		if(meta instanceof FireworkMeta fireworkMeta)
 		{
-			this.effects.addAll(fireworkMeta.getEffects());
-			this.power = fireworkMeta.getPower();
+			if (fireworkMeta.hasEffects())
+			{
+				this.effects.addAll(fireworkMeta.getEffects());
+			}
+			if (fireworkMeta.hasPower())
+			{
+				this.power = fireworkMeta.getPower();
+			}
 		}
 	}
 
 	@Override
 	public int hashCode()
 	{
-		final int prime = 31;
-		int result = super.hashCode();
-		return prime * result + effects.hashCode();
+		return Objects.hash(super.hashCode(), effects, power);
 	}
 
 	@Override
@@ -71,7 +76,7 @@ public class FireworkMetaMock extends ItemMetaMock implements FireworkMeta
 			return false;
 		}
 
-		return effects.equals(other.effects);
+		return Objects.equals(effects, other.effects) && Objects.equals(power, other.power);
 	}
 
 	@Override
@@ -144,22 +149,21 @@ public class FireworkMetaMock extends ItemMetaMock implements FireworkMeta
 	@Override
 	public boolean hasPower()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return power != null;
 	}
 
 	@Override
 	public int getPower()
 	{
-		return power;
+		return power != null ? power : 0;
 	}
 
 	@Override
 	public void setPower(int power)
 	{
-		if (power < 0 || power > 128)
+		if (power < 0 || power > 255)
 		{
-			throw new IllegalArgumentException("Power must be between 0 and 128");
+			throw new IllegalArgumentException("Power must be between 0 and 255");
 		}
 
 		this.power = power;
@@ -179,6 +183,10 @@ public class FireworkMetaMock extends ItemMetaMock implements FireworkMeta
 		serialMock.addEffects(((List<?>) args.get("effects")).stream()
 				.map(e -> (FireworkEffect) FireworkEffect.deserialize((Map<String, Object>) e))
 				.toList());
+		if (args.containsKey("power"))
+		{
+			serialMock.power = (int) args.get("power");
+		}
 		return serialMock;
 	}
 
@@ -192,6 +200,10 @@ public class FireworkMetaMock extends ItemMetaMock implements FireworkMeta
 	public @NotNull Map<String, Object> serialize()
 	{
 		final Map<String, Object> serialized = super.serialize();
+		if (hasPower())
+		{
+			serialized.put("power", power);
+		}
 		serialized.put("effects", effects.stream().map(FireworkEffect::serialize).toList());
 		return serialized;
 	}

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/FireworkMetaMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/FireworkMetaMock.java
@@ -161,10 +161,8 @@ public class FireworkMetaMock extends ItemMetaMock implements FireworkMeta
 	@Override
 	public void setPower(int power)
 	{
-		if (power < 0 || power > 255)
-		{
-			throw new IllegalArgumentException("Power must be between 0 and 255");
-		}
+		Preconditions.checkArgument(power >= 0, "power cannot be less than zero: %s", power);
+		Preconditions.checkArgument(power <= 255, "power cannot be more than 255: %s", power);
 
 		this.power = power;
 	}

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/FireworkMetaMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/FireworkMetaMock.java
@@ -41,7 +41,7 @@ public class FireworkMetaMock extends ItemMetaMock implements FireworkMeta
 	{
 		super(meta);
 
-		if(meta instanceof FireworkMeta fireworkMeta)
+		if (meta instanceof FireworkMeta fireworkMeta)
 		{
 			if (fireworkMeta.hasEffects())
 			{

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/meta/FireworkMetaMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/meta/FireworkMetaMockTest.java
@@ -159,4 +159,5 @@ class FireworkMetaMockTest
 		assertEquals(8, meta2.getPower());
 		assertEquals(2, meta2.getEffectsSize());
 	}
+
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/meta/FireworkMetaMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/meta/FireworkMetaMockTest.java
@@ -119,7 +119,10 @@ class FireworkMetaMockTest
 	void testPower()
 	{
 		FireworkMeta meta = new FireworkMetaMock();
+		assertFalse(meta.hasPower());
+		assertEquals(0, meta.getPower());
 		meta.setPower(8);
+		assertTrue(meta.hasPower());
 		assertEquals(8, meta.getPower());
 	}
 
@@ -127,14 +130,33 @@ class FireworkMetaMockTest
 	void testPowerTooLow()
 	{
 		FireworkMeta meta = new FireworkMetaMock();
-		assertThrows(IllegalArgumentException.class, () -> meta.setPower(-200));
+		assertThrows(IllegalArgumentException.class, () -> meta.setPower(-1));
 	}
 
 	@Test
 	void testPowerTooHigh()
 	{
 		FireworkMeta meta = new FireworkMetaMock();
-		assertThrows(IllegalArgumentException.class, () -> meta.setPower(1024));
+		assertThrows(IllegalArgumentException.class, () -> meta.setPower(256));
 	}
 
+	@Test
+	void testSerialization()
+	{
+		FireworkMeta meta = new FireworkMetaMock();
+
+		FireworkMeta meta2 = FireworkMetaMock.deserialize(meta.serialize());
+		assertEquals(meta, meta2);
+		assertFalse(meta2.hasPower());
+		assertFalse(meta2.hasEffects());
+
+		meta.addEffect(FireworkEffect.builder().withColor(Color.BLUE).with(Type.BALL_LARGE).build());
+		meta.addEffect(FireworkEffect.builder().withColor(Color.RED).with(Type.STAR).build());
+		meta.setPower(8);
+
+		meta2 = FireworkMetaMock.deserialize(meta.serialize());
+		assertEquals(meta, meta2);
+		assertEquals(8, meta2.getPower());
+		assertEquals(2, meta2.getEffectsSize());
+	}
 }


### PR DESCRIPTION
# Description
FireworkMetaMock fixes issue #1212 
- implement .hasPower()
- increase max power to 255 to match 1.21;
- fix serialization bug (power not serialized)
- add tests

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
