### PR TITLE
Implement method World#canGenerateStructures

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
@@ -373,6 +373,7 @@ public class WorldMock implements World
 	private boolean pvp;
 	private boolean hardcore;
 	private boolean getKeepSpawnInMemory = true;
+	private boolean generateStructures = true;
 
 	private final Object2LongOpenHashMap<SpawnCategory> ticksPerSpawn = new Object2LongOpenHashMap<>();
 	private final Object2IntOpenHashMap<SpawnCategory> spawnLimits = new Object2IntOpenHashMap<>();
@@ -472,6 +473,7 @@ public class WorldMock implements World
 		this.worldType = creator.type();
 		this.seed = creator.seed();
 		this.environment = creator.environment();
+		this.generateStructures = creator.generateStructures();
 	}
 
 	/**
@@ -2267,8 +2269,7 @@ public class WorldMock implements World
 	@Override
 	public boolean canGenerateStructures()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.generateStructures;
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
@@ -150,7 +150,8 @@ class ServerMockTest
 		WorldCreator worldCreator = new WorldCreator("test")
 				.seed(12345)
 				.type(WorldType.FLAT)
-				.environment(World.Environment.NORMAL);
+				.environment(World.Environment.NORMAL)
+				.generateStructures(false);
 		World world = server.createWorld(worldCreator);
 
 		assertEquals(1, server.getWorlds().size());
@@ -158,6 +159,7 @@ class ServerMockTest
 		assertEquals(12345, world.getSeed());
 		assertEquals(WorldType.FLAT, world.getWorldType());
 		assertEquals(World.Environment.NORMAL, world.getEnvironment());
+		assertFalse(world.canGenerateStructures());
 
 		assertTrue(server.unloadWorld("test", false));
 		assertEquals(0, server.getWorlds().size());


### PR DESCRIPTION
# Description
Implement `World#canGenerateStructures` with is passed in from WorldCreator. By default its true.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
