### PR TITLE
Improve MockBukkitInject to also support Server type.

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/MockBukkitExtension.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/MockBukkitExtension.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.TestInstancePreDestroyCallback;
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Extension that mocks the Bukkit singleton before each test and subsequently unmocks it after each test. It will also
@@ -83,6 +84,7 @@ import java.util.Optional;
  */
 public class MockBukkitExtension implements TestInstancePostProcessor, TestInstancePreDestroyCallback, ParameterResolver, BeforeAllCallback, AfterAllCallback
 {
+	private final Set<Class<?>> serverSupportedTypes = Set.of(Server.class, ServerMock.class);
 
 	@Override
 	public void postProcessTestInstance(Object testInstance, ExtensionContext context) throws Exception
@@ -95,11 +97,13 @@ public class MockBukkitExtension implements TestInstancePostProcessor, TestInsta
 	{
 		final Optional<Class<?>> classOptional = context.getTestClass();
 		if (classOptional.isEmpty())
+		{
 			return;
+		}
 
 		final List<Field> serverMockFields = FieldUtils.getAllFieldsList(classOptional.get())
 				.stream()
-				.filter(field -> Server.class.isAssignableFrom(field.getType()))
+				.filter(field -> serverSupportedTypes.contains(field.getType()))
 				.filter(field -> field.getAnnotation(MockBukkitInject.class) != null)
 				.toList();
 

--- a/src/main/java/org/mockbukkit/mockbukkit/MockBukkitExtension.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/MockBukkitExtension.java
@@ -1,6 +1,7 @@
 package org.mockbukkit.mockbukkit;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
+import org.bukkit.Server;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -98,7 +99,7 @@ public class MockBukkitExtension implements TestInstancePostProcessor, TestInsta
 
 		final List<Field> serverMockFields = FieldUtils.getAllFieldsList(classOptional.get())
 				.stream()
-				.filter(field -> field.getType() == ServerMock.class)
+				.filter(field -> Server.class.isAssignableFrom(field.getType()))
 				.filter(field -> field.getAnnotation(MockBukkitInject.class) != null)
 				.toList();
 

--- a/src/test/java/org/mockbukkit/mockbukkit/MockBukkitExtensionTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/MockBukkitExtensionTest.java
@@ -1,5 +1,6 @@
 package org.mockbukkit.mockbukkit;
 
+import org.bukkit.Server;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -121,6 +122,22 @@ class MockBukkitExtensionTest
 		void isConstructorInjectedCorrectly()
 		{
 			assertNotNull(constructorParameterServerMock);
+		}
+
+	}
+
+	@Nested
+	@ExtendWith(MockBukkitExtension.class)
+	class WithBukkitServer
+	{
+
+		@MockBukkitInject
+		private Server bukkitServer;
+
+		@Test
+		void fieldIsInjectedCorrectly()
+		{
+			assertNotNull(bukkitServer);
 		}
 
 	}


### PR DESCRIPTION
# Description
As a developer I would expect this injection to work, because the `ServerMock` is a `Server` implementation.
```java
@ExtendWith(MockBukkitExtension.class)
class SampleTest
{

  @MockBukkitInject
  private Server server;
  
  @Test
  void isNotNull()
  {
    assertNotNull(server);
  }

}
```
This PR is a small quality of life improvement that allows this type of unit tests.

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
