### PR TITLE
Feature/fix container inventory not copied

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/AbstractFurnaceStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/AbstractFurnaceStateMock.java
@@ -198,4 +198,15 @@ public abstract class AbstractFurnaceStateMock extends ContainerStateMock implem
 		return Objects.hash(super.hashCode(), burnTime, cookTime, cookTimeTotal, cookSpeedMultiplier);
 	}
 
+	@Override
+	public String toString()
+	{
+		return "AbstractFurnaceStateMock{" +
+				"burnTime=" + burnTime +
+				", cookTime=" + cookTime +
+				", cookTimeTotal=" + cookTimeTotal +
+				", cookSpeedMultiplier=" + cookSpeedMultiplier +
+				"} " + super.toString();
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/AbstractFurnaceStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/AbstractFurnaceStateMock.java
@@ -199,14 +199,11 @@ public abstract class AbstractFurnaceStateMock extends ContainerStateMock implem
 	}
 
 	@Override
-	public String toString()
-	{
-		return "AbstractFurnaceStateMock{" +
-				"burnTime=" + burnTime +
+	protected String toStringInternal() {
+		return super.toStringInternal() +
+				", burnTime=" + burnTime +
 				", cookTime=" + cookTime +
 				", cookTimeTotal=" + cookTimeTotal +
-				", cookSpeedMultiplier=" + cookSpeedMultiplier +
-				"} " + super.toString();
+				", cookSpeedMultiplier=" + cookSpeedMultiplier;
 	}
-
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/AbstractFurnaceStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/AbstractFurnaceStateMock.java
@@ -13,13 +13,14 @@ import org.bukkit.inventory.FurnaceInventory;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Mock implementation of a {@link Furnace}.
  *
  * @see ContainerStateMock
  */
-public abstract class AbstractFurnaceStateMock extends org.mockbukkit.mockbukkit.block.state.ContainerStateMock implements Furnace
+public abstract class AbstractFurnaceStateMock extends ContainerStateMock implements Furnace
 {
 
 	private short burnTime;
@@ -177,6 +178,24 @@ public abstract class AbstractFurnaceStateMock extends org.mockbukkit.mockbukkit
 		mock.setFuel(rawInventory.getFuel());
 		mock.setSmelting(rawInventory.getSmelting());
 		return mock;
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o) return true;
+		if (!(o instanceof AbstractFurnaceStateMock that)) return false;
+		if (!super.equals(o)) return false;
+		return burnTime == that.burnTime
+				&& cookTime == that.cookTime
+				&& cookTimeTotal == that.cookTimeTotal
+				&& Double.compare(cookSpeedMultiplier, that.cookSpeedMultiplier) == 0;
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash(super.hashCode(), burnTime, cookTime, cookTimeTotal, cookSpeedMultiplier);
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/BannerStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/BannerStateMock.java
@@ -205,4 +205,13 @@ public class BannerStateMock extends TileStateMock implements Banner
 		};
 	}
 
+	@Override
+	protected String toStringInternal()
+	{
+		return super.toStringInternal() +
+				", baseColor=" + baseColor +
+				", patterns=" + patterns +
+				", customName=" + customName;
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/BarrelStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/BarrelStateMock.java
@@ -215,11 +215,9 @@ public class BarrelStateMock extends ContainerStateMock implements Barrel
 	}
 
 	@Override
-	public String toString()
+	protected String toStringInternal()
 	{
-		return "BarrelStateMock{" +
-				"isOpen=" + isOpen +
-				"} " + super.toString();
+		return super.toStringInternal() + ", isOpen=" + isOpen;
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/BarrelStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/BarrelStateMock.java
@@ -10,6 +10,7 @@ import org.bukkit.loot.LootTable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -196,6 +197,21 @@ public class BarrelStateMock extends ContainerStateMock implements Barrel
 	{
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o) return true;
+		if (!(o instanceof BarrelStateMock that)) return false;
+		if (!super.equals(o)) return false;
+		return isOpen == that.isOpen;
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash(super.hashCode(), isOpen);
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/BarrelStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/BarrelStateMock.java
@@ -214,4 +214,12 @@ public class BarrelStateMock extends ContainerStateMock implements Barrel
 		return Objects.hash(super.hashCode(), isOpen);
 	}
 
+	@Override
+	public String toString()
+	{
+		return "BarrelStateMock{" +
+				"isOpen=" + isOpen +
+				"} " + super.toString();
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/BeaconStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/BeaconStateMock.java
@@ -81,6 +81,18 @@ public class BeaconStateMock extends TileStateMock implements Beacon
 	}
 
 	@Override
+	protected String toStringInternal()
+	{
+		return super.toStringInternal() +
+				", customName=" + customName +
+				", lock='" + lock + '\'' +
+				", tier=" + tier +
+				", primaryEffect=" + primaryEffect +
+				", secondaryEffect=" + secondaryEffect +
+				", effectRange=" + effectRange;
+	}
+
+	@Override
 	public @NotNull BeaconStateMock copy()
 	{
 		return new BeaconStateMock(this);

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/BeehiveStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/BeehiveStateMock.java
@@ -174,4 +174,14 @@ public class BeehiveStateMock extends TileStateMock implements Beehive
 		this.bees.clear();
 	}
 
