### PR TITLE
Implement calling of PlayerLocaleChangeEvent

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
@@ -2,6 +2,7 @@ package org.mockbukkit.mockbukkit.entity;
 
 import org.bukkit.Input;
 import org.bukkit.entity.EnderPearl;
+import org.bukkit.event.player.PlayerLocaleChangeEvent;
 import org.mockbukkit.mockbukkit.AsyncCatcher;
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.PlayerListMock;
@@ -3403,6 +3404,12 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void setLocale(@NotNull Locale locale)
 	{
 		Preconditions.checkNotNull(locale, "locale cannot be null");
+		if (locale.equals(this.locale))
+		{
+			return;
+		}
+		PlayerLocaleChangeEvent event = new PlayerLocaleChangeEvent(this, locale.toLanguageTag());
+		Bukkit.getPluginManager().callEvent(event);
 		this.locale = locale;
 	}
 

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
@@ -49,6 +49,7 @@ import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerKickEvent;
 import org.bukkit.event.player.PlayerLevelChangeEvent;
+import org.bukkit.event.player.PlayerLocaleChangeEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
@@ -97,6 +98,7 @@ import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.BrokenBarrierException;
@@ -2670,4 +2672,13 @@ class PlayerMockTest
 		assertFalse(actual);
 	}
 
+	@Test
+	void locale_simulateClientLocaleChange()
+	{
+		player.setLocale(Locale.CHINESE);
+
+		assertThat(server.getPluginManager(), hasFiredFilteredEvent(PlayerLocaleChangeEvent.class, event -> event.locale().equals(Locale.CHINESE)));
+		assertEquals(Locale.CHINESE, player.locale());
+		assertEquals("zh", player.getLocale());
+	}
 }


### PR DESCRIPTION
# Description
<!-- State the changes of the pull request below. -->
Implement PlayerLocaleChangeEvent when PlayerMock#setLocale is called and a different locale is passed in. I needed it to test per-player-locale feature in the plugin im working on.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
