### PR TITLE
Improve RegistryAccessMock error messaging when MC/MB version mismatched

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/registry/RegistryAccessMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/registry/RegistryAccessMock.java
@@ -137,7 +137,9 @@ public class RegistryAccessMock implements RegistryAccess
 				{
 					String className = element.getAsString();
 					output.put(registryKey, className);
-				} else {
+				}
+				else
+				{
 					throw new InternalDataLoadException("Null JSON element while retrieving `" + registryKey.key().asString() + "` - MockBukkit / MC version mismatch?");
 				}
 			}

--- a/src/main/java/org/mockbukkit/mockbukkit/registry/RegistryAccessMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/registry/RegistryAccessMock.java
@@ -1,5 +1,6 @@
 package org.mockbukkit.mockbukkit.registry;
 
+import com.google.gson.JsonElement;
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.exception.ReflectionAccessException;
 import org.mockbukkit.mockbukkit.exception.InternalDataLoadException;
@@ -118,7 +119,6 @@ public class RegistryAccessMock implements RegistryAccess
 		}
 	}
 
-
 	private static BiMap<RegistryKey<?>, String> createClassToKeyConversions()
 	{
 		String fileName = "/registries/registry_key_class_relation.json";
@@ -132,8 +132,14 @@ public class RegistryAccessMock implements RegistryAccess
 			JsonObject object = JsonParser.parseReader(new InputStreamReader(inputStream)).getAsJsonObject();
 			for (RegistryKey<?> registryKey : getAllKeys())
 			{
-				String className = object.get(registryKey.key().asString()).getAsString();
-				output.put(registryKey, className);
+				JsonElement element = object.get(registryKey.key().asString());
+				if (element != null)
+				{
+					String className = element.getAsString();
+					output.put(registryKey, className);
+				} else {
+					throw new InternalDataLoadException("Null JSON element while retrieving `" + registryKey.key().asString() + "` - MockBukkit / MC version mismatch?");
+				}
 			}
 		}
 		catch (IOException e)


### PR DESCRIPTION

# Description
Improve RegistryAccessMock error messaging when an expected key is not found in `/registries/registry_key_class_relation.json"` likely due to a MockBukkit/MC version mismatch.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