+	@Override
+	protected String toStringInternal()
+	{
+		return super.toStringInternal() +
+				", bees=" + bees +
+				", flowerLocation=" + flowerLocation +
+				", maxBees=" + maxBees +
+				", sedated=" + sedated;
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/BlastFurnaceStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/BlastFurnaceStateMock.java
@@ -59,4 +59,11 @@ public class BlastFurnaceStateMock extends AbstractFurnaceStateMock implements B
 		return new BlastFurnaceStateMock(this);
 	}
 
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o) return true;
+		if (!(o instanceof BlastFurnaceStateMock)) return false;
+		return super.equals(o);
+	}
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/BlastFurnaceStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/BlastFurnaceStateMock.java
@@ -67,10 +67,4 @@ public class BlastFurnaceStateMock extends AbstractFurnaceStateMock implements B
 		return super.equals(o);
 	}
 
-	@Override
-	public String toString()
-	{
-		return "BlastFurnaceStateMock{} " + super.toString();
-	}
-
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/BlastFurnaceStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/BlastFurnaceStateMock.java
@@ -66,4 +66,11 @@ public class BlastFurnaceStateMock extends AbstractFurnaceStateMock implements B
 		if (!(o instanceof BlastFurnaceStateMock)) return false;
 		return super.equals(o);
 	}
+
+	@Override
+	public String toString()
+	{
+		return "BlastFurnaceStateMock{} " + super.toString();
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/BlockStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/BlockStateMock.java
@@ -403,6 +403,17 @@ public class BlockStateMock implements BlockState
 
 	}
 
