### PR TITLE
Add custom BlockMock implementations  to WorldMock

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
@@ -554,6 +554,23 @@ public class WorldMock implements World
 		return block;
 	}
 
+	public @NotNull void setBlock(@NotNull BlockMock block)
+	{
+		if (block.getY() >= maxHeight)
+		{
+			throw new ArrayIndexOutOfBoundsException("Y larger than max height");
+		}
+		else if (block.getY() < minHeight)
+		{
+			throw new ArrayIndexOutOfBoundsException("Y smaller than min height");
+		}
+		if (!this.equals(block.getWorld())) {
+			throw new IllegalArgumentException("Block world does not match current world");
+		}
+		blocks.put(new Coordinate(block.getX(), block.getY(), block.getZ()), block);
+	}
+
+
 	@Override
 	public boolean isVoidDamageEnabled()
 	{

--- a/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
@@ -554,7 +554,7 @@ public class WorldMock implements World
 		return block;
 	}
 
-	public @NotNull void setBlock(@NotNull BlockMock block)
+	public void setBlock(@NotNull BlockMock block)
 	{
 		if (block.getY() >= maxHeight)
 		{

--- a/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
@@ -42,7 +42,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.util.BoundingBox;
 import org.bukkit.util.Consumer;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -2423,6 +2422,38 @@ class WorldMockTest
 		world.setFullTime(time);
 
 		assertEquals(expected, world.getMoonPhase());
+	}
+
+	@Test
+	void setBlock()
+	{
+		WorldMock world = new WorldMock(Material.DIRT, 3);
+		assertEquals(Material.DIRT, world.getType(0,2,0));
+
+		BlockMock ironblock = new BlockMock(Material.IRON_BLOCK, new Location(world, 0, 2,0));
+		world.setBlock(ironblock);
+		assertEquals(Material.IRON_BLOCK, world.getType(0,2,0));
+
+		BlockMock nullLocation = new BlockMock(Material.STONE);
+		assertThrows(Exception.class, ()-> {
+			world.setBlock(nullLocation);
+		});
+
+		BlockMock differentWorld = new BlockMock(Material.IRON_BLOCK, new Location(new WorldMock(), 0, 2,0));
+		assertThrows(IllegalArgumentException.class, ()-> {
+			world.setBlock(differentWorld);
+		});
+
+		BlockMock tooHigh = new BlockMock(Material.GRANITE, new Location(world, 0, 1000, 0));
+		assertThrows(ArrayIndexOutOfBoundsException.class, ()-> {
+			world.setBlock(tooHigh);
+		});
+
+		BlockMock tooLow = new BlockMock(Material.GRANITE, new Location(world, 0, -1000, 0));
+		assertThrows(ArrayIndexOutOfBoundsException.class, ()-> {
+			world.setBlock(tooLow);
+		});
+
 	}
 
 }


### PR DESCRIPTION
# Description

Allows the addition of a custom implementation of BlockMock to a WorldMock so that testing against BlockStates, BlockData, and item drops are easier.

Addresses: #1173

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
