### PR TITLE
Fix WorldMock#getGameRules method return data

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
@@ -1785,7 +1785,7 @@ public class WorldMock implements World
 	@Override
 	public String @NotNull [] getGameRules()
 	{
-		return gameRules.values().stream().map(Object::toString).toList().toArray(new String[0]);
+		return gameRules.keySet().stream().map(GameRule::getName).toList().toArray(new String[0]);
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
@@ -1456,6 +1456,9 @@ class WorldMockTest
 		WorldMock world = new WorldMock(Material.DIRT, 3);
 		String[] gameRules = world.getGameRules();
 		assertNotEquals(0, Arrays.stream(gameRules).count());
+		for (String gameRule : gameRules) {
+			assertNotNull(GameRule.getByName(gameRule));
+		}
 	}
 
 	@Test


### PR DESCRIPTION
# Description
<!-- State the changes of the pull request below. -->
According to bukkit api documentation, World#getGameRules should return "An array of GameRule names". However, mockbukkit implementation returns the gamrule value instead which does not align with the expected output of that method.

I also printed the return data on a actual papermc server to check:
```
[21:16:31 INFO]: [Multiverse-Core-Debug] [globalSoundEvents, tntExplosionDropDecay, enderPearlsVanishOnDeath, doFireTick, maxCommandChainLength, doVinesSpread, disableElytraMovementCheck, lavaSourceConversion, commandBlockOutput, forgiveDeadPlayers, playersNetherPortalCreativeDelay, doMobSpawning, maxEntityCramming, universalAnger, playersSleepingPercentage, snowAccumulationHeight, blockExplosionDropDecay, doImmediateRespawn, naturalRegeneration, doMobLoot, fallDamage, doEntityDrops, randomTickSpeed, playersNetherPortalDefaultDelay, spawnRadius, freezeDamage, sendCommandFeedback, doWardenSpawning, fireDamage, reducedDebugInfo, waterSourceConversion, projectilesCanBreakBlocks, announceAdvancements, drowningDamage, spawnChunkRadius, disableRaids, doWeatherCycle, mobExplosionDropDecay, doDaylightCycle, showDeathMessages, doTileDrops, doInsomnia, keepInventory, disablePlayerMovementCheck, doLimitedCrafting, mobGriefing, commandModificationBlockLimit, doTraderSpawning, logAdminCommands, spectatorsGenerateChunks, doPatrolSpawning, maxCommandForkCount]

```

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