+	@Override
+	public String toString()
+	{
+		return "BlockStateMock{" +
+				"block=" + block +
+				", blockData=" + blockData +
+				", material=" + material +
+				", metadataTable=" + metadataTable +
+				'}';
+	}
+
 	/**
 	 * Attempts to construct a BlockStateMock by the provided block.
 	 * Will return a basic {@link BlockStateMock} if no implementation is found.

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/BlockStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/BlockStateMock.java
@@ -403,15 +403,34 @@ public class BlockStateMock implements BlockState
 
 	}
 
+	// Implement toStringInternal() instead of overriding toString()
 	@Override
 	public String toString()
 	{
-		return "BlockStateMock{" +
-				"block=" + block +
+		return this.getClass().getSimpleName() + '{' + toStringInternal() + '}';
+	}
+
+	/**
+	 * Provides the contents of {@link #toString()} .
+	 * <p>Implementors must call super as in the following example.</p>
+	 *
+	 * <pre>{@code
+	 *	@Override
+	 *	protected String toStringInternal()
+	 *	{
+	 *		return super.toStringInternal() +
+	 *				", member1=" + member1 +
+	 *				", member2=" + member2;
+	 *	}
+	 * }</pre>
+	 * @return Comma separated list of properties and values.
+	 */
+	protected String toStringInternal()
+	{
+		return "block=" + block +
 				", blockData=" + blockData +
 				", material=" + material +
-				", metadataTable=" + metadataTable +
-				'}';
+				", metadataTable=" + metadataTable;
 	}
 
 	/**

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/BrewingStandStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/BrewingStandStateMock.java
@@ -143,13 +143,12 @@ public class BrewingStandStateMock extends ContainerStateMock implements Brewing
 	}
 
 	@Override
-	public String toString()
+	protected String toStringInternal()
 	{
-		return "BrewingStandStateMock{" +
-				"brewingTime=" + brewingTime +
+		return super.toStringInternal() +
+				", brewingTime=" + brewingTime +
 				", recipeBrewingTime=" + recipeBrewingTime +
-				", fuelLevel=" + fuelLevel +
-				"} " + super.toString();
+				", fuelLevel=" + fuelLevel;
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/BrewingStandStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/BrewingStandStateMock.java
@@ -10,6 +10,8 @@ import org.bukkit.inventory.BrewerInventory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Range;
 
+import java.util.Objects;
+
 /**
  * Mock implementation of a {@link BrewingStand}.
  *
@@ -123,6 +125,21 @@ public class BrewingStandStateMock extends ContainerStateMock implements Brewing
 	public @NotNull BrewerInventory getSnapshotInventory()
 	{
 		return (BrewerInventory) super.getSnapshotInventory();
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o) return true;
+		if (!(o instanceof BrewingStandStateMock that)) return false;
+		if (!super.equals(o)) return false;
+		return recipeBrewingTime == that.recipeBrewingTime && brewingTime == that.brewingTime && fuelLevel == that.fuelLevel;
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash(super.hashCode(), recipeBrewingTime, brewingTime, fuelLevel);
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/BrewingStandStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/BrewingStandStateMock.java
@@ -142,4 +142,14 @@ public class BrewingStandStateMock extends ContainerStateMock implements Brewing
 		return Objects.hash(super.hashCode(), recipeBrewingTime, brewingTime, fuelLevel);
 	}
 
+	@Override
+	public String toString()
+	{
+		return "BrewingStandStateMock{" +
+				"brewingTime=" + brewingTime +
+				", recipeBrewingTime=" + recipeBrewingTime +
+				", fuelLevel=" + fuelLevel +
+				"} " + super.toString();
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/CampfireStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/CampfireStateMock.java
@@ -10,6 +10,8 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Arrays;
+
 /**
  * Mock implementation of a {@link Campfire}.
  *
@@ -172,6 +174,16 @@ public class CampfireStateMock extends TileStateMock implements Campfire
 	{
 		int maxSlots = MAX_SLOTS - 1;
 		Validate.isTrue(index >= 0 && index <= maxSlots, "Slot index must be between 0 and " + maxSlots + " (inclusive)");
+	}
+
+	@Override
+	protected String toStringInternal()
+	{
+		return super.toStringInternal() +
+				", cookingDisabled=" + Arrays.toString(cookingDisabled) +
+				", items=" + Arrays.toString(items) +
+				", cookingProgress=" + Arrays.toString(cookingProgress) +
+				", cookingTime=" + Arrays.toString(cookingTime);
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/ChestStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/ChestStateMock.java
@@ -228,4 +228,12 @@ public class ChestStateMock extends ContainerStateMock implements Chest
 		return Objects.hash(super.hashCode(), isOpen);
 	}
 
+	@Override
+	public String toString()
+	{
+		return "ChestStateMock{" +
+				"isOpen=" + isOpen +
+				"} " + super.toString();
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/ChestStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/ChestStateMock.java
@@ -11,6 +11,7 @@ import org.bukkit.loot.LootTable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -210,6 +211,21 @@ public class ChestStateMock extends ContainerStateMock implements Chest
 	{
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o) return true;
+		if (!(o instanceof ChestStateMock that)) return false;
+		if (!super.equals(o)) return false;
+		return isOpen == that.isOpen;
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash(super.hashCode(), isOpen);
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/ChestStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/ChestStateMock.java
@@ -229,11 +229,9 @@ public class ChestStateMock extends ContainerStateMock implements Chest
 	}
 
 	@Override
-	public String toString()
+	protected String toStringInternal()
 	{
-		return "ChestStateMock{" +
-				"isOpen=" + isOpen +
-				"} " + super.toString();
+		return super.toStringInternal() + ", isOpen=" + isOpen;
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/CommandBlockStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/CommandBlockStateMock.java
@@ -104,4 +104,12 @@ public class CommandBlockStateMock extends TileStateMock implements CommandBlock
 		this.name = name == null ? Component.text("") : name;
 	}
 
+	@Override
+	protected String toStringInternal()
+	{
+		return super.toStringInternal() +
+				", command='" + command + '\'' +
+				", name=" + name;
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/ContainerStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/ContainerStateMock.java
@@ -138,4 +138,14 @@ public abstract class ContainerStateMock extends TileStateMock implements Contai
 		return Objects.hash(super.hashCode(), inventory, customName, lock);
 	}
 
+	@Override
+	public String toString()
+	{
+		return "ContainerStateMock{" +
+				"customName=" + customName +
+				", lock='" + lock + '\'' +
+				", inventory=" + inventory +
+				'}';
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/ContainerStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/ContainerStateMock.java
@@ -55,7 +55,7 @@ public abstract class ContainerStateMock extends TileStateMock implements Contai
 	protected ContainerStateMock(@NotNull ContainerStateMock state)
 	{
 		super(state);
-		this.inventory = state.getInventory();
+		this.inventory = new InventoryMock(state.getInventory());
 		this.customName = state.customName();
 		this.lock = state.getLock();
 	}

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/ContainerStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/ContainerStateMock.java
@@ -11,6 +11,8 @@ import org.bukkit.inventory.Inventory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Objects;
+
 /**
  * Mock implementation of a {@link Container}.
  *
@@ -119,6 +121,21 @@ public abstract class ContainerStateMock extends TileStateMock implements Contai
 	public @NotNull Inventory getSnapshotInventory()
 	{
 		return ((InventoryMock) this.inventory).getSnapshot();
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o) return true;
+		if (!(o instanceof ContainerStateMock that)) return false;
+		if (!super.equals(o)) return false;
+		return Objects.equals(inventory, that.inventory) && Objects.equals(customName, that.customName) && Objects.equals(lock, that.lock);
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash(super.hashCode(), inventory, customName, lock);
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/ContainerStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/ContainerStateMock.java
@@ -149,13 +149,11 @@ public abstract class ContainerStateMock extends TileStateMock implements Contai
 	}
 
 	@Override
-	public String toString()
+	protected String toStringInternal()
 	{
-		return "ContainerStateMock{" +
-				"customName=" + customName +
+		return super.toStringInternal() +
+				", customName=" + customName +
 				", lock='" + lock + '\'' +
-				", inventory=" + inventory +
-				'}';
+				", inventory=" + inventory;
 	}
-
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/ContainerStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/ContainerStateMock.java
@@ -55,7 +55,7 @@ public abstract class ContainerStateMock extends TileStateMock implements Contai
 	protected ContainerStateMock(@NotNull ContainerStateMock state)
 	{
 		super(state);
-		this.inventory = new InventoryMock(state.getInventory());
+		this.inventory = createInventoryCopy(state.getInventory());
 		this.customName = state.customName();
 		this.lock = state.getLock();
 	}
@@ -63,7 +63,17 @@ public abstract class ContainerStateMock extends TileStateMock implements Contai
 	/**
 	 * @return A new inventory, of the correct type for the state.
 	 */
