### PR TITLE
Implemented custom potion name in PotionMetaMock

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/PotionMetaMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/PotionMetaMock.java
@@ -205,27 +205,6 @@ public class PotionMetaMock extends ItemMetaMock implements PotionMeta
 	}
 
 	@Override
-	@Deprecated(forRemoval = true)
-	public boolean hasCustomName()
-	{
-		return this.hasCustomPotionName();
-	}
-
-	@Override
-	@Deprecated(forRemoval = true)
-	public @Nullable String getCustomName()
-	{
-		return this.getCustomPotionName();
-	}
-
-	@Override
-	@Deprecated(forRemoval = true)
-	public void setCustomName(@Nullable String customName)
-	{
-		this.setCustomPotionName(customName);
-	}
-
-	@Override
 	public boolean hasCustomPotionName()
 	{
 		return this.customName != null;

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/PotionMetaMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/PotionMetaMock.java
@@ -32,6 +32,7 @@ public class PotionMetaMock extends ItemMetaMock implements PotionMeta
 	private @Nullable PotionType type;
 	private @NotNull List<PotionEffect> effects = new ArrayList<>();
 	private @Nullable Color color;
+	private @Nullable String customName;
 
 	/**
 	 * Constructs a new {@link PotionMetaMock}.
@@ -204,24 +205,42 @@ public class PotionMetaMock extends ItemMetaMock implements PotionMeta
 	}
 
 	@Override
+	@Deprecated(forRemoval = true)
 	public boolean hasCustomName()
 	{
-		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.hasCustomPotionName();
 	}
 
 	@Override
+	@Deprecated(forRemoval = true)
 	public @Nullable String getCustomName()
 	{
-		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.getCustomPotionName();
 	}
 
 	@Override
-	public void setCustomName(@Nullable String s)
+	@Deprecated(forRemoval = true)
+	public void setCustomName(@Nullable String customName)
 	{
-		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.setCustomPotionName(customName);
+	}
+
+	@Override
+	public boolean hasCustomPotionName()
+	{
+		return this.customName != null;
+	}
+
+	@Override
+	public @Nullable String getCustomPotionName()
+	{
+		return this.customName;
+	}
+
+	@Override
+	public void setCustomPotionName(@Nullable String customName)
+	{
+		this.customName = customName;
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/meta/PotionMetaMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/meta/PotionMetaMockTest.java
@@ -1,6 +1,5 @@
 package org.mockbukkit.mockbukkit.inventory.meta;
 
-import org.mockbukkit.mockbukkit.MockBukkitExtension;
 import org.bukkit.Color;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionEffect;
@@ -8,6 +7,7 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.potion.PotionType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -150,4 +150,17 @@ class PotionMetaMockTest
 		meta.setBasePotionType(null);
 		assertNull(meta.getBasePotionType());
 	}
+
+	@Test
+	void setCustomPotionName()
+	{
+		PotionMeta meta = new PotionMetaMock();
+		assertNull(meta.getCustomPotionName());
+		assertFalse(meta.hasCustomPotionName());
+
+		meta.setCustomPotionName("Custom potion name");
+		assertEquals("Custom potion name", meta.getCustomPotionName());
+		assertTrue(meta.hasCustomPotionName());
+	}
+
 }


### PR DESCRIPTION
# Description
Fixed compilation and added support for custom names in potion meta

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
