### PR TITLE
Fixes #1244 - [de]serializeItem to/from byte[] should include amount

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/util/UnsafeValuesMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/util/UnsafeValuesMock.java
@@ -64,6 +64,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -296,6 +297,7 @@ public class UnsafeValuesMock implements UnsafeValues
 		final ByteArrayOutputStream bao = new ByteArrayOutputStream();
 		try
 		{
+			bao.write(ByteBuffer.allocate(4).putInt(item.getAmount()).array());
 			final ObjectOutputStream oos = new BukkitObjectOutputStreamMock(bao);
 			oos.writeObject(item);
 			return bao.toByteArray();
@@ -314,8 +316,11 @@ public class UnsafeValuesMock implements UnsafeValues
 		final ByteArrayInputStream bai = new ByteArrayInputStream(data);
 		try
 		{
+			int amount = ByteBuffer.wrap(bai.readNBytes(4)).getInt();
 			final ObjectInputStream ois = new BukkitObjectInputStreamMock(bai);
-			return (ItemStackMock) ois.readObject();
+			ItemStackMock stack = (ItemStackMock) ois.readObject();
+			stack.setAmount(amount);
+			return stack;
 		}
 		catch (IOException | ClassNotFoundException e)
 		{

--- a/src/test/java/org/mockbukkit/mockbukkit/util/UnsafeValuesTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/util/UnsafeValuesTest.java
@@ -124,7 +124,7 @@ class UnsafeValuesTest
 				{
 					continue;
 				}
-				ItemStack item = new ItemStackMock(material);
+				ItemStack item = new ItemStackMock(material, 10);
 				args.add(Arguments.of(Named.of(material.name(), item)));
 			}
 			ItemStack item = new ItemStackMock(Material.STONE);


### PR DESCRIPTION
# Description
Fixes #1244

[de]serializeItem to/from byte[] now includes item amount

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