-	protected abstract InventoryMock createInventory();
+	protected abstract @NotNull InventoryMock createInventory();
+
+	/**
+	 * @param inventory Inventory contents to copy.
+	 * @return A new inventory, of the correct type for the state with contents deep-copied from the given inventory.
+	 */
+	protected @NotNull InventoryMock createInventoryCopy(@NotNull Inventory inventory) {
+		InventoryMock other = createInventory();
+		other.setContents(inventory.getContents());
+		return other;
+	}
 
 	@Override
 	public abstract @NotNull ContainerStateMock getSnapshot();

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/CreatureSpawnerStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/CreatureSpawnerStateMock.java
@@ -289,4 +289,18 @@ public class CreatureSpawnerStateMock extends TileStateMock implements CreatureS
 		// override any methods that ever return that so setting the type is enough.
 	}
 
+	@Override
+	protected String toStringInternal()
+	{
+		return super.toStringInternal() +
+				", delay=" + delay +
+				", spawnedType=" + spawnedType +
+				", minSpawnDelay=" + minSpawnDelay +
+				", maxSpawnDelay=" + maxSpawnDelay +
+				", spawnCount=" + spawnCount +
+				", maxNearbyEntities=" + maxNearbyEntities +
+				", requiredPlayerRange=" + requiredPlayerRange +
+				", spawnRange=" + spawnRange;
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/DispenserStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/DispenserStateMock.java
@@ -205,4 +205,11 @@ public class DispenserStateMock extends ContainerStateMock implements Dispenser
 		if (!(o instanceof DispenserStateMock)) return false;
 		return super.equals(o);
 	}
+
+	@Override
+	public String toString()
+	{
+		return "DispenserStateMock{} " + super.toString();
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/DispenserStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/DispenserStateMock.java
@@ -198,4 +198,11 @@ public class DispenserStateMock extends ContainerStateMock implements Dispenser
 		throw new UnimplementedOperationException();
 	}
 
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o) return true;
+		if (!(o instanceof DispenserStateMock)) return false;
+		return super.equals(o);
+	}
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/DispenserStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/DispenserStateMock.java
@@ -206,10 +206,4 @@ public class DispenserStateMock extends ContainerStateMock implements Dispenser
 		return super.equals(o);
 	}
 
-	@Override
-	public String toString()
-	{
-		return "DispenserStateMock{} " + super.toString();
-	}
-
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/DropperStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/DropperStateMock.java
@@ -184,4 +184,11 @@ public class DropperStateMock extends ContainerStateMock implements Dropper
 		throw new UnimplementedOperationException();
 	}
 
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o) return true;
+		if (!(o instanceof DropperStateMock)) return false;
+		return super.equals(o);
+	}
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/DropperStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/DropperStateMock.java
@@ -191,4 +191,11 @@ public class DropperStateMock extends ContainerStateMock implements Dropper
 		if (!(o instanceof DropperStateMock)) return false;
 		return super.equals(o);
 	}
+
+	@Override
+	public String toString()
+	{
+		return "DropperStateMock{} " + super.toString();
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/DropperStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/DropperStateMock.java
@@ -192,10 +192,4 @@ public class DropperStateMock extends ContainerStateMock implements Dropper
 		return super.equals(o);
 	}
 
-	@Override
-	public String toString()
-	{
-		return "DropperStateMock{} " + super.toString();
-	}
-
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/EnchantingTableStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/EnchantingTableStateMock.java
@@ -89,4 +89,11 @@ public class EnchantingTableStateMock extends TileStateMock implements Enchantin
 		this.customName = name == null ? Component.text("") : LegacyComponentSerializer.legacySection().deserialize(name);
 	}
 
+
+	@Override
+	protected String toStringInternal()
+	{
+		return super.toStringInternal() + ", customName=" + customName;
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/EndGatewayStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/EndGatewayStateMock.java
@@ -108,4 +108,14 @@ public class EndGatewayStateMock extends TileStateMock implements EndGateway
 		this.age = age;
 	}
 
+
+	@Override
+	protected String toStringInternal()
+	{
+		return super.toStringInternal() +
+				", age=" + age +
+				", exactTeleport=" + exactTeleport +
+				", exitLocation=" + exitLocation;
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/EnderChestStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/EnderChestStateMock.java
@@ -88,4 +88,9 @@ public class EnderChestStateMock extends TileStateMock implements EnderChest
 		throw new UnimplementedOperationException();
 	}
 
+	@Override
+	protected String toStringInternal()
+	{
+		return super.toStringInternal() + ", isOpen=" + isOpen;
+	}
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/FurnaceStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/FurnaceStateMock.java
@@ -59,4 +59,11 @@ public class FurnaceStateMock extends AbstractFurnaceStateMock implements Furnac
 		return new FurnaceStateMock(this);
 	}
 
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o) return true;
+		if (!(o instanceof FurnaceStateMock)) return false;
+		return super.equals(o);
+	}
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/FurnaceStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/FurnaceStateMock.java
@@ -66,4 +66,11 @@ public class FurnaceStateMock extends AbstractFurnaceStateMock implements Furnac
 		if (!(o instanceof FurnaceStateMock)) return false;
 		return super.equals(o);
 	}
+
+	@Override
+	public String toString()
+	{
+		return "FurnaceStateMock{} " + super.toString();
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/FurnaceStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/FurnaceStateMock.java
@@ -67,10 +67,4 @@ public class FurnaceStateMock extends AbstractFurnaceStateMock implements Furnac
 		return super.equals(o);
 	}
 
