### PR TITLE
Added MockBukkit version to BuildParameters

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,6 +100,7 @@ sourceSets {
 	main {
 		blossom {
 			javaSources {
+				property("mockBukkitVersion", getFullVersion())
 				property("paperApiFullVersion", project.property("paper.api.full-version").toString())
 				property("buildTime", System.currentTimeMillis().toString())
 				property("branch", run("git", "rev-parse", "--abbrev-ref", "HEAD"))

--- a/src/main/java-templates/org/mockbukkit/mockbukkit/BuildParameters.java.peb
+++ b/src/main/java-templates/org/mockbukkit/mockbukkit/BuildParameters.java.peb
@@ -2,6 +2,7 @@ package org.mockbukkit.mockbukkit;
 
 public class BuildParameters
 {
+	public static final String MOCK_BUKKIT_VERSION = "{{ mockBukkitVersion }}";
 	public static final String PAPER_API_FULL_VERSION = "{{ paperApiFullVersion }}";
 	public static final long BUILD_TIME = Long.parseLong("{{ buildTime }}");
 	public static final String BRANCH = "{{ branch }}";


### PR DESCRIPTION
# Description
The ideia behind this PR is to include the plugin version in the `BuildParameters` class, and this will allow us to enrich the errors with the application version in use by the user. See https://github.com/MockBukkit/MockBukkit/issues/1241 and https://github.com/MockBukkit/MockBukkit/pull/1256.

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [N/A] Unit tests added (if applicable).
