### PR TITLE
Fixed Wither health according to Java edition

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/WitherMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/WitherMock.java
@@ -1,6 +1,7 @@
 package org.mockbukkit.mockbukkit.entity;
 
 import org.bukkit.Location;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Wither;
@@ -42,8 +43,8 @@ public class WitherMock extends AbstractBossMock implements Wither
 	{
 		super(server, uuid, "Wither");
 		this.setLocation(new Location(worldMock, 0, 0, 0));
-		setMaxHealth(entityData.getHealth(this.getSubType(), this.getEntityState(), this.getWorld().getDifficulty()));
-		setHealth(getMaxHealth());
+
+		this.attributes.get(Attribute.GENERIC_MAX_HEALTH).setBaseValue(300F);
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/data/EntityData.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/data/EntityData.java
@@ -4,7 +4,6 @@ import com.google.common.base.Preconditions;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import org.bukkit.Difficulty;
 import org.bukkit.entity.EntityType;
 import org.jetbrains.annotations.NotNull;
 import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
@@ -18,7 +17,6 @@ public class EntityData
 
 
 	private static final String STATES = "states";
-	private static final String HEALTH = "health";
 
 	private final EntityType type;
 	private final @NotNull String data;
@@ -71,26 +69,6 @@ public class EntityData
 	public double getEyeHeight(EntitySubType subType, EntityState state)
 	{
 		return getValueFromKey(EYE_HEIGHT, subType, state).getAsDouble();
-	}
-
-	public double getHealth(EntitySubType subType, EntityState state, Difficulty difficulty)
-	{
-		JsonObject stateData = getStateMapping(subType, state);
-
-		JsonElement healthElement = stateData.get(HEALTH);
-		if (healthElement == null || !healthElement.isJsonObject())
-		{
-			throw new UnimplementedOperationException("Difficulty health data for entitytype " + type + " is not implemented.");
-		}
-
-		JsonObject healthData = healthElement.getAsJsonObject();
-		JsonElement difficultyHealth = healthData.get(difficulty.name());
-		if (difficultyHealth == null)
-		{
-			throw new UnimplementedOperationException("Health data for difficulty " + difficulty + " for entitytype " + type + " is not implemented.");
-		}
-
-		return difficultyHealth.getAsDouble();
 	}
 
 	/**

--- a/src/main/resources/entities/wither.json
+++ b/src/main/resources/entities/wither.json
@@ -1,12 +1,6 @@
 {
 	"default": {
 		"eyeHeight": 2.9750001,
-		"health": {
-			"EASY": 300.0,
-			"HARD": 600.0,
-			"NORMAL": 450.0,
-			"PEACEFUL": -1.0
-		},
 		"height": 3.5,
 		"width": 0.9
 	}

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/WitherMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/WitherMockTest.java
@@ -53,7 +53,7 @@ class WitherMockTest
 	}
 
 	@Test
-	void getMaxHeathEasy()
+	void getMaxHealthEasy()
 	{
 		WorldMock worldMock = new WorldMock();
 		worldMock.setDifficulty(Difficulty.EASY);
@@ -62,21 +62,21 @@ class WitherMockTest
 	}
 
 	@Test
-	void getMaxHeathNormal()
+	void getMaxHealthNormal()
 	{
 		WorldMock worldMock = new WorldMock();
 		worldMock.setDifficulty(Difficulty.NORMAL);
 		WitherMock tempWither = new WitherMock(server, UUID.randomUUID(), worldMock);
-		assertEquals(450.0D, tempWither.getMaxHealth());
+		assertEquals(300.0D, tempWither.getMaxHealth());
 	}
 
 	@Test
-	void getMaxHeathHard()
+	void getMaxHealthHard()
 	{
 		WorldMock worldMock = new WorldMock();
 		worldMock.setDifficulty(Difficulty.HARD);
 		WitherMock tempWither = new WitherMock(server, UUID.randomUUID(), worldMock);
-		assertEquals(600.0D, tempWither.getMaxHealth());
+		assertEquals(300.0D, tempWither.getMaxHealth());
 	}
 
 	@Test


### PR DESCRIPTION
# Description
The current implementation for Wither health is following the [bedrock rules](https://minecraft.wiki/w/Wither):
![image](https://github.com/user-attachments/assets/3eb3af69-1947-4a6e-86c6-2b85a1e46fd8)
This PR updates this logic to use the Java edition values.

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