-	@Override
-	public String toString()
-	{
-		return "FurnaceStateMock{} " + super.toString();
-	}
-
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/HopperStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/HopperStateMock.java
@@ -192,4 +192,11 @@ public class HopperStateMock extends ContainerStateMock implements Hopper
 		throw new UnimplementedOperationException();
 	}
 
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o) return true;
+		if (!(o instanceof HopperStateMock)) return false;
+		return super.equals(o);
+	}
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/HopperStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/HopperStateMock.java
@@ -200,10 +200,4 @@ public class HopperStateMock extends ContainerStateMock implements Hopper
 		return super.equals(o);
 	}
 
-	@Override
-	public String toString()
-	{
-		return "HopperStateMock{} " + super.toString();
-	}
-
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/HopperStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/HopperStateMock.java
@@ -199,4 +199,11 @@ public class HopperStateMock extends ContainerStateMock implements Hopper
 		if (!(o instanceof HopperStateMock)) return false;
 		return super.equals(o);
 	}
+
+	@Override
+	public String toString()
+	{
+		return "HopperStateMock{} " + super.toString();
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/JukeboxStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/JukeboxStateMock.java
@@ -152,4 +152,12 @@ public class JukeboxStateMock extends TileStateMock implements Jukebox
 		throw new UnimplementedOperationException();
 	}
 
+	@Override
+	protected String toStringInternal()
+	{
+		return super.toStringInternal() +
+				", playing=" + playing +
+				", recordItem=" + recordItem;
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/LecternStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/LecternStateMock.java
@@ -11,6 +11,8 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Objects;
+
 /**
  * Mock implementation of a {@link Lectern}.
  *
@@ -106,6 +108,21 @@ public class LecternStateMock extends ContainerStateMock implements Lectern
 		{
 			return 1;
 		}
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o) return true;
+		if (!(o instanceof LecternStateMock that)) return false;
+		if (!super.equals(o)) return false;
+		return currentPage == that.currentPage;
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash(super.hashCode(), currentPage);
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/LecternStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/LecternStateMock.java
@@ -125,12 +125,11 @@ public class LecternStateMock extends ContainerStateMock implements Lectern
 		return Objects.hash(super.hashCode(), currentPage);
 	}
 
+
 	@Override
-	public String toString()
+	protected String toStringInternal()
 	{
-		return "LecternStateMock{" +
-				"currentPage=" + currentPage +
-				"} " + super.toString();
+		return super.toStringInternal() + ", currentPage=" + currentPage;
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/LecternStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/LecternStateMock.java
@@ -125,4 +125,12 @@ public class LecternStateMock extends ContainerStateMock implements Lectern
 		return Objects.hash(super.hashCode(), currentPage);
 	}
 
+	@Override
+	public String toString()
+	{
+		return "LecternStateMock{" +
+				"currentPage=" + currentPage +
+				"} " + super.toString();
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/SculkSensorStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/SculkSensorStateMock.java
@@ -91,4 +91,12 @@ public class SculkSensorStateMock extends TileStateMock implements SculkSensor
 		this.listenerRange = range;
 	}
 
+	@Override
+	protected String toStringInternal()
+	{
+		return super.toStringInternal() +
+				", lastVibrationFrequency=" + lastVibrationFrequency +
+				", listenerRange=" + listenerRange;
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/SculkShriekerStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/SculkShriekerStateMock.java
@@ -84,4 +84,10 @@ public class SculkShriekerStateMock extends TileStateMock implements SculkShriek
 		throw new UnimplementedOperationException();
 	}
 
+	@Override
+	protected String toStringInternal()
+	{
+		return super.toStringInternal() + ", warningLevel=" + warningLevel;
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/ShulkerBoxStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/ShulkerBoxStateMock.java
@@ -13,6 +13,7 @@ import org.bukkit.loot.LootTable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -244,6 +245,21 @@ public class ShulkerBoxStateMock extends ContainerStateMock implements ShulkerBo
 	{
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o) return true;
+		if (!(o instanceof ShulkerBoxStateMock that)) return false;
+		if (!super.equals(o)) return false;
+		return isOpen == that.isOpen && color == that.color;
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash(super.hashCode(), color, isOpen);
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/ShulkerBoxStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/ShulkerBoxStateMock.java
@@ -262,13 +262,13 @@ public class ShulkerBoxStateMock extends ContainerStateMock implements ShulkerBo
 		return Objects.hash(super.hashCode(), color, isOpen);
 	}
 
+
 	@Override
-	public String toString()
+	protected String toStringInternal()
 	{
-		return "ShulkerBoxStateMock{" +
-				"color=" + color +
-				", isOpen=" + isOpen +
-				"} " + super.toString();
+		return super.toStringInternal() +
+				", color=" + color +
+				", isOpen=" + isOpen;
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/ShulkerBoxStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/ShulkerBoxStateMock.java
@@ -262,4 +262,13 @@ public class ShulkerBoxStateMock extends ContainerStateMock implements ShulkerBo
 		return Objects.hash(super.hashCode(), color, isOpen);
 	}
 
+	@Override
+	public String toString()
+	{
+		return "ShulkerBoxStateMock{" +
+				"color=" + color +
+				", isOpen=" + isOpen +
+				"} " + super.toString();
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/SignStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/SignStateMock.java
@@ -320,6 +320,25 @@ public class SignStateMock extends TileStateMock implements Sign
 			this.color = color;
 		}
 
+		@Override
+		public String toString()
+		{
+			return "SignSideMock{" +
+					"color=" + color +
+					", lines=" + Arrays.toString(lines) +
+					", glowing=" + glowing +
+					'}';
+		}
+
+	}
+
+
+	@Override
+	protected String toStringInternal()
+	{
+		return super.toStringInternal() +
+				", back=" + back +
+				", front=" + front;
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/SkullStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/SkullStateMock.java
@@ -229,4 +229,10 @@ public class SkullStateMock extends TileStateMock implements Skull
 		throw new UnsupportedOperationException("Must change block type");
 	}
 
+	@Override
+	protected String toStringInternal()
+	{
+		return super.toStringInternal() + ", profile=" + profile;
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/SmokerStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/SmokerStateMock.java
@@ -59,4 +59,12 @@ public class SmokerStateMock extends AbstractFurnaceStateMock implements Smoker
 		return new SmokerStateMock(this);
 	}
 
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o) return true;
+		if (!(o instanceof Smoker)) return false;
+		return super.equals(o);
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/SmokerStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/SmokerStateMock.java
@@ -67,10 +67,4 @@ public class SmokerStateMock extends AbstractFurnaceStateMock implements Smoker
 		return super.equals(o);
 	}
 
-	@Override
-	public String toString()
-	{
-		return "SmokerStateMock{} " + super.toString();
-	}
-
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/SmokerStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/SmokerStateMock.java
@@ -67,4 +67,10 @@ public class SmokerStateMock extends AbstractFurnaceStateMock implements Smoker
 		return super.equals(o);
 	}
 
+	@Override
+	public String toString()
+	{
+		return "SmokerStateMock{} " + super.toString();
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/StructureStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/StructureStateMock.java
@@ -281,4 +281,23 @@ public class StructureStateMock extends TileStateMock implements Structure
 		return num >= min && num <= max;
 	}
 
+	@Override
+	protected String toStringInternal()
+	{
+		return super.toStringInternal() +
+				", author='" + author + '\'' +
+				", structureName='" + structureName + '\'' +
+				", relativePosition=" + relativePosition +
+				", structureSize=" + structureSize +
+				", mirror=" + mirror +
+				", rotation=" + rotation +
+				", usageMode=" + usageMode +
+				", ignoreEntities=" + ignoreEntities +
+				", showAir=" + showAir +
+				", showBoundingBox=" + showBoundingBox +
+				", integrity=" + integrity +
+				", seed=" + seed +
+				", metadata='" + metadata + '\'';
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/TileStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/TileStateMock.java
@@ -86,21 +86,6 @@ public abstract class TileStateMock extends BlockStateMock implements TileState
 	}
 
 	@Override
-	public boolean equals(Object o)
-	{
-		if (this == o) return true;
-		if (!(o instanceof TileStateMock that)) return false;
-		if (!super.equals(o)) return false;
-		return Objects.equals(container, that.container);
-	}
-
-	@Override
-	public int hashCode()
-	{
-		return Objects.hash(super.hashCode(), container);
-	}
-
-	@Override
 	public String toString()
 	{
 		return "TileStateMock{" +

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/TileStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/TileStateMock.java
@@ -100,4 +100,12 @@ public abstract class TileStateMock extends BlockStateMock implements TileState
 		return Objects.hash(super.hashCode(), container);
 	}
 
+	@Override
+	public String toString()
+	{
+		return "TileStateMock{" +
+				"container=" + container +
+				"} " + super.toString();
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/TileStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/TileStateMock.java
@@ -85,4 +85,19 @@ public abstract class TileStateMock extends BlockStateMock implements TileState
 		return Objects.hash(super.hashCode(), container);
 	}
 
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o) return true;
+		if (!(o instanceof TileStateMock that)) return false;
+		if (!super.equals(o)) return false;
+		return Objects.equals(container, that.container);
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash(super.hashCode(), container);
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/TileStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/TileStateMock.java
@@ -4,7 +4,6 @@ import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 import org.mockbukkit.mockbukkit.persistence.PersistentDataContainerMock;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockState;
 import org.bukkit.block.TileState;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.jetbrains.annotations.NotNull;
@@ -86,11 +85,9 @@ public abstract class TileStateMock extends BlockStateMock implements TileState
 	}
 
 	@Override
-	public String toString()
+	protected String toStringInternal()
 	{
-		return "TileStateMock{" +
-				"container=" + container +
-				"} " + super.toString();
+		return super.toStringInternal() + ", container=" + container;
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryMock.java
@@ -798,4 +798,15 @@ public class InventoryMock implements Inventory
 		return Objects.hash(Arrays.hashCode(items), holder, type, maxStackSize, viewers);
 	}
 
+	@Override
+	public String toString()
+	{
+		return "InventoryMock{" +
+				"holder=" + (holder != null ? Objects.toIdentityString(holder) : null) +
+				", type=" + type +
+				", maxStackSize=" + maxStackSize +
+				", viewers=" + viewers.size() +
+				", items=" + Arrays.toString(items) +
+				'}';
+	}
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryMock.java
@@ -96,7 +96,7 @@ public class InventoryMock implements Inventory
 	}
 
 	/**
-	 * Copy constructor. Holder is copied by reference, inventory contests are cloned.
+	 * Copy constructor. Holder is copied by reference, inventory contents are cloned.
 	 * @param other Inventory to copy.
 	 */
 	public InventoryMock(@NotNull Inventory other)

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryMock.java
@@ -780,6 +780,7 @@ public class InventoryMock implements Inventory
 				&& Objects.equals(customTitle, that.customTitle);
 	}
 
+	/** Note: does not compare holder or viewers (matches spigot/paper). */
 	@Override
 	public boolean equals(Object o)
 	{
@@ -787,24 +788,22 @@ public class InventoryMock implements Inventory
 		if (!(o instanceof InventoryMock that)) return false;
 		return maxStackSize == that.maxStackSize
 				&& Objects.deepEquals(items, that.items)
-				&& Objects.equals(holder, that.holder)
-				&& type == that.type
-				&& Objects.equals(viewers, that.viewers);
+				&& type == that.type;
 	}
 
 	@Override
 	public int hashCode()
 	{
-		return Objects.hash(Arrays.hashCode(items), holder, type, maxStackSize, viewers);
+		return Objects.hash(Arrays.hashCode(items), type, maxStackSize);
 	}
 
 	@Override
 	public String toString()
 	{
 		return "InventoryMock{" +
-				"holder=" + (holder != null ? Objects.toIdentityString(holder) : null) +
-				", type=" + type +
+				"type=" + type +
 				", maxStackSize=" + maxStackSize +
+				", holder=" + (holder != null ? Objects.toIdentityString(holder) : null) +
 				", viewers=" + viewers.size() +
 				", items=" + Arrays.toString(items) +
 				'}';

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryMock.java
@@ -96,6 +96,18 @@ public class InventoryMock implements Inventory
 	}
 
 	/**
+	 * Copy constructor. Holder is copied by reference, inventory contests are cloned.
+	 * @param other Inventory to copy.
+	 */
+	public InventoryMock(@NotNull Inventory other)
+	{
+		this.holder = other.getHolder();
+		this.type = other.getType();
+		this.items = new ItemStack[other.getSize()];
+		this.setContents(other.getContents());
+	}
+
+	/**
 	 * Asserts that a certain condition is true for all items, even {@code nulls}, in this inventory.
 	 *
 	 * @param condition The condition to check for.
@@ -766,6 +778,24 @@ public class InventoryMock implements Inventory
 				&& Objects.equals(holder, that.holder)
 				&& type == that.type
 				&& Objects.equals(customTitle, that.customTitle);
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o) return true;
+		if (!(o instanceof InventoryMock that)) return false;
+		return maxStackSize == that.maxStackSize
+				&& Objects.deepEquals(items, that.items)
+				&& Objects.equals(holder, that.holder)
+				&& type == that.type
+				&& Objects.equals(viewers, that.viewers);
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash(Arrays.hashCode(items), holder, type, maxStackSize, viewers);
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/metadata/MetadataTable.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/metadata/MetadataTable.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Mock implementation of a {@link Metadatable}.
@@ -86,6 +87,14 @@ public class MetadataTable implements Metadatable
 				iterator.remove();
 			}
 		}
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o) return true;
+		if (!(o instanceof MetadataTable that)) return false;
+		return Objects.equals(metadata, that.metadata);
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/block/state/AbstractFurnaceStateMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/state/AbstractFurnaceStateMockTest.java
@@ -14,12 +14,18 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
-class AbstractFurnaceStateMockTest
+class AbstractFurnaceStateMockTest extends ContainerStateMockTest
 {
 
 	private WorldMock world;
 	private BlockMock block;
 	private TestFurnaceState furnace;
+
+	@Override
+	protected ContainerStateMock instance()
+	{
+		return furnace;
+	}
 
 	@BeforeEach
 	void setUp()

--- a/src/test/java/org/mockbukkit/mockbukkit/block/state/BarrelStateMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/state/BarrelStateMockTest.java
@@ -14,12 +14,18 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
-class BarrelStateMockTest
+class BarrelStateMockTest extends ContainerStateMockTest
 {
 
 	private WorldMock world;
 	private BlockMock block;
 	private BarrelStateMock barrel;
+
+	@Override
+	protected ContainerStateMock instance()
+	{
+		return barrel;
+	}
 
 	@BeforeEach
 	void setUp()

--- a/src/test/java/org/mockbukkit/mockbukkit/block/state/BrewingStandStateMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/state/BrewingStandStateMockTest.java
@@ -19,12 +19,18 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 @ExtendWith(MockBukkitExtension.class)
-class BrewingStandStateMockTest
+class BrewingStandStateMockTest extends ContainerStateMockTest
 {
 
 	private WorldMock world;
 	private BlockMock block;
 	private BrewingStandStateMock brewingStand;
+
+	@Override
+	protected ContainerStateMock instance()
+	{
+		return brewingStand;
+	}
 
 	@BeforeEach
 	void setUp()

--- a/src/test/java/org/mockbukkit/mockbukkit/block/state/ChestStateMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/state/ChestStateMockTest.java
@@ -14,12 +14,18 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
-class ChestStateMockTest
+class ChestStateMockTest extends ContainerStateMockTest
 {
 
 	private WorldMock world;
 	private BlockMock block;
 	private ChestStateMock chest;
+
+	@Override
+	protected ContainerStateMock instance()
+	{
+		return chest;
+	}
 
 	@BeforeEach
 	void setUp()

--- a/src/test/java/org/mockbukkit/mockbukkit/block/state/ContainerStateMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/state/ContainerStateMockTest.java
@@ -1,8 +1,70 @@
 package org.mockbukkit.mockbukkit.block.state;
 
+import org.bukkit.Material;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+import org.mockbukkit.mockbukkit.inventory.ItemStackMock;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockBukkitExtension.class)
 public abstract class ContainerStateMockTest
 {
 
 	protected abstract ContainerStateMock instance();
+
+	private void addItem(ContainerStateMock container)
+	{
+		container.getInventory().addItem(new ItemStackMock(Material.EMERALD, 4));
+	}
+
+	private void checkFirstItemIsFourEmeralds(ContainerStateMock container)
+	{
+		Inventory inventory = container.getInventory();
+		assertFalse(inventory.isEmpty());
+		ItemStack item = inventory.getItem(0);
+		assertNotNull(item);
+		assertEquals(Material.EMERALD, item.getType());
+		assertEquals(4, item.getAmount());
+	}
+
+	private void changeFirstItem(ContainerStateMock container)
+	{
+		Inventory inventory = container.getInventory();
+		ItemStack item = inventory.getItem(0);
+		assertNotNull(item);
+		item.setType(Material.DIAMOND_BLOCK);
+		item.setAmount(2);
+	}
+
+	private ContainerStateMock initInstance()
+	{
+		ContainerStateMock original = instance();
+		original.setLock("jeb");
+		original.setCustomName("stash");
+		addItem(original);
+		return original;
+	}
+
+	@Test
+	void testCopy_deeplyCopies()
+	{
+		ContainerStateMock original = initInstance();
+		ContainerStateMock copy = (ContainerStateMock) original.copy();
+		assertNotNull(copy);
+		assertEquals(original, copy);
+		checkFirstItemIsFourEmeralds(copy);
+
+		changeFirstItem(copy);
+		copy.setLock("val");
+		copy.setCustomName("box");
+
+		checkFirstItemIsFourEmeralds(original);
+		assertEquals("jeb", original.getLock());
+		assertEquals("stash", original.getCustomName());
+	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/block/state/ContainerStateMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/state/ContainerStateMockTest.java
@@ -1,0 +1,8 @@
+package org.mockbukkit.mockbukkit.block.state;
+
+public abstract class ContainerStateMockTest
+{
+
+	protected abstract ContainerStateMock instance();
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/state/DispenserStateMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/state/DispenserStateMockTest.java
@@ -11,12 +11,18 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
-class DispenserStateMockTest
+class DispenserStateMockTest extends ContainerStateMockTest
 {
 
 	private WorldMock world;
 	private BlockMock block;
 	private DispenserStateMock dispenser;
+
+	@Override
+	protected ContainerStateMock instance()
+	{
+		return dispenser;
+	}
 
 	@BeforeEach
 	void setUp()

--- a/src/test/java/org/mockbukkit/mockbukkit/block/state/DropperStateMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/state/DropperStateMockTest.java
@@ -11,12 +11,18 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
-class DropperStateMockTest
+class DropperStateMockTest extends ContainerStateMockTest
 {
 
 	private WorldMock world;
 	private BlockMock block;
 	private DropperStateMock dropper;
+
+	@Override
+	protected ContainerStateMock instance()
+	{
+		return dropper;
+	}
 
 	@BeforeEach
 	void setUp()

--- a/src/test/java/org/mockbukkit/mockbukkit/block/state/HopperStateMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/state/HopperStateMockTest.java
@@ -11,12 +11,18 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
-class HopperStateMockTest
+class HopperStateMockTest extends ContainerStateMockTest
 {
 
 	private WorldMock world;
 	private BlockMock block;
 	private HopperStateMock hopper;
+
+	@Override
+	protected ContainerStateMock instance()
+	{
+		return hopper;
+	}
 
 	@BeforeEach
 	void setUp()

--- a/src/test/java/org/mockbukkit/mockbukkit/block/state/LecternStateMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/state/LecternStateMockTest.java
@@ -18,12 +18,18 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 @ExtendWith(MockBukkitExtension.class)
-class LecternStateMockTest
+class LecternStateMockTest extends ContainerStateMockTest
 {
 
 	private WorldMock world;
 	private BlockMock block;
 	private LecternStateMock lectern;
+
+	@Override
+	protected ContainerStateMock instance()
+	{
+		return lectern;
+	}
 
 	@BeforeEach
 	void setUp()

--- a/src/test/java/org/mockbukkit/mockbukkit/block/state/ShulkerBoxStateMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/state/ShulkerBoxStateMockTest.java
@@ -24,12 +24,18 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class ShulkerBoxStateMockTest
+class ShulkerBoxStateMockTest extends ContainerStateMockTest
 {
 
 	private WorldMock world;
 	private BlockMock block;
 	private ShulkerBoxStateMock shulkerBox;
+
+	@Override
+	protected ContainerStateMock instance()
+	{
+		return shulkerBox;
+	}
 
 	@BeforeEach
 	void setUp()


### PR DESCRIPTION
# Description
- fixed ContainerStateMock was creating a shallow copy of inventories
- adds equals and hashCode to ContainerStateMock concretions to be able to use assertEquals in tests
- added toString impls to ContainerStateMock concretions to improve client test debugging

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
