### PR TITLE
Add crafting recipes

### DIFF
--- a/metaminer/src/main/java/org/mockbukkit/metaminer/MetaMiner.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/MetaMiner.java
@@ -1,22 +1,21 @@
 package org.mockbukkit.metaminer;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.logging.Level;
+
 import org.apache.commons.io.FileUtils;
-import org.bukkit.Bukkit;
-import org.bukkit.Material;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.mockbukkit.metaminer.internal.MaterialDataGenerator;
 import org.mockbukkit.metaminer.internal.potion.PotionDataGenerator;
 import org.mockbukkit.metaminer.internal.tags.InternalTagDataGenerator;
 import org.mockbukkit.metaminer.keyed.KeyedDataGenerator;
 import org.mockbukkit.metaminer.keyed.RegistryKeyClassDataGenerator;
+import org.mockbukkit.metaminer.recipes.RecipeDataGenerator;
 import org.mockbukkit.metaminer.tags.TagDataGenerator;
 import org.mockbukkit.metaminer.tests.ItemStackTestDataGenerator;
 import org.mockbukkit.metaminer.translation.TranslationDataGenerator;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-import java.util.logging.Level;
 
 public class MetaMiner extends JavaPlugin
 {
@@ -55,11 +54,13 @@ public class MetaMiner extends JavaPlugin
 	{
 		File testFolder = new File(this.getDataFolder(), "src/test/resources");
 		File mainFolder = new File(this.getDataFolder(), "src/main/resources");
-		return List.of(new KeyedDataGenerator(mainFolder), new InternalTagDataGenerator(mainFolder),
+		return List.of(
+				new KeyedDataGenerator(mainFolder), new InternalTagDataGenerator(mainFolder),
 				new PotionDataGenerator(mainFolder), new TagDataGenerator(mainFolder),
 				new MaterialDataGenerator(mainFolder), new RegistryKeyClassDataGenerator(mainFolder),
 				new MaterialDataGenerator(mainFolder), new TranslationDataGenerator(this.getDataFolder()),
-				new RegistryKeyClassDataGenerator(mainFolder), new ItemStackTestDataGenerator(testFolder));
+				new RegistryKeyClassDataGenerator(mainFolder), new ItemStackTestDataGenerator(testFolder),
+				new RecipeDataGenerator(mainFolder));
 	}
 
 }

--- a/metaminer/src/main/java/org/mockbukkit/metaminer/json/CollectionElementFactory.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/json/CollectionElementFactory.java
@@ -1,14 +1,16 @@
 package org.mockbukkit.metaminer.json;
 
+import java.util.Collection;
+import java.util.function.Function;
+
+import com.google.common.base.Preconditions;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.Collection;
 
 public class CollectionElementFactory
 {
-
 	/**
 	 * Converts a collection into a JsonElement.
 	 *
@@ -17,18 +19,34 @@ public class CollectionElementFactory
 	 * @return The element
 	 */
 	@Nullable
-	public static JsonArray toJson(@Nullable Collection<?> collection)
+	public static <T> JsonArray toJson(@Nullable Collection<T> collection)
 	{
+		return toJson(collection, ElementFactory::toJson);
+	}
+
+	/**
+	 * Converts a collection into a JsonElement.
+	 *
+	 * @param collection The collection to be converted.
+	 * @param toJson The function to apply.
+	 *
+	 * @return The element
+	 */
+	@Nullable
+	public static <T> JsonArray toJson(@Nullable Collection<T> collection, @NotNull Function<T, JsonElement> toJson)
+	{
+		Preconditions.checkArgument(toJson != null, "toJson must not be null");
+
 		if (collection == null)
 		{
 			return null;
 		}
 
-		JsonArray jsonElements = new JsonArray();
+		JsonArray jsonElements = new JsonArray(collection.size());
 
-		for (Object element : collection)
+		for (T element : collection)
 		{
-			@Nullable JsonElement jsonElement = ElementFactory.toJson(element);
+			@Nullable JsonElement jsonElement = toJson.apply(element);
 			if (jsonElement != null)
 			{
 				jsonElements.add(jsonElement);

--- a/metaminer/src/main/java/org/mockbukkit/metaminer/json/ElementFactory.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/json/ElementFactory.java
@@ -1,5 +1,11 @@
 package org.mockbukkit.metaminer.json;
 
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
 import com.google.gson.JsonElement;
 import net.kyori.adventure.key.Keyed;
 import net.kyori.adventure.text.Component;
@@ -8,16 +14,14 @@ import org.bukkit.attribute.Attributable;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.inventory.EquipmentSlotGroup;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.RecipeChoice;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.PotionEffect;
 import org.jetbrains.annotations.Nullable;
+import org.mockbukkit.metaminer.json.recipe.RecipeChoiceElementFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 
 public class ElementFactory
 {
@@ -60,6 +64,18 @@ public class ElementFactory
 		if (Color.class.isAssignableFrom(returnType))
 		{
 			return ColorElementFactory.toJson((Color) object);
+		}
+		if (ItemStack.class.isAssignableFrom(returnType))
+		{
+			return ItemStackElementFactory.toJson((ItemStack) object);
+		}
+		if (ItemMeta.class.isAssignableFrom(returnType))
+		{
+			return ItemMetaElementFactory.toJson((ItemMeta) object);
+		}
+		if (RecipeChoice.class.isAssignableFrom(returnType))
+		{
+			return RecipeChoiceElementFactory.toJson((RecipeChoice) object);
 		}
 		if (PotionEffect.class.isAssignableFrom(returnType))
 		{

--- a/metaminer/src/main/java/org/mockbukkit/metaminer/json/ItemMetaElementFactory.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/json/ItemMetaElementFactory.java
@@ -1,0 +1,60 @@
+package org.mockbukkit.metaminer.json;
+
+import com.google.gson.JsonObject;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.Nullable;
+
+public class ItemMetaElementFactory
+{
+	/**
+	 * Converts a item meta into a JsonElement.
+	 *
+	 * @param itemMeta The item meta to be converted.
+	 *
+	 * @return The element
+	 */
+	@Nullable
+	public static JsonObject toJson(@Nullable ItemMeta itemMeta)
+	{
+		if (itemMeta == null)
+		{
+			return null;
+		}
+
+		JsonObject json = new JsonObject();
+
+		json.add("customName", ComponentElementFactory.toJson(itemMeta.customName()));
+		json.add("lore", CollectionElementFactory.toJson(itemMeta.lore()));
+		json.add("tooltipStyle", KeyedElementFactory.toJson(itemMeta.getTooltipStyle()));
+		json.add("itemModel", KeyedElementFactory.toJson(itemMeta.getItemModel()));
+
+		json.addProperty("unbreakable", itemMeta.isUnbreakable());
+		json.addProperty("glider", itemMeta.isGlider());
+
+		if (itemMeta.hasCustomModelData())
+		{
+			json.addProperty("customModelData", itemMeta.getCustomModelData());
+		}
+		if (itemMeta.hasDamageResistant())
+		{
+			json.add("damageResistant", KeyedElementFactory.toJson(itemMeta.getDamageResistant()));
+		}
+		if (itemMeta.hasMaxStackSize())
+		{
+			json.addProperty("maxStackSize", itemMeta.getMaxStackSize());
+		}
+		if (itemMeta.hasRarity())
+		{
+			json.add("rarity", EnumElementFactory.toJson(itemMeta.getRarity()));
+		}
+
+		// TODO: Improve the item meta information
+
+		return json;
+	}
+
+	private ItemMetaElementFactory()
+	{
+		// Hide the public constructor
+	}
+}

--- a/metaminer/src/main/java/org/mockbukkit/metaminer/json/ItemMetaElementFactory.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/json/ItemMetaElementFactory.java
@@ -24,7 +24,7 @@ public class ItemMetaElementFactory
 		JsonObject json = new JsonObject();
 
 		json.add("customName", ComponentElementFactory.toJson(itemMeta.customName()));
-		json.add("lore", CollectionElementFactory.toJson(itemMeta.lore()));
+		json.add("lore", CollectionElementFactory.toJson(itemMeta.lore(), ComponentElementFactory::toJson));
 		json.add("tooltipStyle", KeyedElementFactory.toJson(itemMeta.getTooltipStyle()));
 		json.add("itemModel", KeyedElementFactory.toJson(itemMeta.getItemModel()));
 

--- a/metaminer/src/main/java/org/mockbukkit/metaminer/json/ItemStackElementFactory.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/json/ItemStackElementFactory.java
@@ -1,0 +1,56 @@
+package org.mockbukkit.metaminer.json;
+
+import com.google.gson.JsonObject;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+public class ItemStackElementFactory
+{
+	/**
+	 * Converts a item stack into a JsonElement.
+	 *
+	 * @param itemStack The item stack to be converted.
+	 *
+	 * @return The element
+	 */
+	@Nullable
+	public static JsonObject toJson(@Nullable ItemStack itemStack)
+	{
+		return toJson(itemStack, false);
+	}
+
+	/**
+	 * Converts a item stack into a JsonElement.
+	 *
+	 * @param itemStack The item stack to be converted.
+	 * @param includeMeta If should include meta.
+	 *
+	 * @return The element
+	 */
+	@Nullable
+	public static JsonObject toJson(@Nullable ItemStack itemStack, boolean includeMeta)
+	{
+		if (itemStack == null)
+		{
+			return null;
+		}
+
+		JsonObject json = new JsonObject();
+
+		json.add("type", KeyedElementFactory.toJson(itemStack.getType()));
+		json.addProperty("amount", itemStack.getAmount());
+
+		var meta = ItemMetaElementFactory.toJson(itemStack.getItemMeta());
+		if (includeMeta && meta != null && !meta.isEmpty())
+		{
+			json.add("meta", meta);
+		}
+
+		return json;
+	}
+
+	private ItemStackElementFactory()
+	{
+		// Hide the public constructor
+	}
+}

--- a/metaminer/src/main/java/org/mockbukkit/metaminer/json/MapElementFactory.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/json/MapElementFactory.java
@@ -1,9 +1,13 @@
 package org.mockbukkit.metaminer.json;
 
-import com.google.gson.JsonObject;
-import org.jetbrains.annotations.Nullable;
-
 import java.util.Map;
+import java.util.function.Function;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class MapElementFactory
 {
@@ -17,6 +21,24 @@ public class MapElementFactory
 	@Nullable
 	public static JsonObject toJson(@Nullable Map<?, ?> map)
 	{
+		return toJson(map, String::valueOf, ElementFactory::toJson);
+	}
+
+	/**
+	 * Converts a map into a JsonElement.
+	 *
+	 * @param map The map to be converted.
+	 *
+	 * @return The element
+	 */
+	@Nullable
+	public static <K, V> JsonObject toJson(@Nullable Map<K, V> map,
+										   @NotNull Function<K, String> keyFactory,
+										   @NotNull Function<V, JsonElement> valueFactory)
+	{
+		Preconditions.checkArgument(keyFactory != null, "keyFactory must not be null");
+		Preconditions.checkArgument(valueFactory != null, "valueFactory must not be null");
+
 		if (map == null)
 		{
 			return null;
@@ -26,10 +48,12 @@ public class MapElementFactory
 
 		for (var element : map.entrySet())
 		{
-			Object key = element.getKey();
-			Object value = element.getValue();
+			K key = element.getKey();
+			V value = element.getValue();
 
-			jsonElement.add(String.valueOf(key), ElementFactory.toJson(value));
+			String jsonKey = keyFactory.apply(key);
+			JsonElement jsonValue = valueFactory.apply(value);
+			jsonElement.add(jsonKey, jsonValue);
 		}
 
 		return jsonElement.isEmpty() ? null : jsonElement;

--- a/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/BlastingRecipeElementFactory.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/BlastingRecipeElementFactory.java
@@ -1,0 +1,39 @@
+package org.mockbukkit.metaminer.json.recipe;
+
+import com.google.gson.JsonObject;
+import org.bukkit.inventory.BlastingRecipe;
+import org.bukkit.inventory.Recipe;
+import org.jetbrains.annotations.Nullable;
+
+public class BlastingRecipeElementFactory
+{
+
+	/**
+	 * Converts a recipe into a JsonElement.
+	 *
+	 * @param recipe The recipe to be converted.
+	 *
+	 * @return The element
+	 */
+	@Nullable
+	public static JsonObject toJson(@Nullable Recipe recipe)
+	{
+		if (recipe == null)
+		{
+			return null;
+		}
+
+		if (recipe instanceof BlastingRecipe blastingRecipe)
+		{
+			return CookingRecipeElementFactory.toJson(blastingRecipe);
+		}
+
+		throw new IllegalArgumentException("Recipe is not a BlastingRecipe");
+	}
+
+	private BlastingRecipeElementFactory()
+	{
+		// Hide the public constructor
+	}
+
+}

--- a/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/CampfireRecipeElementFactory.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/CampfireRecipeElementFactory.java
@@ -1,0 +1,39 @@
+package org.mockbukkit.metaminer.json.recipe;
+
+import com.google.gson.JsonObject;
+import org.bukkit.inventory.CampfireRecipe;
+import org.bukkit.inventory.Recipe;
+import org.jetbrains.annotations.Nullable;
+
+public class CampfireRecipeElementFactory
+{
+
+	/**
+	 * Converts a recipe into a JsonElement.
+	 *
+	 * @param recipe The recipe to be converted.
+	 *
+	 * @return The element
+	 */
+	@Nullable
+	public static JsonObject toJson(@Nullable Recipe recipe)
+	{
+		if (recipe == null)
+		{
+			return null;
+		}
+
+		if (recipe instanceof CampfireRecipe campfireRecipe)
+		{
+			return CookingRecipeElementFactory.toJson(campfireRecipe);
+		}
+
+		throw new IllegalArgumentException("Recipe is not a CampfireRecipe");
+	}
+
+	private CampfireRecipeElementFactory()
+	{
+		// Hide the public constructor
+	}
+
+}

--- a/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/CookingRecipeElementFactory.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/CookingRecipeElementFactory.java
@@ -1,0 +1,45 @@
+package org.mockbukkit.metaminer.json.recipe;
+
+import com.google.gson.JsonObject;
+import org.bukkit.inventory.CookingRecipe;
+import org.jetbrains.annotations.Nullable;
+import org.mockbukkit.metaminer.json.EnumElementFactory;
+import org.mockbukkit.metaminer.json.ItemStackElementFactory;
+import org.mockbukkit.metaminer.json.KeyedElementFactory;
+
+public class CookingRecipeElementFactory
+{
+
+	/**
+	 * Converts a cooking recipe into a JsonElement.
+	 *
+	 * @param cookingRecipe The cooking recipe to be converted.
+	 *
+	 * @return The element
+	 */
+	@Nullable
+	public static JsonObject toJson(@Nullable CookingRecipe<?> cookingRecipe)
+	{
+		if (cookingRecipe == null)
+		{
+			return null;
+		}
+
+		JsonObject json = new JsonObject();
+		json.add("key", KeyedElementFactory.toJson(cookingRecipe.getKey()));
+		json.add("category", EnumElementFactory.toJson(cookingRecipe.getCategory()));
+		json.add("input", RecipeChoiceElementFactory.toJson(cookingRecipe.getInputChoice()));
+		json.add("result", ItemStackElementFactory.toJson(cookingRecipe.getResult()));
+		json.addProperty("group", cookingRecipe.getGroup());
+		json.addProperty("experience", cookingRecipe.getExperience());
+		json.addProperty("cookingTime", cookingRecipe.getCookingTime());
+
+		return json;
+	}
+
+	private CookingRecipeElementFactory()
+	{
+		// Hide the public constructor
+	}
+
+}

--- a/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/CraftingRecipeElementFactory.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/CraftingRecipeElementFactory.java
@@ -2,8 +2,8 @@ package org.mockbukkit.metaminer.json.recipe;
 
 import java.util.stream.Stream;
 
+import com.google.common.base.Preconditions;
 import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import org.bukkit.inventory.ComplexRecipe;
 import org.bukkit.inventory.CraftingRecipe;
@@ -11,6 +11,7 @@ import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.ShapelessRecipe;
 import org.bukkit.inventory.TransmuteRecipe;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.Nullable;
 import org.mockbukkit.metaminer.json.CollectionElementFactory;
 import org.mockbukkit.metaminer.json.EnumElementFactory;
@@ -42,7 +43,7 @@ public class CraftingRecipeElementFactory
 		json.add("category", EnumElementFactory.toJson(craftingRecipe.getCategory()));
 		json.add("result", ItemStackElementFactory.toJson(craftingRecipe.getResult()));
 		json.addProperty("group", craftingRecipe.getGroup());
-		json.add("input", getCraftingShape(craftingRecipe));
+		populateWithCraftingShape(json, craftingRecipe);
 
 		return json;
 	}
@@ -70,47 +71,41 @@ public class CraftingRecipeElementFactory
 		throw new IllegalArgumentException("Recipe is not a CraftingRecipe");
 	}
 
-	private static JsonElement getCraftingShape(@Nullable CraftingRecipe craftingRecipe)
+	private static void populateWithCraftingShape(@NonNull JsonObject json, @Nullable CraftingRecipe craftingRecipe)
 	{
-		return switch (craftingRecipe)
+		Preconditions.checkNotNull(json, "The json cannot be null");
+		switch (craftingRecipe)
 		{
-			case null -> null;
+			case null ->
+			{
+				// Nothing to do here
+			}
 			case ShapelessRecipe shapelessRecipe ->
 			{
-				JsonObject json = new JsonObject();
 				json.addProperty("type", "shapeless");
 				json.add("choices", CollectionElementFactory.toJson(shapelessRecipe.getChoiceList()));
-				yield json;
 			}
 			case ShapedRecipe shapedRecipe ->
 			{
-				JsonObject json = new JsonObject();
 				json.addProperty("type", "shaped");
 				json.add("choiceMap", MapElementFactory.toJson(shapedRecipe.getChoiceMap()));
 
 				JsonArray shapes = new JsonArray();
 				Stream.of(shapedRecipe.getShape()).forEachOrdered(shapes::add);
 				json.add("shape", shapes);
-
-				yield json;
 			}
 			case TransmuteRecipe transmuteRecipe ->
 			{
-				JsonObject json = new JsonObject();
 				json.addProperty("type", "transmute");
 				json.add("input", RecipeChoiceElementFactory.toJson(transmuteRecipe.getInput()));
 				json.add("material", RecipeChoiceElementFactory.toJson(transmuteRecipe.getMaterial()));
-				yield json;
 			}
 			case ComplexRecipe complexRecipe ->
 			{
-				JsonObject json = new JsonObject();
 				json.addProperty("type", "complex");
-				// TODO:
-				yield json;
 			}
 			default -> throw new UnsupportedOperationException(String.format("Unknown recipe type: %s", craftingRecipe.getClass().getName()));
-		};
+		}
 	}
 
 	private CraftingRecipeElementFactory()

--- a/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/CraftingRecipeElementFactory.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/CraftingRecipeElementFactory.java
@@ -101,9 +101,7 @@ public class CraftingRecipeElementFactory
 				json.add("material", RecipeChoiceElementFactory.toJson(transmuteRecipe.getMaterial()));
 			}
 			case ComplexRecipe complexRecipe ->
-			{
-				json.addProperty("type", "complex");
-			}
+					json.addProperty("type", "complex");
 			default -> throw new UnsupportedOperationException(String.format("Unknown recipe type: %s", craftingRecipe.getClass().getName()));
 		}
 	}

--- a/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/CraftingRecipeElementFactory.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/CraftingRecipeElementFactory.java
@@ -1,0 +1,121 @@
+package org.mockbukkit.metaminer.json.recipe;
+
+import java.util.stream.Stream;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.bukkit.inventory.ComplexRecipe;
+import org.bukkit.inventory.CraftingRecipe;
+import org.bukkit.inventory.Recipe;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.ShapelessRecipe;
+import org.bukkit.inventory.TransmuteRecipe;
+import org.jetbrains.annotations.Nullable;
+import org.mockbukkit.metaminer.json.CollectionElementFactory;
+import org.mockbukkit.metaminer.json.EnumElementFactory;
+import org.mockbukkit.metaminer.json.ItemStackElementFactory;
+import org.mockbukkit.metaminer.json.KeyedElementFactory;
+import org.mockbukkit.metaminer.json.MapElementFactory;
+
+public class CraftingRecipeElementFactory
+{
+
+	/**
+	 * Converts a crafting recipe into a JsonElement.
+	 *
+	 * @param craftingRecipe The crafting recipe to be converted.
+	 *
+	 * @return The element
+	 */
+	@Nullable
+	public static JsonObject toJson(@Nullable CraftingRecipe craftingRecipe)
+	{
+		if (craftingRecipe == null)
+		{
+			return null;
+		}
+
+		JsonObject json = new JsonObject();
+
+		json.add("key", KeyedElementFactory.toJson(craftingRecipe.getKey()));
+		json.add("category", EnumElementFactory.toJson(craftingRecipe.getCategory()));
+		json.add("result", ItemStackElementFactory.toJson(craftingRecipe.getResult()));
+		json.addProperty("group", craftingRecipe.getGroup());
+		json.add("input", getCraftingShape(craftingRecipe));
+
+		return json;
+	}
+
+	/**
+	 * Converts a recipe into a JsonElement.
+	 *
+	 * @param recipe The recipe to be converted.
+	 *
+	 * @return The element
+	 */
+	@Nullable
+	public static JsonObject toJson(@Nullable Recipe recipe)
+	{
+		if (recipe == null)
+		{
+			return null;
+		}
+
+		if (recipe instanceof CraftingRecipe craftingRecipe)
+		{
+			return toJson(craftingRecipe);
+		}
+
+		throw new IllegalArgumentException("Recipe is not a CraftingRecipe");
+	}
+
+	private static JsonElement getCraftingShape(@Nullable CraftingRecipe craftingRecipe)
+	{
+		return switch (craftingRecipe)
+		{
+			case null -> null;
+			case ShapelessRecipe shapelessRecipe ->
+			{
+				JsonObject json = new JsonObject();
+				json.addProperty("type", "shapeless");
+				json.add("choices", CollectionElementFactory.toJson(shapelessRecipe.getChoiceList()));
+				yield json;
+			}
+			case ShapedRecipe shapedRecipe ->
+			{
+				JsonObject json = new JsonObject();
+				json.addProperty("type", "shaped");
+				json.add("choiceMap", MapElementFactory.toJson(shapedRecipe.getChoiceMap()));
+
+				JsonArray shapes = new JsonArray();
+				Stream.of(shapedRecipe.getShape()).forEachOrdered(shapes::add);
+				json.add("shape", shapes);
+
+				yield json;
+			}
+			case TransmuteRecipe transmuteRecipe ->
+			{
+				JsonObject json = new JsonObject();
+				json.addProperty("type", "transmute");
+				json.add("input", RecipeChoiceElementFactory.toJson(transmuteRecipe.getInput()));
+				json.add("material", RecipeChoiceElementFactory.toJson(transmuteRecipe.getMaterial()));
+				yield json;
+			}
+			case ComplexRecipe complexRecipe ->
+			{
+				JsonObject json = new JsonObject();
+				json.addProperty("type", "complex");
+				// TODO:
+				yield json;
+			}
+			default -> throw new UnsupportedOperationException(String.format("Unknown recipe type: %s", craftingRecipe.getClass().getName()));
+		};
+	}
+
+	private CraftingRecipeElementFactory()
+	{
+		// Hide the public constructor
+	}
+
+}

--- a/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/RecipeChoiceElementFactory.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/RecipeChoiceElementFactory.java
@@ -5,6 +5,7 @@ import org.bukkit.inventory.RecipeChoice;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mockbukkit.metaminer.json.CollectionElementFactory;
+import org.mockbukkit.metaminer.json.ItemStackElementFactory;
 
 public class RecipeChoiceElementFactory
 {
@@ -26,19 +27,19 @@ public class RecipeChoiceElementFactory
 
 		if (recipeChoice instanceof RecipeChoice.MaterialChoice materialChoice)
 		{
-			return getMaterialChoise(materialChoice);
+			return getMaterialChoice(materialChoice);
 		}
 
 		if (recipeChoice instanceof RecipeChoice.ExactChoice exactChoice)
 		{
-			return getExactChoise(exactChoice);
+			return getExactChoice(exactChoice);
 		}
 
 		throw new UnsupportedOperationException("Unsupported recipe choice: " + recipeChoice.getClass().getName());
 	}
 
 	@NotNull
-	private static JsonObject getMaterialChoise(RecipeChoice.MaterialChoice materialChoice)
+	private static JsonObject getMaterialChoice(RecipeChoice.MaterialChoice materialChoice)
 	{
 		JsonObject json = new JsonObject();
 		json.addProperty("type", "material");
@@ -47,11 +48,11 @@ public class RecipeChoiceElementFactory
 	}
 
 	@NotNull
-	private static JsonObject getExactChoise(RecipeChoice.ExactChoice exactChoice)
+	private static JsonObject getExactChoice(RecipeChoice.ExactChoice exactChoice)
 	{
 		JsonObject json = new JsonObject();
 		json.addProperty("type", "exact");
-		// TODO:
+		json.add("choices", CollectionElementFactory.toJson(exactChoice.getChoices(), ItemStackElementFactory::toJson));
 		return json;
 	}
 

--- a/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/RecipeChoiceElementFactory.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/RecipeChoiceElementFactory.java
@@ -1,0 +1,63 @@
+package org.mockbukkit.metaminer.json.recipe;
+
+import com.google.gson.JsonObject;
+import org.bukkit.inventory.RecipeChoice;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.mockbukkit.metaminer.json.CollectionElementFactory;
+
+public class RecipeChoiceElementFactory
+{
+
+	/**
+	 * Converts a recipe choice into a JsonElement.
+	 *
+	 * @param recipeChoice The recipe choice to be converted.
+	 *
+	 * @return The element
+	 */
+	@Nullable
+	public static JsonObject toJson(@Nullable RecipeChoice recipeChoice)
+	{
+		if (recipeChoice == null)
+		{
+			return null;
+		}
+
+		if (recipeChoice instanceof RecipeChoice.MaterialChoice materialChoice)
+		{
+			return getMaterialChoise(materialChoice);
+		}
+
+		if (recipeChoice instanceof RecipeChoice.ExactChoice exactChoice)
+		{
+			return getExactChoise(exactChoice);
+		}
+
+		throw new UnsupportedOperationException("Unsupported recipe choice: " + recipeChoice.getClass().getName());
+	}
+
+	@NotNull
+	private static JsonObject getMaterialChoise(RecipeChoice.MaterialChoice materialChoice)
+	{
+		JsonObject json = new JsonObject();
+		json.addProperty("type", "material");
+		json.add("choices", CollectionElementFactory.toJson(materialChoice.getChoices()));
+		return json;
+	}
+
+	@NotNull
+	private static JsonObject getExactChoise(RecipeChoice.ExactChoice exactChoice)
+	{
+		JsonObject json = new JsonObject();
+		json.addProperty("type", "exact");
+		// TODO:
+		return json;
+	}
+
+	private RecipeChoiceElementFactory()
+	{
+		// Hide the public constructor
+	}
+
+}

--- a/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/SmeltingRecipeElementFactory.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/SmeltingRecipeElementFactory.java
@@ -1,0 +1,39 @@
+package org.mockbukkit.metaminer.json.recipe;
+
+import com.google.gson.JsonObject;
+import org.bukkit.inventory.FurnaceRecipe;
+import org.bukkit.inventory.Recipe;
+import org.jetbrains.annotations.Nullable;
+
+public class SmeltingRecipeElementFactory
+{
+
+	/**
+	 * Converts a recipe into a JsonElement.
+	 *
+	 * @param recipe The recipe to be converted.
+	 *
+	 * @return The element
+	 */
+	@Nullable
+	public static JsonObject toJson(@Nullable Recipe recipe)
+	{
+		if (recipe == null)
+		{
+			return null;
+		}
+
+		if (recipe instanceof FurnaceRecipe smeltingRecipe)
+		{
+			return CookingRecipeElementFactory.toJson(smeltingRecipe);
+		}
+
+		throw new IllegalArgumentException("Recipe is not a FurnaceRecipe");
+	}
+
+	private SmeltingRecipeElementFactory()
+	{
+		// Hide the public constructor
+	}
+
+}

--- a/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/SmithingRecipeElementFactory.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/SmithingRecipeElementFactory.java
@@ -1,0 +1,66 @@
+package org.mockbukkit.metaminer.json.recipe;
+
+import com.google.gson.JsonObject;
+import org.bukkit.inventory.Recipe;
+import org.bukkit.inventory.SmithingRecipe;
+import org.jetbrains.annotations.Nullable;
+import org.mockbukkit.metaminer.json.ItemStackElementFactory;
+import org.mockbukkit.metaminer.json.KeyedElementFactory;
+
+public class SmithingRecipeElementFactory
+{
+
+	/**
+	 * Converts a smithing recipe into a JsonElement.
+	 *
+	 * @param smithingRecipe The smithing recipe to be converted.
+	 *
+	 * @return The element
+	 */
+	@Nullable
+	public static JsonObject toJson(@Nullable SmithingRecipe smithingRecipe)
+	{
+		if (smithingRecipe == null)
+		{
+			return null;
+		}
+
+		JsonObject json = new JsonObject();
+		json.add("key", KeyedElementFactory.toJson(smithingRecipe.getKey()));
+		json.add("base", RecipeChoiceElementFactory.toJson(smithingRecipe.getBase()));
+		json.add("addition", RecipeChoiceElementFactory.toJson(smithingRecipe.getAddition()));
+		json.add("result", ItemStackElementFactory.toJson(smithingRecipe.getResult()));
+		json.addProperty("copyDataComponents", smithingRecipe.willCopyDataComponents());
+
+		return json;
+	}
+
+	/**
+	 * Converts a recipe into a JsonElement.
+	 *
+	 * @param recipe The recipe to be converted.
+	 *
+	 * @return The element
+	 */
+	@Nullable
+	public static JsonObject toJson(@Nullable Recipe recipe)
+	{
+		if (recipe == null)
+		{
+			return null;
+		}
+
+		if (recipe instanceof SmithingRecipe smithingRecipe)
+		{
+			return toJson(smithingRecipe);
+		}
+
+		throw new IllegalArgumentException("Recipe is not a SmithingRecipe");
+	}
+
+	private SmithingRecipeElementFactory()
+	{
+		// Hide the public constructor
+	}
+
+}

--- a/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/SmokingRecipeElementFactory.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/SmokingRecipeElementFactory.java
@@ -1,0 +1,39 @@
+package org.mockbukkit.metaminer.json.recipe;
+
+import com.google.gson.JsonObject;
+import org.bukkit.inventory.Recipe;
+import org.bukkit.inventory.SmokingRecipe;
+import org.jetbrains.annotations.Nullable;
+
+public class SmokingRecipeElementFactory
+{
+
+	/**
+	 * Converts a recipe into a JsonElement.
+	 *
+	 * @param recipe The recipe to be converted.
+	 *
+	 * @return The element
+	 */
+	@Nullable
+	public static JsonObject toJson(@Nullable Recipe recipe)
+	{
+		if (recipe == null)
+		{
+			return null;
+		}
+
+		if (recipe instanceof SmokingRecipe smokingRecipe)
+		{
+			return CookingRecipeElementFactory.toJson(smokingRecipe);
+		}
+
+		throw new IllegalArgumentException("Recipe is not a SmokingRecipe");
+	}
+
+	private SmokingRecipeElementFactory()
+	{
+		// Hide the public constructor
+	}
+
+}

--- a/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/StoneCuttingRecipeElementFactory.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/json/recipe/StoneCuttingRecipeElementFactory.java
@@ -1,0 +1,65 @@
+package org.mockbukkit.metaminer.json.recipe;
+
+import com.google.gson.JsonObject;
+import org.bukkit.inventory.Recipe;
+import org.bukkit.inventory.StonecuttingRecipe;
+import org.jetbrains.annotations.Nullable;
+import org.mockbukkit.metaminer.json.ItemStackElementFactory;
+import org.mockbukkit.metaminer.json.KeyedElementFactory;
+
+public class StoneCuttingRecipeElementFactory
+{
+
+	/**
+	 * Converts a stonecutting recipe into a JsonElement.
+	 *
+	 * @param stonecuttingRecipe The stonecutting recipe to be converted.
+	 *
+	 * @return The element
+	 */
+	@Nullable
+	public static JsonObject toJson(@Nullable StonecuttingRecipe stonecuttingRecipe)
+	{
+		if (stonecuttingRecipe == null)
+		{
+			return null;
+		}
+
+		JsonObject json = new JsonObject();
+		json.add("key", KeyedElementFactory.toJson(stonecuttingRecipe.getKey()));
+		json.add("input", RecipeChoiceElementFactory.toJson(stonecuttingRecipe.getInputChoice()));
+		json.add("result", ItemStackElementFactory.toJson(stonecuttingRecipe.getResult()));
+		json.addProperty("group", stonecuttingRecipe.getGroup());
+
+		return json;
+	}
+
+	/**
+	 * Converts a recipe into a JsonElement.
+	 *
+	 * @param recipe The recipe to be converted.
+	 *
+	 * @return The element
+	 */
+	@Nullable
+	public static JsonObject toJson(@Nullable Recipe recipe)
+	{
+		if (recipe == null)
+		{
+			return null;
+		}
+
+		if (recipe instanceof StonecuttingRecipe stonecuttingRecipe)
+		{
+			return toJson(stonecuttingRecipe);
+		}
+
+		throw new IllegalArgumentException("Recipe is not a StonecuttingRecipe");
+	}
+
+	private StoneCuttingRecipeElementFactory()
+	{
+		// Hide the public constructor
+	}
+
+}

--- a/metaminer/src/main/java/org/mockbukkit/metaminer/recipes/RecipeDataGenerator.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/recipes/RecipeDataGenerator.java
@@ -90,10 +90,13 @@ public class RecipeDataGenerator implements DataGenerator
 
 		// Process each groups
 		LOGGER.info("Recipe summary:");
+		int totalRecipes = 0;
 		for (Map.Entry<String, List<Recipe>> entry : recipes.entrySet())
 		{
 			String recipeType = entry.getKey();
 			List<Recipe> recipeList = entry.getValue();
+
+			totalRecipes += recipeList.size();
 
 			LOGGER.info(" - {}: {}", recipeType, recipeList.size());
 
@@ -104,6 +107,8 @@ public class RecipeDataGenerator implements DataGenerator
 			recipeList.stream().map(factory).forEach(recipeListJson::add);
 			JsonUtil.dump(recipeListJson, new File(dataFolder, String.format("%s.json", recipeType)));
 		}
+
+		LOGGER.info(" - TOTAL: {}", totalRecipes);
 	}
 
 	@Nullable

--- a/metaminer/src/main/java/org/mockbukkit/metaminer/recipes/RecipeDataGenerator.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/recipes/RecipeDataGenerator.java
@@ -1,0 +1,126 @@
+package org.mockbukkit.metaminer.recipes;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import org.bukkit.Bukkit;
+import org.bukkit.inventory.BlastingRecipe;
+import org.bukkit.inventory.CampfireRecipe;
+import org.bukkit.inventory.CraftingRecipe;
+import org.bukkit.inventory.FurnaceRecipe;
+import org.bukkit.inventory.Recipe;
+import org.bukkit.inventory.SmithingRecipe;
+import org.bukkit.inventory.SmokingRecipe;
+import org.bukkit.inventory.StonecuttingRecipe;
+import org.jetbrains.annotations.Nullable;
+import org.mockbukkit.metaminer.DataGenerator;
+import org.mockbukkit.metaminer.json.recipe.BlastingRecipeElementFactory;
+import org.mockbukkit.metaminer.json.recipe.CampfireRecipeElementFactory;
+import org.mockbukkit.metaminer.json.recipe.CraftingRecipeElementFactory;
+import org.mockbukkit.metaminer.json.recipe.SmeltingRecipeElementFactory;
+import org.mockbukkit.metaminer.json.recipe.SmithingRecipeElementFactory;
+import org.mockbukkit.metaminer.json.recipe.SmokingRecipeElementFactory;
+import org.mockbukkit.metaminer.json.recipe.StoneCuttingRecipeElementFactory;
+import org.mockbukkit.metaminer.util.JsonUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RecipeDataGenerator implements DataGenerator
+{
+	private static final Logger LOGGER = LoggerFactory.getLogger(RecipeDataGenerator.class);
+
+	public static final String CRAFTING = "crafting";
+	public static final String SMELTING = "smelting";
+	public static final String BLASTING = "blasting";
+	public static final String SMOKING = "smoking";
+	public static final String CAMPFIRE_COOKING = "campfire_cooking";
+	public static final String STONECUTTING = "stonecutting";
+	public static final String SMITHING = "smithing";
+
+	private static final Map<Class<? extends Recipe>, String> RECIPE_CLASS_MAP = Map.of(
+			CraftingRecipe.class, CRAFTING,
+			FurnaceRecipe.class, SMELTING,
+			BlastingRecipe.class, BLASTING,
+			SmokingRecipe.class, SMOKING,
+			CampfireRecipe.class, CAMPFIRE_COOKING,
+			StonecuttingRecipe.class, STONECUTTING,
+			SmithingRecipe.class, SMITHING
+	);
+
+	private static final Map<String, Function<Recipe, JsonElement>> RECIPE_FACTORY_MAP = Map.of(
+			CRAFTING, CraftingRecipeElementFactory::toJson,
+			SMELTING, SmeltingRecipeElementFactory::toJson,
+			BLASTING, BlastingRecipeElementFactory::toJson,
+			SMOKING, SmokingRecipeElementFactory::toJson,
+			CAMPFIRE_COOKING, CampfireRecipeElementFactory::toJson,
+			STONECUTTING, StoneCuttingRecipeElementFactory::toJson,
+			SMITHING, SmithingRecipeElementFactory::toJson
+	);
+
+	private final File dataFolder;
+
+	public RecipeDataGenerator(File parentDataFolder)
+	{
+		this.dataFolder = new File(parentDataFolder, "recipes");
+	}
+
+	@Override
+	public void generateData() throws IOException
+	{
+		Map<String, List<Recipe>> recipes = new HashMap<>();
+
+		// Group all the existing recipes into groups
+		Iterator<Recipe> iterator = Bukkit.recipeIterator();
+		while (iterator.hasNext())
+		{
+			Recipe recipe = iterator.next();
+			String recipeType = getRecipeType(recipe);
+
+			recipes.computeIfAbsent(recipeType, k -> new ArrayList<>()).add(recipe);
+		}
+
+		// Process each groups
+		LOGGER.info("Recipe summary:");
+		for (Map.Entry<String, List<Recipe>> entry : recipes.entrySet())
+		{
+			String recipeType = entry.getKey();
+			List<Recipe> recipeList = entry.getValue();
+
+			LOGGER.info(" - {}: {}", recipeType, recipeList.size());
+
+			Function<Recipe, JsonElement> factory = RECIPE_FACTORY_MAP.get(recipeType);
+			Preconditions.checkNotNull(factory, "Recipe with type '%s' does not have a factory.", recipeType);
+
+			JsonArray recipeListJson = new JsonArray(recipeList.size());
+			recipeList.stream().map(factory).forEach(recipeListJson::add);
+			JsonUtil.dump(recipeListJson, new File(dataFolder, String.format("%s.json", recipeType)));
+		}
+	}
+
+	@Nullable
+	private String getRecipeType(Recipe recipe)
+	{
+		for (var mapEntry : RECIPE_CLASS_MAP.entrySet())
+		{
+			Class<?> clazz = mapEntry.getKey();
+
+			Preconditions.checkArgument(Recipe.class.isAssignableFrom(clazz), "The class %s is not a Recipe", clazz.getName());
+			if (clazz.isInstance(recipe))
+			{
+				return mapEntry.getValue();
+			}
+		}
+
+		throw new IllegalArgumentException("Unknown recipe type for class " + recipe.getClass().getName());
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -151,6 +150,7 @@ import org.mockbukkit.mockbukkit.inventory.ItemFactoryMock;
 import org.mockbukkit.mockbukkit.inventory.LecternInventoryMock;
 import org.mockbukkit.mockbukkit.inventory.LoomInventoryMock;
 import org.mockbukkit.mockbukkit.inventory.PlayerInventoryMock;
+import org.mockbukkit.mockbukkit.inventory.RecipeManager;
 import org.mockbukkit.mockbukkit.inventory.ShulkerBoxInventoryMock;
 import org.mockbukkit.mockbukkit.inventory.SmithingInventoryMock;
 import org.mockbukkit.mockbukkit.inventory.StonecutterInventoryMock;
@@ -188,7 +188,7 @@ public class ServerMock extends Server.Spigot implements Server
 	private final Map<String, TagRegistry> materialTags = new HashMap<>();
 	private final Set<EntityMock> entities = new HashSet<>();
 	private final List<World> worlds = new ArrayList<>();
-	private final List<Recipe> recipes = new LinkedList<>();
+	private @Nullable List<Recipe> recipes;
 	private final Map<NamespacedKey, KeyedBossBarMock> bossBars = new HashMap<>();
 	private final ItemFactoryMock factory = new ItemFactoryMock();
 	private final PlayerMockFactory playerFactory = new PlayerMockFactory(this);
@@ -1065,7 +1065,7 @@ public class ServerMock extends Server.Spigot implements Server
 		if (recipe == null)
 			return false;
 		// Pretend we sent the packet if resendRecipes is true
-		return recipes.add(recipe);
+		return getRecipes().add(recipe);
 	}
 
 	@Override
@@ -1073,7 +1073,7 @@ public class ServerMock extends Server.Spigot implements Server
 	public @NotNull List<Recipe> getRecipesFor(@NotNull ItemStack item)
 	{
 		Preconditions.checkNotNull(item, "item cannot be null");
-		return recipes.stream().filter(recipe ->
+		return getRecipes().stream().filter(recipe ->
 		{
 			ItemStack result = recipe.getResult();
 			return result.getType() == item.getType() && (result.getDurability() == -1 || result.getDurability() == item.getDurability());
@@ -1086,7 +1086,7 @@ public class ServerMock extends Server.Spigot implements Server
 	{
 		Preconditions.checkNotNull(key, "key cannot be null");
 
-		for (Recipe recipe : recipes)
+		for (Recipe recipe : getRecipes())
 		{
 			// Seriously why can't the Recipe interface itself just extend Keyed...
 			if (recipe instanceof Keyed keyed && keyed.getKey().equals(key))
@@ -1165,13 +1165,13 @@ public class ServerMock extends Server.Spigot implements Server
 	@Override
 	public @NotNull Iterator<Recipe> recipeIterator()
 	{
-		return recipes.iterator();
+		return getRecipes().iterator();
 	}
 
 	@Override
 	public void clearRecipes()
 	{
-		recipes.clear();
+		getRecipes().clear();
 	}
 
 	@Override
@@ -2823,4 +2823,19 @@ public class ServerMock extends Server.Spigot implements Server
 		return this.serverConfiguration;
 	}
 
+	/**
+	 * Helper function to lazy load the recipes.
+	 *
+	 * @return The server recipes.
+	 */
+	@NotNull
+	private List<Recipe> getRecipes()
+	{
+		if (this.recipes == null)
+		{
+			this.recipes = new ArrayList<>(RecipeManager.loadDefaultRecipesAsLists());
+		}
+
+		return this.recipes;
+	}
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
@@ -151,6 +151,7 @@ import org.mockbukkit.mockbukkit.inventory.LecternInventoryMock;
 import org.mockbukkit.mockbukkit.inventory.LoomInventoryMock;
 import org.mockbukkit.mockbukkit.inventory.PlayerInventoryMock;
 import org.mockbukkit.mockbukkit.inventory.RecipeManager;
+import org.mockbukkit.mockbukkit.inventory.RecipeType;
 import org.mockbukkit.mockbukkit.inventory.ShulkerBoxInventoryMock;
 import org.mockbukkit.mockbukkit.inventory.SmithingInventoryMock;
 import org.mockbukkit.mockbukkit.inventory.StonecutterInventoryMock;
@@ -188,7 +189,7 @@ public class ServerMock extends Server.Spigot implements Server
 	private final Map<String, TagRegistry> materialTags = new HashMap<>();
 	private final Set<EntityMock> entities = new HashSet<>();
 	private final List<World> worlds = new ArrayList<>();
-	private @Nullable List<Recipe> recipes;
+	private final RecipeManager recipeManager = new RecipeManager();
 	private final Map<NamespacedKey, KeyedBossBarMock> bossBars = new HashMap<>();
 	private final ItemFactoryMock factory = new ItemFactoryMock();
 	private final PlayerMockFactory playerFactory = new PlayerMockFactory(this);
@@ -1065,19 +1066,14 @@ public class ServerMock extends Server.Spigot implements Server
 		if (recipe == null)
 			return false;
 		// Pretend we sent the packet if resendRecipes is true
-		return getRecipes().add(recipe);
+		return this.recipeManager.addRecipe(RecipeType.CRAFTING, recipe);
 	}
 
 	@Override
-	@SuppressWarnings("deprecation")
 	public @NotNull List<Recipe> getRecipesFor(@NotNull ItemStack item)
 	{
 		Preconditions.checkNotNull(item, "item cannot be null");
-		return getRecipes().stream().filter(recipe ->
-		{
-			ItemStack result = recipe.getResult();
-			return result.getType() == item.getType() && (result.getDurability() == -1 || result.getDurability() == item.getDurability());
-		}).toList();
+		return this.recipeManager.getRecipesFor(RecipeType.CRAFTING, item);
 	}
 
 	@Nullable
@@ -1085,17 +1081,7 @@ public class ServerMock extends Server.Spigot implements Server
 	public Recipe getRecipe(@NotNull NamespacedKey key)
 	{
 		Preconditions.checkNotNull(key, "key cannot be null");
-
-		for (Recipe recipe : getRecipes())
-		{
-			// Seriously why can't the Recipe interface itself just extend Keyed...
-			if (recipe instanceof Keyed keyed && keyed.getKey().equals(key))
-			{
-				return recipe;
-			}
-		}
-
-		return null;
+		return this.recipeManager.getRecipeByKey(RecipeType.CRAFTING, key);
 	}
 
 	@Nullable
@@ -1165,13 +1151,13 @@ public class ServerMock extends Server.Spigot implements Server
 	@Override
 	public @NotNull Iterator<Recipe> recipeIterator()
 	{
-		return getRecipes().iterator();
+		return this.recipeManager.getRecipes(RecipeType.CRAFTING).iterator();
 	}
 
 	@Override
 	public void clearRecipes()
 	{
-		getRecipes().clear();
+		this.recipeManager.clearRecipes(RecipeType.CRAFTING);
 	}
 
 	@Override
@@ -2823,19 +2809,4 @@ public class ServerMock extends Server.Spigot implements Server
 		return this.serverConfiguration;
 	}
 
-	/**
-	 * Helper function to lazy load the recipes.
-	 *
-	 * @return The server recipes.
-	 */
-	@NotNull
-	private List<Recipe> getRecipes()
-	{
-		if (this.recipes == null)
-		{
-			this.recipes = new ArrayList<>(RecipeManager.loadDefaultRecipesAsLists());
-		}
-
-		return this.recipes;
-	}
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/ComplexRecipeMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/ComplexRecipeMock.java
@@ -1,0 +1,32 @@
+package org.mockbukkit.mockbukkit.inventory;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ComplexRecipe;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+public class ComplexRecipeMock implements ComplexRecipe
+{
+	private final NamespacedKey key;
+	private final ItemStack result;
+
+	public ComplexRecipeMock(@NotNull NamespacedKey key, @NotNull ItemStack result)
+	{
+		this.key = Preconditions.checkNotNull(key, "The key must not be null");
+		this.result = Preconditions.checkNotNull(result, "The result must not be null");
+	}
+
+	@Override
+	public @NotNull NamespacedKey getKey()
+	{
+		return this.key;
+	}
+
+	@Override
+	public @NotNull ItemStack getResult()
+	{
+		return this.result;
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/CraftingRecipeFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/CraftingRecipeFactory.java
@@ -1,0 +1,210 @@
+package org.mockbukkit.mockbukkit.inventory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiFunction;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ComplexRecipe;
+import org.bukkit.inventory.CraftingRecipe;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.RecipeChoice;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.ShapelessRecipe;
+import org.bukkit.inventory.TransmuteRecipe;
+import org.bukkit.inventory.recipe.CraftingBookCategory;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
+
+public class CraftingRecipeFactory
+{
+
+	public static final String SHAPED_TYPE = "shaped";
+	public static final String SHAPELESS_TYPE = "shapeless";
+	public static final String TRANSMUTE_TYPE = "transmute";
+	public static final String COMPLEX_TYPE = "complex";
+
+	private static final String FIELD_CATEGORY = "category";
+	private static final String FIELD_CHOICE_MAP = "choiceMap";
+	private static final String FIELD_CHOICES = "choices";
+	private static final String FIELD_GROUP = "group";
+	private static final String FIELD_INPUT = "input";
+	private static final String FIELD_KEY = "key";
+	private static final String FIELD_MATERIAL = "material";
+	private static final String FIELD_RESULT = "result";
+	private static final String FIELD_SHAPE = "shape";
+	private static final String FIELD_TYPE = "type";
+
+	@NotNull
+	public static ShapedRecipe createShapedRecipe(@NotNull JsonObject jsonRecipe)
+	{
+		Preconditions.checkNotNull(jsonRecipe, "jsonRecipe is null");
+
+		// Validate type
+		Preconditions.checkArgument(jsonRecipe.has(FIELD_TYPE), "jsonRecipe has no type");
+		String type = jsonRecipe.get(FIELD_TYPE).getAsString();
+		Preconditions.checkArgument(SHAPED_TYPE.equalsIgnoreCase(type), "jsonRecipe is not a shaped recipe (%s)", type);
+
+		// Materials
+		Preconditions.checkArgument(jsonRecipe.has(FIELD_CHOICE_MAP), "jsonRecipe has no choiceMap");
+		JsonObject choiceMap = jsonRecipe.get(FIELD_CHOICE_MAP).getAsJsonObject();
+
+		// Shape
+		Preconditions.checkArgument(jsonRecipe.has(FIELD_SHAPE), "jsonRecipe has no shape");
+		JsonArray shapes = jsonRecipe.get(FIELD_SHAPE).getAsJsonArray();
+		List<String> shapesList = shapes.asList().stream()
+				.map(JsonElement::getAsString)
+				.toList();
+
+		// Create the shaped recipe
+		ShapedRecipe shapedRecipe = createRecipe(jsonRecipe, ShapedRecipe::new);
+		populateCraftingRecipe(jsonRecipe, shapedRecipe);
+		shapedRecipe.shape(shapesList.toArray(new String[0]));
+
+		for (var choice : choiceMap.entrySet())
+		{
+			String charKey = choice.getKey();
+			Preconditions.checkArgument(charKey.length() == 1, "The key should have one character");
+			JsonObject value = choice.getValue().getAsJsonObject();
+			RecipeChoice recipeChoice = createRecipeChoice(value);
+			shapedRecipe.setIngredient(charKey.charAt(0), recipeChoice);
+		}
+
+		return shapedRecipe;
+	}
+
+	@NotNull
+	public static ShapelessRecipe createShapelessRecipe(@NotNull JsonObject jsonRecipe)
+	{
+		Preconditions.checkNotNull(jsonRecipe, "jsonRecipe is null");
+
+		// Validate type
+		Preconditions.checkArgument(jsonRecipe.has(FIELD_TYPE), "jsonRecipe has no type");
+		String type = jsonRecipe.get(FIELD_TYPE).getAsString();
+		Preconditions.checkArgument(SHAPELESS_TYPE.equalsIgnoreCase(type), "jsonRecipe is not a shapeless recipe (%s)", type);
+
+		// Create the shaped recipe
+		ShapelessRecipe shapelessRecipe = createRecipe(jsonRecipe, ShapelessRecipe::new);
+		populateCraftingRecipe(jsonRecipe, shapelessRecipe);
+
+		// Shape
+		Preconditions.checkArgument(jsonRecipe.has(FIELD_CHOICES), "jsonRecipe has no choices");
+		JsonArray choicesArray = jsonRecipe.get(FIELD_CHOICES).getAsJsonArray();
+		createRecipeChoices(choicesArray).forEach(shapelessRecipe::addIngredient);
+
+		return shapelessRecipe;
+	}
+
+	@NotNull
+	public static TransmuteRecipe createTransmuteRecipe(@NotNull JsonObject jsonRecipe)
+	{
+		Preconditions.checkNotNull(jsonRecipe, "jsonRecipe is null");
+
+		// Validate type
+		Preconditions.checkArgument(jsonRecipe.has(FIELD_TYPE), "jsonRecipe has no type");
+		String type = jsonRecipe.get(FIELD_TYPE).getAsString();
+		Preconditions.checkArgument(TRANSMUTE_TYPE.equalsIgnoreCase(type), "jsonRecipe is not a shapeless recipe (%s)", type);
+
+		// Input
+		Preconditions.checkArgument(jsonRecipe.has(FIELD_INPUT), "jsonRecipe has no input");
+		JsonObject inputJson = jsonRecipe.get(FIELD_INPUT).getAsJsonObject();
+		RecipeChoice input = createRecipeChoice(inputJson);
+
+		// Material
+		Preconditions.checkArgument(jsonRecipe.has(FIELD_MATERIAL), "jsonRecipe has no material");
+		JsonObject materialJson = jsonRecipe.get(FIELD_MATERIAL).getAsJsonObject();
+		RecipeChoice material = createRecipeChoice(materialJson);
+
+		// Create the shaped recipe
+		TransmuteRecipe transmuteRecipe = createRecipe(jsonRecipe, (key, result) -> new TransmuteRecipe(key, result.getType(), input, material));
+		populateCraftingRecipe(jsonRecipe, transmuteRecipe);
+
+		return transmuteRecipe;
+	}
+
+	@NotNull
+	public static ComplexRecipe createComplexRecipe(@NotNull JsonObject jsonRecipe)
+	{
+		// Validate type
+		Preconditions.checkArgument(jsonRecipe.has(FIELD_TYPE), "jsonRecipe has no type");
+		String type = jsonRecipe.get(FIELD_TYPE).getAsString();
+		Preconditions.checkArgument(COMPLEX_TYPE.equalsIgnoreCase(type), "jsonRecipe is not a complex recipe (%s)", type);
+
+		return createRecipe(jsonRecipe, ComplexRecipeMock::new);
+	}
+
+	private static <T> T createRecipe(@NotNull JsonObject jsonRecipe, @NonNull BiFunction<NamespacedKey, ItemStack, T> factory)
+	{
+		// Validate key
+		Preconditions.checkArgument(jsonRecipe.has(FIELD_KEY), "jsonRecipe has no key");
+		NamespacedKey key = NamespacedKey.fromString(jsonRecipe.get(FIELD_KEY).getAsString());
+		Preconditions.checkArgument(key != null, "jsonRecipe has no key");
+
+		// Validate result
+		Preconditions.checkArgument(jsonRecipe.has(FIELD_RESULT), "jsonRecipe has no result");
+		ItemStackMock result = ItemStackMock.fromJson(jsonRecipe.get(FIELD_RESULT).getAsJsonObject());
+
+		return factory.apply(key, result);
+	}
+
+	private static RecipeChoice createRecipeChoice(@NotNull JsonObject value)
+	{
+		Preconditions.checkArgument(value.has(FIELD_TYPE), "Choice map has no type");
+		String choiceType = value.get(FIELD_TYPE).getAsString();
+
+		if (FIELD_MATERIAL.equalsIgnoreCase(choiceType))
+		{
+			List<Material> materials = value.get(FIELD_CHOICES).getAsJsonArray()
+					.asList().stream()
+					.map(JsonElement::getAsString)
+					.map(NamespacedKey::fromString)
+					.filter(Objects::nonNull)
+					.map(NamespacedKey::getKey)
+					.map(String::toUpperCase)
+					.map(Material::valueOf)
+					.toList();
+			return new RecipeChoice.MaterialChoice(materials);
+		}
+
+		throw new UnsupportedOperationException("Unsupported choice type: " + choiceType);
+	}
+
+	private static List<RecipeChoice> createRecipeChoices(@NotNull JsonArray choicesArray)
+	{
+		List<RecipeChoice> choices = new ArrayList<>(choicesArray.size());
+
+		for (var element : choicesArray)
+		{
+			var value = element.getAsJsonObject();
+			choices.add(createRecipeChoice(value));
+		}
+
+		return choices;
+	}
+
+	private static void populateCraftingRecipe(@NonNull JsonObject jsonRecipe, @NonNull CraftingRecipe craftingRecipe)
+	{
+		// Group
+		Preconditions.checkArgument(jsonRecipe.has(FIELD_GROUP), "jsonRecipe has no group");
+		String group = jsonRecipe.get(FIELD_GROUP).getAsString();
+
+		// category
+		Preconditions.checkArgument(jsonRecipe.has(FIELD_CATEGORY), "jsonRecipe has no category");
+		CraftingBookCategory category = CraftingBookCategory.valueOf(jsonRecipe.get(FIELD_CATEGORY).getAsString().toUpperCase());
+
+		craftingRecipe.setGroup(group);
+		craftingRecipe.setCategory(category);
+	}
+
+	private CraftingRecipeFactory()
+	{
+		// Hide the public constructor
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/CraftingRecipeFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/CraftingRecipeFactory.java
@@ -24,7 +24,6 @@ import org.jetbrains.annotations.NotNull;
 
 public class CraftingRecipeFactory
 {
-
 	public static final String SHAPED_TYPE = "shaped";
 	public static final String SHAPELESS_TYPE = "shapeless";
 	public static final String TRANSMUTE_TYPE = "transmute";
@@ -41,13 +40,16 @@ public class CraftingRecipeFactory
 	private static final String FIELD_SHAPE = "shape";
 	private static final String FIELD_TYPE = "type";
 
+	private static final String JSON_RECIPE_IS_NULL = "jsonRecipe is null";
+	private static final String JSON_RECIPE_HAS_NO_TYPE = "jsonRecipe has no type";
+
 	@NotNull
 	public static ShapedRecipe createShapedRecipe(@NotNull JsonObject jsonRecipe)
 	{
-		Preconditions.checkNotNull(jsonRecipe, "jsonRecipe is null");
+		Preconditions.checkNotNull(jsonRecipe, JSON_RECIPE_IS_NULL);
 
 		// Validate type
-		Preconditions.checkArgument(jsonRecipe.has(FIELD_TYPE), "jsonRecipe has no type");
+		Preconditions.checkArgument(jsonRecipe.has(FIELD_TYPE), JSON_RECIPE_HAS_NO_TYPE);
 		String type = jsonRecipe.get(FIELD_TYPE).getAsString();
 		Preconditions.checkArgument(SHAPED_TYPE.equalsIgnoreCase(type), "jsonRecipe is not a shaped recipe (%s)", type);
 
@@ -82,10 +84,10 @@ public class CraftingRecipeFactory
 	@NotNull
 	public static ShapelessRecipe createShapelessRecipe(@NotNull JsonObject jsonRecipe)
 	{
-		Preconditions.checkNotNull(jsonRecipe, "jsonRecipe is null");
+		Preconditions.checkNotNull(jsonRecipe, JSON_RECIPE_IS_NULL);
 
 		// Validate type
-		Preconditions.checkArgument(jsonRecipe.has(FIELD_TYPE), "jsonRecipe has no type");
+		Preconditions.checkArgument(jsonRecipe.has(FIELD_TYPE), JSON_RECIPE_HAS_NO_TYPE);
 		String type = jsonRecipe.get(FIELD_TYPE).getAsString();
 		Preconditions.checkArgument(SHAPELESS_TYPE.equalsIgnoreCase(type), "jsonRecipe is not a shapeless recipe (%s)", type);
 
@@ -104,10 +106,10 @@ public class CraftingRecipeFactory
 	@NotNull
 	public static TransmuteRecipe createTransmuteRecipe(@NotNull JsonObject jsonRecipe)
 	{
-		Preconditions.checkNotNull(jsonRecipe, "jsonRecipe is null");
+		Preconditions.checkNotNull(jsonRecipe, JSON_RECIPE_IS_NULL);
 
 		// Validate type
-		Preconditions.checkArgument(jsonRecipe.has(FIELD_TYPE), "jsonRecipe has no type");
+		Preconditions.checkArgument(jsonRecipe.has(FIELD_TYPE), JSON_RECIPE_HAS_NO_TYPE);
 		String type = jsonRecipe.get(FIELD_TYPE).getAsString();
 		Preconditions.checkArgument(TRANSMUTE_TYPE.equalsIgnoreCase(type), "jsonRecipe is not a shapeless recipe (%s)", type);
 
@@ -132,7 +134,7 @@ public class CraftingRecipeFactory
 	public static ComplexRecipe createComplexRecipe(@NotNull JsonObject jsonRecipe)
 	{
 		// Validate type
-		Preconditions.checkArgument(jsonRecipe.has(FIELD_TYPE), "jsonRecipe has no type");
+		Preconditions.checkArgument(jsonRecipe.has(FIELD_TYPE), JSON_RECIPE_HAS_NO_TYPE);
 		String type = jsonRecipe.get(FIELD_TYPE).getAsString();
 		Preconditions.checkArgument(COMPLEX_TYPE.equalsIgnoreCase(type), "jsonRecipe is not a complex recipe (%s)", type);
 

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMock.java
@@ -1,25 +1,28 @@
 package org.mockbukkit.mockbukkit.inventory;
 
+import java.lang.reflect.InvocationTargetException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
 import com.google.common.base.Preconditions;
+import com.google.gson.JsonObject;
 import io.papermc.paper.persistence.PersistentDataContainerView;
 import io.papermc.paper.registry.RegistryKey;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.event.HoverEvent;
-import net.kyori.adventure.text.event.HoverEventSource;
-import net.kyori.adventure.text.format.Style;
-import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.inventory.ItemFlag;
-import org.bukkit.inventory.ItemRarity;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ItemType;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mockbukkit.mockbukkit.exception.ItemMetaInitException;
@@ -27,14 +30,24 @@ import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 import org.mockbukkit.mockbukkit.inventory.meta.ItemMetaMock;
 import org.mockbukkit.mockbukkit.persistence.PersistentDataContainerViewMock;
 
-import java.lang.reflect.InvocationTargetException;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-
 public class ItemStackMock extends ItemStack
 {
+	private static final String FIELD_AMOUNT = "amount";
+	private static final String FIELD_MATERIAL = "type";
+
+	@NonNull
+	@ApiStatus.Internal
+	public static ItemStackMock fromJson(@NonNull JsonObject json)
+	{
+		Preconditions.checkNotNull(json, "json cannot be null");
+
+		int amountValue = json.get(FIELD_AMOUNT).getAsInt();
+		NamespacedKey materialKey = NamespacedKey.fromString(json.get(FIELD_MATERIAL).getAsString());
+		Preconditions.checkArgument(materialKey != null, "Material field does not exist");
+		Material materialValue = Material.valueOf(materialKey.getKey().toUpperCase(Locale.ROOT));
+
+		return new ItemStackMock(materialValue, amountValue);
+	}
 
 	private ItemType type = ItemTypeMock.AIR;
 	private int amount = 1;

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
@@ -17,48 +17,157 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import org.bukkit.Keyed;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.mockbukkit.mockbukkit.MockBukkit;
 
-public enum RecipeManager
+public class RecipeManager
 {
-	BLASTING("blasting"),
-	CAMPFIRE_COOKING("campfire_cooking"),
-	CRAFTING("crafting"),
-	SMELTING("smelting"),
-	SMITHING("smithing"),
-	SMOKING("smoking"),
-	STONECUTTING("stonecutting");
 
-	private final String name;
+	/**
+	 * This field is used as cache. The values are lazy loaded with method {@link #getRecipes()}.
+	 * This field should not be accessed directly, it's preferred to use the method {@link #getRecipes()} instead.
+	 */
+	private Map<RecipeType, List<Recipe>> recipes = null;
 
-	RecipeManager(@NotNull String name)
+	/**
+	 * Get the list of recipes available.
+	 *
+	 * @return The list of recipes available.
+	 */
+	@NotNull
+	public Map<RecipeType, List<Recipe>> getRecipes()
 	{
-		this.name = Preconditions.checkNotNull(name, "name cannot be null");
+		if (this.recipes == null)
+		{
+			this.recipes = new EnumMap<>(RecipeManager.loadDefaultRecipes());
+		}
+
+		return this.recipes;
 	}
 
-	public static List<Recipe> loadDefaultRecipes(RecipeManager recipeType)
+	/**
+	 * Get the list of recipes available for that recipe type.
+	 *
+	 * @param recipeType The recipe type.
+	 *
+	 * @return The list of recipes available.
+	 */
+	@NotNull
+	public List<Recipe> getRecipes(@NotNull RecipeType recipeType)
+	{
+		Preconditions.checkArgument(recipeType != null, "Recipe type cannot be null");
+		return getRecipes().getOrDefault(recipeType, Collections.emptyList());
+	}
+
+	/**
+	 * Helper function to lazy load the recipes.
+	 *
+	 * @param recipeType 	The recipe type to get the recipes.
+	 * @param recipeKey 	The recipe key to get the recipes.
+	 *
+	 * @return The server recipes.
+	 */
+	@Nullable
+	public Recipe getRecipeByKey(@NotNull RecipeType recipeType, @NotNull NamespacedKey recipeKey)
+	{
+		Preconditions.checkArgument(recipeType != null, "Recipe type cannot be null");
+		Preconditions.checkArgument(recipeKey != null, "Recipe key cannot be null");
+
+		List<Recipe> recipesToSearch = getRecipes().get(recipeType);
+		for (Recipe recipe : recipesToSearch)
+		{
+			if (recipe instanceof Keyed keyed && recipeKey.equals(keyed.getKey()))
+			{
+				return recipe;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get the list of recipes available to create a desired item.
+	 *
+	 * @param recipeType The recipe type.
+	 * @param itemStack  The desired item.
+	 *
+	 * @return The list of recipes available to create.
+	 */
+	@NotNull
+	public List<Recipe> getRecipesFor(@NotNull RecipeType recipeType, @NotNull ItemStack itemStack)
+	{
+		Preconditions.checkArgument(recipeType != null, "Recipe type cannot be null");
+		return getRecipes(recipeType).stream()
+				.filter(recipe -> itemStack.isSimilar(recipe.getResult()))
+				.toList();
+	}
+
+	/**
+	 * Add a recipe to the list of recipes.
+	 *
+	 * @param recipeType 	The recipe type.
+	 * @param recipe		The recipe to be added.
+	 *
+	 * @return {@code true} if added, otherwise {@code false}.
+	 */
+	public boolean addRecipe(@NotNull RecipeType recipeType, @NotNull Recipe recipe)
+	{
+		Preconditions.checkArgument(recipeType != null, "The recipe type cannot be null");
+		Preconditions.checkArgument(recipe != null, "The recipe cannot be null");
+		return getRecipes(recipeType).add(recipe);
+	}
+
+	/**
+	 * Remove a recipe to the list of recipes.
+	 *
+	 * @param recipeType 	The recipe type.
+	 * @param recipe		The recipe to be removed.
+	 *
+	 * @return {@code true} if removed, otherwise {@code false}.
+	 */
+	public boolean removeRecipe(@NotNull RecipeType recipeType, @NotNull Recipe recipe)
+	{
+		Preconditions.checkArgument(recipeType != null, "The recipe type cannot be null");
+		Preconditions.checkArgument(recipe != null, "The recipe cannot be null");
+		return getRecipes(recipeType).remove(recipe);
+	}
+
+	/**
+	 * Clears the list of recipes.
+	 */
+	public void clearRecipes(RecipeType recipeType)
+	{
+		getRecipes(recipeType).clear();
+	}
+
+	// Static methods
+
+	public static List<Recipe> loadDefaultRecipes(RecipeType recipeType)
 	{
 		return switch (recipeType)
 		{
-			case BLASTING -> Collections.emptyList();
-			case CAMPFIRE_COOKING -> Collections.emptyList();
-			case CRAFTING -> loadCraftingRecipes();
-			case SMELTING -> Collections.emptyList();
-			case SMITHING -> Collections.emptyList();
-			case SMOKING -> Collections.emptyList();
-			case STONECUTTING -> Collections.emptyList();
+			case RecipeType.BLASTING -> Collections.emptyList();
+			case RecipeType.CAMPFIRE_COOKING -> Collections.emptyList();
+			case RecipeType.CRAFTING -> loadCraftingRecipes();
+			case RecipeType.SMELTING -> Collections.emptyList();
+			case RecipeType.SMITHING -> Collections.emptyList();
+			case RecipeType.SMOKING -> Collections.emptyList();
+			case RecipeType.STONECUTTING -> Collections.emptyList();
 		};
 	}
 
-	public static Map<RecipeManager, List<Recipe>> loadDefaultRecipes()
+	public static Map<RecipeType, List<Recipe>> loadDefaultRecipes()
 	{
-		Map<RecipeManager, List<Recipe>> recipesMap = new EnumMap<>(RecipeManager.class);
-		for (RecipeManager recipeManager : RecipeManager.values())
+		Map<RecipeType, List<Recipe>> recipesMap = new EnumMap<>(RecipeType.class);
+		for (RecipeType recipeType : RecipeType.values())
 		{
-			var recipes = RecipeManager.loadDefaultRecipes(recipeManager);
-			recipesMap.put(recipeManager, recipes);
+			var recipes = RecipeManager.loadDefaultRecipes(recipeType);
+			recipesMap.put(recipeType, recipes);
 		}
 		return recipesMap;
 	}

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
@@ -28,6 +28,8 @@ import org.mockbukkit.mockbukkit.MockBukkit;
 public class RecipeManager
 {
 
+	private static final String RECIPE_TYPE_CANNOT_BE_NULL = "Recipe type cannot be null";
+
 	/**
 	 * This field is used as cache. The values are lazy loaded with method {@link #getRecipes()}.
 	 * This field should not be accessed directly, it's preferred to use the method {@link #getRecipes()} instead.
@@ -60,7 +62,7 @@ public class RecipeManager
 	@NotNull
 	public List<Recipe> getRecipes(@NotNull RecipeType recipeType)
 	{
-		Preconditions.checkArgument(recipeType != null, "Recipe type cannot be null");
+		Preconditions.checkArgument(recipeType != null, RECIPE_TYPE_CANNOT_BE_NULL);
 		return getRecipes().getOrDefault(recipeType, Collections.emptyList());
 	}
 
@@ -75,7 +77,7 @@ public class RecipeManager
 	@Nullable
 	public Recipe getRecipeByKey(@NotNull RecipeType recipeType, @NotNull NamespacedKey recipeKey)
 	{
-		Preconditions.checkArgument(recipeType != null, "Recipe type cannot be null");
+		Preconditions.checkArgument(recipeType != null, RECIPE_TYPE_CANNOT_BE_NULL);
 		Preconditions.checkArgument(recipeKey != null, "Recipe key cannot be null");
 
 		List<Recipe> recipesToSearch = getRecipes().get(recipeType);
@@ -101,7 +103,7 @@ public class RecipeManager
 	@NotNull
 	public List<Recipe> getRecipesFor(@NotNull RecipeType recipeType, @NotNull ItemStack itemStack)
 	{
-		Preconditions.checkArgument(recipeType != null, "Recipe type cannot be null");
+		Preconditions.checkArgument(recipeType != null, RECIPE_TYPE_CANNOT_BE_NULL);
 		return getRecipes(recipeType).stream()
 				.filter(recipe -> itemStack.isSimilar(recipe.getResult()))
 				.toList();

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
@@ -1,0 +1,117 @@
+package org.mockbukkit.mockbukkit.inventory;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.bukkit.inventory.Recipe;
+import org.jetbrains.annotations.NotNull;
+import org.mockbukkit.mockbukkit.MockBukkit;
+
+public enum RecipeManager
+{
+	BLASTING("blasting"),
+	CAMPFIRE_COOKING("campfire_cooking"),
+	CRAFTING("crafting"),
+	SMELTING("smelting"),
+	SMITHING("smithing"),
+	SMOKING("smoking"),
+	STONECUTTING("stonecutting");
+
+	private final String name;
+
+	RecipeManager(@NotNull String name)
+	{
+		this.name = Preconditions.checkNotNull(name, "name cannot be null");
+	}
+
+	public static List<Recipe> loadDefaultRecipes(RecipeManager recipeType)
+	{
+		return switch (recipeType)
+		{
+			case BLASTING -> Collections.emptyList();
+			case CAMPFIRE_COOKING -> Collections.emptyList();
+			case CRAFTING -> loadCraftingRecipes();
+			case SMELTING -> Collections.emptyList();
+			case SMITHING -> Collections.emptyList();
+			case SMOKING -> Collections.emptyList();
+			case STONECUTTING -> Collections.emptyList();
+		};
+	}
+
+	public static Map<RecipeManager, List<Recipe>> loadDefaultRecipes()
+	{
+		Map<RecipeManager, List<Recipe>> recipesMap = new EnumMap<>(RecipeManager.class);
+		for (RecipeManager recipeManager : RecipeManager.values())
+		{
+			var recipes = RecipeManager.loadDefaultRecipes(recipeManager);
+			recipesMap.put(recipeManager, recipes);
+		}
+		return recipesMap;
+	}
+
+	public static List<Recipe> loadDefaultRecipesAsLists()
+	{
+		return loadDefaultRecipes().values().stream()
+				.flatMap(Collection::stream)
+				.toList();
+	}
+
+	private static List<Recipe> loadCraftingRecipes()
+	{
+		List<Recipe> recipesList = new ArrayList<>();
+		URL resource = MockBukkit.class.getClassLoader().getResource("recipes/crafting.json");
+		try
+		{
+			File file = new File(resource.toURI());
+			JsonArray recipes = JsonParser.parseReader(new FileReader(file)).getAsJsonArray();
+
+			for (JsonElement recipeElement : recipes)
+			{
+				Preconditions.checkArgument(recipeElement.isJsonObject(), "The recipe is not a JSON object");
+				JsonObject recipe = recipeElement.getAsJsonObject();
+				String recipeTypeString = recipe.get("type").getAsString();
+				if (CraftingRecipeFactory.SHAPED_TYPE.equalsIgnoreCase(recipeTypeString))
+				{
+					recipesList.add(CraftingRecipeFactory.createShapedRecipe(recipe));
+				}
+				else if (CraftingRecipeFactory.SHAPELESS_TYPE.equalsIgnoreCase(recipeTypeString))
+				{
+					recipesList.add(CraftingRecipeFactory.createShapelessRecipe(recipe));
+				}
+				else if (CraftingRecipeFactory.TRANSMUTE_TYPE.equalsIgnoreCase(recipeTypeString))
+				{
+					recipesList.add(CraftingRecipeFactory.createTransmuteRecipe(recipe));
+				}
+				else if (CraftingRecipeFactory.COMPLEX_TYPE.equalsIgnoreCase(recipeTypeString))
+				{
+					recipesList.add(CraftingRecipeFactory.createComplexRecipe(recipe));
+				}
+				else
+				{
+					throw new IllegalArgumentException("Unknown recipe type: " + recipeTypeString);
+				}
+			}
+		}
+		catch (URISyntaxException | FileNotFoundException e)
+		{
+			throw new IllegalArgumentException("Error while loading crafting recipes", e);
+		}
+
+		return recipesList;
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeType.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeType.java
@@ -1,0 +1,27 @@
+package org.mockbukkit.mockbukkit.inventory;
+
+import com.google.common.base.Preconditions;
+import org.jetbrains.annotations.NotNull;
+
+public enum RecipeType
+{
+	BLASTING("blasting"),
+	CAMPFIRE_COOKING("campfire_cooking"),
+	CRAFTING("crafting"),
+	SMELTING("smelting"),
+	SMITHING("smithing"),
+	SMOKING("smoking"),
+	STONECUTTING("stonecutting");
+
+	private final String key;
+
+	RecipeType(@NotNull String key)
+	{
+		this.key = Preconditions.checkNotNull(key, "key cannot be null");
+	}
+
+	public String getKey()
+	{
+		return key;
+	}
+}

--- a/src/main/resources/recipes/blasting.json
+++ b/src/main/resources/recipes/blasting.json
@@ -1,0 +1,432 @@
+[
+	{
+		"category": "MISC",
+		"cookingTime": 100,
+		"experience": 0.1,
+		"group": "coal",
+		"input": {
+			"choices": [
+				"minecraft:coal_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:coal_from_blasting_coal_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:coal"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 100,
+		"experience": 0.1,
+		"group": "coal",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_coal_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:coal_from_blasting_deepslate_coal_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:coal"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 100,
+		"experience": 0.7,
+		"group": "copper_ingot",
+		"input": {
+			"choices": [
+				"minecraft:copper_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:copper_ingot_from_blasting_copper_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:copper_ingot"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 100,
+		"experience": 0.7,
+		"group": "copper_ingot",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_copper_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:copper_ingot_from_blasting_deepslate_copper_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:copper_ingot"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 100,
+		"experience": 0.7,
+		"group": "copper_ingot",
+		"input": {
+			"choices": [
+				"minecraft:raw_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:copper_ingot_from_blasting_raw_copper",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:copper_ingot"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 100,
+		"experience": 1.0,
+		"group": "diamond",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_diamond_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:diamond_from_blasting_deepslate_diamond_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:diamond"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 100,
+		"experience": 1.0,
+		"group": "diamond",
+		"input": {
+			"choices": [
+				"minecraft:diamond_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:diamond_from_blasting_diamond_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:diamond"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 100,
+		"experience": 1.0,
+		"group": "emerald",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_emerald_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:emerald_from_blasting_deepslate_emerald_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:emerald"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 100,
+		"experience": 1.0,
+		"group": "emerald",
+		"input": {
+			"choices": [
+				"minecraft:emerald_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:emerald_from_blasting_emerald_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:emerald"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 100,
+		"experience": 1.0,
+		"group": "gold_ingot",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_gold_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:gold_ingot_from_blasting_deepslate_gold_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:gold_ingot"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 100,
+		"experience": 1.0,
+		"group": "gold_ingot",
+		"input": {
+			"choices": [
+				"minecraft:gold_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:gold_ingot_from_blasting_gold_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:gold_ingot"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 100,
+		"experience": 1.0,
+		"group": "gold_ingot",
+		"input": {
+			"choices": [
+				"minecraft:nether_gold_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:gold_ingot_from_blasting_nether_gold_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:gold_ingot"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 100,
+		"experience": 1.0,
+		"group": "gold_ingot",
+		"input": {
+			"choices": [
+				"minecraft:raw_gold"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:gold_ingot_from_blasting_raw_gold",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:gold_ingot"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 100,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:golden_axe",
+				"minecraft:golden_boots",
+				"minecraft:golden_chestplate",
+				"minecraft:golden_helmet",
+				"minecraft:golden_hoe",
+				"minecraft:golden_horse_armor",
+				"minecraft:golden_leggings",
+				"minecraft:golden_pickaxe",
+				"minecraft:golden_shovel",
+				"minecraft:golden_sword"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:gold_nugget_from_blasting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:gold_nugget"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 100,
+		"experience": 0.7,
+		"group": "iron_ingot",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_iron_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:iron_ingot_from_blasting_deepslate_iron_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:iron_ingot"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 100,
+		"experience": 0.7,
+		"group": "iron_ingot",
+		"input": {
+			"choices": [
+				"minecraft:iron_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:iron_ingot_from_blasting_iron_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:iron_ingot"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 100,
+		"experience": 0.7,
+		"group": "iron_ingot",
+		"input": {
+			"choices": [
+				"minecraft:raw_iron"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:iron_ingot_from_blasting_raw_iron",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:iron_ingot"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 100,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:chainmail_boots",
+				"minecraft:chainmail_chestplate",
+				"minecraft:chainmail_helmet",
+				"minecraft:chainmail_leggings",
+				"minecraft:iron_axe",
+				"minecraft:iron_boots",
+				"minecraft:iron_chestplate",
+				"minecraft:iron_helmet",
+				"minecraft:iron_hoe",
+				"minecraft:iron_horse_armor",
+				"minecraft:iron_leggings",
+				"minecraft:iron_pickaxe",
+				"minecraft:iron_shovel",
+				"minecraft:iron_sword"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:iron_nugget_from_blasting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:iron_nugget"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 100,
+		"experience": 0.2,
+		"group": "lapis_lazuli",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_lapis_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:lapis_lazuli_from_blasting_deepslate_lapis_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:lapis_lazuli"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 100,
+		"experience": 0.2,
+		"group": "lapis_lazuli",
+		"input": {
+			"choices": [
+				"minecraft:lapis_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:lapis_lazuli_from_blasting_lapis_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:lapis_lazuli"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 100,
+		"experience": 2.0,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:ancient_debris"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:netherite_scrap_from_blasting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:netherite_scrap"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 100,
+		"experience": 0.2,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:nether_quartz_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:quartz_from_blasting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:quartz"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 100,
+		"experience": 0.7,
+		"group": "redstone",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_redstone_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:redstone_from_blasting_deepslate_redstone_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:redstone"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 100,
+		"experience": 0.7,
+		"group": "redstone",
+		"input": {
+			"choices": [
+				"minecraft:redstone_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:redstone_from_blasting_redstone_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:redstone"
+		}
+	}
+]

--- a/src/main/resources/recipes/campfire_cooking.json
+++ b/src/main/resources/recipes/campfire_cooking.json
@@ -1,0 +1,155 @@
+[
+	{
+		"category": "FOOD",
+		"cookingTime": 600,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:potato"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:baked_potato_from_campfire_cooking",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:baked_potato"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 600,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:beef"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cooked_beef_from_campfire_cooking",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cooked_beef"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 600,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:chicken"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cooked_chicken_from_campfire_cooking",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cooked_chicken"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 600,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cod"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cooked_cod_from_campfire_cooking",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cooked_cod"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 600,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:mutton"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cooked_mutton_from_campfire_cooking",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cooked_mutton"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 600,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:porkchop"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cooked_porkchop_from_campfire_cooking",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cooked_porkchop"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 600,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:rabbit"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cooked_rabbit_from_campfire_cooking",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cooked_rabbit"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 600,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:salmon"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cooked_salmon_from_campfire_cooking",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cooked_salmon"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 600,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:kelp"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:dried_kelp_from_campfire_cooking",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:dried_kelp"
+		}
+	}
+]

--- a/src/main/resources/recipes/crafting.json
+++ b/src/main/resources/recipes/crafting.json
@@ -1,0 +1,44285 @@
+[
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "boat",
+		"key": "minecraft:acacia_boat",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:acacia_boat"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wooden_button",
+		"key": "minecraft:acacia_button",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:acacia_button"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:chest"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:acacia_boat"
+				],
+				"type": "material"
+			}
+		],
+		"group": "chest_boat",
+		"key": "minecraft:acacia_chest_boat",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:acacia_chest_boat"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_door",
+		"key": "minecraft:acacia_door",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:acacia_door"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence",
+		"key": "minecraft:acacia_fence",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:acacia_fence"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence_gate",
+		"key": "minecraft:acacia_fence_gate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:acacia_fence_gate"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_acacia_log"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stripped_acacia_log"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stripped_acacia_log"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:stripped_acacia_log"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stripped_acacia_log"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:stripped_acacia_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "hanging_sign",
+		"key": "minecraft:acacia_hanging_sign",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:acacia_hanging_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:acacia_log",
+					"minecraft:acacia_wood",
+					"minecraft:stripped_acacia_log",
+					"minecraft:stripped_acacia_wood"
+				],
+				"type": "material"
+			}
+		],
+		"group": "planks",
+		"key": "minecraft:acacia_planks",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:acacia_planks"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_pressure_plate",
+		"key": "minecraft:acacia_pressure_plate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:acacia_pressure_plate"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_sign",
+		"key": "minecraft:acacia_sign",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:acacia_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_slab",
+		"key": "minecraft:acacia_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:acacia_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_stairs",
+		"key": "minecraft:acacia_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:acacia_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_trapdoor",
+		"key": "minecraft:acacia_trapdoor",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:acacia_trapdoor"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_log"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:acacia_log"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_log"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bark",
+		"key": "minecraft:acacia_wood",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:acacia_wood"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:redstone_torch"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:activator_rail",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:activator_rail"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:amethyst_shard"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:amethyst_shard"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:amethyst_shard"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:amethyst_shard"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:amethyst_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:amethyst_block"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:diorite"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:andesite",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:andesite"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:andesite"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:andesite"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:andesite"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:andesite_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:andesite_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:andesite"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:andesite"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:andesite"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:andesite"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:andesite"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:andesite"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:andesite_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:andesite_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:andesite"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:andesite"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:andesite"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:andesite"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:andesite"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:andesite"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:andesite_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:andesite_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_block"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:iron_block"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_block"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:anvil",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:anvil"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"key": "minecraft:armor_dye",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		},
+		"type": "complex"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:smooth_stone_slab"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:armor_stand",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:armor_stand"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:flint"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:feather"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:arrow",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:arrow"
+		},
+		"shape": [
+			"a",
+			"b",
+			"c"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bamboo"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:bamboo"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:bamboo"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:bamboo"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:bamboo"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:bamboo"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:bamboo"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:bamboo"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:bamboo"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:bamboo_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:bamboo_block"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wooden_button",
+		"key": "minecraft:bamboo_button",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:bamboo_button"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:chest"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:bamboo_raft"
+				],
+				"type": "material"
+			}
+		],
+		"group": "chest_boat",
+		"key": "minecraft:bamboo_chest_raft",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:bamboo_chest_raft"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_door",
+		"key": "minecraft:bamboo_door",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:bamboo_door"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence",
+		"key": "minecraft:bamboo_fence",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:bamboo_fence"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence_gate",
+		"key": "minecraft:bamboo_fence_gate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:bamboo_fence_gate"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_bamboo_block"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stripped_bamboo_block"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stripped_bamboo_block"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:stripped_bamboo_block"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stripped_bamboo_block"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:stripped_bamboo_block"
+				],
+				"type": "material"
+			}
+		},
+		"group": "hanging_sign",
+		"key": "minecraft:bamboo_hanging_sign",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:bamboo_hanging_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:bamboo_slab"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:bamboo_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:bamboo_mosaic",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:bamboo_mosaic"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:bamboo_mosaic"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:bamboo_mosaic"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:bamboo_mosaic"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:bamboo_mosaic_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:bamboo_mosaic_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:bamboo_mosaic"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:bamboo_mosaic"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:bamboo_mosaic"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:bamboo_mosaic"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:bamboo_mosaic"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:bamboo_mosaic"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:bamboo_mosaic_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:bamboo_mosaic_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bamboo_block",
+					"minecraft:stripped_bamboo_block"
+				],
+				"type": "material"
+			}
+		],
+		"group": "planks",
+		"key": "minecraft:bamboo_planks",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:bamboo_planks"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_pressure_plate",
+		"key": "minecraft:bamboo_pressure_plate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:bamboo_pressure_plate"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "boat",
+		"key": "minecraft:bamboo_raft",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:bamboo_raft"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_sign",
+		"key": "minecraft:bamboo_sign",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:bamboo_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_slab",
+		"key": "minecraft:bamboo_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:bamboo_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_stairs",
+		"key": "minecraft:bamboo_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:bamboo_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:bamboo_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_trapdoor",
+		"key": "minecraft:bamboo_trapdoor",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:bamboo_trapdoor"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"key": "minecraft:banner_duplicate",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		},
+		"type": "complex"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:acacia_slab",
+					"minecraft:bamboo_slab",
+					"minecraft:birch_slab",
+					"minecraft:cherry_slab",
+					"minecraft:crimson_slab",
+					"minecraft:dark_oak_slab",
+					"minecraft:jungle_slab",
+					"minecraft:mangrove_slab",
+					"minecraft:oak_slab",
+					"minecraft:pale_oak_slab",
+					"minecraft:spruce_slab",
+					"minecraft:warped_slab"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:acacia_slab",
+					"minecraft:bamboo_slab",
+					"minecraft:birch_slab",
+					"minecraft:cherry_slab",
+					"minecraft:crimson_slab",
+					"minecraft:dark_oak_slab",
+					"minecraft:jungle_slab",
+					"minecraft:mangrove_slab",
+					"minecraft:oak_slab",
+					"minecraft:pale_oak_slab",
+					"minecraft:spruce_slab",
+					"minecraft:warped_slab"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:barrel",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:barrel"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:nether_star"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:obsidian"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:obsidian"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:obsidian"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:beacon",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:beacon"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:beehive",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:beehive"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bowl"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:beetroot"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:beetroot"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:beetroot"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:beetroot"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:beetroot"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:beetroot"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:beetroot_soup",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:beetroot_soup"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "boat",
+		"key": "minecraft:birch_boat",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:birch_boat"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wooden_button",
+		"key": "minecraft:birch_button",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:birch_button"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:chest"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:birch_boat"
+				],
+				"type": "material"
+			}
+		],
+		"group": "chest_boat",
+		"key": "minecraft:birch_chest_boat",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:birch_chest_boat"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_door",
+		"key": "minecraft:birch_door",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:birch_door"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence",
+		"key": "minecraft:birch_fence",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:birch_fence"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence_gate",
+		"key": "minecraft:birch_fence_gate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:birch_fence_gate"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_birch_log"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stripped_birch_log"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stripped_birch_log"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:stripped_birch_log"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stripped_birch_log"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:stripped_birch_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "hanging_sign",
+		"key": "minecraft:birch_hanging_sign",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:birch_hanging_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:birch_log",
+					"minecraft:birch_wood",
+					"minecraft:stripped_birch_log",
+					"minecraft:stripped_birch_wood"
+				],
+				"type": "material"
+			}
+		],
+		"group": "planks",
+		"key": "minecraft:birch_planks",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:birch_planks"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_pressure_plate",
+		"key": "minecraft:birch_pressure_plate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:birch_pressure_plate"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_sign",
+		"key": "minecraft:birch_sign",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:birch_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_slab",
+		"key": "minecraft:birch_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:birch_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_stairs",
+		"key": "minecraft:birch_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:birch_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:birch_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_trapdoor",
+		"key": "minecraft:birch_trapdoor",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:birch_trapdoor"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:birch_log"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:birch_log"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:birch_log"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:birch_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bark",
+		"key": "minecraft:birch_wood",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:birch_wood"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:black_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:black_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:black_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:black_wool"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:black_wool"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:black_wool"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "banner",
+		"key": "minecraft:black_banner",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:black_banner"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:black_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:black_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:black_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bed",
+		"key": "minecraft:black_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:black_bed"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_bundle",
+				"minecraft:blue_bundle",
+				"minecraft:brown_bundle",
+				"minecraft:bundle",
+				"minecraft:cyan_bundle",
+				"minecraft:gray_bundle",
+				"minecraft:green_bundle",
+				"minecraft:light_blue_bundle",
+				"minecraft:light_gray_bundle",
+				"minecraft:lime_bundle",
+				"minecraft:magenta_bundle",
+				"minecraft:orange_bundle",
+				"minecraft:pink_bundle",
+				"minecraft:purple_bundle",
+				"minecraft:red_bundle",
+				"minecraft:white_bundle",
+				"minecraft:yellow_bundle"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:black_bundle",
+		"material": {
+			"choices": [
+				"minecraft:black_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:black_bundle"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:candle"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "dyed_candle",
+		"key": "minecraft:black_candle",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:black_candle"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:black_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:black_wool"
+				],
+				"type": "material"
+			}
+		},
+		"group": "carpet",
+		"key": "minecraft:black_carpet",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:black_carpet"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:black_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			}
+		],
+		"group": "concrete_powder",
+		"key": "minecraft:black_concrete_powder",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:black_concrete_powder"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:ink_sac"
+				],
+				"type": "material"
+			}
+		],
+		"group": "black_dye",
+		"key": "minecraft:black_dye",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:black_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:wither_rose"
+				],
+				"type": "material"
+			}
+		],
+		"group": "black_dye",
+		"key": "minecraft:black_dye_from_wither_rose",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:black_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_shulker_box",
+				"minecraft:blue_shulker_box",
+				"minecraft:brown_shulker_box",
+				"minecraft:cyan_shulker_box",
+				"minecraft:gray_shulker_box",
+				"minecraft:green_shulker_box",
+				"minecraft:light_blue_shulker_box",
+				"minecraft:light_gray_shulker_box",
+				"minecraft:lime_shulker_box",
+				"minecraft:magenta_shulker_box",
+				"minecraft:orange_shulker_box",
+				"minecraft:pink_shulker_box",
+				"minecraft:purple_shulker_box",
+				"minecraft:red_shulker_box",
+				"minecraft:shulker_box",
+				"minecraft:white_shulker_box",
+				"minecraft:yellow_shulker_box"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:black_shulker_box",
+		"material": {
+			"choices": [
+				"minecraft:black_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:black_shulker_box"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:black_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass",
+		"key": "minecraft:black_stained_glass",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:black_stained_glass"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:black_stained_glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:black_stained_glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:black_stained_glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:black_stained_glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:black_stained_glass"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:black_stained_glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:black_stained_glass_pane",
+		"result": {
+			"amount": 16,
+			"type": "minecraft:black_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:black_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:black_stained_glass_pane_from_glass_pane",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:black_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:black_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_terracotta",
+		"key": "minecraft:black_terracotta",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:black_terracotta"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:blackstone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:blackstone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:blackstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:blackstone_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:blackstone_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:blackstone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:blackstone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:blackstone"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:blackstone"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:blackstone"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:blackstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:blackstone_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:blackstone_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:blackstone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:blackstone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:blackstone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:blackstone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:blackstone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:blackstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:blackstone_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:blackstone_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:furnace"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:smooth_stone"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:smooth_stone"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:smooth_stone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:blast_furnace",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:blast_furnace"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:blaze_rod"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:blaze_powder",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:blaze_powder"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:blue_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:blue_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:blue_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:blue_wool"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:blue_wool"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:blue_wool"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "banner",
+		"key": "minecraft:blue_banner",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:blue_banner"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:blue_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:blue_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:blue_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bed",
+		"key": "minecraft:blue_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:blue_bed"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_bundle",
+				"minecraft:blue_bundle",
+				"minecraft:brown_bundle",
+				"minecraft:bundle",
+				"minecraft:cyan_bundle",
+				"minecraft:gray_bundle",
+				"minecraft:green_bundle",
+				"minecraft:light_blue_bundle",
+				"minecraft:light_gray_bundle",
+				"minecraft:lime_bundle",
+				"minecraft:magenta_bundle",
+				"minecraft:orange_bundle",
+				"minecraft:pink_bundle",
+				"minecraft:purple_bundle",
+				"minecraft:red_bundle",
+				"minecraft:white_bundle",
+				"minecraft:yellow_bundle"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:blue_bundle",
+		"material": {
+			"choices": [
+				"minecraft:blue_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:blue_bundle"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:candle"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:blue_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "dyed_candle",
+		"key": "minecraft:blue_candle",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:blue_candle"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:blue_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:blue_wool"
+				],
+				"type": "material"
+			}
+		},
+		"group": "carpet",
+		"key": "minecraft:blue_carpet",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:blue_carpet"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:blue_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			}
+		],
+		"group": "concrete_powder",
+		"key": "minecraft:blue_concrete_powder",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:blue_concrete_powder"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:lapis_lazuli"
+				],
+				"type": "material"
+			}
+		],
+		"group": "blue_dye",
+		"key": "minecraft:blue_dye",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:blue_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:cornflower"
+				],
+				"type": "material"
+			}
+		],
+		"group": "blue_dye",
+		"key": "minecraft:blue_dye_from_cornflower",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:blue_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:packed_ice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:packed_ice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:packed_ice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:packed_ice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:packed_ice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:packed_ice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:packed_ice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:packed_ice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:packed_ice"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:blue_ice",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:blue_ice"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_shulker_box",
+				"minecraft:blue_shulker_box",
+				"minecraft:brown_shulker_box",
+				"minecraft:cyan_shulker_box",
+				"minecraft:gray_shulker_box",
+				"minecraft:green_shulker_box",
+				"minecraft:light_blue_shulker_box",
+				"minecraft:light_gray_shulker_box",
+				"minecraft:lime_shulker_box",
+				"minecraft:magenta_shulker_box",
+				"minecraft:orange_shulker_box",
+				"minecraft:pink_shulker_box",
+				"minecraft:purple_shulker_box",
+				"minecraft:red_shulker_box",
+				"minecraft:shulker_box",
+				"minecraft:white_shulker_box",
+				"minecraft:yellow_shulker_box"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:blue_shulker_box",
+		"material": {
+			"choices": [
+				"minecraft:blue_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:blue_shulker_box"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:blue_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass",
+		"key": "minecraft:blue_stained_glass",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:blue_stained_glass"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:blue_stained_glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:blue_stained_glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:blue_stained_glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:blue_stained_glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:blue_stained_glass"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:blue_stained_glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:blue_stained_glass_pane",
+		"result": {
+			"amount": 16,
+			"type": "minecraft:blue_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:blue_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:blue_stained_glass_pane_from_glass_pane",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:blue_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:blue_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_terracotta",
+		"key": "minecraft:blue_terracotta",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:blue_terracotta"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:bolt_armor_trim_smithing_template"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:copper_block",
+					"minecraft:waxed_copper_block"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:bolt_armor_trim_smithing_template",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:bolt_armor_trim_smithing_template"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:bone_meal"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:bone_meal"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:bone_meal"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:bone_meal"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:bone_meal"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:bone_meal"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:bone_meal"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:bone_meal"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:bone_meal"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:bone_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:bone_block"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bone"
+				],
+				"type": "material"
+			}
+		],
+		"group": "bonemeal",
+		"key": "minecraft:bone_meal",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:bone_meal"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bone_block"
+				],
+				"type": "material"
+			}
+		],
+		"group": "bonemeal",
+		"key": "minecraft:bone_meal_from_bone_block",
+		"result": {
+			"amount": 9,
+			"type": "minecraft:bone_meal"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:book",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:book"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"key": "minecraft:book_cloning",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		},
+		"type": "complex"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:book"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:book"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:book"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:bookshelf",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:bookshelf"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:vine"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:bordure_indented_banner_pattern",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:bordure_indented_banner_pattern"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:string"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:string"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:string"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:bow",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:bow"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:bowl",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:bowl"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:wheat"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:wheat"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:wheat"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:bread",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:bread"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:blaze_rod"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:blackstone",
+					"minecraft:cobbled_deepslate",
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:blackstone",
+					"minecraft:cobbled_deepslate",
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:blackstone",
+					"minecraft:cobbled_deepslate",
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:brewing_stand",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:brewing_stand"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:brick_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:brick_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:bricks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:bricks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:bricks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:brick_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:brick_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:bricks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:brick_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:brick_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:brick"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:brick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:brick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:brick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:bricks",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:bricks"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:brown_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:brown_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:brown_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:brown_wool"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:brown_wool"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:brown_wool"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "banner",
+		"key": "minecraft:brown_banner",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:brown_banner"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:brown_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:brown_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:brown_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bed",
+		"key": "minecraft:brown_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:brown_bed"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_bundle",
+				"minecraft:blue_bundle",
+				"minecraft:brown_bundle",
+				"minecraft:bundle",
+				"minecraft:cyan_bundle",
+				"minecraft:gray_bundle",
+				"minecraft:green_bundle",
+				"minecraft:light_blue_bundle",
+				"minecraft:light_gray_bundle",
+				"minecraft:lime_bundle",
+				"minecraft:magenta_bundle",
+				"minecraft:orange_bundle",
+				"minecraft:pink_bundle",
+				"minecraft:purple_bundle",
+				"minecraft:red_bundle",
+				"minecraft:white_bundle",
+				"minecraft:yellow_bundle"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:brown_bundle",
+		"material": {
+			"choices": [
+				"minecraft:brown_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:brown_bundle"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:candle"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:brown_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "dyed_candle",
+		"key": "minecraft:brown_candle",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:brown_candle"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:brown_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:brown_wool"
+				],
+				"type": "material"
+			}
+		},
+		"group": "carpet",
+		"key": "minecraft:brown_carpet",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:brown_carpet"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:brown_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			}
+		],
+		"group": "concrete_powder",
+		"key": "minecraft:brown_concrete_powder",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:brown_concrete_powder"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:cocoa_beans"
+				],
+				"type": "material"
+			}
+		],
+		"group": "brown_dye",
+		"key": "minecraft:brown_dye",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:brown_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_shulker_box",
+				"minecraft:blue_shulker_box",
+				"minecraft:brown_shulker_box",
+				"minecraft:cyan_shulker_box",
+				"minecraft:gray_shulker_box",
+				"minecraft:green_shulker_box",
+				"minecraft:light_blue_shulker_box",
+				"minecraft:light_gray_shulker_box",
+				"minecraft:lime_shulker_box",
+				"minecraft:magenta_shulker_box",
+				"minecraft:orange_shulker_box",
+				"minecraft:pink_shulker_box",
+				"minecraft:purple_shulker_box",
+				"minecraft:red_shulker_box",
+				"minecraft:shulker_box",
+				"minecraft:white_shulker_box",
+				"minecraft:yellow_shulker_box"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:brown_shulker_box",
+		"material": {
+			"choices": [
+				"minecraft:brown_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:brown_shulker_box"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:brown_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass",
+		"key": "minecraft:brown_stained_glass",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:brown_stained_glass"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:brown_stained_glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:brown_stained_glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:brown_stained_glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:brown_stained_glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:brown_stained_glass"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:brown_stained_glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:brown_stained_glass_pane",
+		"result": {
+			"amount": 16,
+			"type": "minecraft:brown_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:brown_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:brown_stained_glass_pane_from_glass_pane",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:brown_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:brown_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_terracotta",
+		"key": "minecraft:brown_terracotta",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:brown_terracotta"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:feather"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:brush",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:brush"
+		},
+		"shape": [
+			"a",
+			"b",
+			"c"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:bucket",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:bucket"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:string"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:bundle",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:bundle"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:milk_bucket"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:milk_bucket"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:milk_bucket"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:sugar"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:egg"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:sugar"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:wheat"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:wheat"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:wheat"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:cake",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cake"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:amethyst_shard"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:amethyst_shard"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:sculk_sensor"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:amethyst_shard"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:calibrated_sculk_sensor",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:calibrated_sculk_sensor"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:charcoal",
+					"minecraft:coal"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:acacia_log",
+					"minecraft:acacia_wood",
+					"minecraft:birch_log",
+					"minecraft:birch_wood",
+					"minecraft:cherry_log",
+					"minecraft:cherry_wood",
+					"minecraft:crimson_hyphae",
+					"minecraft:crimson_stem",
+					"minecraft:dark_oak_log",
+					"minecraft:dark_oak_wood",
+					"minecraft:jungle_log",
+					"minecraft:jungle_wood",
+					"minecraft:mangrove_log",
+					"minecraft:mangrove_wood",
+					"minecraft:oak_log",
+					"minecraft:oak_wood",
+					"minecraft:pale_oak_log",
+					"minecraft:pale_oak_wood",
+					"minecraft:spruce_log",
+					"minecraft:spruce_wood",
+					"minecraft:stripped_acacia_log",
+					"minecraft:stripped_acacia_wood",
+					"minecraft:stripped_birch_log",
+					"minecraft:stripped_birch_wood",
+					"minecraft:stripped_cherry_log",
+					"minecraft:stripped_cherry_wood",
+					"minecraft:stripped_crimson_hyphae",
+					"minecraft:stripped_crimson_stem",
+					"minecraft:stripped_dark_oak_log",
+					"minecraft:stripped_dark_oak_wood",
+					"minecraft:stripped_jungle_log",
+					"minecraft:stripped_jungle_wood",
+					"minecraft:stripped_mangrove_log",
+					"minecraft:stripped_mangrove_wood",
+					"minecraft:stripped_oak_log",
+					"minecraft:stripped_oak_wood",
+					"minecraft:stripped_pale_oak_log",
+					"minecraft:stripped_pale_oak_wood",
+					"minecraft:stripped_spruce_log",
+					"minecraft:stripped_spruce_wood",
+					"minecraft:stripped_warped_hyphae",
+					"minecraft:stripped_warped_stem",
+					"minecraft:warped_hyphae",
+					"minecraft:warped_stem"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:acacia_log",
+					"minecraft:acacia_wood",
+					"minecraft:birch_log",
+					"minecraft:birch_wood",
+					"minecraft:cherry_log",
+					"minecraft:cherry_wood",
+					"minecraft:crimson_hyphae",
+					"minecraft:crimson_stem",
+					"minecraft:dark_oak_log",
+					"minecraft:dark_oak_wood",
+					"minecraft:jungle_log",
+					"minecraft:jungle_wood",
+					"minecraft:mangrove_log",
+					"minecraft:mangrove_wood",
+					"minecraft:oak_log",
+					"minecraft:oak_wood",
+					"minecraft:pale_oak_log",
+					"minecraft:pale_oak_wood",
+					"minecraft:spruce_log",
+					"minecraft:spruce_wood",
+					"minecraft:stripped_acacia_log",
+					"minecraft:stripped_acacia_wood",
+					"minecraft:stripped_birch_log",
+					"minecraft:stripped_birch_wood",
+					"minecraft:stripped_cherry_log",
+					"minecraft:stripped_cherry_wood",
+					"minecraft:stripped_crimson_hyphae",
+					"minecraft:stripped_crimson_stem",
+					"minecraft:stripped_dark_oak_log",
+					"minecraft:stripped_dark_oak_wood",
+					"minecraft:stripped_jungle_log",
+					"minecraft:stripped_jungle_wood",
+					"minecraft:stripped_mangrove_log",
+					"minecraft:stripped_mangrove_wood",
+					"minecraft:stripped_oak_log",
+					"minecraft:stripped_oak_wood",
+					"minecraft:stripped_pale_oak_log",
+					"minecraft:stripped_pale_oak_wood",
+					"minecraft:stripped_spruce_log",
+					"minecraft:stripped_spruce_wood",
+					"minecraft:stripped_warped_hyphae",
+					"minecraft:stripped_warped_stem",
+					"minecraft:warped_hyphae",
+					"minecraft:warped_stem"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:acacia_log",
+					"minecraft:acacia_wood",
+					"minecraft:birch_log",
+					"minecraft:birch_wood",
+					"minecraft:cherry_log",
+					"minecraft:cherry_wood",
+					"minecraft:crimson_hyphae",
+					"minecraft:crimson_stem",
+					"minecraft:dark_oak_log",
+					"minecraft:dark_oak_wood",
+					"minecraft:jungle_log",
+					"minecraft:jungle_wood",
+					"minecraft:mangrove_log",
+					"minecraft:mangrove_wood",
+					"minecraft:oak_log",
+					"minecraft:oak_wood",
+					"minecraft:pale_oak_log",
+					"minecraft:pale_oak_wood",
+					"minecraft:spruce_log",
+					"minecraft:spruce_wood",
+					"minecraft:stripped_acacia_log",
+					"minecraft:stripped_acacia_wood",
+					"minecraft:stripped_birch_log",
+					"minecraft:stripped_birch_wood",
+					"minecraft:stripped_cherry_log",
+					"minecraft:stripped_cherry_wood",
+					"minecraft:stripped_crimson_hyphae",
+					"minecraft:stripped_crimson_stem",
+					"minecraft:stripped_dark_oak_log",
+					"minecraft:stripped_dark_oak_wood",
+					"minecraft:stripped_jungle_log",
+					"minecraft:stripped_jungle_wood",
+					"minecraft:stripped_mangrove_log",
+					"minecraft:stripped_mangrove_wood",
+					"minecraft:stripped_oak_log",
+					"minecraft:stripped_oak_wood",
+					"minecraft:stripped_pale_oak_log",
+					"minecraft:stripped_pale_oak_wood",
+					"minecraft:stripped_spruce_log",
+					"minecraft:stripped_spruce_wood",
+					"minecraft:stripped_warped_hyphae",
+					"minecraft:stripped_warped_stem",
+					"minecraft:warped_hyphae",
+					"minecraft:warped_stem"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:campfire",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:campfire"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:string"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:candle",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:candle"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:fishing_rod"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:carrot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:carrot_on_a_stick",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:carrot_on_a_stick"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:cartography_table",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cartography_table"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:cauldron",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cauldron"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:chain",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chain"
+		},
+		"shape": [
+			"a",
+			"b",
+			"c"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "boat",
+		"key": "minecraft:cherry_boat",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cherry_boat"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wooden_button",
+		"key": "minecraft:cherry_button",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cherry_button"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:chest"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:cherry_boat"
+				],
+				"type": "material"
+			}
+		],
+		"group": "chest_boat",
+		"key": "minecraft:cherry_chest_boat",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cherry_chest_boat"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_door",
+		"key": "minecraft:cherry_door",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:cherry_door"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence",
+		"key": "minecraft:cherry_fence",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:cherry_fence"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence_gate",
+		"key": "minecraft:cherry_fence_gate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cherry_fence_gate"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_cherry_log"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stripped_cherry_log"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stripped_cherry_log"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:stripped_cherry_log"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stripped_cherry_log"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:stripped_cherry_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "hanging_sign",
+		"key": "minecraft:cherry_hanging_sign",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:cherry_hanging_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:cherry_log",
+					"minecraft:cherry_wood",
+					"minecraft:stripped_cherry_log",
+					"minecraft:stripped_cherry_wood"
+				],
+				"type": "material"
+			}
+		],
+		"group": "planks",
+		"key": "minecraft:cherry_planks",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:cherry_planks"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_pressure_plate",
+		"key": "minecraft:cherry_pressure_plate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cherry_pressure_plate"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_sign",
+		"key": "minecraft:cherry_sign",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:cherry_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_slab",
+		"key": "minecraft:cherry_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:cherry_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_stairs",
+		"key": "minecraft:cherry_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:cherry_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:cherry_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_trapdoor",
+		"key": "minecraft:cherry_trapdoor",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:cherry_trapdoor"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cherry_log"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cherry_log"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:cherry_log"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:cherry_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bark",
+		"key": "minecraft:cherry_wood",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:cherry_wood"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:chest",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chest"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:chest"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:minecart"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:chest_minecart",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chest_minecart"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_slab",
+					"minecraft:bamboo_slab",
+					"minecraft:birch_slab",
+					"minecraft:cherry_slab",
+					"minecraft:crimson_slab",
+					"minecraft:dark_oak_slab",
+					"minecraft:jungle_slab",
+					"minecraft:mangrove_slab",
+					"minecraft:oak_slab",
+					"minecraft:pale_oak_slab",
+					"minecraft:spruce_slab",
+					"minecraft:warped_slab"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_slab",
+					"minecraft:bamboo_slab",
+					"minecraft:birch_slab",
+					"minecraft:cherry_slab",
+					"minecraft:crimson_slab",
+					"minecraft:dark_oak_slab",
+					"minecraft:jungle_slab",
+					"minecraft:mangrove_slab",
+					"minecraft:oak_slab",
+					"minecraft:pale_oak_slab",
+					"minecraft:spruce_slab",
+					"minecraft:warped_slab"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_slab",
+					"minecraft:bamboo_slab",
+					"minecraft:birch_slab",
+					"minecraft:cherry_slab",
+					"minecraft:crimson_slab",
+					"minecraft:dark_oak_slab",
+					"minecraft:jungle_slab",
+					"minecraft:mangrove_slab",
+					"minecraft:oak_slab",
+					"minecraft:pale_oak_slab",
+					"minecraft:spruce_slab",
+					"minecraft:warped_slab"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:chiseled_bookshelf",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_bookshelf"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cut_copper_slab"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cut_copper_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:chiseled_copper",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_copper"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cobbled_deepslate_slab"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cobbled_deepslate_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:chiseled_deepslate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_deepslate"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:nether_brick_slab"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:nether_brick_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:chiseled_nether_bricks",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_nether_bricks"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_blackstone_slab"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:polished_blackstone_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:chiseled_polished_blackstone",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_polished_blackstone"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:quartz_slab"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:quartz_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:chiseled_quartz_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_quartz_block"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:red_sandstone_slab"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:red_sandstone_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:chiseled_red_sandstone",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_red_sandstone"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:resin_brick_slab"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:resin_brick_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:chiseled_resin_bricks",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_resin_bricks"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:sandstone_slab"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:sandstone_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:chiseled_sandstone",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_sandstone"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stone_brick_slab"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stone_brick_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:chiseled_stone_bricks",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_stone_bricks"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:tuff_slab"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:tuff_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:chiseled_tuff",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_tuff"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:tuff_brick_slab"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:tuff_brick_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:chiseled_tuff_bricks",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_tuff_bricks"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:clay_ball"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:clay_ball"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:clay_ball"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:clay_ball"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:clay",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:clay"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:clock",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:clock"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:coal_block"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:coal",
+		"result": {
+			"amount": 9,
+			"type": "minecraft:coal"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:coal"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:coal"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:coal"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:coal"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:coal"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:coal"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:coal"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:coal"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:coal"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:coal_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:coal_block"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:dirt"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:dirt"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:coarse_dirt",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:coarse_dirt"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:coast_armor_trim_smithing_template"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:coast_armor_trim_smithing_template",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:coast_armor_trim_smithing_template"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cobbled_deepslate"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cobbled_deepslate"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:cobbled_deepslate"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:cobbled_deepslate_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:cobbled_deepslate_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cobbled_deepslate"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:cobbled_deepslate"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:cobbled_deepslate"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:cobbled_deepslate"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:cobbled_deepslate"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:cobbled_deepslate"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:cobbled_deepslate_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:cobbled_deepslate_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cobbled_deepslate"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cobbled_deepslate"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:cobbled_deepslate"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:cobbled_deepslate"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:cobbled_deepslate"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:cobbled_deepslate"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:cobbled_deepslate_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:cobbled_deepslate_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:cobblestone_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:cobblestone_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:cobblestone_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:cobblestone_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:cobblestone_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:cobblestone_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:redstone_torch"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:redstone_torch"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:quartz"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:redstone_torch"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:comparator",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:comparator"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:compass",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:compass"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_slab",
+					"minecraft:bamboo_slab",
+					"minecraft:birch_slab",
+					"minecraft:cherry_slab",
+					"minecraft:crimson_slab",
+					"minecraft:dark_oak_slab",
+					"minecraft:jungle_slab",
+					"minecraft:mangrove_slab",
+					"minecraft:oak_slab",
+					"minecraft:pale_oak_slab",
+					"minecraft:spruce_slab",
+					"minecraft:warped_slab"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_slab",
+					"minecraft:bamboo_slab",
+					"minecraft:birch_slab",
+					"minecraft:cherry_slab",
+					"minecraft:crimson_slab",
+					"minecraft:dark_oak_slab",
+					"minecraft:jungle_slab",
+					"minecraft:mangrove_slab",
+					"minecraft:oak_slab",
+					"minecraft:pale_oak_slab",
+					"minecraft:spruce_slab",
+					"minecraft:warped_slab"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_slab",
+					"minecraft:bamboo_slab",
+					"minecraft:birch_slab",
+					"minecraft:cherry_slab",
+					"minecraft:crimson_slab",
+					"minecraft:dark_oak_slab",
+					"minecraft:jungle_slab",
+					"minecraft:mangrove_slab",
+					"minecraft:oak_slab",
+					"minecraft:pale_oak_slab",
+					"minecraft:spruce_slab",
+					"minecraft:warped_slab"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_slab",
+					"minecraft:bamboo_slab",
+					"minecraft:birch_slab",
+					"minecraft:cherry_slab",
+					"minecraft:crimson_slab",
+					"minecraft:dark_oak_slab",
+					"minecraft:jungle_slab",
+					"minecraft:mangrove_slab",
+					"minecraft:oak_slab",
+					"minecraft:pale_oak_slab",
+					"minecraft:spruce_slab",
+					"minecraft:warped_slab"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:acacia_slab",
+					"minecraft:bamboo_slab",
+					"minecraft:birch_slab",
+					"minecraft:cherry_slab",
+					"minecraft:crimson_slab",
+					"minecraft:dark_oak_slab",
+					"minecraft:jungle_slab",
+					"minecraft:mangrove_slab",
+					"minecraft:oak_slab",
+					"minecraft:pale_oak_slab",
+					"minecraft:spruce_slab",
+					"minecraft:warped_slab"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:acacia_slab",
+					"minecraft:bamboo_slab",
+					"minecraft:birch_slab",
+					"minecraft:cherry_slab",
+					"minecraft:crimson_slab",
+					"minecraft:dark_oak_slab",
+					"minecraft:jungle_slab",
+					"minecraft:mangrove_slab",
+					"minecraft:oak_slab",
+					"minecraft:pale_oak_slab",
+					"minecraft:spruce_slab",
+					"minecraft:warped_slab"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:acacia_slab",
+					"minecraft:bamboo_slab",
+					"minecraft:birch_slab",
+					"minecraft:cherry_slab",
+					"minecraft:crimson_slab",
+					"minecraft:dark_oak_slab",
+					"minecraft:jungle_slab",
+					"minecraft:mangrove_slab",
+					"minecraft:oak_slab",
+					"minecraft:pale_oak_slab",
+					"minecraft:spruce_slab",
+					"minecraft:warped_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:composter",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:composter"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:nautilus_shell"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:nautilus_shell"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:nautilus_shell"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:nautilus_shell"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:heart_of_the_sea"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:nautilus_shell"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:nautilus_shell"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:nautilus_shell"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:nautilus_shell"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:conduit",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:conduit"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:wheat"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cocoa_beans"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:wheat"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:cookie",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:cookie"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:copper_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:copper_block"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:copper_block"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:copper_block"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:blaze_rod"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:copper_block"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:copper_bulb",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:copper_bulb"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:copper_door",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:copper_door"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:copper_block"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:copper_block"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:copper_block"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:copper_block"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:copper_grate",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:copper_grate"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:copper_block"
+				],
+				"type": "material"
+			}
+		],
+		"group": "copper_ingot",
+		"key": "minecraft:copper_ingot",
+		"result": {
+			"amount": 9,
+			"type": "minecraft:copper_ingot"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:waxed_copper_block"
+				],
+				"type": "material"
+			}
+		],
+		"group": "copper_ingot",
+		"key": "minecraft:copper_ingot_from_waxed_copper_block",
+		"result": {
+			"amount": 9,
+			"type": "minecraft:copper_ingot"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:copper_trapdoor",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:copper_trapdoor"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:crafting_table"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:dropper"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:crafter",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:crafter"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:crafting_table",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:crafting_table"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:pale_oak_log"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:resin_block"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:pale_oak_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:creaking_heart",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:creaking_heart"
+		},
+		"shape": [
+			"a",
+			"b",
+			"c"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:creeper_head"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:creeper_banner_pattern",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:creeper_banner_pattern"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wooden_button",
+		"key": "minecraft:crimson_button",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:crimson_button"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_door",
+		"key": "minecraft:crimson_door",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:crimson_door"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence",
+		"key": "minecraft:crimson_fence",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:crimson_fence"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence_gate",
+		"key": "minecraft:crimson_fence_gate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:crimson_fence_gate"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_crimson_stem"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stripped_crimson_stem"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stripped_crimson_stem"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:stripped_crimson_stem"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stripped_crimson_stem"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:stripped_crimson_stem"
+				],
+				"type": "material"
+			}
+		},
+		"group": "hanging_sign",
+		"key": "minecraft:crimson_hanging_sign",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:crimson_hanging_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:crimson_stem"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:crimson_stem"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:crimson_stem"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:crimson_stem"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bark",
+		"key": "minecraft:crimson_hyphae",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:crimson_hyphae"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:crimson_hyphae",
+					"minecraft:crimson_stem",
+					"minecraft:stripped_crimson_hyphae",
+					"minecraft:stripped_crimson_stem"
+				],
+				"type": "material"
+			}
+		],
+		"group": "planks",
+		"key": "minecraft:crimson_planks",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:crimson_planks"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_pressure_plate",
+		"key": "minecraft:crimson_pressure_plate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:crimson_pressure_plate"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_sign",
+		"key": "minecraft:crimson_sign",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:crimson_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_slab",
+		"key": "minecraft:crimson_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:crimson_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_stairs",
+		"key": "minecraft:crimson_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:crimson_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:crimson_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_trapdoor",
+		"key": "minecraft:crimson_trapdoor",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:crimson_trapdoor"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:string"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:tripwire_hook"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:string"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:crossbow",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:crossbow"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:copper_block"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:copper_block"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:copper_block"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:copper_block"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:cut_copper",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:cut_copper"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cut_copper"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cut_copper"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:cut_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:cut_copper_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:cut_copper_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cut_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:cut_copper"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:cut_copper"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:cut_copper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:cut_copper"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:cut_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:cut_copper_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:cut_copper_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:red_sandstone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:red_sandstone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:red_sandstone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:red_sandstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:cut_red_sandstone",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:cut_red_sandstone"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cut_red_sandstone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cut_red_sandstone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:cut_red_sandstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:cut_red_sandstone_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:cut_red_sandstone_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:sandstone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:sandstone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:sandstone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:sandstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:cut_sandstone",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:cut_sandstone"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cut_sandstone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cut_sandstone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:cut_sandstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:cut_sandstone_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:cut_sandstone_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cyan_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cyan_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:cyan_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:cyan_wool"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:cyan_wool"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:cyan_wool"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "banner",
+		"key": "minecraft:cyan_banner",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cyan_banner"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cyan_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cyan_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:cyan_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bed",
+		"key": "minecraft:cyan_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cyan_bed"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_bundle",
+				"minecraft:blue_bundle",
+				"minecraft:brown_bundle",
+				"minecraft:bundle",
+				"minecraft:cyan_bundle",
+				"minecraft:gray_bundle",
+				"minecraft:green_bundle",
+				"minecraft:light_blue_bundle",
+				"minecraft:light_gray_bundle",
+				"minecraft:lime_bundle",
+				"minecraft:magenta_bundle",
+				"minecraft:orange_bundle",
+				"minecraft:pink_bundle",
+				"minecraft:purple_bundle",
+				"minecraft:red_bundle",
+				"minecraft:white_bundle",
+				"minecraft:yellow_bundle"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cyan_bundle",
+		"material": {
+			"choices": [
+				"minecraft:cyan_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cyan_bundle"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:candle"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:cyan_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "dyed_candle",
+		"key": "minecraft:cyan_candle",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cyan_candle"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cyan_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cyan_wool"
+				],
+				"type": "material"
+			}
+		},
+		"group": "carpet",
+		"key": "minecraft:cyan_carpet",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:cyan_carpet"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:cyan_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			}
+		],
+		"group": "concrete_powder",
+		"key": "minecraft:cyan_concrete_powder",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:cyan_concrete_powder"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:blue_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:green_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "cyan_dye",
+		"key": "minecraft:cyan_dye",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:cyan_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:pitcher_plant"
+				],
+				"type": "material"
+			}
+		],
+		"group": "cyan_dye",
+		"key": "minecraft:cyan_dye_from_pitcher_plant",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:cyan_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_shulker_box",
+				"minecraft:blue_shulker_box",
+				"minecraft:brown_shulker_box",
+				"minecraft:cyan_shulker_box",
+				"minecraft:gray_shulker_box",
+				"minecraft:green_shulker_box",
+				"minecraft:light_blue_shulker_box",
+				"minecraft:light_gray_shulker_box",
+				"minecraft:lime_shulker_box",
+				"minecraft:magenta_shulker_box",
+				"minecraft:orange_shulker_box",
+				"minecraft:pink_shulker_box",
+				"minecraft:purple_shulker_box",
+				"minecraft:red_shulker_box",
+				"minecraft:shulker_box",
+				"minecraft:white_shulker_box",
+				"minecraft:yellow_shulker_box"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cyan_shulker_box",
+		"material": {
+			"choices": [
+				"minecraft:cyan_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cyan_shulker_box"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:cyan_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass",
+		"key": "minecraft:cyan_stained_glass",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:cyan_stained_glass"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cyan_stained_glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cyan_stained_glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:cyan_stained_glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:cyan_stained_glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:cyan_stained_glass"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:cyan_stained_glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:cyan_stained_glass_pane",
+		"result": {
+			"amount": 16,
+			"type": "minecraft:cyan_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:cyan_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:cyan_stained_glass_pane_from_glass_pane",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:cyan_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:cyan_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_terracotta",
+		"key": "minecraft:cyan_terracotta",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:cyan_terracotta"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "boat",
+		"key": "minecraft:dark_oak_boat",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:dark_oak_boat"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wooden_button",
+		"key": "minecraft:dark_oak_button",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:dark_oak_button"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:chest"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:dark_oak_boat"
+				],
+				"type": "material"
+			}
+		],
+		"group": "chest_boat",
+		"key": "minecraft:dark_oak_chest_boat",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:dark_oak_chest_boat"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_door",
+		"key": "minecraft:dark_oak_door",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:dark_oak_door"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence",
+		"key": "minecraft:dark_oak_fence",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:dark_oak_fence"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence_gate",
+		"key": "minecraft:dark_oak_fence_gate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:dark_oak_fence_gate"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_dark_oak_log"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stripped_dark_oak_log"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stripped_dark_oak_log"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:stripped_dark_oak_log"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stripped_dark_oak_log"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:stripped_dark_oak_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "hanging_sign",
+		"key": "minecraft:dark_oak_hanging_sign",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:dark_oak_hanging_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:dark_oak_log",
+					"minecraft:dark_oak_wood",
+					"minecraft:stripped_dark_oak_log",
+					"minecraft:stripped_dark_oak_wood"
+				],
+				"type": "material"
+			}
+		],
+		"group": "planks",
+		"key": "minecraft:dark_oak_planks",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:dark_oak_planks"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_pressure_plate",
+		"key": "minecraft:dark_oak_pressure_plate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:dark_oak_pressure_plate"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_sign",
+		"key": "minecraft:dark_oak_sign",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:dark_oak_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_slab",
+		"key": "minecraft:dark_oak_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:dark_oak_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_stairs",
+		"key": "minecraft:dark_oak_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:dark_oak_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:dark_oak_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_trapdoor",
+		"key": "minecraft:dark_oak_trapdoor",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:dark_oak_trapdoor"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:dark_oak_log"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:dark_oak_log"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:dark_oak_log"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:dark_oak_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bark",
+		"key": "minecraft:dark_oak_wood",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:dark_oak_wood"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:black_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:dark_prismarine",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:dark_prismarine"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:dark_prismarine"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:dark_prismarine"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:dark_prismarine"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:dark_prismarine_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:dark_prismarine_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:dark_prismarine"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:dark_prismarine"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:dark_prismarine"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:dark_prismarine"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:dark_prismarine"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:dark_prismarine"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:dark_prismarine_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:dark_prismarine_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:quartz"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:quartz"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:quartz"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:acacia_slab",
+					"minecraft:bamboo_slab",
+					"minecraft:birch_slab",
+					"minecraft:cherry_slab",
+					"minecraft:crimson_slab",
+					"minecraft:dark_oak_slab",
+					"minecraft:jungle_slab",
+					"minecraft:mangrove_slab",
+					"minecraft:oak_slab",
+					"minecraft:pale_oak_slab",
+					"minecraft:spruce_slab",
+					"minecraft:warped_slab"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:acacia_slab",
+					"minecraft:bamboo_slab",
+					"minecraft:birch_slab",
+					"minecraft:cherry_slab",
+					"minecraft:crimson_slab",
+					"minecraft:dark_oak_slab",
+					"minecraft:jungle_slab",
+					"minecraft:mangrove_slab",
+					"minecraft:oak_slab",
+					"minecraft:pale_oak_slab",
+					"minecraft:spruce_slab",
+					"minecraft:warped_slab"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:acacia_slab",
+					"minecraft:bamboo_slab",
+					"minecraft:birch_slab",
+					"minecraft:cherry_slab",
+					"minecraft:crimson_slab",
+					"minecraft:dark_oak_slab",
+					"minecraft:jungle_slab",
+					"minecraft:mangrove_slab",
+					"minecraft:oak_slab",
+					"minecraft:pale_oak_slab",
+					"minecraft:spruce_slab",
+					"minecraft:warped_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:daylight_detector",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:daylight_detector"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"key": "minecraft:decorated_pot",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		},
+		"type": "complex"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:brick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:brick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:brick"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:brick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:decorated_pot_simple",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:decorated_pot"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:deepslate_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:deepslate_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:deepslate_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:deepslate_brick_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:deepslate_brick_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:deepslate_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:deepslate_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:deepslate_bricks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:deepslate_bricks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:deepslate_bricks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:deepslate_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:deepslate_brick_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:deepslate_brick_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:deepslate_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:deepslate_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:deepslate_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:deepslate_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:deepslate_bricks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:deepslate_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:deepslate_brick_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:deepslate_brick_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_deepslate"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:polished_deepslate"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:polished_deepslate"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:polished_deepslate"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:deepslate_bricks",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:deepslate_bricks"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:deepslate_tiles"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:deepslate_tiles"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:deepslate_tiles"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:deepslate_tile_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:deepslate_tile_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:deepslate_tiles"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:deepslate_tiles"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:deepslate_tiles"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:deepslate_tiles"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:deepslate_tiles"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:deepslate_tiles"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:deepslate_tile_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:deepslate_tile_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:deepslate_tiles"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:deepslate_tiles"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:deepslate_tiles"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:deepslate_tiles"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:deepslate_tiles"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:deepslate_tiles"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:deepslate_tile_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:deepslate_tile_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:deepslate_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:deepslate_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:deepslate_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:deepslate_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:deepslate_tiles",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:deepslate_tiles"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stone_pressure_plate"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:detector_rail",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:detector_rail"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:diamond_block"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:diamond",
+		"result": {
+			"amount": 9,
+			"type": "minecraft:diamond"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:diamond_axe",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:diamond_axe"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:diamond_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:diamond_block"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:diamond_boots",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:diamond_boots"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:diamond_chestplate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:diamond_chestplate"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:diamond_helmet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:diamond_helmet"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:diamond_hoe",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:diamond_hoe"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:diamond_leggings",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:diamond_leggings"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:diamond_pickaxe",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:diamond_pickaxe"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:diamond_shovel",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:diamond_shovel"
+		},
+		"shape": [
+			"a",
+			"b",
+			"c"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:diamond_sword",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:diamond_sword"
+		},
+		"shape": [
+			"a",
+			"b",
+			"c"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:quartz"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:quartz"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:diorite",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:diorite"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diorite"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:diorite"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diorite"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:diorite_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:diorite_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diorite"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diorite"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:diorite"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diorite"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:diorite"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diorite"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:diorite_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:diorite_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diorite"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:diorite"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diorite"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diorite"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:diorite"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diorite"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:diorite_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:diorite_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:bow"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:dispenser",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:dispenser"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:dried_kelp_block"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:dried_kelp",
+		"result": {
+			"amount": 9,
+			"type": "minecraft:dried_kelp"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:dried_kelp"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:dried_kelp"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:dried_kelp"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:dried_kelp"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:dried_kelp"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:dried_kelp"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:dried_kelp"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:dried_kelp"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:dried_kelp"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:dried_kelp_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:dried_kelp_block"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:pointed_dripstone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:pointed_dripstone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:pointed_dripstone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:pointed_dripstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:dripstone_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:dripstone_block"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:dropper",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:dropper"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:dune_armor_trim_smithing_template"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:sandstone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:dune_armor_trim_smithing_template",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:dune_armor_trim_smithing_template"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:black_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:blue_bed",
+					"minecraft:brown_bed",
+					"minecraft:cyan_bed",
+					"minecraft:gray_bed",
+					"minecraft:green_bed",
+					"minecraft:light_blue_bed",
+					"minecraft:light_gray_bed",
+					"minecraft:lime_bed",
+					"minecraft:magenta_bed",
+					"minecraft:orange_bed",
+					"minecraft:pink_bed",
+					"minecraft:purple_bed",
+					"minecraft:red_bed",
+					"minecraft:white_bed",
+					"minecraft:yellow_bed"
+				],
+				"type": "material"
+			}
+		],
+		"group": "bed",
+		"key": "minecraft:dye_black_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:black_bed"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:black_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:blue_carpet",
+					"minecraft:brown_carpet",
+					"minecraft:cyan_carpet",
+					"minecraft:gray_carpet",
+					"minecraft:green_carpet",
+					"minecraft:light_blue_carpet",
+					"minecraft:light_gray_carpet",
+					"minecraft:lime_carpet",
+					"minecraft:magenta_carpet",
+					"minecraft:orange_carpet",
+					"minecraft:pink_carpet",
+					"minecraft:purple_carpet",
+					"minecraft:red_carpet",
+					"minecraft:white_carpet",
+					"minecraft:yellow_carpet"
+				],
+				"type": "material"
+			}
+		],
+		"group": "carpet",
+		"key": "minecraft:dye_black_carpet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:black_carpet"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:black_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:blue_wool",
+					"minecraft:brown_wool",
+					"minecraft:cyan_wool",
+					"minecraft:gray_wool",
+					"minecraft:green_wool",
+					"minecraft:light_blue_wool",
+					"minecraft:light_gray_wool",
+					"minecraft:lime_wool",
+					"minecraft:magenta_wool",
+					"minecraft:orange_wool",
+					"minecraft:pink_wool",
+					"minecraft:purple_wool",
+					"minecraft:red_wool",
+					"minecraft:white_wool",
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wool",
+		"key": "minecraft:dye_black_wool",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:black_wool"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:blue_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_bed",
+					"minecraft:brown_bed",
+					"minecraft:cyan_bed",
+					"minecraft:gray_bed",
+					"minecraft:green_bed",
+					"minecraft:light_blue_bed",
+					"minecraft:light_gray_bed",
+					"minecraft:lime_bed",
+					"minecraft:magenta_bed",
+					"minecraft:orange_bed",
+					"minecraft:pink_bed",
+					"minecraft:purple_bed",
+					"minecraft:red_bed",
+					"minecraft:white_bed",
+					"minecraft:yellow_bed"
+				],
+				"type": "material"
+			}
+		],
+		"group": "bed",
+		"key": "minecraft:dye_blue_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:blue_bed"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:blue_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_carpet",
+					"minecraft:brown_carpet",
+					"minecraft:cyan_carpet",
+					"minecraft:gray_carpet",
+					"minecraft:green_carpet",
+					"minecraft:light_blue_carpet",
+					"minecraft:light_gray_carpet",
+					"minecraft:lime_carpet",
+					"minecraft:magenta_carpet",
+					"minecraft:orange_carpet",
+					"minecraft:pink_carpet",
+					"minecraft:purple_carpet",
+					"minecraft:red_carpet",
+					"minecraft:white_carpet",
+					"minecraft:yellow_carpet"
+				],
+				"type": "material"
+			}
+		],
+		"group": "carpet",
+		"key": "minecraft:dye_blue_carpet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:blue_carpet"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:blue_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_wool",
+					"minecraft:brown_wool",
+					"minecraft:cyan_wool",
+					"minecraft:gray_wool",
+					"minecraft:green_wool",
+					"minecraft:light_blue_wool",
+					"minecraft:light_gray_wool",
+					"minecraft:lime_wool",
+					"minecraft:magenta_wool",
+					"minecraft:orange_wool",
+					"minecraft:pink_wool",
+					"minecraft:purple_wool",
+					"minecraft:red_wool",
+					"minecraft:white_wool",
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wool",
+		"key": "minecraft:dye_blue_wool",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:blue_wool"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:brown_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_bed",
+					"minecraft:blue_bed",
+					"minecraft:cyan_bed",
+					"minecraft:gray_bed",
+					"minecraft:green_bed",
+					"minecraft:light_blue_bed",
+					"minecraft:light_gray_bed",
+					"minecraft:lime_bed",
+					"minecraft:magenta_bed",
+					"minecraft:orange_bed",
+					"minecraft:pink_bed",
+					"minecraft:purple_bed",
+					"minecraft:red_bed",
+					"minecraft:white_bed",
+					"minecraft:yellow_bed"
+				],
+				"type": "material"
+			}
+		],
+		"group": "bed",
+		"key": "minecraft:dye_brown_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:brown_bed"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:brown_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_carpet",
+					"minecraft:blue_carpet",
+					"minecraft:cyan_carpet",
+					"minecraft:gray_carpet",
+					"minecraft:green_carpet",
+					"minecraft:light_blue_carpet",
+					"minecraft:light_gray_carpet",
+					"minecraft:lime_carpet",
+					"minecraft:magenta_carpet",
+					"minecraft:orange_carpet",
+					"minecraft:pink_carpet",
+					"minecraft:purple_carpet",
+					"minecraft:red_carpet",
+					"minecraft:white_carpet",
+					"minecraft:yellow_carpet"
+				],
+				"type": "material"
+			}
+		],
+		"group": "carpet",
+		"key": "minecraft:dye_brown_carpet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:brown_carpet"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:brown_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_wool",
+					"minecraft:blue_wool",
+					"minecraft:cyan_wool",
+					"minecraft:gray_wool",
+					"minecraft:green_wool",
+					"minecraft:light_blue_wool",
+					"minecraft:light_gray_wool",
+					"minecraft:lime_wool",
+					"minecraft:magenta_wool",
+					"minecraft:orange_wool",
+					"minecraft:pink_wool",
+					"minecraft:purple_wool",
+					"minecraft:red_wool",
+					"minecraft:white_wool",
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wool",
+		"key": "minecraft:dye_brown_wool",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:brown_wool"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:cyan_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_bed",
+					"minecraft:blue_bed",
+					"minecraft:brown_bed",
+					"minecraft:gray_bed",
+					"minecraft:green_bed",
+					"minecraft:light_blue_bed",
+					"minecraft:light_gray_bed",
+					"minecraft:lime_bed",
+					"minecraft:magenta_bed",
+					"minecraft:orange_bed",
+					"minecraft:pink_bed",
+					"minecraft:purple_bed",
+					"minecraft:red_bed",
+					"minecraft:white_bed",
+					"minecraft:yellow_bed"
+				],
+				"type": "material"
+			}
+		],
+		"group": "bed",
+		"key": "minecraft:dye_cyan_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cyan_bed"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:cyan_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_carpet",
+					"minecraft:blue_carpet",
+					"minecraft:brown_carpet",
+					"minecraft:gray_carpet",
+					"minecraft:green_carpet",
+					"minecraft:light_blue_carpet",
+					"minecraft:light_gray_carpet",
+					"minecraft:lime_carpet",
+					"minecraft:magenta_carpet",
+					"minecraft:orange_carpet",
+					"minecraft:pink_carpet",
+					"minecraft:purple_carpet",
+					"minecraft:red_carpet",
+					"minecraft:white_carpet",
+					"minecraft:yellow_carpet"
+				],
+				"type": "material"
+			}
+		],
+		"group": "carpet",
+		"key": "minecraft:dye_cyan_carpet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cyan_carpet"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:cyan_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_wool",
+					"minecraft:blue_wool",
+					"minecraft:brown_wool",
+					"minecraft:gray_wool",
+					"minecraft:green_wool",
+					"minecraft:light_blue_wool",
+					"minecraft:light_gray_wool",
+					"minecraft:lime_wool",
+					"minecraft:magenta_wool",
+					"minecraft:orange_wool",
+					"minecraft:pink_wool",
+					"minecraft:purple_wool",
+					"minecraft:red_wool",
+					"minecraft:white_wool",
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wool",
+		"key": "minecraft:dye_cyan_wool",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cyan_wool"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:gray_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_bed",
+					"minecraft:blue_bed",
+					"minecraft:brown_bed",
+					"minecraft:cyan_bed",
+					"minecraft:green_bed",
+					"minecraft:light_blue_bed",
+					"minecraft:light_gray_bed",
+					"minecraft:lime_bed",
+					"minecraft:magenta_bed",
+					"minecraft:orange_bed",
+					"minecraft:pink_bed",
+					"minecraft:purple_bed",
+					"minecraft:red_bed",
+					"minecraft:white_bed",
+					"minecraft:yellow_bed"
+				],
+				"type": "material"
+			}
+		],
+		"group": "bed",
+		"key": "minecraft:dye_gray_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:gray_bed"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:gray_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_carpet",
+					"minecraft:blue_carpet",
+					"minecraft:brown_carpet",
+					"minecraft:cyan_carpet",
+					"minecraft:green_carpet",
+					"minecraft:light_blue_carpet",
+					"minecraft:light_gray_carpet",
+					"minecraft:lime_carpet",
+					"minecraft:magenta_carpet",
+					"minecraft:orange_carpet",
+					"minecraft:pink_carpet",
+					"minecraft:purple_carpet",
+					"minecraft:red_carpet",
+					"minecraft:white_carpet",
+					"minecraft:yellow_carpet"
+				],
+				"type": "material"
+			}
+		],
+		"group": "carpet",
+		"key": "minecraft:dye_gray_carpet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:gray_carpet"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:gray_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_wool",
+					"minecraft:blue_wool",
+					"minecraft:brown_wool",
+					"minecraft:cyan_wool",
+					"minecraft:green_wool",
+					"minecraft:light_blue_wool",
+					"minecraft:light_gray_wool",
+					"minecraft:lime_wool",
+					"minecraft:magenta_wool",
+					"minecraft:orange_wool",
+					"minecraft:pink_wool",
+					"minecraft:purple_wool",
+					"minecraft:red_wool",
+					"minecraft:white_wool",
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wool",
+		"key": "minecraft:dye_gray_wool",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:gray_wool"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:green_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_bed",
+					"minecraft:blue_bed",
+					"minecraft:brown_bed",
+					"minecraft:cyan_bed",
+					"minecraft:gray_bed",
+					"minecraft:light_blue_bed",
+					"minecraft:light_gray_bed",
+					"minecraft:lime_bed",
+					"minecraft:magenta_bed",
+					"minecraft:orange_bed",
+					"minecraft:pink_bed",
+					"minecraft:purple_bed",
+					"minecraft:red_bed",
+					"minecraft:white_bed",
+					"minecraft:yellow_bed"
+				],
+				"type": "material"
+			}
+		],
+		"group": "bed",
+		"key": "minecraft:dye_green_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:green_bed"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:green_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_carpet",
+					"minecraft:blue_carpet",
+					"minecraft:brown_carpet",
+					"minecraft:cyan_carpet",
+					"minecraft:gray_carpet",
+					"minecraft:light_blue_carpet",
+					"minecraft:light_gray_carpet",
+					"minecraft:lime_carpet",
+					"minecraft:magenta_carpet",
+					"minecraft:orange_carpet",
+					"minecraft:pink_carpet",
+					"minecraft:purple_carpet",
+					"minecraft:red_carpet",
+					"minecraft:white_carpet",
+					"minecraft:yellow_carpet"
+				],
+				"type": "material"
+			}
+		],
+		"group": "carpet",
+		"key": "minecraft:dye_green_carpet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:green_carpet"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:green_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_wool",
+					"minecraft:blue_wool",
+					"minecraft:brown_wool",
+					"minecraft:cyan_wool",
+					"minecraft:gray_wool",
+					"minecraft:light_blue_wool",
+					"minecraft:light_gray_wool",
+					"minecraft:lime_wool",
+					"minecraft:magenta_wool",
+					"minecraft:orange_wool",
+					"minecraft:pink_wool",
+					"minecraft:purple_wool",
+					"minecraft:red_wool",
+					"minecraft:white_wool",
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wool",
+		"key": "minecraft:dye_green_wool",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:green_wool"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:light_blue_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_bed",
+					"minecraft:blue_bed",
+					"minecraft:brown_bed",
+					"minecraft:cyan_bed",
+					"minecraft:gray_bed",
+					"minecraft:green_bed",
+					"minecraft:light_gray_bed",
+					"minecraft:lime_bed",
+					"minecraft:magenta_bed",
+					"minecraft:orange_bed",
+					"minecraft:pink_bed",
+					"minecraft:purple_bed",
+					"minecraft:red_bed",
+					"minecraft:white_bed",
+					"minecraft:yellow_bed"
+				],
+				"type": "material"
+			}
+		],
+		"group": "bed",
+		"key": "minecraft:dye_light_blue_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_blue_bed"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:light_blue_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_carpet",
+					"minecraft:blue_carpet",
+					"minecraft:brown_carpet",
+					"minecraft:cyan_carpet",
+					"minecraft:gray_carpet",
+					"minecraft:green_carpet",
+					"minecraft:light_gray_carpet",
+					"minecraft:lime_carpet",
+					"minecraft:magenta_carpet",
+					"minecraft:orange_carpet",
+					"minecraft:pink_carpet",
+					"minecraft:purple_carpet",
+					"minecraft:red_carpet",
+					"minecraft:white_carpet",
+					"minecraft:yellow_carpet"
+				],
+				"type": "material"
+			}
+		],
+		"group": "carpet",
+		"key": "minecraft:dye_light_blue_carpet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_blue_carpet"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:light_blue_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_wool",
+					"minecraft:blue_wool",
+					"minecraft:brown_wool",
+					"minecraft:cyan_wool",
+					"minecraft:gray_wool",
+					"minecraft:green_wool",
+					"minecraft:light_gray_wool",
+					"minecraft:lime_wool",
+					"minecraft:magenta_wool",
+					"minecraft:orange_wool",
+					"minecraft:pink_wool",
+					"minecraft:purple_wool",
+					"minecraft:red_wool",
+					"minecraft:white_wool",
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wool",
+		"key": "minecraft:dye_light_blue_wool",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_blue_wool"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:light_gray_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_bed",
+					"minecraft:blue_bed",
+					"minecraft:brown_bed",
+					"minecraft:cyan_bed",
+					"minecraft:gray_bed",
+					"minecraft:green_bed",
+					"minecraft:light_blue_bed",
+					"minecraft:lime_bed",
+					"minecraft:magenta_bed",
+					"minecraft:orange_bed",
+					"minecraft:pink_bed",
+					"minecraft:purple_bed",
+					"minecraft:red_bed",
+					"minecraft:white_bed",
+					"minecraft:yellow_bed"
+				],
+				"type": "material"
+			}
+		],
+		"group": "bed",
+		"key": "minecraft:dye_light_gray_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_gray_bed"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:light_gray_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_carpet",
+					"minecraft:blue_carpet",
+					"minecraft:brown_carpet",
+					"minecraft:cyan_carpet",
+					"minecraft:gray_carpet",
+					"minecraft:green_carpet",
+					"minecraft:light_blue_carpet",
+					"minecraft:lime_carpet",
+					"minecraft:magenta_carpet",
+					"minecraft:orange_carpet",
+					"minecraft:pink_carpet",
+					"minecraft:purple_carpet",
+					"minecraft:red_carpet",
+					"minecraft:white_carpet",
+					"minecraft:yellow_carpet"
+				],
+				"type": "material"
+			}
+		],
+		"group": "carpet",
+		"key": "minecraft:dye_light_gray_carpet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_gray_carpet"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:light_gray_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_wool",
+					"minecraft:blue_wool",
+					"minecraft:brown_wool",
+					"minecraft:cyan_wool",
+					"minecraft:gray_wool",
+					"minecraft:green_wool",
+					"minecraft:light_blue_wool",
+					"minecraft:lime_wool",
+					"minecraft:magenta_wool",
+					"minecraft:orange_wool",
+					"minecraft:pink_wool",
+					"minecraft:purple_wool",
+					"minecraft:red_wool",
+					"minecraft:white_wool",
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wool",
+		"key": "minecraft:dye_light_gray_wool",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_gray_wool"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:lime_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_bed",
+					"minecraft:blue_bed",
+					"minecraft:brown_bed",
+					"minecraft:cyan_bed",
+					"minecraft:gray_bed",
+					"minecraft:green_bed",
+					"minecraft:light_blue_bed",
+					"minecraft:light_gray_bed",
+					"minecraft:magenta_bed",
+					"minecraft:orange_bed",
+					"minecraft:pink_bed",
+					"minecraft:purple_bed",
+					"minecraft:red_bed",
+					"minecraft:white_bed",
+					"minecraft:yellow_bed"
+				],
+				"type": "material"
+			}
+		],
+		"group": "bed",
+		"key": "minecraft:dye_lime_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:lime_bed"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:lime_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_carpet",
+					"minecraft:blue_carpet",
+					"minecraft:brown_carpet",
+					"minecraft:cyan_carpet",
+					"minecraft:gray_carpet",
+					"minecraft:green_carpet",
+					"minecraft:light_blue_carpet",
+					"minecraft:light_gray_carpet",
+					"minecraft:magenta_carpet",
+					"minecraft:orange_carpet",
+					"minecraft:pink_carpet",
+					"minecraft:purple_carpet",
+					"minecraft:red_carpet",
+					"minecraft:white_carpet",
+					"minecraft:yellow_carpet"
+				],
+				"type": "material"
+			}
+		],
+		"group": "carpet",
+		"key": "minecraft:dye_lime_carpet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:lime_carpet"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:lime_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_wool",
+					"minecraft:blue_wool",
+					"minecraft:brown_wool",
+					"minecraft:cyan_wool",
+					"minecraft:gray_wool",
+					"minecraft:green_wool",
+					"minecraft:light_blue_wool",
+					"minecraft:light_gray_wool",
+					"minecraft:magenta_wool",
+					"minecraft:orange_wool",
+					"minecraft:pink_wool",
+					"minecraft:purple_wool",
+					"minecraft:red_wool",
+					"minecraft:white_wool",
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wool",
+		"key": "minecraft:dye_lime_wool",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:lime_wool"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:magenta_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_bed",
+					"minecraft:blue_bed",
+					"minecraft:brown_bed",
+					"minecraft:cyan_bed",
+					"minecraft:gray_bed",
+					"minecraft:green_bed",
+					"minecraft:light_blue_bed",
+					"minecraft:light_gray_bed",
+					"minecraft:lime_bed",
+					"minecraft:orange_bed",
+					"minecraft:pink_bed",
+					"minecraft:purple_bed",
+					"minecraft:red_bed",
+					"minecraft:white_bed",
+					"minecraft:yellow_bed"
+				],
+				"type": "material"
+			}
+		],
+		"group": "bed",
+		"key": "minecraft:dye_magenta_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:magenta_bed"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:magenta_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_carpet",
+					"minecraft:blue_carpet",
+					"minecraft:brown_carpet",
+					"minecraft:cyan_carpet",
+					"minecraft:gray_carpet",
+					"minecraft:green_carpet",
+					"minecraft:light_blue_carpet",
+					"minecraft:light_gray_carpet",
+					"minecraft:lime_carpet",
+					"minecraft:orange_carpet",
+					"minecraft:pink_carpet",
+					"minecraft:purple_carpet",
+					"minecraft:red_carpet",
+					"minecraft:white_carpet",
+					"minecraft:yellow_carpet"
+				],
+				"type": "material"
+			}
+		],
+		"group": "carpet",
+		"key": "minecraft:dye_magenta_carpet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:magenta_carpet"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:magenta_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_wool",
+					"minecraft:blue_wool",
+					"minecraft:brown_wool",
+					"minecraft:cyan_wool",
+					"minecraft:gray_wool",
+					"minecraft:green_wool",
+					"minecraft:light_blue_wool",
+					"minecraft:light_gray_wool",
+					"minecraft:lime_wool",
+					"minecraft:orange_wool",
+					"minecraft:pink_wool",
+					"minecraft:purple_wool",
+					"minecraft:red_wool",
+					"minecraft:white_wool",
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wool",
+		"key": "minecraft:dye_magenta_wool",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:magenta_wool"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:orange_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_bed",
+					"minecraft:blue_bed",
+					"minecraft:brown_bed",
+					"minecraft:cyan_bed",
+					"minecraft:gray_bed",
+					"minecraft:green_bed",
+					"minecraft:light_blue_bed",
+					"minecraft:light_gray_bed",
+					"minecraft:lime_bed",
+					"minecraft:magenta_bed",
+					"minecraft:pink_bed",
+					"minecraft:purple_bed",
+					"minecraft:red_bed",
+					"minecraft:white_bed",
+					"minecraft:yellow_bed"
+				],
+				"type": "material"
+			}
+		],
+		"group": "bed",
+		"key": "minecraft:dye_orange_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:orange_bed"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:orange_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_carpet",
+					"minecraft:blue_carpet",
+					"minecraft:brown_carpet",
+					"minecraft:cyan_carpet",
+					"minecraft:gray_carpet",
+					"minecraft:green_carpet",
+					"minecraft:light_blue_carpet",
+					"minecraft:light_gray_carpet",
+					"minecraft:lime_carpet",
+					"minecraft:magenta_carpet",
+					"minecraft:pink_carpet",
+					"minecraft:purple_carpet",
+					"minecraft:red_carpet",
+					"minecraft:white_carpet",
+					"minecraft:yellow_carpet"
+				],
+				"type": "material"
+			}
+		],
+		"group": "carpet",
+		"key": "minecraft:dye_orange_carpet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:orange_carpet"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:orange_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_wool",
+					"minecraft:blue_wool",
+					"minecraft:brown_wool",
+					"minecraft:cyan_wool",
+					"minecraft:gray_wool",
+					"minecraft:green_wool",
+					"minecraft:light_blue_wool",
+					"minecraft:light_gray_wool",
+					"minecraft:lime_wool",
+					"minecraft:magenta_wool",
+					"minecraft:pink_wool",
+					"minecraft:purple_wool",
+					"minecraft:red_wool",
+					"minecraft:white_wool",
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wool",
+		"key": "minecraft:dye_orange_wool",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:orange_wool"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:pink_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_bed",
+					"minecraft:blue_bed",
+					"minecraft:brown_bed",
+					"minecraft:cyan_bed",
+					"minecraft:gray_bed",
+					"minecraft:green_bed",
+					"minecraft:light_blue_bed",
+					"minecraft:light_gray_bed",
+					"minecraft:lime_bed",
+					"minecraft:magenta_bed",
+					"minecraft:orange_bed",
+					"minecraft:purple_bed",
+					"minecraft:red_bed",
+					"minecraft:white_bed",
+					"minecraft:yellow_bed"
+				],
+				"type": "material"
+			}
+		],
+		"group": "bed",
+		"key": "minecraft:dye_pink_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:pink_bed"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:pink_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_carpet",
+					"minecraft:blue_carpet",
+					"minecraft:brown_carpet",
+					"minecraft:cyan_carpet",
+					"minecraft:gray_carpet",
+					"minecraft:green_carpet",
+					"minecraft:light_blue_carpet",
+					"minecraft:light_gray_carpet",
+					"minecraft:lime_carpet",
+					"minecraft:magenta_carpet",
+					"minecraft:orange_carpet",
+					"minecraft:purple_carpet",
+					"minecraft:red_carpet",
+					"minecraft:white_carpet",
+					"minecraft:yellow_carpet"
+				],
+				"type": "material"
+			}
+		],
+		"group": "carpet",
+		"key": "minecraft:dye_pink_carpet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:pink_carpet"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:pink_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_wool",
+					"minecraft:blue_wool",
+					"minecraft:brown_wool",
+					"minecraft:cyan_wool",
+					"minecraft:gray_wool",
+					"minecraft:green_wool",
+					"minecraft:light_blue_wool",
+					"minecraft:light_gray_wool",
+					"minecraft:lime_wool",
+					"minecraft:magenta_wool",
+					"minecraft:orange_wool",
+					"minecraft:purple_wool",
+					"minecraft:red_wool",
+					"minecraft:white_wool",
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wool",
+		"key": "minecraft:dye_pink_wool",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:pink_wool"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:purple_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_bed",
+					"minecraft:blue_bed",
+					"minecraft:brown_bed",
+					"minecraft:cyan_bed",
+					"minecraft:gray_bed",
+					"minecraft:green_bed",
+					"minecraft:light_blue_bed",
+					"minecraft:light_gray_bed",
+					"minecraft:lime_bed",
+					"minecraft:magenta_bed",
+					"minecraft:orange_bed",
+					"minecraft:pink_bed",
+					"minecraft:red_bed",
+					"minecraft:white_bed",
+					"minecraft:yellow_bed"
+				],
+				"type": "material"
+			}
+		],
+		"group": "bed",
+		"key": "minecraft:dye_purple_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:purple_bed"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:purple_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_carpet",
+					"minecraft:blue_carpet",
+					"minecraft:brown_carpet",
+					"minecraft:cyan_carpet",
+					"minecraft:gray_carpet",
+					"minecraft:green_carpet",
+					"minecraft:light_blue_carpet",
+					"minecraft:light_gray_carpet",
+					"minecraft:lime_carpet",
+					"minecraft:magenta_carpet",
+					"minecraft:orange_carpet",
+					"minecraft:pink_carpet",
+					"minecraft:red_carpet",
+					"minecraft:white_carpet",
+					"minecraft:yellow_carpet"
+				],
+				"type": "material"
+			}
+		],
+		"group": "carpet",
+		"key": "minecraft:dye_purple_carpet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:purple_carpet"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:purple_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_wool",
+					"minecraft:blue_wool",
+					"minecraft:brown_wool",
+					"minecraft:cyan_wool",
+					"minecraft:gray_wool",
+					"minecraft:green_wool",
+					"minecraft:light_blue_wool",
+					"minecraft:light_gray_wool",
+					"minecraft:lime_wool",
+					"minecraft:magenta_wool",
+					"minecraft:orange_wool",
+					"minecraft:pink_wool",
+					"minecraft:red_wool",
+					"minecraft:white_wool",
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wool",
+		"key": "minecraft:dye_purple_wool",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:purple_wool"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:red_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_bed",
+					"minecraft:blue_bed",
+					"minecraft:brown_bed",
+					"minecraft:cyan_bed",
+					"minecraft:gray_bed",
+					"minecraft:green_bed",
+					"minecraft:light_blue_bed",
+					"minecraft:light_gray_bed",
+					"minecraft:lime_bed",
+					"minecraft:magenta_bed",
+					"minecraft:orange_bed",
+					"minecraft:pink_bed",
+					"minecraft:purple_bed",
+					"minecraft:white_bed",
+					"minecraft:yellow_bed"
+				],
+				"type": "material"
+			}
+		],
+		"group": "bed",
+		"key": "minecraft:dye_red_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:red_bed"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:red_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_carpet",
+					"minecraft:blue_carpet",
+					"minecraft:brown_carpet",
+					"minecraft:cyan_carpet",
+					"minecraft:gray_carpet",
+					"minecraft:green_carpet",
+					"minecraft:light_blue_carpet",
+					"minecraft:light_gray_carpet",
+					"minecraft:lime_carpet",
+					"minecraft:magenta_carpet",
+					"minecraft:orange_carpet",
+					"minecraft:pink_carpet",
+					"minecraft:purple_carpet",
+					"minecraft:white_carpet",
+					"minecraft:yellow_carpet"
+				],
+				"type": "material"
+			}
+		],
+		"group": "carpet",
+		"key": "minecraft:dye_red_carpet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:red_carpet"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:red_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_wool",
+					"minecraft:blue_wool",
+					"minecraft:brown_wool",
+					"minecraft:cyan_wool",
+					"minecraft:gray_wool",
+					"minecraft:green_wool",
+					"minecraft:light_blue_wool",
+					"minecraft:light_gray_wool",
+					"minecraft:lime_wool",
+					"minecraft:magenta_wool",
+					"minecraft:orange_wool",
+					"minecraft:pink_wool",
+					"minecraft:purple_wool",
+					"minecraft:white_wool",
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wool",
+		"key": "minecraft:dye_red_wool",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:red_wool"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:white_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_bed",
+					"minecraft:blue_bed",
+					"minecraft:brown_bed",
+					"minecraft:cyan_bed",
+					"minecraft:gray_bed",
+					"minecraft:green_bed",
+					"minecraft:light_blue_bed",
+					"minecraft:light_gray_bed",
+					"minecraft:lime_bed",
+					"minecraft:magenta_bed",
+					"minecraft:orange_bed",
+					"minecraft:pink_bed",
+					"minecraft:purple_bed",
+					"minecraft:red_bed",
+					"minecraft:yellow_bed"
+				],
+				"type": "material"
+			}
+		],
+		"group": "bed",
+		"key": "minecraft:dye_white_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:white_bed"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:white_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_carpet",
+					"minecraft:blue_carpet",
+					"minecraft:brown_carpet",
+					"minecraft:cyan_carpet",
+					"minecraft:gray_carpet",
+					"minecraft:green_carpet",
+					"minecraft:light_blue_carpet",
+					"minecraft:light_gray_carpet",
+					"minecraft:lime_carpet",
+					"minecraft:magenta_carpet",
+					"minecraft:orange_carpet",
+					"minecraft:pink_carpet",
+					"minecraft:purple_carpet",
+					"minecraft:red_carpet",
+					"minecraft:yellow_carpet"
+				],
+				"type": "material"
+			}
+		],
+		"group": "carpet",
+		"key": "minecraft:dye_white_carpet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:white_carpet"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:white_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_wool",
+					"minecraft:blue_wool",
+					"minecraft:brown_wool",
+					"minecraft:cyan_wool",
+					"minecraft:gray_wool",
+					"minecraft:green_wool",
+					"minecraft:light_blue_wool",
+					"minecraft:light_gray_wool",
+					"minecraft:lime_wool",
+					"minecraft:magenta_wool",
+					"minecraft:orange_wool",
+					"minecraft:pink_wool",
+					"minecraft:purple_wool",
+					"minecraft:red_wool",
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wool",
+		"key": "minecraft:dye_white_wool",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:white_wool"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:yellow_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_bed",
+					"minecraft:blue_bed",
+					"minecraft:brown_bed",
+					"minecraft:cyan_bed",
+					"minecraft:gray_bed",
+					"minecraft:green_bed",
+					"minecraft:light_blue_bed",
+					"minecraft:light_gray_bed",
+					"minecraft:lime_bed",
+					"minecraft:magenta_bed",
+					"minecraft:orange_bed",
+					"minecraft:pink_bed",
+					"minecraft:purple_bed",
+					"minecraft:red_bed",
+					"minecraft:white_bed"
+				],
+				"type": "material"
+			}
+		],
+		"group": "bed",
+		"key": "minecraft:dye_yellow_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:yellow_bed"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:yellow_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_carpet",
+					"minecraft:blue_carpet",
+					"minecraft:brown_carpet",
+					"minecraft:cyan_carpet",
+					"minecraft:gray_carpet",
+					"minecraft:green_carpet",
+					"minecraft:light_blue_carpet",
+					"minecraft:light_gray_carpet",
+					"minecraft:lime_carpet",
+					"minecraft:magenta_carpet",
+					"minecraft:orange_carpet",
+					"minecraft:pink_carpet",
+					"minecraft:purple_carpet",
+					"minecraft:red_carpet",
+					"minecraft:white_carpet"
+				],
+				"type": "material"
+			}
+		],
+		"group": "carpet",
+		"key": "minecraft:dye_yellow_carpet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:yellow_carpet"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:yellow_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:black_wool",
+					"minecraft:blue_wool",
+					"minecraft:brown_wool",
+					"minecraft:cyan_wool",
+					"minecraft:gray_wool",
+					"minecraft:green_wool",
+					"minecraft:light_blue_wool",
+					"minecraft:light_gray_wool",
+					"minecraft:lime_wool",
+					"minecraft:magenta_wool",
+					"minecraft:orange_wool",
+					"minecraft:pink_wool",
+					"minecraft:purple_wool",
+					"minecraft:red_wool",
+					"minecraft:white_wool"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wool",
+		"key": "minecraft:dye_yellow_wool",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:yellow_wool"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:emerald_block"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:emerald",
+		"result": {
+			"amount": 9,
+			"type": "minecraft:emerald"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:emerald"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:emerald"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:emerald"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:emerald"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:emerald"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:emerald"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:emerald"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:emerald"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:emerald"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:emerald_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:emerald_block"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:book"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:obsidian"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:obsidian"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:obsidian"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:obsidian"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:enchanting_table",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:enchanting_table"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:ender_eye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:ghast_tear"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:end_crystal",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:end_crystal"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:blaze_rod"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:popped_chorus_fruit"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:end_rod",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:end_rod"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:end_stone_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:end_stone_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:end_stone_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:end_stone_brick_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:end_stone_brick_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:end_stone_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:end_stone_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:end_stone_bricks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:end_stone_bricks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:end_stone_bricks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:end_stone_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:end_stone_brick_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:end_stone_brick_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:end_stone_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:end_stone_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:end_stone_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:end_stone_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:end_stone_bricks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:end_stone_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:end_stone_brick_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:end_stone_brick_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:end_stone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:end_stone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:end_stone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:end_stone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:end_stone_bricks",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:end_stone_bricks"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:obsidian"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:obsidian"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:obsidian"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:obsidian"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:ender_eye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:obsidian"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:obsidian"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:obsidian"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:obsidian"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:ender_chest",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:ender_chest"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:ender_pearl"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:blaze_powder"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:ender_eye",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:ender_eye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:exposed_cut_copper_slab"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:exposed_cut_copper_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:exposed_chiseled_copper",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:exposed_chiseled_copper"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:exposed_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:exposed_copper"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:blaze_rod"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:exposed_copper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:exposed_copper_bulb",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:exposed_copper_bulb"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:exposed_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:exposed_copper"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:exposed_copper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:exposed_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:exposed_copper_grate",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:exposed_copper_grate"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:exposed_copper"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:exposed_copper"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:exposed_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:exposed_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:exposed_cut_copper",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:exposed_cut_copper"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:exposed_cut_copper"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:exposed_cut_copper"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:exposed_cut_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:exposed_cut_copper_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:exposed_cut_copper_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:exposed_cut_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:exposed_cut_copper"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:exposed_cut_copper"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:exposed_cut_copper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:exposed_cut_copper"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:exposed_cut_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:exposed_cut_copper_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:exposed_cut_copper_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:eye_armor_trim_smithing_template"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:end_stone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:eye_armor_trim_smithing_template",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:eye_armor_trim_smithing_template"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:spider_eye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:brown_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sugar"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:fermented_spider_eye",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:fermented_spider_eye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:bricks"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:field_masoned_banner_pattern",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:field_masoned_banner_pattern"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:gunpowder"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:blaze_powder"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:charcoal",
+					"minecraft:coal"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:fire_charge",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:fire_charge"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"key": "minecraft:firework_rocket",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		},
+		"type": "complex"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:gunpowder"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:firework_rocket_simple",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:firework_rocket"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"key": "minecraft:firework_star",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		},
+		"type": "complex"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"key": "minecraft:firework_star_fade",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		},
+		"type": "complex"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:string"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:string"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:fishing_rod",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:fishing_rod"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:flint"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:flint"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:fletching_table",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:fletching_table"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:flint"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:flint_and_steel",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:flint_and_steel"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:flow_armor_trim_smithing_template"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:breeze_rod"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:flow_armor_trim_smithing_template",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:flow_armor_trim_smithing_template"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:oxeye_daisy"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:flower_banner_pattern",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:flower_banner_pattern"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:brick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:brick"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:brick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:flower_pot",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:flower_pot"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:blackstone",
+					"minecraft:cobbled_deepslate",
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:blackstone",
+					"minecraft:cobbled_deepslate",
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:blackstone",
+					"minecraft:cobbled_deepslate",
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:blackstone",
+					"minecraft:cobbled_deepslate",
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:blackstone",
+					"minecraft:cobbled_deepslate",
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:blackstone",
+					"minecraft:cobbled_deepslate",
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:blackstone",
+					"minecraft:cobbled_deepslate",
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:blackstone",
+					"minecraft:cobbled_deepslate",
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:furnace",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:furnace"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:furnace"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:minecart"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:furnace_minecart",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:furnace_minecart"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:glass_bottle",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:glass_bottle"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:glass_pane",
+		"result": {
+			"amount": 16,
+			"type": "minecraft:glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:melon_slice"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:glistering_melon_slice",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:glistering_melon_slice"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:item_frame"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:glow_ink_sac"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:glow_item_frame",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:glow_item_frame"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glowstone_dust"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glowstone_dust"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glowstone_dust"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glowstone_dust"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:glowstone",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:glowstone"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:gold_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:gold_block"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:gold_block"
+				],
+				"type": "material"
+			}
+		],
+		"group": "gold_ingot",
+		"key": "minecraft:gold_ingot_from_gold_block",
+		"result": {
+			"amount": 9,
+			"type": "minecraft:gold_ingot"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			}
+		},
+		"group": "gold_ingot",
+		"key": "minecraft:gold_ingot_from_nuggets",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:gold_ingot"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:gold_nugget",
+		"result": {
+			"amount": 9,
+			"type": "minecraft:gold_nugget"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:apple"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:golden_apple",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:golden_apple"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:golden_axe",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:golden_axe"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:golden_boots",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:golden_boots"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:carrot"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:gold_nugget"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:golden_carrot",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:golden_carrot"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:golden_chestplate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:golden_chestplate"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:golden_helmet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:golden_helmet"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:golden_hoe",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:golden_hoe"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:golden_leggings",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:golden_leggings"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:golden_pickaxe",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:golden_pickaxe"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:golden_shovel",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:golden_shovel"
+		},
+		"shape": [
+			"a",
+			"b",
+			"c"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:golden_sword",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:golden_sword"
+		},
+		"shape": [
+			"a",
+			"b",
+			"c"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:diorite"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:quartz"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:granite",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:granite"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:granite"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:granite"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:granite"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:granite_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:granite_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:granite"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:granite"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:granite"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:granite"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:granite"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:granite"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:granite_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:granite_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:granite"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:granite"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:granite"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:granite"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:granite"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:granite"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:granite_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:granite_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:gray_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:gray_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:gray_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:gray_wool"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:gray_wool"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:gray_wool"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "banner",
+		"key": "minecraft:gray_banner",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:gray_banner"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:gray_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:gray_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:gray_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bed",
+		"key": "minecraft:gray_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:gray_bed"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_bundle",
+				"minecraft:blue_bundle",
+				"minecraft:brown_bundle",
+				"minecraft:bundle",
+				"minecraft:cyan_bundle",
+				"minecraft:gray_bundle",
+				"minecraft:green_bundle",
+				"minecraft:light_blue_bundle",
+				"minecraft:light_gray_bundle",
+				"minecraft:lime_bundle",
+				"minecraft:magenta_bundle",
+				"minecraft:orange_bundle",
+				"minecraft:pink_bundle",
+				"minecraft:purple_bundle",
+				"minecraft:red_bundle",
+				"minecraft:white_bundle",
+				"minecraft:yellow_bundle"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:gray_bundle",
+		"material": {
+			"choices": [
+				"minecraft:gray_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:gray_bundle"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:candle"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gray_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "dyed_candle",
+		"key": "minecraft:gray_candle",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:gray_candle"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:gray_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:gray_wool"
+				],
+				"type": "material"
+			}
+		},
+		"group": "carpet",
+		"key": "minecraft:gray_carpet",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:gray_carpet"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:gray_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			}
+		],
+		"group": "concrete_powder",
+		"key": "minecraft:gray_concrete_powder",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:gray_concrete_powder"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:black_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:white_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:gray_dye",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:gray_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:closed_eyeblossom"
+				],
+				"type": "material"
+			}
+		],
+		"group": "gray_dye",
+		"key": "minecraft:gray_dye_from_closed_eyeblossom",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:gray_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_shulker_box",
+				"minecraft:blue_shulker_box",
+				"minecraft:brown_shulker_box",
+				"minecraft:cyan_shulker_box",
+				"minecraft:gray_shulker_box",
+				"minecraft:green_shulker_box",
+				"minecraft:light_blue_shulker_box",
+				"minecraft:light_gray_shulker_box",
+				"minecraft:lime_shulker_box",
+				"minecraft:magenta_shulker_box",
+				"minecraft:orange_shulker_box",
+				"minecraft:pink_shulker_box",
+				"minecraft:purple_shulker_box",
+				"minecraft:red_shulker_box",
+				"minecraft:shulker_box",
+				"minecraft:white_shulker_box",
+				"minecraft:yellow_shulker_box"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:gray_shulker_box",
+		"material": {
+			"choices": [
+				"minecraft:gray_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:gray_shulker_box"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:gray_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass",
+		"key": "minecraft:gray_stained_glass",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:gray_stained_glass"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:gray_stained_glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:gray_stained_glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:gray_stained_glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:gray_stained_glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:gray_stained_glass"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:gray_stained_glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:gray_stained_glass_pane",
+		"result": {
+			"amount": 16,
+			"type": "minecraft:gray_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:gray_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:gray_stained_glass_pane_from_glass_pane",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:gray_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:gray_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_terracotta",
+		"key": "minecraft:gray_terracotta",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:gray_terracotta"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:green_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:green_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:green_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:green_wool"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:green_wool"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:green_wool"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "banner",
+		"key": "minecraft:green_banner",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:green_banner"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:green_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:green_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:green_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bed",
+		"key": "minecraft:green_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:green_bed"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_bundle",
+				"minecraft:blue_bundle",
+				"minecraft:brown_bundle",
+				"minecraft:bundle",
+				"minecraft:cyan_bundle",
+				"minecraft:gray_bundle",
+				"minecraft:green_bundle",
+				"minecraft:light_blue_bundle",
+				"minecraft:light_gray_bundle",
+				"minecraft:lime_bundle",
+				"minecraft:magenta_bundle",
+				"minecraft:orange_bundle",
+				"minecraft:pink_bundle",
+				"minecraft:purple_bundle",
+				"minecraft:red_bundle",
+				"minecraft:white_bundle",
+				"minecraft:yellow_bundle"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:green_bundle",
+		"material": {
+			"choices": [
+				"minecraft:green_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:green_bundle"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:candle"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:green_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "dyed_candle",
+		"key": "minecraft:green_candle",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:green_candle"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:green_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:green_wool"
+				],
+				"type": "material"
+			}
+		},
+		"group": "carpet",
+		"key": "minecraft:green_carpet",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:green_carpet"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:green_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			}
+		],
+		"group": "concrete_powder",
+		"key": "minecraft:green_concrete_powder",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:green_concrete_powder"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_shulker_box",
+				"minecraft:blue_shulker_box",
+				"minecraft:brown_shulker_box",
+				"minecraft:cyan_shulker_box",
+				"minecraft:gray_shulker_box",
+				"minecraft:green_shulker_box",
+				"minecraft:light_blue_shulker_box",
+				"minecraft:light_gray_shulker_box",
+				"minecraft:lime_shulker_box",
+				"minecraft:magenta_shulker_box",
+				"minecraft:orange_shulker_box",
+				"minecraft:pink_shulker_box",
+				"minecraft:purple_shulker_box",
+				"minecraft:red_shulker_box",
+				"minecraft:shulker_box",
+				"minecraft:white_shulker_box",
+				"minecraft:yellow_shulker_box"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:green_shulker_box",
+		"material": {
+			"choices": [
+				"minecraft:green_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:green_shulker_box"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:green_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass",
+		"key": "minecraft:green_stained_glass",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:green_stained_glass"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:green_stained_glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:green_stained_glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:green_stained_glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:green_stained_glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:green_stained_glass"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:green_stained_glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:green_stained_glass_pane",
+		"result": {
+			"amount": 16,
+			"type": "minecraft:green_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:green_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:green_stained_glass_pane_from_glass_pane",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:green_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:green_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_terracotta",
+		"key": "minecraft:green_terracotta",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:green_terracotta"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stone_slab"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:grindstone",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:grindstone"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:wheat"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:wheat"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:wheat"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:wheat"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:wheat"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:wheat"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:wheat"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:wheat"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:wheat"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:hay_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:hay_block"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:heavy_weighted_pressure_plate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:heavy_weighted_pressure_plate"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:honey_bottle"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:honey_bottle"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:honey_bottle"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:honey_bottle"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:honey_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:honey_block"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:honey_block"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:glass_bottle"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:glass_bottle"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:glass_bottle"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:glass_bottle"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:honey_bottle",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:honey_bottle"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:honeycomb_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:honeycomb_block"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:chest"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:hopper",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:hopper"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:hopper"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:minecart"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:hopper_minecart",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:hopper_minecart"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:host_armor_trim_smithing_template"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:host_armor_trim_smithing_template",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:host_armor_trim_smithing_template"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:iron_axe",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:iron_axe"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:iron_bars",
+		"result": {
+			"amount": 16,
+			"type": "minecraft:iron_bars"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:iron_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:iron_block"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:iron_boots",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:iron_boots"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:iron_chestplate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:iron_chestplate"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:iron_door",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:iron_door"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:iron_helmet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:iron_helmet"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:iron_hoe",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:iron_hoe"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:iron_block"
+				],
+				"type": "material"
+			}
+		],
+		"group": "iron_ingot",
+		"key": "minecraft:iron_ingot_from_iron_block",
+		"result": {
+			"amount": 9,
+			"type": "minecraft:iron_ingot"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			}
+		},
+		"group": "iron_ingot",
+		"key": "minecraft:iron_ingot_from_nuggets",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:iron_ingot"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:iron_leggings",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:iron_leggings"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:iron_nugget",
+		"result": {
+			"amount": 9,
+			"type": "minecraft:iron_nugget"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:iron_pickaxe",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:iron_pickaxe"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:iron_shovel",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:iron_shovel"
+		},
+		"shape": [
+			"a",
+			"b",
+			"c"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:iron_sword",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:iron_sword"
+		},
+		"shape": [
+			"a",
+			"b",
+			"c"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:iron_trapdoor",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:iron_trapdoor"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:item_frame",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:item_frame"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:carved_pumpkin"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:torch"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:jack_o_lantern",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:jack_o_lantern"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:jukebox",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:jukebox"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "boat",
+		"key": "minecraft:jungle_boat",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:jungle_boat"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wooden_button",
+		"key": "minecraft:jungle_button",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:jungle_button"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:chest"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:jungle_boat"
+				],
+				"type": "material"
+			}
+		],
+		"group": "chest_boat",
+		"key": "minecraft:jungle_chest_boat",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:jungle_chest_boat"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_door",
+		"key": "minecraft:jungle_door",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:jungle_door"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence",
+		"key": "minecraft:jungle_fence",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:jungle_fence"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence_gate",
+		"key": "minecraft:jungle_fence_gate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:jungle_fence_gate"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_jungle_log"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stripped_jungle_log"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stripped_jungle_log"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:stripped_jungle_log"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stripped_jungle_log"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:stripped_jungle_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "hanging_sign",
+		"key": "minecraft:jungle_hanging_sign",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:jungle_hanging_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:jungle_log",
+					"minecraft:jungle_wood",
+					"minecraft:stripped_jungle_log",
+					"minecraft:stripped_jungle_wood"
+				],
+				"type": "material"
+			}
+		],
+		"group": "planks",
+		"key": "minecraft:jungle_planks",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:jungle_planks"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_pressure_plate",
+		"key": "minecraft:jungle_pressure_plate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:jungle_pressure_plate"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_sign",
+		"key": "minecraft:jungle_sign",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:jungle_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_slab",
+		"key": "minecraft:jungle_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:jungle_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_stairs",
+		"key": "minecraft:jungle_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:jungle_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:jungle_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_trapdoor",
+		"key": "minecraft:jungle_trapdoor",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:jungle_trapdoor"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:jungle_log"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:jungle_log"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:jungle_log"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:jungle_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bark",
+		"key": "minecraft:jungle_wood",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:jungle_wood"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:ladder",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:ladder"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:torch"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:lantern",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:lantern"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:lapis_lazuli"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:lapis_lazuli"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:lapis_lazuli"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:lapis_lazuli"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:lapis_lazuli"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:lapis_lazuli"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:lapis_lazuli"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:lapis_lazuli"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:lapis_lazuli"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:lapis_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:lapis_block"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:lapis_block"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:lapis_lazuli",
+		"result": {
+			"amount": 9,
+			"type": "minecraft:lapis_lazuli"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:string"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:string"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:string"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:slime_ball"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:string"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:lead",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:lead"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:rabbit_hide"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:rabbit_hide"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:rabbit_hide"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:rabbit_hide"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:leather",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:leather"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:leather_boots",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:leather_boots"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:leather_chestplate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:leather_chestplate"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:leather_helmet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:leather_helmet"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:leather_horse_armor",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:leather_horse_armor"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:leather"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:leather_leggings",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:leather_leggings"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_slab",
+					"minecraft:bamboo_slab",
+					"minecraft:birch_slab",
+					"minecraft:cherry_slab",
+					"minecraft:crimson_slab",
+					"minecraft:dark_oak_slab",
+					"minecraft:jungle_slab",
+					"minecraft:mangrove_slab",
+					"minecraft:oak_slab",
+					"minecraft:pale_oak_slab",
+					"minecraft:spruce_slab",
+					"minecraft:warped_slab"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:acacia_slab",
+					"minecraft:bamboo_slab",
+					"minecraft:birch_slab",
+					"minecraft:cherry_slab",
+					"minecraft:crimson_slab",
+					"minecraft:dark_oak_slab",
+					"minecraft:jungle_slab",
+					"minecraft:mangrove_slab",
+					"minecraft:oak_slab",
+					"minecraft:pale_oak_slab",
+					"minecraft:spruce_slab",
+					"minecraft:warped_slab"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_slab",
+					"minecraft:bamboo_slab",
+					"minecraft:birch_slab",
+					"minecraft:cherry_slab",
+					"minecraft:crimson_slab",
+					"minecraft:dark_oak_slab",
+					"minecraft:jungle_slab",
+					"minecraft:mangrove_slab",
+					"minecraft:oak_slab",
+					"minecraft:pale_oak_slab",
+					"minecraft:spruce_slab",
+					"minecraft:warped_slab"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:bookshelf"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:acacia_slab",
+					"minecraft:bamboo_slab",
+					"minecraft:birch_slab",
+					"minecraft:cherry_slab",
+					"minecraft:crimson_slab",
+					"minecraft:dark_oak_slab",
+					"minecraft:jungle_slab",
+					"minecraft:mangrove_slab",
+					"minecraft:oak_slab",
+					"minecraft:pale_oak_slab",
+					"minecraft:spruce_slab",
+					"minecraft:warped_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:lectern",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:lectern"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:lever",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:lever"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:light_blue_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:light_blue_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:light_blue_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:light_blue_wool"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:light_blue_wool"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:light_blue_wool"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "banner",
+		"key": "minecraft:light_blue_banner",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_blue_banner"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:light_blue_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:light_blue_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:light_blue_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bed",
+		"key": "minecraft:light_blue_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_blue_bed"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_bundle",
+				"minecraft:blue_bundle",
+				"minecraft:brown_bundle",
+				"minecraft:bundle",
+				"minecraft:cyan_bundle",
+				"minecraft:gray_bundle",
+				"minecraft:green_bundle",
+				"minecraft:light_blue_bundle",
+				"minecraft:light_gray_bundle",
+				"minecraft:lime_bundle",
+				"minecraft:magenta_bundle",
+				"minecraft:orange_bundle",
+				"minecraft:pink_bundle",
+				"minecraft:purple_bundle",
+				"minecraft:red_bundle",
+				"minecraft:white_bundle",
+				"minecraft:yellow_bundle"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:light_blue_bundle",
+		"material": {
+			"choices": [
+				"minecraft:light_blue_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_blue_bundle"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:candle"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:light_blue_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "dyed_candle",
+		"key": "minecraft:light_blue_candle",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_blue_candle"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:light_blue_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:light_blue_wool"
+				],
+				"type": "material"
+			}
+		},
+		"group": "carpet",
+		"key": "minecraft:light_blue_carpet",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:light_blue_carpet"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:light_blue_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			}
+		],
+		"group": "concrete_powder",
+		"key": "minecraft:light_blue_concrete_powder",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:light_blue_concrete_powder"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:blue_orchid"
+				],
+				"type": "material"
+			}
+		],
+		"group": "light_blue_dye",
+		"key": "minecraft:light_blue_dye_from_blue_orchid",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_blue_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:blue_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:white_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "light_blue_dye",
+		"key": "minecraft:light_blue_dye_from_blue_white_dye",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:light_blue_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_shulker_box",
+				"minecraft:blue_shulker_box",
+				"minecraft:brown_shulker_box",
+				"minecraft:cyan_shulker_box",
+				"minecraft:gray_shulker_box",
+				"minecraft:green_shulker_box",
+				"minecraft:light_blue_shulker_box",
+				"minecraft:light_gray_shulker_box",
+				"minecraft:lime_shulker_box",
+				"minecraft:magenta_shulker_box",
+				"minecraft:orange_shulker_box",
+				"minecraft:pink_shulker_box",
+				"minecraft:purple_shulker_box",
+				"minecraft:red_shulker_box",
+				"minecraft:shulker_box",
+				"minecraft:white_shulker_box",
+				"minecraft:yellow_shulker_box"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:light_blue_shulker_box",
+		"material": {
+			"choices": [
+				"minecraft:light_blue_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_blue_shulker_box"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:light_blue_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass",
+		"key": "minecraft:light_blue_stained_glass",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:light_blue_stained_glass"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:light_blue_stained_glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:light_blue_stained_glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:light_blue_stained_glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:light_blue_stained_glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:light_blue_stained_glass"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:light_blue_stained_glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:light_blue_stained_glass_pane",
+		"result": {
+			"amount": 16,
+			"type": "minecraft:light_blue_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:light_blue_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:light_blue_stained_glass_pane_from_glass_pane",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:light_blue_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:light_blue_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_terracotta",
+		"key": "minecraft:light_blue_terracotta",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:light_blue_terracotta"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:light_gray_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:light_gray_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:light_gray_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:light_gray_wool"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:light_gray_wool"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:light_gray_wool"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "banner",
+		"key": "minecraft:light_gray_banner",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_gray_banner"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:light_gray_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:light_gray_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:light_gray_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bed",
+		"key": "minecraft:light_gray_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_gray_bed"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_bundle",
+				"minecraft:blue_bundle",
+				"minecraft:brown_bundle",
+				"minecraft:bundle",
+				"minecraft:cyan_bundle",
+				"minecraft:gray_bundle",
+				"minecraft:green_bundle",
+				"minecraft:light_blue_bundle",
+				"minecraft:light_gray_bundle",
+				"minecraft:lime_bundle",
+				"minecraft:magenta_bundle",
+				"minecraft:orange_bundle",
+				"minecraft:pink_bundle",
+				"minecraft:purple_bundle",
+				"minecraft:red_bundle",
+				"minecraft:white_bundle",
+				"minecraft:yellow_bundle"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:light_gray_bundle",
+		"material": {
+			"choices": [
+				"minecraft:light_gray_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_gray_bundle"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:candle"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:light_gray_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "dyed_candle",
+		"key": "minecraft:light_gray_candle",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_gray_candle"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:light_gray_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:light_gray_wool"
+				],
+				"type": "material"
+			}
+		},
+		"group": "carpet",
+		"key": "minecraft:light_gray_carpet",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:light_gray_carpet"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:light_gray_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			}
+		],
+		"group": "concrete_powder",
+		"key": "minecraft:light_gray_concrete_powder",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:light_gray_concrete_powder"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:azure_bluet"
+				],
+				"type": "material"
+			}
+		],
+		"group": "light_gray_dye",
+		"key": "minecraft:light_gray_dye_from_azure_bluet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_gray_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:black_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:white_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:white_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "light_gray_dye",
+		"key": "minecraft:light_gray_dye_from_black_white_dye",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:light_gray_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:gray_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:white_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "light_gray_dye",
+		"key": "minecraft:light_gray_dye_from_gray_white_dye",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:light_gray_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:oxeye_daisy"
+				],
+				"type": "material"
+			}
+		],
+		"group": "light_gray_dye",
+		"key": "minecraft:light_gray_dye_from_oxeye_daisy",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_gray_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:white_tulip"
+				],
+				"type": "material"
+			}
+		],
+		"group": "light_gray_dye",
+		"key": "minecraft:light_gray_dye_from_white_tulip",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_gray_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_shulker_box",
+				"minecraft:blue_shulker_box",
+				"minecraft:brown_shulker_box",
+				"minecraft:cyan_shulker_box",
+				"minecraft:gray_shulker_box",
+				"minecraft:green_shulker_box",
+				"minecraft:light_blue_shulker_box",
+				"minecraft:light_gray_shulker_box",
+				"minecraft:lime_shulker_box",
+				"minecraft:magenta_shulker_box",
+				"minecraft:orange_shulker_box",
+				"minecraft:pink_shulker_box",
+				"minecraft:purple_shulker_box",
+				"minecraft:red_shulker_box",
+				"minecraft:shulker_box",
+				"minecraft:white_shulker_box",
+				"minecraft:yellow_shulker_box"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:light_gray_shulker_box",
+		"material": {
+			"choices": [
+				"minecraft:light_gray_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_gray_shulker_box"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:light_gray_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass",
+		"key": "minecraft:light_gray_stained_glass",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:light_gray_stained_glass"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:light_gray_stained_glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:light_gray_stained_glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:light_gray_stained_glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:light_gray_stained_glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:light_gray_stained_glass"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:light_gray_stained_glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:light_gray_stained_glass_pane",
+		"result": {
+			"amount": 16,
+			"type": "minecraft:light_gray_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:light_gray_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:light_gray_stained_glass_pane_from_glass_pane",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:light_gray_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:light_gray_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_terracotta",
+		"key": "minecraft:light_gray_terracotta",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:light_gray_terracotta"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:light_weighted_pressure_plate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_weighted_pressure_plate"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:lightning_rod",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:lightning_rod"
+		},
+		"shape": [
+			"a",
+			"b",
+			"c"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:lime_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:lime_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:lime_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:lime_wool"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:lime_wool"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:lime_wool"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "banner",
+		"key": "minecraft:lime_banner",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:lime_banner"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:lime_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:lime_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:lime_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bed",
+		"key": "minecraft:lime_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:lime_bed"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_bundle",
+				"minecraft:blue_bundle",
+				"minecraft:brown_bundle",
+				"minecraft:bundle",
+				"minecraft:cyan_bundle",
+				"minecraft:gray_bundle",
+				"minecraft:green_bundle",
+				"minecraft:light_blue_bundle",
+				"minecraft:light_gray_bundle",
+				"minecraft:lime_bundle",
+				"minecraft:magenta_bundle",
+				"minecraft:orange_bundle",
+				"minecraft:pink_bundle",
+				"minecraft:purple_bundle",
+				"minecraft:red_bundle",
+				"minecraft:white_bundle",
+				"minecraft:yellow_bundle"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:lime_bundle",
+		"material": {
+			"choices": [
+				"minecraft:lime_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:lime_bundle"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:candle"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:lime_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "dyed_candle",
+		"key": "minecraft:lime_candle",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:lime_candle"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:lime_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:lime_wool"
+				],
+				"type": "material"
+			}
+		},
+		"group": "carpet",
+		"key": "minecraft:lime_carpet",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:lime_carpet"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:lime_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			}
+		],
+		"group": "concrete_powder",
+		"key": "minecraft:lime_concrete_powder",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:lime_concrete_powder"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:green_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:white_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:lime_dye",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:lime_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_shulker_box",
+				"minecraft:blue_shulker_box",
+				"minecraft:brown_shulker_box",
+				"minecraft:cyan_shulker_box",
+				"minecraft:gray_shulker_box",
+				"minecraft:green_shulker_box",
+				"minecraft:light_blue_shulker_box",
+				"minecraft:light_gray_shulker_box",
+				"minecraft:lime_shulker_box",
+				"minecraft:magenta_shulker_box",
+				"minecraft:orange_shulker_box",
+				"minecraft:pink_shulker_box",
+				"minecraft:purple_shulker_box",
+				"minecraft:red_shulker_box",
+				"minecraft:shulker_box",
+				"minecraft:white_shulker_box",
+				"minecraft:yellow_shulker_box"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:lime_shulker_box",
+		"material": {
+			"choices": [
+				"minecraft:lime_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:lime_shulker_box"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:lime_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass",
+		"key": "minecraft:lime_stained_glass",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:lime_stained_glass"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:lime_stained_glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:lime_stained_glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:lime_stained_glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:lime_stained_glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:lime_stained_glass"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:lime_stained_glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:lime_stained_glass_pane",
+		"result": {
+			"amount": 16,
+			"type": "minecraft:lime_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:lime_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:lime_stained_glass_pane_from_glass_pane",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:lime_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:lime_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_terracotta",
+		"key": "minecraft:lime_terracotta",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:lime_terracotta"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:chiseled_stone_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:chiseled_stone_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:chiseled_stone_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:chiseled_stone_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:netherite_ingot"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:chiseled_stone_bricks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:chiseled_stone_bricks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:chiseled_stone_bricks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:chiseled_stone_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:lodestone",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:lodestone"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:string"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:string"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:loom",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:loom"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:heavy_core"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:breeze_rod"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:mace",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:mace"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:magenta_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:magenta_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:magenta_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:magenta_wool"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:magenta_wool"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:magenta_wool"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "banner",
+		"key": "minecraft:magenta_banner",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:magenta_banner"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:magenta_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:magenta_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:magenta_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bed",
+		"key": "minecraft:magenta_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:magenta_bed"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_bundle",
+				"minecraft:blue_bundle",
+				"minecraft:brown_bundle",
+				"minecraft:bundle",
+				"minecraft:cyan_bundle",
+				"minecraft:gray_bundle",
+				"minecraft:green_bundle",
+				"minecraft:light_blue_bundle",
+				"minecraft:light_gray_bundle",
+				"minecraft:lime_bundle",
+				"minecraft:magenta_bundle",
+				"minecraft:orange_bundle",
+				"minecraft:pink_bundle",
+				"minecraft:purple_bundle",
+				"minecraft:red_bundle",
+				"minecraft:white_bundle",
+				"minecraft:yellow_bundle"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:magenta_bundle",
+		"material": {
+			"choices": [
+				"minecraft:magenta_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:magenta_bundle"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:candle"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:magenta_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "dyed_candle",
+		"key": "minecraft:magenta_candle",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:magenta_candle"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:magenta_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:magenta_wool"
+				],
+				"type": "material"
+			}
+		},
+		"group": "carpet",
+		"key": "minecraft:magenta_carpet",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:magenta_carpet"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:magenta_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			}
+		],
+		"group": "concrete_powder",
+		"key": "minecraft:magenta_concrete_powder",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:magenta_concrete_powder"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:allium"
+				],
+				"type": "material"
+			}
+		],
+		"group": "magenta_dye",
+		"key": "minecraft:magenta_dye_from_allium",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:magenta_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:blue_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:pink_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "magenta_dye",
+		"key": "minecraft:magenta_dye_from_blue_red_pink",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:magenta_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:blue_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:white_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "magenta_dye",
+		"key": "minecraft:magenta_dye_from_blue_red_white_dye",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:magenta_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:lilac"
+				],
+				"type": "material"
+			}
+		],
+		"group": "magenta_dye",
+		"key": "minecraft:magenta_dye_from_lilac",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:magenta_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:purple_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:pink_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "magenta_dye",
+		"key": "minecraft:magenta_dye_from_purple_and_pink",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:magenta_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_shulker_box",
+				"minecraft:blue_shulker_box",
+				"minecraft:brown_shulker_box",
+				"minecraft:cyan_shulker_box",
+				"minecraft:gray_shulker_box",
+				"minecraft:green_shulker_box",
+				"minecraft:light_blue_shulker_box",
+				"minecraft:light_gray_shulker_box",
+				"minecraft:lime_shulker_box",
+				"minecraft:magenta_shulker_box",
+				"minecraft:orange_shulker_box",
+				"minecraft:pink_shulker_box",
+				"minecraft:purple_shulker_box",
+				"minecraft:red_shulker_box",
+				"minecraft:shulker_box",
+				"minecraft:white_shulker_box",
+				"minecraft:yellow_shulker_box"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:magenta_shulker_box",
+		"material": {
+			"choices": [
+				"minecraft:magenta_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:magenta_shulker_box"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:magenta_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass",
+		"key": "minecraft:magenta_stained_glass",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:magenta_stained_glass"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:magenta_stained_glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:magenta_stained_glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:magenta_stained_glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:magenta_stained_glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:magenta_stained_glass"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:magenta_stained_glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:magenta_stained_glass_pane",
+		"result": {
+			"amount": 16,
+			"type": "minecraft:magenta_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:magenta_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:magenta_stained_glass_pane_from_glass_pane",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:magenta_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:magenta_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_terracotta",
+		"key": "minecraft:magenta_terracotta",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:magenta_terracotta"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:magma_cream"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:magma_cream"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:magma_cream"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:magma_cream"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:magma_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:magma_block"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:blaze_powder"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:slime_ball"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:magma_cream",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:magma_cream"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "boat",
+		"key": "minecraft:mangrove_boat",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:mangrove_boat"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wooden_button",
+		"key": "minecraft:mangrove_button",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:mangrove_button"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:chest"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:mangrove_boat"
+				],
+				"type": "material"
+			}
+		],
+		"group": "chest_boat",
+		"key": "minecraft:mangrove_chest_boat",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:mangrove_chest_boat"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_door",
+		"key": "minecraft:mangrove_door",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:mangrove_door"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence",
+		"key": "minecraft:mangrove_fence",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:mangrove_fence"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence_gate",
+		"key": "minecraft:mangrove_fence_gate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:mangrove_fence_gate"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_mangrove_log"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stripped_mangrove_log"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stripped_mangrove_log"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:stripped_mangrove_log"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stripped_mangrove_log"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:stripped_mangrove_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "hanging_sign",
+		"key": "minecraft:mangrove_hanging_sign",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:mangrove_hanging_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:mangrove_log",
+					"minecraft:mangrove_wood",
+					"minecraft:stripped_mangrove_log",
+					"minecraft:stripped_mangrove_wood"
+				],
+				"type": "material"
+			}
+		],
+		"group": "planks",
+		"key": "minecraft:mangrove_planks",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:mangrove_planks"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_pressure_plate",
+		"key": "minecraft:mangrove_pressure_plate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:mangrove_pressure_plate"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_sign",
+		"key": "minecraft:mangrove_sign",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:mangrove_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_slab",
+		"key": "minecraft:mangrove_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:mangrove_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_stairs",
+		"key": "minecraft:mangrove_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:mangrove_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:mangrove_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_trapdoor",
+		"key": "minecraft:mangrove_trapdoor",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:mangrove_trapdoor"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:mangrove_log"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:mangrove_log"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:mangrove_log"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:mangrove_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bark",
+		"key": "minecraft:mangrove_wood",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:mangrove_wood"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:compass"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:map",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:map"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"key": "minecraft:map_cloning",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		},
+		"type": "complex"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:filled_map"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:map_extending",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:map"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:melon_slice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:melon_slice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:melon_slice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:melon_slice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:melon_slice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:melon_slice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:melon_slice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:melon_slice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:melon_slice"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:melon",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:melon"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:melon_slice"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:melon_seeds",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:melon_seeds"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:minecart",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:minecart"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:enchanted_golden_apple"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:mojang_banner_pattern",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:mojang_banner_pattern"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:moss_block"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:moss_block"
+				],
+				"type": "material"
+			}
+		},
+		"group": "carpet",
+		"key": "minecraft:moss_carpet",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:moss_carpet"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:moss_block"
+				],
+				"type": "material"
+			}
+		],
+		"group": "mossy_cobblestone",
+		"key": "minecraft:mossy_cobblestone_from_moss_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:mossy_cobblestone"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:vine"
+				],
+				"type": "material"
+			}
+		],
+		"group": "mossy_cobblestone",
+		"key": "minecraft:mossy_cobblestone_from_vine",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:mossy_cobblestone"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:mossy_cobblestone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:mossy_cobblestone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:mossy_cobblestone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:mossy_cobblestone_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:mossy_cobblestone_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:mossy_cobblestone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:mossy_cobblestone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:mossy_cobblestone"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:mossy_cobblestone"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:mossy_cobblestone"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:mossy_cobblestone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:mossy_cobblestone_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:mossy_cobblestone_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:mossy_cobblestone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:mossy_cobblestone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:mossy_cobblestone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:mossy_cobblestone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:mossy_cobblestone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:mossy_cobblestone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:mossy_cobblestone_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:mossy_cobblestone_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:mossy_stone_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:mossy_stone_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:mossy_stone_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:mossy_stone_brick_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:mossy_stone_brick_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:mossy_stone_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:mossy_stone_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:mossy_stone_bricks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:mossy_stone_bricks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:mossy_stone_bricks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:mossy_stone_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:mossy_stone_brick_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:mossy_stone_brick_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:mossy_stone_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:mossy_stone_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:mossy_stone_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:mossy_stone_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:mossy_stone_bricks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:mossy_stone_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:mossy_stone_brick_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:mossy_stone_brick_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:stone_bricks"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:moss_block"
+				],
+				"type": "material"
+			}
+		],
+		"group": "mossy_stone_bricks",
+		"key": "minecraft:mossy_stone_bricks_from_moss_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:mossy_stone_bricks"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:stone_bricks"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:vine"
+				],
+				"type": "material"
+			}
+		],
+		"group": "mossy_stone_bricks",
+		"key": "minecraft:mossy_stone_bricks_from_vine",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:mossy_stone_bricks"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:mud_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:mud_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:mud_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:mud_brick_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:mud_brick_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:mud_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:mud_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:mud_bricks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:mud_bricks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:mud_bricks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:mud_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:mud_brick_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:mud_brick_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:mud_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:mud_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:mud_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:mud_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:mud_bricks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:mud_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:mud_brick_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:mud_brick_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:packed_mud"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:packed_mud"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:packed_mud"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:packed_mud"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:mud_bricks",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:mud_bricks"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:mud"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:mangrove_roots"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:muddy_mangrove_roots",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:muddy_mangrove_roots"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:brown_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:bowl"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:mushroom_stew",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:mushroom_stew"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:disc_fragment_5"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:disc_fragment_5"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:disc_fragment_5"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:disc_fragment_5"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:disc_fragment_5"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:disc_fragment_5"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:disc_fragment_5"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:disc_fragment_5"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:disc_fragment_5"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:music_disc_5",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:music_disc_5"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:nether_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:nether_brick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:nether_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:nether_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:nether_brick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:nether_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:nether_brick_fence",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:nether_brick_fence"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:nether_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:nether_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:nether_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:nether_brick_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:nether_brick_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:nether_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:nether_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:nether_bricks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:nether_bricks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:nether_bricks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:nether_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:nether_brick_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:nether_brick_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:nether_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:nether_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:nether_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:nether_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:nether_bricks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:nether_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:nether_brick_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:nether_brick_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:nether_brick"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:nether_brick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:nether_brick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:nether_brick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:nether_bricks",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:nether_bricks"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:nether_wart"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:nether_wart"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:nether_wart"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:nether_wart"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:nether_wart"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:nether_wart"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:nether_wart"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:nether_wart"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:nether_wart"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:nether_wart_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:nether_wart_block"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:netherite_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:netherite_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:netherite_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:netherite_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:netherite_ingot"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:netherite_ingot"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:netherite_ingot"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:netherite_ingot"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:netherite_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:netherite_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:netherite_block"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:netherite_scrap"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:netherite_scrap"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:netherite_scrap"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:netherite_scrap"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			}
+		],
+		"group": "netherite_ingot",
+		"key": "minecraft:netherite_ingot",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:netherite_ingot"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:netherite_block"
+				],
+				"type": "material"
+			}
+		],
+		"group": "netherite_ingot",
+		"key": "minecraft:netherite_ingot_from_netherite_block",
+		"result": {
+			"amount": 9,
+			"type": "minecraft:netherite_ingot"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:netherite_upgrade_smithing_template"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:netherrack"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:netherite_upgrade_smithing_template",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:netherite_upgrade_smithing_template"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:note_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:note_block"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "boat",
+		"key": "minecraft:oak_boat",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:oak_boat"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wooden_button",
+		"key": "minecraft:oak_button",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:oak_button"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:chest"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:oak_boat"
+				],
+				"type": "material"
+			}
+		],
+		"group": "chest_boat",
+		"key": "minecraft:oak_chest_boat",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:oak_chest_boat"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_door",
+		"key": "minecraft:oak_door",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:oak_door"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence",
+		"key": "minecraft:oak_fence",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:oak_fence"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence_gate",
+		"key": "minecraft:oak_fence_gate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:oak_fence_gate"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_oak_log"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stripped_oak_log"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stripped_oak_log"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:stripped_oak_log"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stripped_oak_log"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:stripped_oak_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "hanging_sign",
+		"key": "minecraft:oak_hanging_sign",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:oak_hanging_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:oak_log",
+					"minecraft:oak_wood",
+					"minecraft:stripped_oak_log",
+					"minecraft:stripped_oak_wood"
+				],
+				"type": "material"
+			}
+		],
+		"group": "planks",
+		"key": "minecraft:oak_planks",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:oak_planks"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_pressure_plate",
+		"key": "minecraft:oak_pressure_plate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:oak_pressure_plate"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_sign",
+		"key": "minecraft:oak_sign",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:oak_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_slab",
+		"key": "minecraft:oak_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:oak_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_stairs",
+		"key": "minecraft:oak_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:oak_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:oak_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_trapdoor",
+		"key": "minecraft:oak_trapdoor",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:oak_trapdoor"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:oak_log"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:oak_log"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:oak_log"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:oak_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bark",
+		"key": "minecraft:oak_wood",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:oak_wood"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:quartz"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:observer",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:observer"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:orange_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:orange_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:orange_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:orange_wool"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:orange_wool"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:orange_wool"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "banner",
+		"key": "minecraft:orange_banner",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:orange_banner"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:orange_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:orange_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:orange_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bed",
+		"key": "minecraft:orange_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:orange_bed"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_bundle",
+				"minecraft:blue_bundle",
+				"minecraft:brown_bundle",
+				"minecraft:bundle",
+				"minecraft:cyan_bundle",
+				"minecraft:gray_bundle",
+				"minecraft:green_bundle",
+				"minecraft:light_blue_bundle",
+				"minecraft:light_gray_bundle",
+				"minecraft:lime_bundle",
+				"minecraft:magenta_bundle",
+				"minecraft:orange_bundle",
+				"minecraft:pink_bundle",
+				"minecraft:purple_bundle",
+				"minecraft:red_bundle",
+				"minecraft:white_bundle",
+				"minecraft:yellow_bundle"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:orange_bundle",
+		"material": {
+			"choices": [
+				"minecraft:orange_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:orange_bundle"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:candle"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:orange_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "dyed_candle",
+		"key": "minecraft:orange_candle",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:orange_candle"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:orange_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:orange_wool"
+				],
+				"type": "material"
+			}
+		},
+		"group": "carpet",
+		"key": "minecraft:orange_carpet",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:orange_carpet"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:orange_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			}
+		],
+		"group": "concrete_powder",
+		"key": "minecraft:orange_concrete_powder",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:orange_concrete_powder"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:open_eyeblossom"
+				],
+				"type": "material"
+			}
+		],
+		"group": "orange_dye",
+		"key": "minecraft:orange_dye_from_open_eyeblossom",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:orange_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:orange_tulip"
+				],
+				"type": "material"
+			}
+		],
+		"group": "orange_dye",
+		"key": "minecraft:orange_dye_from_orange_tulip",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:orange_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:red_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:yellow_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "orange_dye",
+		"key": "minecraft:orange_dye_from_red_yellow",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:orange_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:torchflower"
+				],
+				"type": "material"
+			}
+		],
+		"group": "orange_dye",
+		"key": "minecraft:orange_dye_from_torchflower",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:orange_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_shulker_box",
+				"minecraft:blue_shulker_box",
+				"minecraft:brown_shulker_box",
+				"minecraft:cyan_shulker_box",
+				"minecraft:gray_shulker_box",
+				"minecraft:green_shulker_box",
+				"minecraft:light_blue_shulker_box",
+				"minecraft:light_gray_shulker_box",
+				"minecraft:lime_shulker_box",
+				"minecraft:magenta_shulker_box",
+				"minecraft:orange_shulker_box",
+				"minecraft:pink_shulker_box",
+				"minecraft:purple_shulker_box",
+				"minecraft:red_shulker_box",
+				"minecraft:shulker_box",
+				"minecraft:white_shulker_box",
+				"minecraft:yellow_shulker_box"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:orange_shulker_box",
+		"material": {
+			"choices": [
+				"minecraft:orange_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:orange_shulker_box"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:orange_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass",
+		"key": "minecraft:orange_stained_glass",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:orange_stained_glass"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:orange_stained_glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:orange_stained_glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:orange_stained_glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:orange_stained_glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:orange_stained_glass"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:orange_stained_glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:orange_stained_glass_pane",
+		"result": {
+			"amount": 16,
+			"type": "minecraft:orange_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:orange_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:orange_stained_glass_pane_from_glass_pane",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:orange_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:orange_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_terracotta",
+		"key": "minecraft:orange_terracotta",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:orange_terracotta"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:oxidized_cut_copper_slab"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:oxidized_cut_copper_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:oxidized_chiseled_copper",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:oxidized_chiseled_copper"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:oxidized_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:oxidized_copper"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:blaze_rod"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:oxidized_copper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:oxidized_copper_bulb",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:oxidized_copper_bulb"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:oxidized_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:oxidized_copper"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:oxidized_copper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:oxidized_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:oxidized_copper_grate",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:oxidized_copper_grate"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:oxidized_copper"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:oxidized_copper"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:oxidized_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:oxidized_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:oxidized_cut_copper",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:oxidized_cut_copper"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:oxidized_cut_copper"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:oxidized_cut_copper"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:oxidized_cut_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:oxidized_cut_copper_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:oxidized_cut_copper_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:oxidized_cut_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:oxidized_cut_copper"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:oxidized_cut_copper"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:oxidized_cut_copper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:oxidized_cut_copper"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:oxidized_cut_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:oxidized_cut_copper_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:oxidized_cut_copper_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:ice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:ice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:ice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:ice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:ice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:ice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:ice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:ice"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:ice"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:packed_ice",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:packed_ice"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:mud"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:wheat"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:packed_mud",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:packed_mud"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:black_wool",
+					"minecraft:blue_wool",
+					"minecraft:brown_wool",
+					"minecraft:cyan_wool",
+					"minecraft:gray_wool",
+					"minecraft:green_wool",
+					"minecraft:light_blue_wool",
+					"minecraft:light_gray_wool",
+					"minecraft:lime_wool",
+					"minecraft:magenta_wool",
+					"minecraft:orange_wool",
+					"minecraft:pink_wool",
+					"minecraft:purple_wool",
+					"minecraft:red_wool",
+					"minecraft:white_wool",
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:painting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:painting"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:pale_moss_block"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:pale_moss_block"
+				],
+				"type": "material"
+			}
+		},
+		"group": "carpet",
+		"key": "minecraft:pale_moss_carpet",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:pale_moss_carpet"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "boat",
+		"key": "minecraft:pale_oak_boat",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:pale_oak_boat"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wooden_button",
+		"key": "minecraft:pale_oak_button",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:pale_oak_button"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:chest"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:pale_oak_boat"
+				],
+				"type": "material"
+			}
+		],
+		"group": "chest_boat",
+		"key": "minecraft:pale_oak_chest_boat",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:pale_oak_chest_boat"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_door",
+		"key": "minecraft:pale_oak_door",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:pale_oak_door"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence",
+		"key": "minecraft:pale_oak_fence",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:pale_oak_fence"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence_gate",
+		"key": "minecraft:pale_oak_fence_gate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:pale_oak_fence_gate"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_pale_oak_log"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stripped_pale_oak_log"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stripped_pale_oak_log"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:stripped_pale_oak_log"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stripped_pale_oak_log"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:stripped_pale_oak_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "hanging_sign",
+		"key": "minecraft:pale_oak_hanging_sign",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:pale_oak_hanging_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:pale_oak_log",
+					"minecraft:pale_oak_wood",
+					"minecraft:stripped_pale_oak_log",
+					"minecraft:stripped_pale_oak_wood"
+				],
+				"type": "material"
+			}
+		],
+		"group": "planks",
+		"key": "minecraft:pale_oak_planks",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:pale_oak_planks"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_pressure_plate",
+		"key": "minecraft:pale_oak_pressure_plate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:pale_oak_pressure_plate"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_sign",
+		"key": "minecraft:pale_oak_sign",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:pale_oak_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_slab",
+		"key": "minecraft:pale_oak_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:pale_oak_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_stairs",
+		"key": "minecraft:pale_oak_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:pale_oak_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:pale_oak_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_trapdoor",
+		"key": "minecraft:pale_oak_trapdoor",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:pale_oak_trapdoor"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:pale_oak_log"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:pale_oak_log"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:pale_oak_log"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:pale_oak_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bark",
+		"key": "minecraft:pale_oak_wood",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:pale_oak_wood"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:sugar_cane"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:sugar_cane"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:sugar_cane"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:paper",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:paper"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:pink_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:pink_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:pink_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:pink_wool"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:pink_wool"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:pink_wool"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "banner",
+		"key": "minecraft:pink_banner",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:pink_banner"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:pink_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:pink_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:pink_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bed",
+		"key": "minecraft:pink_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:pink_bed"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_bundle",
+				"minecraft:blue_bundle",
+				"minecraft:brown_bundle",
+				"minecraft:bundle",
+				"minecraft:cyan_bundle",
+				"minecraft:gray_bundle",
+				"minecraft:green_bundle",
+				"minecraft:light_blue_bundle",
+				"minecraft:light_gray_bundle",
+				"minecraft:lime_bundle",
+				"minecraft:magenta_bundle",
+				"minecraft:orange_bundle",
+				"minecraft:pink_bundle",
+				"minecraft:purple_bundle",
+				"minecraft:red_bundle",
+				"minecraft:white_bundle",
+				"minecraft:yellow_bundle"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:pink_bundle",
+		"material": {
+			"choices": [
+				"minecraft:pink_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:pink_bundle"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:candle"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:pink_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "dyed_candle",
+		"key": "minecraft:pink_candle",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:pink_candle"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:pink_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:pink_wool"
+				],
+				"type": "material"
+			}
+		},
+		"group": "carpet",
+		"key": "minecraft:pink_carpet",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:pink_carpet"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:pink_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			}
+		],
+		"group": "concrete_powder",
+		"key": "minecraft:pink_concrete_powder",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:pink_concrete_powder"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:peony"
+				],
+				"type": "material"
+			}
+		],
+		"group": "pink_dye",
+		"key": "minecraft:pink_dye_from_peony",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:pink_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:pink_petals"
+				],
+				"type": "material"
+			}
+		],
+		"group": "pink_dye",
+		"key": "minecraft:pink_dye_from_pink_petals",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:pink_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:pink_tulip"
+				],
+				"type": "material"
+			}
+		],
+		"group": "pink_dye",
+		"key": "minecraft:pink_dye_from_pink_tulip",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:pink_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:red_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:white_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "pink_dye",
+		"key": "minecraft:pink_dye_from_red_white_dye",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:pink_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_shulker_box",
+				"minecraft:blue_shulker_box",
+				"minecraft:brown_shulker_box",
+				"minecraft:cyan_shulker_box",
+				"minecraft:gray_shulker_box",
+				"minecraft:green_shulker_box",
+				"minecraft:light_blue_shulker_box",
+				"minecraft:light_gray_shulker_box",
+				"minecraft:lime_shulker_box",
+				"minecraft:magenta_shulker_box",
+				"minecraft:orange_shulker_box",
+				"minecraft:pink_shulker_box",
+				"minecraft:purple_shulker_box",
+				"minecraft:red_shulker_box",
+				"minecraft:shulker_box",
+				"minecraft:white_shulker_box",
+				"minecraft:yellow_shulker_box"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:pink_shulker_box",
+		"material": {
+			"choices": [
+				"minecraft:pink_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:pink_shulker_box"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:pink_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass",
+		"key": "minecraft:pink_stained_glass",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:pink_stained_glass"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:pink_stained_glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:pink_stained_glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:pink_stained_glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:pink_stained_glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:pink_stained_glass"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:pink_stained_glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:pink_stained_glass_pane",
+		"result": {
+			"amount": 16,
+			"type": "minecraft:pink_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:pink_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:pink_stained_glass_pane_from_glass_pane",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:pink_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:pink_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_terracotta",
+		"key": "minecraft:pink_terracotta",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:pink_terracotta"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:piston",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:piston"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:andesite"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:andesite"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:andesite"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:andesite"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_andesite",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:polished_andesite"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_andesite"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:polished_andesite"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:polished_andesite"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_andesite_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:polished_andesite_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_andesite"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:polished_andesite"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:polished_andesite"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:polished_andesite"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:polished_andesite"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:polished_andesite"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_andesite_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:polished_andesite_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:basalt"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:basalt"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:basalt"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:basalt"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_basalt",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:polished_basalt"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:blackstone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:blackstone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:blackstone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:blackstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_blackstone",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:polished_blackstone"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_blackstone_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:polished_blackstone_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:polished_blackstone_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_blackstone_brick_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:polished_blackstone_brick_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_blackstone_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:polished_blackstone_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:polished_blackstone_bricks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:polished_blackstone_bricks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:polished_blackstone_bricks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:polished_blackstone_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_blackstone_brick_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:polished_blackstone_brick_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_blackstone_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:polished_blackstone_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:polished_blackstone_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:polished_blackstone_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:polished_blackstone_bricks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:polished_blackstone_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_blackstone_brick_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:polished_blackstone_brick_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_blackstone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:polished_blackstone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:polished_blackstone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:polished_blackstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_blackstone_bricks",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:polished_blackstone_bricks"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:polished_blackstone"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:polished_blackstone_button",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_blackstone_button"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_blackstone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:polished_blackstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_blackstone_pressure_plate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_blackstone_pressure_plate"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_blackstone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:polished_blackstone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:polished_blackstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_blackstone_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:polished_blackstone_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_blackstone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:polished_blackstone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:polished_blackstone"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:polished_blackstone"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:polished_blackstone"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:polished_blackstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_blackstone_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:polished_blackstone_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_blackstone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:polished_blackstone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:polished_blackstone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:polished_blackstone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:polished_blackstone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:polished_blackstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_blackstone_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:polished_blackstone_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:cobbled_deepslate"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:cobbled_deepslate"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:cobbled_deepslate"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:cobbled_deepslate"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_deepslate",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:polished_deepslate"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_deepslate"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:polished_deepslate"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:polished_deepslate"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_deepslate_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:polished_deepslate_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_deepslate"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:polished_deepslate"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:polished_deepslate"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:polished_deepslate"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:polished_deepslate"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:polished_deepslate"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_deepslate_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:polished_deepslate_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_deepslate"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:polished_deepslate"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:polished_deepslate"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:polished_deepslate"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:polished_deepslate"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:polished_deepslate"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_deepslate_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:polished_deepslate_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diorite"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:diorite"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diorite"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diorite"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_diorite",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:polished_diorite"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_diorite"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:polished_diorite"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:polished_diorite"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_diorite_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:polished_diorite_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_diorite"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:polished_diorite"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:polished_diorite"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:polished_diorite"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:polished_diorite"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:polished_diorite"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_diorite_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:polished_diorite_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:granite"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:granite"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:granite"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:granite"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_granite",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:polished_granite"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_granite"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:polished_granite"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:polished_granite"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_granite_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:polished_granite_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_granite"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:polished_granite"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:polished_granite"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:polished_granite"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:polished_granite"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:polished_granite"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_granite_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:polished_granite_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:tuff"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:tuff"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:tuff"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:tuff"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_tuff",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:polished_tuff"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_tuff"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:polished_tuff"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:polished_tuff"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_tuff_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:polished_tuff_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_tuff"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:polished_tuff"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:polished_tuff"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:polished_tuff"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:polished_tuff"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:polished_tuff"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_tuff_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:polished_tuff_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_tuff"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:polished_tuff"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:polished_tuff"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:polished_tuff"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:polished_tuff"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:polished_tuff"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:polished_tuff_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:polished_tuff_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:gold_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:powered_rail",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:powered_rail"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:prismarine",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:prismarine"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:prismarine_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:prismarine_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:prismarine_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:prismarine_brick_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:prismarine_brick_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:prismarine_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:prismarine_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:prismarine_bricks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:prismarine_bricks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:prismarine_bricks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:prismarine_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:prismarine_brick_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:prismarine_brick_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:prismarine_bricks",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:prismarine_bricks"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:prismarine"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:prismarine"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:prismarine"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:prismarine_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:prismarine_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:prismarine"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:prismarine"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:prismarine"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:prismarine"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:prismarine"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:prismarine"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:prismarine_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:prismarine_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:prismarine"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:prismarine"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:prismarine"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:prismarine"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:prismarine"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:prismarine"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:prismarine_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:prismarine_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:pumpkin"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sugar"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:egg"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:pumpkin_pie",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:pumpkin_pie"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:pumpkin"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:pumpkin_seeds",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:pumpkin_seeds"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:purple_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:purple_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:purple_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:purple_wool"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:purple_wool"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:purple_wool"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "banner",
+		"key": "minecraft:purple_banner",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:purple_banner"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:purple_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:purple_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:purple_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bed",
+		"key": "minecraft:purple_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:purple_bed"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_bundle",
+				"minecraft:blue_bundle",
+				"minecraft:brown_bundle",
+				"minecraft:bundle",
+				"minecraft:cyan_bundle",
+				"minecraft:gray_bundle",
+				"minecraft:green_bundle",
+				"minecraft:light_blue_bundle",
+				"minecraft:light_gray_bundle",
+				"minecraft:lime_bundle",
+				"minecraft:magenta_bundle",
+				"minecraft:orange_bundle",
+				"minecraft:pink_bundle",
+				"minecraft:purple_bundle",
+				"minecraft:red_bundle",
+				"minecraft:white_bundle",
+				"minecraft:yellow_bundle"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:purple_bundle",
+		"material": {
+			"choices": [
+				"minecraft:purple_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:purple_bundle"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:candle"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:purple_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "dyed_candle",
+		"key": "minecraft:purple_candle",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:purple_candle"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:purple_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:purple_wool"
+				],
+				"type": "material"
+			}
+		},
+		"group": "carpet",
+		"key": "minecraft:purple_carpet",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:purple_carpet"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:purple_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			}
+		],
+		"group": "concrete_powder",
+		"key": "minecraft:purple_concrete_powder",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:purple_concrete_powder"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:blue_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:purple_dye",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:purple_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_shulker_box",
+				"minecraft:blue_shulker_box",
+				"minecraft:brown_shulker_box",
+				"minecraft:cyan_shulker_box",
+				"minecraft:gray_shulker_box",
+				"minecraft:green_shulker_box",
+				"minecraft:light_blue_shulker_box",
+				"minecraft:light_gray_shulker_box",
+				"minecraft:lime_shulker_box",
+				"minecraft:magenta_shulker_box",
+				"minecraft:orange_shulker_box",
+				"minecraft:pink_shulker_box",
+				"minecraft:purple_shulker_box",
+				"minecraft:red_shulker_box",
+				"minecraft:shulker_box",
+				"minecraft:white_shulker_box",
+				"minecraft:yellow_shulker_box"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:purple_shulker_box",
+		"material": {
+			"choices": [
+				"minecraft:purple_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:purple_shulker_box"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:purple_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass",
+		"key": "minecraft:purple_stained_glass",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:purple_stained_glass"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:purple_stained_glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:purple_stained_glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:purple_stained_glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:purple_stained_glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:purple_stained_glass"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:purple_stained_glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:purple_stained_glass_pane",
+		"result": {
+			"amount": 16,
+			"type": "minecraft:purple_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:purple_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:purple_stained_glass_pane_from_glass_pane",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:purple_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:purple_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_terracotta",
+		"key": "minecraft:purple_terracotta",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:purple_terracotta"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:popped_chorus_fruit"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:popped_chorus_fruit"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:popped_chorus_fruit"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:popped_chorus_fruit"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:purpur_block",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:purpur_block"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:purpur_slab"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:purpur_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:purpur_pillar",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:purpur_pillar"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:purpur_block",
+					"minecraft:purpur_pillar"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:purpur_block",
+					"minecraft:purpur_pillar"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:purpur_block",
+					"minecraft:purpur_pillar"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:purpur_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:purpur_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:purpur_block",
+					"minecraft:purpur_pillar"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:purpur_block",
+					"minecraft:purpur_pillar"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:purpur_block",
+					"minecraft:purpur_pillar"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:purpur_block",
+					"minecraft:purpur_pillar"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:purpur_block",
+					"minecraft:purpur_pillar"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:purpur_block",
+					"minecraft:purpur_pillar"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:purpur_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:purpur_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:quartz"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:quartz"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:quartz"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:quartz"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:quartz_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:quartz_block"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:quartz_block"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:quartz_block"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:quartz_block"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:quartz_block"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:quartz_bricks",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:quartz_bricks"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:quartz_block"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:quartz_block"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:quartz_pillar",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:quartz_pillar"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:chiseled_quartz_block",
+					"minecraft:quartz_block",
+					"minecraft:quartz_pillar"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:chiseled_quartz_block",
+					"minecraft:quartz_block",
+					"minecraft:quartz_pillar"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:chiseled_quartz_block",
+					"minecraft:quartz_block",
+					"minecraft:quartz_pillar"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:quartz_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:quartz_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:chiseled_quartz_block",
+					"minecraft:quartz_block",
+					"minecraft:quartz_pillar"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:chiseled_quartz_block",
+					"minecraft:quartz_block",
+					"minecraft:quartz_pillar"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:chiseled_quartz_block",
+					"minecraft:quartz_block",
+					"minecraft:quartz_pillar"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:chiseled_quartz_block",
+					"minecraft:quartz_block",
+					"minecraft:quartz_pillar"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:chiseled_quartz_block",
+					"minecraft:quartz_block",
+					"minecraft:quartz_pillar"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:chiseled_quartz_block",
+					"minecraft:quartz_block",
+					"minecraft:quartz_pillar"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:quartz_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:quartz_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:baked_potato"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:cooked_rabbit"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:bowl"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:carrot"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:brown_mushroom"
+				],
+				"type": "material"
+			}
+		],
+		"group": "rabbit_stew",
+		"key": "minecraft:rabbit_stew_from_brown_mushroom",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:rabbit_stew"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:baked_potato"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:cooked_rabbit"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:bowl"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:carrot"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_mushroom"
+				],
+				"type": "material"
+			}
+		],
+		"group": "rabbit_stew",
+		"key": "minecraft:rabbit_stew_from_red_mushroom",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:rabbit_stew"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:rail",
+		"result": {
+			"amount": 16,
+			"type": "minecraft:rail"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:raiser_armor_trim_smithing_template"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:raiser_armor_trim_smithing_template",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:raiser_armor_trim_smithing_template"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:raw_copper_block"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:raw_copper",
+		"result": {
+			"amount": 9,
+			"type": "minecraft:raw_copper"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:raw_copper"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:raw_copper"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:raw_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:raw_copper"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:raw_copper"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:raw_copper"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:raw_copper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:raw_copper"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:raw_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:raw_copper_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:raw_copper_block"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:raw_gold_block"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:raw_gold",
+		"result": {
+			"amount": 9,
+			"type": "minecraft:raw_gold"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:raw_gold"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:raw_gold"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:raw_gold"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:raw_gold"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:raw_gold"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:raw_gold"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:raw_gold"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:raw_gold"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:raw_gold"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:raw_gold_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:raw_gold_block"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:raw_iron_block"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:raw_iron",
+		"result": {
+			"amount": 9,
+			"type": "minecraft:raw_iron"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:raw_iron"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:raw_iron"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:raw_iron"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:raw_iron"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:raw_iron"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:raw_iron"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:raw_iron"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:raw_iron"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:raw_iron"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:raw_iron_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:raw_iron_block"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:echo_shard"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:echo_shard"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:echo_shard"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:echo_shard"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:compass"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:echo_shard"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:echo_shard"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:echo_shard"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:echo_shard"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:recovery_compass",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:recovery_compass"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:red_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:red_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:red_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:red_wool"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:red_wool"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:red_wool"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "banner",
+		"key": "minecraft:red_banner",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:red_banner"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:red_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:red_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:red_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bed",
+		"key": "minecraft:red_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:red_bed"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_bundle",
+				"minecraft:blue_bundle",
+				"minecraft:brown_bundle",
+				"minecraft:bundle",
+				"minecraft:cyan_bundle",
+				"minecraft:gray_bundle",
+				"minecraft:green_bundle",
+				"minecraft:light_blue_bundle",
+				"minecraft:light_gray_bundle",
+				"minecraft:lime_bundle",
+				"minecraft:magenta_bundle",
+				"minecraft:orange_bundle",
+				"minecraft:pink_bundle",
+				"minecraft:purple_bundle",
+				"minecraft:red_bundle",
+				"minecraft:white_bundle",
+				"minecraft:yellow_bundle"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:red_bundle",
+		"material": {
+			"choices": [
+				"minecraft:red_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:red_bundle"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:candle"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "dyed_candle",
+		"key": "minecraft:red_candle",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:red_candle"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:red_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:red_wool"
+				],
+				"type": "material"
+			}
+		},
+		"group": "carpet",
+		"key": "minecraft:red_carpet",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:red_carpet"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:red_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			}
+		],
+		"group": "concrete_powder",
+		"key": "minecraft:red_concrete_powder",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:red_concrete_powder"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:beetroot"
+				],
+				"type": "material"
+			}
+		],
+		"group": "red_dye",
+		"key": "minecraft:red_dye_from_beetroot",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:red_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:poppy"
+				],
+				"type": "material"
+			}
+		],
+		"group": "red_dye",
+		"key": "minecraft:red_dye_from_poppy",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:red_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:rose_bush"
+				],
+				"type": "material"
+			}
+		],
+		"group": "red_dye",
+		"key": "minecraft:red_dye_from_rose_bush",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:red_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:red_tulip"
+				],
+				"type": "material"
+			}
+		],
+		"group": "red_dye",
+		"key": "minecraft:red_dye_from_tulip",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:red_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:red_nether_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:red_nether_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:red_nether_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:red_nether_brick_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:red_nether_brick_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:red_nether_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:red_nether_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:red_nether_bricks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:red_nether_bricks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:red_nether_bricks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:red_nether_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:red_nether_brick_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:red_nether_brick_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:red_nether_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:red_nether_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:red_nether_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:red_nether_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:red_nether_bricks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:red_nether_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:red_nether_brick_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:red_nether_brick_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:nether_brick"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:nether_wart"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:nether_wart"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:nether_brick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:red_nether_bricks",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:red_nether_bricks"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:red_sand"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:red_sand"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:red_sand"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:red_sand"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:red_sandstone",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:red_sandstone"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:chiseled_red_sandstone",
+					"minecraft:red_sandstone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:chiseled_red_sandstone",
+					"minecraft:red_sandstone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:chiseled_red_sandstone",
+					"minecraft:red_sandstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:red_sandstone_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:red_sandstone_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:chiseled_red_sandstone",
+					"minecraft:cut_red_sandstone",
+					"minecraft:red_sandstone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:chiseled_red_sandstone",
+					"minecraft:cut_red_sandstone",
+					"minecraft:red_sandstone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:chiseled_red_sandstone",
+					"minecraft:cut_red_sandstone",
+					"minecraft:red_sandstone"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:chiseled_red_sandstone",
+					"minecraft:cut_red_sandstone",
+					"minecraft:red_sandstone"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:chiseled_red_sandstone",
+					"minecraft:cut_red_sandstone",
+					"minecraft:red_sandstone"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:chiseled_red_sandstone",
+					"minecraft:cut_red_sandstone",
+					"minecraft:red_sandstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:red_sandstone_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:red_sandstone_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:red_sandstone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:red_sandstone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:red_sandstone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:red_sandstone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:red_sandstone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:red_sandstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:red_sandstone_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:red_sandstone_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_shulker_box",
+				"minecraft:blue_shulker_box",
+				"minecraft:brown_shulker_box",
+				"minecraft:cyan_shulker_box",
+				"minecraft:gray_shulker_box",
+				"minecraft:green_shulker_box",
+				"minecraft:light_blue_shulker_box",
+				"minecraft:light_gray_shulker_box",
+				"minecraft:lime_shulker_box",
+				"minecraft:magenta_shulker_box",
+				"minecraft:orange_shulker_box",
+				"minecraft:pink_shulker_box",
+				"minecraft:purple_shulker_box",
+				"minecraft:red_shulker_box",
+				"minecraft:shulker_box",
+				"minecraft:white_shulker_box",
+				"minecraft:yellow_shulker_box"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:red_shulker_box",
+		"material": {
+			"choices": [
+				"minecraft:red_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:red_shulker_box"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:red_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass",
+		"key": "minecraft:red_stained_glass",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:red_stained_glass"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:red_stained_glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:red_stained_glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:red_stained_glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:red_stained_glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:red_stained_glass"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:red_stained_glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:red_stained_glass_pane",
+		"result": {
+			"amount": 16,
+			"type": "minecraft:red_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:red_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:red_stained_glass_pane_from_glass_pane",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:red_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:red_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_terracotta",
+		"key": "minecraft:red_terracotta",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:red_terracotta"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:redstone_block"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:redstone",
+		"result": {
+			"amount": 9,
+			"type": "minecraft:redstone"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:redstone_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:redstone_block"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:glowstone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:redstone_lamp",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:redstone_lamp"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:redstone_torch",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:redstone_torch"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"key": "minecraft:repair_item",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		},
+		"type": "complex"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:redstone_torch"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:redstone_torch"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:repeater",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:repeater"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:resin_clump"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:resin_clump"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:resin_clump"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:resin_clump"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:resin_clump"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:resin_clump"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:resin_clump"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:resin_clump"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:resin_clump"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:resin_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:resin_block"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:resin_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:resin_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:resin_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:resin_brick_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:resin_brick_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:resin_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:resin_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:resin_bricks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:resin_bricks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:resin_bricks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:resin_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:resin_brick_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:resin_brick_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:resin_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:resin_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:resin_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:resin_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:resin_bricks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:resin_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:resin_brick_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:resin_brick_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:resin_brick"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:resin_brick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:resin_brick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:resin_brick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:resin_bricks",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:resin_bricks"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:resin_block"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:resin_clump",
+		"result": {
+			"amount": 9,
+			"type": "minecraft:resin_clump"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:crying_obsidian"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:crying_obsidian"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:crying_obsidian"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glowstone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:glowstone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glowstone"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:crying_obsidian"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:crying_obsidian"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:crying_obsidian"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:respawn_anchor",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:respawn_anchor"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:rib_armor_trim_smithing_template"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:netherrack"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:rib_armor_trim_smithing_template",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:rib_armor_trim_smithing_template"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:sandstone",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:sandstone"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:chiseled_sandstone",
+					"minecraft:sandstone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:chiseled_sandstone",
+					"minecraft:sandstone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:chiseled_sandstone",
+					"minecraft:sandstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:sandstone_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:sandstone_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:chiseled_sandstone",
+					"minecraft:cut_sandstone",
+					"minecraft:sandstone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:chiseled_sandstone",
+					"minecraft:cut_sandstone",
+					"minecraft:sandstone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:chiseled_sandstone",
+					"minecraft:cut_sandstone",
+					"minecraft:sandstone"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:chiseled_sandstone",
+					"minecraft:cut_sandstone",
+					"minecraft:sandstone"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:chiseled_sandstone",
+					"minecraft:cut_sandstone",
+					"minecraft:sandstone"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:chiseled_sandstone",
+					"minecraft:cut_sandstone",
+					"minecraft:sandstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:sandstone_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:sandstone_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:sandstone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:sandstone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:sandstone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:sandstone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:sandstone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:sandstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:sandstone_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:sandstone_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:bamboo"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:string"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:bamboo"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:bamboo"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:bamboo"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:bamboo"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:bamboo"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:scaffolding",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:scaffolding"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:prismarine_crystals"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:prismarine_crystals"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:prismarine_crystals"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:prismarine_crystals"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:prismarine_crystals"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:prismarine_shard"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:sea_lantern",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:sea_lantern"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:sentry_armor_trim_smithing_template"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:sentry_armor_trim_smithing_template",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:sentry_armor_trim_smithing_template"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:shaper_armor_trim_smithing_template"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:shaper_armor_trim_smithing_template",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:shaper_armor_trim_smithing_template"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:shears",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:shears"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:shield",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:shield"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"key": "minecraft:shield_decoration",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		},
+		"type": "complex"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:shulker_shell"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:chest"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:shulker_shell"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:shulker_box",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:shulker_box"
+		},
+		"shape": [
+			"a",
+			"b",
+			"c"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:silence_armor_trim_smithing_template"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:cobbled_deepslate"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:silence_armor_trim_smithing_template",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:silence_armor_trim_smithing_template"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:paper"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:wither_skeleton_skull"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:skull_banner_pattern",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:skull_banner_pattern"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:slime_block"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:slime_ball",
+		"result": {
+			"amount": 9,
+			"type": "minecraft:slime_ball"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:slime_ball"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:slime_ball"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:slime_ball"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:slime_ball"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:slime_ball"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:slime_ball"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:slime_ball"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:slime_ball"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:slime_ball"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:slime_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:slime_block"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:smithing_table",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:smithing_table"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:acacia_log",
+					"minecraft:acacia_wood",
+					"minecraft:birch_log",
+					"minecraft:birch_wood",
+					"minecraft:cherry_log",
+					"minecraft:cherry_wood",
+					"minecraft:crimson_hyphae",
+					"minecraft:crimson_stem",
+					"minecraft:dark_oak_log",
+					"minecraft:dark_oak_wood",
+					"minecraft:jungle_log",
+					"minecraft:jungle_wood",
+					"minecraft:mangrove_log",
+					"minecraft:mangrove_wood",
+					"minecraft:oak_log",
+					"minecraft:oak_wood",
+					"minecraft:pale_oak_log",
+					"minecraft:pale_oak_wood",
+					"minecraft:spruce_log",
+					"minecraft:spruce_wood",
+					"minecraft:stripped_acacia_log",
+					"minecraft:stripped_acacia_wood",
+					"minecraft:stripped_birch_log",
+					"minecraft:stripped_birch_wood",
+					"minecraft:stripped_cherry_log",
+					"minecraft:stripped_cherry_wood",
+					"minecraft:stripped_crimson_hyphae",
+					"minecraft:stripped_crimson_stem",
+					"minecraft:stripped_dark_oak_log",
+					"minecraft:stripped_dark_oak_wood",
+					"minecraft:stripped_jungle_log",
+					"minecraft:stripped_jungle_wood",
+					"minecraft:stripped_mangrove_log",
+					"minecraft:stripped_mangrove_wood",
+					"minecraft:stripped_oak_log",
+					"minecraft:stripped_oak_wood",
+					"minecraft:stripped_pale_oak_log",
+					"minecraft:stripped_pale_oak_wood",
+					"minecraft:stripped_spruce_log",
+					"minecraft:stripped_spruce_wood",
+					"minecraft:stripped_warped_hyphae",
+					"minecraft:stripped_warped_stem",
+					"minecraft:warped_hyphae",
+					"minecraft:warped_stem"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_log",
+					"minecraft:acacia_wood",
+					"minecraft:birch_log",
+					"minecraft:birch_wood",
+					"minecraft:cherry_log",
+					"minecraft:cherry_wood",
+					"minecraft:crimson_hyphae",
+					"minecraft:crimson_stem",
+					"minecraft:dark_oak_log",
+					"minecraft:dark_oak_wood",
+					"minecraft:jungle_log",
+					"minecraft:jungle_wood",
+					"minecraft:mangrove_log",
+					"minecraft:mangrove_wood",
+					"minecraft:oak_log",
+					"minecraft:oak_wood",
+					"minecraft:pale_oak_log",
+					"minecraft:pale_oak_wood",
+					"minecraft:spruce_log",
+					"minecraft:spruce_wood",
+					"minecraft:stripped_acacia_log",
+					"minecraft:stripped_acacia_wood",
+					"minecraft:stripped_birch_log",
+					"minecraft:stripped_birch_wood",
+					"minecraft:stripped_cherry_log",
+					"minecraft:stripped_cherry_wood",
+					"minecraft:stripped_crimson_hyphae",
+					"minecraft:stripped_crimson_stem",
+					"minecraft:stripped_dark_oak_log",
+					"minecraft:stripped_dark_oak_wood",
+					"minecraft:stripped_jungle_log",
+					"minecraft:stripped_jungle_wood",
+					"minecraft:stripped_mangrove_log",
+					"minecraft:stripped_mangrove_wood",
+					"minecraft:stripped_oak_log",
+					"minecraft:stripped_oak_wood",
+					"minecraft:stripped_pale_oak_log",
+					"minecraft:stripped_pale_oak_wood",
+					"minecraft:stripped_spruce_log",
+					"minecraft:stripped_spruce_wood",
+					"minecraft:stripped_warped_hyphae",
+					"minecraft:stripped_warped_stem",
+					"minecraft:warped_hyphae",
+					"minecraft:warped_stem"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:furnace"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_log",
+					"minecraft:acacia_wood",
+					"minecraft:birch_log",
+					"minecraft:birch_wood",
+					"minecraft:cherry_log",
+					"minecraft:cherry_wood",
+					"minecraft:crimson_hyphae",
+					"minecraft:crimson_stem",
+					"minecraft:dark_oak_log",
+					"minecraft:dark_oak_wood",
+					"minecraft:jungle_log",
+					"minecraft:jungle_wood",
+					"minecraft:mangrove_log",
+					"minecraft:mangrove_wood",
+					"minecraft:oak_log",
+					"minecraft:oak_wood",
+					"minecraft:pale_oak_log",
+					"minecraft:pale_oak_wood",
+					"minecraft:spruce_log",
+					"minecraft:spruce_wood",
+					"minecraft:stripped_acacia_log",
+					"minecraft:stripped_acacia_wood",
+					"minecraft:stripped_birch_log",
+					"minecraft:stripped_birch_wood",
+					"minecraft:stripped_cherry_log",
+					"minecraft:stripped_cherry_wood",
+					"minecraft:stripped_crimson_hyphae",
+					"minecraft:stripped_crimson_stem",
+					"minecraft:stripped_dark_oak_log",
+					"minecraft:stripped_dark_oak_wood",
+					"minecraft:stripped_jungle_log",
+					"minecraft:stripped_jungle_wood",
+					"minecraft:stripped_mangrove_log",
+					"minecraft:stripped_mangrove_wood",
+					"minecraft:stripped_oak_log",
+					"minecraft:stripped_oak_wood",
+					"minecraft:stripped_pale_oak_log",
+					"minecraft:stripped_pale_oak_wood",
+					"minecraft:stripped_spruce_log",
+					"minecraft:stripped_spruce_wood",
+					"minecraft:stripped_warped_hyphae",
+					"minecraft:stripped_warped_stem",
+					"minecraft:warped_hyphae",
+					"minecraft:warped_stem"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:acacia_log",
+					"minecraft:acacia_wood",
+					"minecraft:birch_log",
+					"minecraft:birch_wood",
+					"minecraft:cherry_log",
+					"minecraft:cherry_wood",
+					"minecraft:crimson_hyphae",
+					"minecraft:crimson_stem",
+					"minecraft:dark_oak_log",
+					"minecraft:dark_oak_wood",
+					"minecraft:jungle_log",
+					"minecraft:jungle_wood",
+					"minecraft:mangrove_log",
+					"minecraft:mangrove_wood",
+					"minecraft:oak_log",
+					"minecraft:oak_wood",
+					"minecraft:pale_oak_log",
+					"minecraft:pale_oak_wood",
+					"minecraft:spruce_log",
+					"minecraft:spruce_wood",
+					"minecraft:stripped_acacia_log",
+					"minecraft:stripped_acacia_wood",
+					"minecraft:stripped_birch_log",
+					"minecraft:stripped_birch_wood",
+					"minecraft:stripped_cherry_log",
+					"minecraft:stripped_cherry_wood",
+					"minecraft:stripped_crimson_hyphae",
+					"minecraft:stripped_crimson_stem",
+					"minecraft:stripped_dark_oak_log",
+					"minecraft:stripped_dark_oak_wood",
+					"minecraft:stripped_jungle_log",
+					"minecraft:stripped_jungle_wood",
+					"minecraft:stripped_mangrove_log",
+					"minecraft:stripped_mangrove_wood",
+					"minecraft:stripped_oak_log",
+					"minecraft:stripped_oak_wood",
+					"minecraft:stripped_pale_oak_log",
+					"minecraft:stripped_pale_oak_wood",
+					"minecraft:stripped_spruce_log",
+					"minecraft:stripped_spruce_wood",
+					"minecraft:stripped_warped_hyphae",
+					"minecraft:stripped_warped_stem",
+					"minecraft:warped_hyphae",
+					"minecraft:warped_stem"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:smoker",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:smoker"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:smooth_quartz"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:smooth_quartz"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:smooth_quartz"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:smooth_quartz_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:smooth_quartz_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:smooth_quartz"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:smooth_quartz"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:smooth_quartz"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:smooth_quartz"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:smooth_quartz"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:smooth_quartz"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:smooth_quartz_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:smooth_quartz_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:smooth_red_sandstone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:smooth_red_sandstone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:smooth_red_sandstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:smooth_red_sandstone_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:smooth_red_sandstone_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:smooth_red_sandstone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:smooth_red_sandstone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:smooth_red_sandstone"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:smooth_red_sandstone"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:smooth_red_sandstone"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:smooth_red_sandstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:smooth_red_sandstone_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:smooth_red_sandstone_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:smooth_sandstone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:smooth_sandstone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:smooth_sandstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:smooth_sandstone_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:smooth_sandstone_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:smooth_sandstone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:smooth_sandstone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:smooth_sandstone"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:smooth_sandstone"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:smooth_sandstone"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:smooth_sandstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:smooth_sandstone_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:smooth_sandstone_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:smooth_stone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:smooth_stone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:smooth_stone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:smooth_stone_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:smooth_stone_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:snout_armor_trim_smithing_template"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:blackstone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:snout_armor_trim_smithing_template",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:snout_armor_trim_smithing_template"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:snow_block"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:snow_block"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:snow_block"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:snow",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:snow"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:snowball"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:snowball"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:snowball"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:snowball"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:snow_block",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:snow_block"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:soul_sand",
+					"minecraft:soul_soil"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:acacia_log",
+					"minecraft:acacia_wood",
+					"minecraft:birch_log",
+					"minecraft:birch_wood",
+					"minecraft:cherry_log",
+					"minecraft:cherry_wood",
+					"minecraft:crimson_hyphae",
+					"minecraft:crimson_stem",
+					"minecraft:dark_oak_log",
+					"minecraft:dark_oak_wood",
+					"minecraft:jungle_log",
+					"minecraft:jungle_wood",
+					"minecraft:mangrove_log",
+					"minecraft:mangrove_wood",
+					"minecraft:oak_log",
+					"minecraft:oak_wood",
+					"minecraft:pale_oak_log",
+					"minecraft:pale_oak_wood",
+					"minecraft:spruce_log",
+					"minecraft:spruce_wood",
+					"minecraft:stripped_acacia_log",
+					"minecraft:stripped_acacia_wood",
+					"minecraft:stripped_birch_log",
+					"minecraft:stripped_birch_wood",
+					"minecraft:stripped_cherry_log",
+					"minecraft:stripped_cherry_wood",
+					"minecraft:stripped_crimson_hyphae",
+					"minecraft:stripped_crimson_stem",
+					"minecraft:stripped_dark_oak_log",
+					"minecraft:stripped_dark_oak_wood",
+					"minecraft:stripped_jungle_log",
+					"minecraft:stripped_jungle_wood",
+					"minecraft:stripped_mangrove_log",
+					"minecraft:stripped_mangrove_wood",
+					"minecraft:stripped_oak_log",
+					"minecraft:stripped_oak_wood",
+					"minecraft:stripped_pale_oak_log",
+					"minecraft:stripped_pale_oak_wood",
+					"minecraft:stripped_spruce_log",
+					"minecraft:stripped_spruce_wood",
+					"minecraft:stripped_warped_hyphae",
+					"minecraft:stripped_warped_stem",
+					"minecraft:warped_hyphae",
+					"minecraft:warped_stem"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:acacia_log",
+					"minecraft:acacia_wood",
+					"minecraft:birch_log",
+					"minecraft:birch_wood",
+					"minecraft:cherry_log",
+					"minecraft:cherry_wood",
+					"minecraft:crimson_hyphae",
+					"minecraft:crimson_stem",
+					"minecraft:dark_oak_log",
+					"minecraft:dark_oak_wood",
+					"minecraft:jungle_log",
+					"minecraft:jungle_wood",
+					"minecraft:mangrove_log",
+					"minecraft:mangrove_wood",
+					"minecraft:oak_log",
+					"minecraft:oak_wood",
+					"minecraft:pale_oak_log",
+					"minecraft:pale_oak_wood",
+					"minecraft:spruce_log",
+					"minecraft:spruce_wood",
+					"minecraft:stripped_acacia_log",
+					"minecraft:stripped_acacia_wood",
+					"minecraft:stripped_birch_log",
+					"minecraft:stripped_birch_wood",
+					"minecraft:stripped_cherry_log",
+					"minecraft:stripped_cherry_wood",
+					"minecraft:stripped_crimson_hyphae",
+					"minecraft:stripped_crimson_stem",
+					"minecraft:stripped_dark_oak_log",
+					"minecraft:stripped_dark_oak_wood",
+					"minecraft:stripped_jungle_log",
+					"minecraft:stripped_jungle_wood",
+					"minecraft:stripped_mangrove_log",
+					"minecraft:stripped_mangrove_wood",
+					"minecraft:stripped_oak_log",
+					"minecraft:stripped_oak_wood",
+					"minecraft:stripped_pale_oak_log",
+					"minecraft:stripped_pale_oak_wood",
+					"minecraft:stripped_spruce_log",
+					"minecraft:stripped_spruce_wood",
+					"minecraft:stripped_warped_hyphae",
+					"minecraft:stripped_warped_stem",
+					"minecraft:warped_hyphae",
+					"minecraft:warped_stem"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:acacia_log",
+					"minecraft:acacia_wood",
+					"minecraft:birch_log",
+					"minecraft:birch_wood",
+					"minecraft:cherry_log",
+					"minecraft:cherry_wood",
+					"minecraft:crimson_hyphae",
+					"minecraft:crimson_stem",
+					"minecraft:dark_oak_log",
+					"minecraft:dark_oak_wood",
+					"minecraft:jungle_log",
+					"minecraft:jungle_wood",
+					"minecraft:mangrove_log",
+					"minecraft:mangrove_wood",
+					"minecraft:oak_log",
+					"minecraft:oak_wood",
+					"minecraft:pale_oak_log",
+					"minecraft:pale_oak_wood",
+					"minecraft:spruce_log",
+					"minecraft:spruce_wood",
+					"minecraft:stripped_acacia_log",
+					"minecraft:stripped_acacia_wood",
+					"minecraft:stripped_birch_log",
+					"minecraft:stripped_birch_wood",
+					"minecraft:stripped_cherry_log",
+					"minecraft:stripped_cherry_wood",
+					"minecraft:stripped_crimson_hyphae",
+					"minecraft:stripped_crimson_stem",
+					"minecraft:stripped_dark_oak_log",
+					"minecraft:stripped_dark_oak_wood",
+					"minecraft:stripped_jungle_log",
+					"minecraft:stripped_jungle_wood",
+					"minecraft:stripped_mangrove_log",
+					"minecraft:stripped_mangrove_wood",
+					"minecraft:stripped_oak_log",
+					"minecraft:stripped_oak_wood",
+					"minecraft:stripped_pale_oak_log",
+					"minecraft:stripped_pale_oak_wood",
+					"minecraft:stripped_spruce_log",
+					"minecraft:stripped_spruce_wood",
+					"minecraft:stripped_warped_hyphae",
+					"minecraft:stripped_warped_stem",
+					"minecraft:warped_hyphae",
+					"minecraft:warped_stem"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:soul_campfire",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:soul_campfire"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:soul_torch"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:iron_nugget"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:soul_lantern",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:soul_lantern"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:charcoal",
+					"minecraft:coal"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:soul_sand",
+					"minecraft:soul_soil"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:soul_torch",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:soul_torch"
+		},
+		"shape": [
+			"a",
+			"b",
+			"c"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:glowstone_dust"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glowstone_dust"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:arrow"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glowstone_dust"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glowstone_dust"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:spectral_arrow",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:spectral_arrow"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:spire_armor_trim_smithing_template"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:purpur_block"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:spire_armor_trim_smithing_template",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:spire_armor_trim_smithing_template"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "boat",
+		"key": "minecraft:spruce_boat",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:spruce_boat"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wooden_button",
+		"key": "minecraft:spruce_button",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:spruce_button"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:chest"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:spruce_boat"
+				],
+				"type": "material"
+			}
+		],
+		"group": "chest_boat",
+		"key": "minecraft:spruce_chest_boat",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:spruce_chest_boat"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_door",
+		"key": "minecraft:spruce_door",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:spruce_door"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence",
+		"key": "minecraft:spruce_fence",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:spruce_fence"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence_gate",
+		"key": "minecraft:spruce_fence_gate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:spruce_fence_gate"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_spruce_log"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stripped_spruce_log"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stripped_spruce_log"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:stripped_spruce_log"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stripped_spruce_log"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:stripped_spruce_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "hanging_sign",
+		"key": "minecraft:spruce_hanging_sign",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:spruce_hanging_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:spruce_log",
+					"minecraft:spruce_wood",
+					"minecraft:stripped_spruce_log",
+					"minecraft:stripped_spruce_wood"
+				],
+				"type": "material"
+			}
+		],
+		"group": "planks",
+		"key": "minecraft:spruce_planks",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:spruce_planks"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_pressure_plate",
+		"key": "minecraft:spruce_pressure_plate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:spruce_pressure_plate"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_sign",
+		"key": "minecraft:spruce_sign",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:spruce_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_slab",
+		"key": "minecraft:spruce_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:spruce_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_stairs",
+		"key": "minecraft:spruce_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:spruce_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:spruce_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_trapdoor",
+		"key": "minecraft:spruce_trapdoor",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:spruce_trapdoor"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:spruce_log"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:spruce_log"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:spruce_log"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:spruce_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bark",
+		"key": "minecraft:spruce_wood",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:spruce_wood"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:amethyst_shard"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:copper_ingot"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:spyglass",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:spyglass"
+		},
+		"shape": [
+			"a",
+			"b",
+			"c"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "sticks",
+		"key": "minecraft:stick",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:stick"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:bamboo"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:bamboo"
+				],
+				"type": "material"
+			}
+		},
+		"group": "sticks",
+		"key": "minecraft:stick_from_bamboo_item",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:stick"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:slime_ball"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:piston"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:sticky_piston",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:sticky_piston"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:blackstone",
+					"minecraft:cobbled_deepslate",
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:blackstone",
+					"minecraft:cobbled_deepslate",
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:blackstone",
+					"minecraft:cobbled_deepslate",
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:stone_axe",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:stone_axe"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stone_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stone_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stone_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:stone_brick_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:stone_brick_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stone_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stone_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stone_bricks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:stone_bricks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stone_bricks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:stone_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:stone_brick_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:stone_brick_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stone_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stone_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stone_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stone_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stone_bricks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stone_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:stone_brick_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:stone_brick_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:stone_bricks",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:stone_bricks"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:stone_button",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:stone_button"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:blackstone",
+					"minecraft:cobbled_deepslate",
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:blackstone",
+					"minecraft:cobbled_deepslate",
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:stone_hoe",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:stone_hoe"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:blackstone",
+					"minecraft:cobbled_deepslate",
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:blackstone",
+					"minecraft:cobbled_deepslate",
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:blackstone",
+					"minecraft:cobbled_deepslate",
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:stone_pickaxe",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:stone_pickaxe"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:stone_pressure_plate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:stone_pressure_plate"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:blackstone",
+					"minecraft:cobbled_deepslate",
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:stone_shovel",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:stone_shovel"
+		},
+		"shape": [
+			"a",
+			"b",
+			"c"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:stone_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:stone_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:stone_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:stone_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:blackstone",
+					"minecraft:cobbled_deepslate",
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:blackstone",
+					"minecraft:cobbled_deepslate",
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:stone_sword",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:stone_sword"
+		},
+		"shape": [
+			"a",
+			"b",
+			"c"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:stonecutter",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:stonecutter"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stripped_acacia_log"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stripped_acacia_log"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stripped_acacia_log"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_acacia_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bark",
+		"key": "minecraft:stripped_acacia_wood",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:stripped_acacia_wood"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stripped_birch_log"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stripped_birch_log"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stripped_birch_log"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_birch_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bark",
+		"key": "minecraft:stripped_birch_wood",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:stripped_birch_wood"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stripped_cherry_log"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stripped_cherry_log"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stripped_cherry_log"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_cherry_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bark",
+		"key": "minecraft:stripped_cherry_wood",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:stripped_cherry_wood"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stripped_crimson_stem"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stripped_crimson_stem"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stripped_crimson_stem"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_crimson_stem"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bark",
+		"key": "minecraft:stripped_crimson_hyphae",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:stripped_crimson_hyphae"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stripped_dark_oak_log"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stripped_dark_oak_log"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stripped_dark_oak_log"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_dark_oak_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bark",
+		"key": "minecraft:stripped_dark_oak_wood",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:stripped_dark_oak_wood"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stripped_jungle_log"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stripped_jungle_log"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stripped_jungle_log"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_jungle_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bark",
+		"key": "minecraft:stripped_jungle_wood",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:stripped_jungle_wood"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stripped_mangrove_log"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stripped_mangrove_log"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stripped_mangrove_log"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_mangrove_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bark",
+		"key": "minecraft:stripped_mangrove_wood",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:stripped_mangrove_wood"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stripped_oak_log"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stripped_oak_log"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stripped_oak_log"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_oak_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bark",
+		"key": "minecraft:stripped_oak_wood",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:stripped_oak_wood"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stripped_pale_oak_log"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stripped_pale_oak_log"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stripped_pale_oak_log"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_pale_oak_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bark",
+		"key": "minecraft:stripped_pale_oak_wood",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:stripped_pale_oak_wood"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stripped_spruce_log"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stripped_spruce_log"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stripped_spruce_log"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_spruce_log"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bark",
+		"key": "minecraft:stripped_spruce_wood",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:stripped_spruce_wood"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stripped_warped_stem"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stripped_warped_stem"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stripped_warped_stem"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_warped_stem"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bark",
+		"key": "minecraft:stripped_warped_hyphae",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:stripped_warped_hyphae"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:honey_bottle"
+				],
+				"type": "material"
+			}
+		],
+		"group": "sugar",
+		"key": "minecraft:sugar_from_honey_bottle",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:sugar"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:sugar_cane"
+				],
+				"type": "material"
+			}
+		],
+		"group": "sugar",
+		"key": "minecraft:sugar_from_sugar_cane",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:sugar"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bowl"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:brown_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:allium"
+				],
+				"type": "material"
+			}
+		],
+		"group": "suspicious_stew",
+		"key": "minecraft:suspicious_stew_from_allium",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:suspicious_stew"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bowl"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:brown_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:azure_bluet"
+				],
+				"type": "material"
+			}
+		],
+		"group": "suspicious_stew",
+		"key": "minecraft:suspicious_stew_from_azure_bluet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:suspicious_stew"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bowl"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:brown_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:blue_orchid"
+				],
+				"type": "material"
+			}
+		],
+		"group": "suspicious_stew",
+		"key": "minecraft:suspicious_stew_from_blue_orchid",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:suspicious_stew"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bowl"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:brown_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:closed_eyeblossom"
+				],
+				"type": "material"
+			}
+		],
+		"group": "suspicious_stew",
+		"key": "minecraft:suspicious_stew_from_closed_eyeblossom",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:suspicious_stew"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bowl"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:brown_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:cornflower"
+				],
+				"type": "material"
+			}
+		],
+		"group": "suspicious_stew",
+		"key": "minecraft:suspicious_stew_from_cornflower",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:suspicious_stew"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bowl"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:brown_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:dandelion"
+				],
+				"type": "material"
+			}
+		],
+		"group": "suspicious_stew",
+		"key": "minecraft:suspicious_stew_from_dandelion",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:suspicious_stew"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bowl"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:brown_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:lily_of_the_valley"
+				],
+				"type": "material"
+			}
+		],
+		"group": "suspicious_stew",
+		"key": "minecraft:suspicious_stew_from_lily_of_the_valley",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:suspicious_stew"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bowl"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:brown_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:open_eyeblossom"
+				],
+				"type": "material"
+			}
+		],
+		"group": "suspicious_stew",
+		"key": "minecraft:suspicious_stew_from_open_eyeblossom",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:suspicious_stew"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bowl"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:brown_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:orange_tulip"
+				],
+				"type": "material"
+			}
+		],
+		"group": "suspicious_stew",
+		"key": "minecraft:suspicious_stew_from_orange_tulip",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:suspicious_stew"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bowl"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:brown_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:oxeye_daisy"
+				],
+				"type": "material"
+			}
+		],
+		"group": "suspicious_stew",
+		"key": "minecraft:suspicious_stew_from_oxeye_daisy",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:suspicious_stew"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bowl"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:brown_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:pink_tulip"
+				],
+				"type": "material"
+			}
+		],
+		"group": "suspicious_stew",
+		"key": "minecraft:suspicious_stew_from_pink_tulip",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:suspicious_stew"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bowl"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:brown_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:poppy"
+				],
+				"type": "material"
+			}
+		],
+		"group": "suspicious_stew",
+		"key": "minecraft:suspicious_stew_from_poppy",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:suspicious_stew"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bowl"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:brown_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_tulip"
+				],
+				"type": "material"
+			}
+		],
+		"group": "suspicious_stew",
+		"key": "minecraft:suspicious_stew_from_red_tulip",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:suspicious_stew"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bowl"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:brown_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:torchflower"
+				],
+				"type": "material"
+			}
+		],
+		"group": "suspicious_stew",
+		"key": "minecraft:suspicious_stew_from_torchflower",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:suspicious_stew"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bowl"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:brown_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:white_tulip"
+				],
+				"type": "material"
+			}
+		],
+		"group": "suspicious_stew",
+		"key": "minecraft:suspicious_stew_from_white_tulip",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:suspicious_stew"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bowl"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:brown_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:red_mushroom"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:wither_rose"
+				],
+				"type": "material"
+			}
+		],
+		"group": "suspicious_stew",
+		"key": "minecraft:suspicious_stew_from_wither_rose",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:suspicious_stew"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:hay_block"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:target",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:target"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:tide_armor_trim_smithing_template"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:prismarine"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:tide_armor_trim_smithing_template",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:tide_armor_trim_smithing_template"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:amethyst_shard"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:amethyst_shard"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:amethyst_shard"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:amethyst_shard"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:tinted_glass",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:tinted_glass"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"key": "minecraft:tipped_arrow",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		},
+		"type": "complex"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:gunpowder"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:red_sand",
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:gunpowder"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:red_sand",
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:gunpowder"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:red_sand",
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:gunpowder"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:red_sand",
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:gunpowder"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:tnt",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:tnt"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:tnt"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:minecart"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:tnt_minecart",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:tnt_minecart"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:charcoal",
+					"minecraft:coal"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:torch",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:torch"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:chest"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:tripwire_hook"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:trapped_chest",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:trapped_chest"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:iron_ingot"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:tripwire_hook",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:tripwire_hook"
+		},
+		"shape": [
+			"a",
+			"b",
+			"c"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:tuff_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:tuff_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:tuff_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:tuff_brick_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:tuff_brick_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:tuff_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:tuff_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:tuff_bricks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:tuff_bricks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:tuff_bricks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:tuff_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:tuff_brick_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:tuff_brick_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:tuff_bricks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:tuff_bricks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:tuff_bricks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:tuff_bricks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:tuff_bricks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:tuff_bricks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:tuff_brick_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:tuff_brick_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:polished_tuff"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:polished_tuff"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:polished_tuff"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:polished_tuff"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:tuff_bricks",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:tuff_bricks"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:tuff"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:tuff"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:tuff"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:tuff_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:tuff_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:tuff"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:tuff"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:tuff"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:tuff"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:tuff"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:tuff"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:tuff_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:tuff_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:tuff"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:tuff"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:tuff"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:tuff"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:tuff"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:tuff"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:tuff_wall",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:tuff_wall"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:turtle_scute"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:turtle_scute"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:turtle_scute"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:turtle_scute"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:turtle_scute"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:turtle_helmet",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:turtle_helmet"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:vex_armor_trim_smithing_template"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:cobblestone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:vex_armor_trim_smithing_template",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:vex_armor_trim_smithing_template"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:ward_armor_trim_smithing_template"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:cobbled_deepslate"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:ward_armor_trim_smithing_template",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:ward_armor_trim_smithing_template"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		],
+		"group": "wooden_button",
+		"key": "minecraft:warped_button",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:warped_button"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_door",
+		"key": "minecraft:warped_door",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:warped_door"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence",
+		"key": "minecraft:warped_fence",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:warped_fence"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_fence_gate",
+		"key": "minecraft:warped_fence_gate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:warped_fence_gate"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:fishing_rod"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:warped_fungus"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:warped_fungus_on_a_stick",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:warped_fungus_on_a_stick"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:chain"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stripped_warped_stem"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stripped_warped_stem"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stripped_warped_stem"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:stripped_warped_stem"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stripped_warped_stem"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:stripped_warped_stem"
+				],
+				"type": "material"
+			}
+		},
+		"group": "hanging_sign",
+		"key": "minecraft:warped_hanging_sign",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:warped_hanging_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:warped_stem"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:warped_stem"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:warped_stem"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:warped_stem"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bark",
+		"key": "minecraft:warped_hyphae",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:warped_hyphae"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:stripped_warped_hyphae",
+					"minecraft:stripped_warped_stem",
+					"minecraft:warped_hyphae",
+					"minecraft:warped_stem"
+				],
+				"type": "material"
+			}
+		],
+		"group": "planks",
+		"key": "minecraft:warped_planks",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:warped_planks"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_pressure_plate",
+		"key": "minecraft:warped_pressure_plate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:warped_pressure_plate"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_sign",
+		"key": "minecraft:warped_sign",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:warped_sign"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_slab",
+		"key": "minecraft:warped_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:warped_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_stairs",
+		"key": "minecraft:warped_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:warped_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "wooden_trapdoor",
+		"key": "minecraft:warped_trapdoor",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:warped_trapdoor"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:waxed_cut_copper_slab"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:waxed_cut_copper_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "waxed_cut_copper_chiseled",
+		"key": "minecraft:waxed_chiseled_copper",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_chiseled_copper"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:chiseled_copper"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_chiseled_copper",
+		"key": "minecraft:waxed_chiseled_copper_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_chiseled_copper"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:copper_block"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_copper_block",
+		"key": "minecraft:waxed_copper_block_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_copper_block"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:waxed_copper_block"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:waxed_copper_block"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:blaze_rod"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:waxed_copper_block"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:waxed_copper_bulb",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_copper_bulb"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:copper_bulb"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_copper_bulb",
+		"key": "minecraft:waxed_copper_bulb_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_copper_bulb"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:copper_door"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_copper_door",
+		"key": "minecraft:waxed_copper_door_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_copper_door"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:waxed_copper_block"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:waxed_copper_block"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:waxed_copper_block"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:waxed_copper_block"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:waxed_copper_grate",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_copper_grate"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:copper_grate"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_copper_grate",
+		"key": "minecraft:waxed_copper_grate_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_copper_grate"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:copper_trapdoor"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_copper_trapdoor",
+		"key": "minecraft:waxed_copper_trapdoor_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_copper_trapdoor"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:waxed_copper_block"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:waxed_copper_block"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:waxed_copper_block"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:waxed_copper_block"
+				],
+				"type": "material"
+			}
+		},
+		"group": "waxed_cut_copper",
+		"key": "minecraft:waxed_cut_copper",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_cut_copper"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:cut_copper"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_cut_copper",
+		"key": "minecraft:waxed_cut_copper_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_cut_copper"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:waxed_cut_copper"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:waxed_cut_copper"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:waxed_cut_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "waxed_cut_copper_slab",
+		"key": "minecraft:waxed_cut_copper_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:waxed_cut_copper_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:cut_copper_slab"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_cut_copper_slab",
+		"key": "minecraft:waxed_cut_copper_slab_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_cut_copper_slab"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:waxed_cut_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:waxed_cut_copper"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:waxed_cut_copper"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:waxed_cut_copper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:waxed_cut_copper"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:waxed_cut_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "waxed_cut_copper_stairs",
+		"key": "minecraft:waxed_cut_copper_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_cut_copper_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:cut_copper_stairs"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_cut_copper_stairs",
+		"key": "minecraft:waxed_cut_copper_stairs_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_cut_copper_stairs"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:waxed_exposed_cut_copper_slab"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:waxed_exposed_cut_copper_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "waxed_exposed_cut_copper_chiseled",
+		"key": "minecraft:waxed_exposed_chiseled_copper",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_exposed_chiseled_copper"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:exposed_chiseled_copper"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_exposed_chiseled_copper",
+		"key": "minecraft:waxed_exposed_chiseled_copper_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_exposed_chiseled_copper"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:waxed_exposed_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:waxed_exposed_copper"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:blaze_rod"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:waxed_exposed_copper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:waxed_exposed_copper_bulb",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_exposed_copper_bulb"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:exposed_copper_bulb"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_exposed_copper_bulb",
+		"key": "minecraft:waxed_exposed_copper_bulb_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_exposed_copper_bulb"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:exposed_copper_door"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_exposed_copper_door",
+		"key": "minecraft:waxed_exposed_copper_door_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_exposed_copper_door"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:exposed_copper"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_exposed_copper",
+		"key": "minecraft:waxed_exposed_copper_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_exposed_copper"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:waxed_exposed_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:waxed_exposed_copper"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:waxed_exposed_copper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:waxed_exposed_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:waxed_exposed_copper_grate",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_exposed_copper_grate"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:exposed_copper_grate"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_exposed_copper_grate",
+		"key": "minecraft:waxed_exposed_copper_grate_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_exposed_copper_grate"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:exposed_copper_trapdoor"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_exposed_copper_trapdoor",
+		"key": "minecraft:waxed_exposed_copper_trapdoor_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_exposed_copper_trapdoor"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:waxed_exposed_copper"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:waxed_exposed_copper"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:waxed_exposed_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:waxed_exposed_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "waxed_exposed_cut_copper",
+		"key": "minecraft:waxed_exposed_cut_copper",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_exposed_cut_copper"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:exposed_cut_copper"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_exposed_cut_copper",
+		"key": "minecraft:waxed_exposed_cut_copper_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_exposed_cut_copper"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:waxed_exposed_cut_copper"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:waxed_exposed_cut_copper"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:waxed_exposed_cut_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "waxed_exposed_cut_copper_slab",
+		"key": "minecraft:waxed_exposed_cut_copper_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:waxed_exposed_cut_copper_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:exposed_cut_copper_slab"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_exposed_cut_copper_slab",
+		"key": "minecraft:waxed_exposed_cut_copper_slab_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_exposed_cut_copper_slab"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:waxed_exposed_cut_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:waxed_exposed_cut_copper"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:waxed_exposed_cut_copper"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:waxed_exposed_cut_copper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:waxed_exposed_cut_copper"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:waxed_exposed_cut_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "waxed_exposed_cut_copper_stairs",
+		"key": "minecraft:waxed_exposed_cut_copper_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_exposed_cut_copper_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:exposed_cut_copper_stairs"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_exposed_cut_copper_stairs",
+		"key": "minecraft:waxed_exposed_cut_copper_stairs_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_exposed_cut_copper_stairs"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:waxed_oxidized_cut_copper_slab"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:waxed_oxidized_cut_copper_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "waxed_oxidized_cut_copper_chiseled",
+		"key": "minecraft:waxed_oxidized_chiseled_copper",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_oxidized_chiseled_copper"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:oxidized_chiseled_copper"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_oxidized_chiseled_copper",
+		"key": "minecraft:waxed_oxidized_chiseled_copper_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_oxidized_chiseled_copper"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:waxed_oxidized_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:waxed_oxidized_copper"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:blaze_rod"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:waxed_oxidized_copper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:waxed_oxidized_copper_bulb",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_oxidized_copper_bulb"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:oxidized_copper_bulb"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_oxidized_copper_bulb",
+		"key": "minecraft:waxed_oxidized_copper_bulb_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_oxidized_copper_bulb"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:oxidized_copper_door"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_oxidized_copper_door",
+		"key": "minecraft:waxed_oxidized_copper_door_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_oxidized_copper_door"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:oxidized_copper"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_oxidized_copper",
+		"key": "minecraft:waxed_oxidized_copper_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_oxidized_copper"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:waxed_oxidized_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:waxed_oxidized_copper"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:waxed_oxidized_copper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:waxed_oxidized_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:waxed_oxidized_copper_grate",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_oxidized_copper_grate"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:oxidized_copper_grate"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_oxidized_copper_grate",
+		"key": "minecraft:waxed_oxidized_copper_grate_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_oxidized_copper_grate"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:oxidized_copper_trapdoor"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_oxidized_copper_trapdoor",
+		"key": "minecraft:waxed_oxidized_copper_trapdoor_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_oxidized_copper_trapdoor"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:waxed_oxidized_copper"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:waxed_oxidized_copper"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:waxed_oxidized_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:waxed_oxidized_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "waxed_oxidized_cut_copper",
+		"key": "minecraft:waxed_oxidized_cut_copper",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_oxidized_cut_copper"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:oxidized_cut_copper"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_oxidized_cut_copper",
+		"key": "minecraft:waxed_oxidized_cut_copper_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_oxidized_cut_copper"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:waxed_oxidized_cut_copper"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:waxed_oxidized_cut_copper"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:waxed_oxidized_cut_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "waxed_oxidized_cut_copper_slab",
+		"key": "minecraft:waxed_oxidized_cut_copper_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:waxed_oxidized_cut_copper_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:oxidized_cut_copper_slab"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_oxidized_cut_copper_slab",
+		"key": "minecraft:waxed_oxidized_cut_copper_slab_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_oxidized_cut_copper_slab"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:waxed_oxidized_cut_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:waxed_oxidized_cut_copper"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:waxed_oxidized_cut_copper"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:waxed_oxidized_cut_copper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:waxed_oxidized_cut_copper"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:waxed_oxidized_cut_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "waxed_oxidized_cut_copper_stairs",
+		"key": "minecraft:waxed_oxidized_cut_copper_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_oxidized_cut_copper_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:oxidized_cut_copper_stairs"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_oxidized_cut_copper_stairs",
+		"key": "minecraft:waxed_oxidized_cut_copper_stairs_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_oxidized_cut_copper_stairs"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:waxed_weathered_cut_copper_slab"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:waxed_weathered_cut_copper_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "waxed_weathered_cut_copper_chiseled",
+		"key": "minecraft:waxed_weathered_chiseled_copper",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_weathered_chiseled_copper"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:weathered_chiseled_copper"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_weathered_chiseled_copper",
+		"key": "minecraft:waxed_weathered_chiseled_copper_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_weathered_chiseled_copper"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:waxed_weathered_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:waxed_weathered_copper"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:blaze_rod"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:waxed_weathered_copper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:waxed_weathered_copper_bulb",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_weathered_copper_bulb"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:weathered_copper_bulb"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_weathered_copper_bulb",
+		"key": "minecraft:waxed_weathered_copper_bulb_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_weathered_copper_bulb"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:weathered_copper_door"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_weathered_copper_door",
+		"key": "minecraft:waxed_weathered_copper_door_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_weathered_copper_door"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:weathered_copper"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_weathered_copper",
+		"key": "minecraft:waxed_weathered_copper_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_weathered_copper"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:waxed_weathered_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:waxed_weathered_copper"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:waxed_weathered_copper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:waxed_weathered_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:waxed_weathered_copper_grate",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_weathered_copper_grate"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:weathered_copper_grate"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_weathered_copper_grate",
+		"key": "minecraft:waxed_weathered_copper_grate_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_weathered_copper_grate"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:weathered_copper_trapdoor"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_weathered_copper_trapdoor",
+		"key": "minecraft:waxed_weathered_copper_trapdoor_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_weathered_copper_trapdoor"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:waxed_weathered_copper"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:waxed_weathered_copper"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:waxed_weathered_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:waxed_weathered_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "waxed_weathered_cut_copper",
+		"key": "minecraft:waxed_weathered_cut_copper",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_weathered_cut_copper"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:weathered_cut_copper"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_weathered_cut_copper",
+		"key": "minecraft:waxed_weathered_cut_copper_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_weathered_cut_copper"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:waxed_weathered_cut_copper"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:waxed_weathered_cut_copper"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:waxed_weathered_cut_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "waxed_weathered_cut_copper_slab",
+		"key": "minecraft:waxed_weathered_cut_copper_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:waxed_weathered_cut_copper_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:weathered_cut_copper_slab"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_weathered_cut_copper_slab",
+		"key": "minecraft:waxed_weathered_cut_copper_slab_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_weathered_cut_copper_slab"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:waxed_weathered_cut_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:waxed_weathered_cut_copper"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:waxed_weathered_cut_copper"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:waxed_weathered_cut_copper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:waxed_weathered_cut_copper"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:waxed_weathered_cut_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "waxed_weathered_cut_copper_stairs",
+		"key": "minecraft:waxed_weathered_cut_copper_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_weathered_cut_copper_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:weathered_cut_copper_stairs"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:honeycomb"
+				],
+				"type": "material"
+			}
+		],
+		"group": "waxed_weathered_cut_copper_stairs",
+		"key": "minecraft:waxed_weathered_cut_copper_stairs_from_honeycomb",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_weathered_cut_copper_stairs"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:wayfinder_armor_trim_smithing_template"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:wayfinder_armor_trim_smithing_template",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:wayfinder_armor_trim_smithing_template"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:weathered_cut_copper_slab"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:weathered_cut_copper_slab"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:weathered_chiseled_copper",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:weathered_chiseled_copper"
+		},
+		"shape": [
+			"a",
+			"b"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "REDSTONE",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:weathered_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:weathered_copper"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:blaze_rod"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:weathered_copper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:redstone"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:weathered_copper_bulb",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:weathered_copper_bulb"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"b": {
+				"choices": [
+					"minecraft:weathered_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:weathered_copper"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:weathered_copper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:weathered_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:weathered_copper_grate",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:weathered_copper_grate"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:weathered_copper"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:weathered_copper"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:weathered_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:weathered_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:weathered_cut_copper",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:weathered_cut_copper"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:weathered_cut_copper"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:weathered_cut_copper"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:weathered_cut_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:weathered_cut_copper_slab",
+		"result": {
+			"amount": 6,
+			"type": "minecraft:weathered_cut_copper_slab"
+		},
+		"shape": [
+			"abc"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:weathered_cut_copper"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:weathered_cut_copper"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:weathered_cut_copper"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:weathered_cut_copper"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:weathered_cut_copper"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:weathered_cut_copper"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:weathered_cut_copper_stairs",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:weathered_cut_copper_stairs"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:hay_block"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:wheat",
+		"result": {
+			"amount": 9,
+			"type": "minecraft:wheat"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:white_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:white_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:white_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:white_wool"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:white_wool"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:white_wool"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "banner",
+		"key": "minecraft:white_banner",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:white_banner"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:white_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:white_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:white_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bed",
+		"key": "minecraft:white_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:white_bed"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_bundle",
+				"minecraft:blue_bundle",
+				"minecraft:brown_bundle",
+				"minecraft:bundle",
+				"minecraft:cyan_bundle",
+				"minecraft:gray_bundle",
+				"minecraft:green_bundle",
+				"minecraft:light_blue_bundle",
+				"minecraft:light_gray_bundle",
+				"minecraft:lime_bundle",
+				"minecraft:magenta_bundle",
+				"minecraft:orange_bundle",
+				"minecraft:pink_bundle",
+				"minecraft:purple_bundle",
+				"minecraft:red_bundle",
+				"minecraft:white_bundle",
+				"minecraft:yellow_bundle"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:white_bundle",
+		"material": {
+			"choices": [
+				"minecraft:white_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:white_bundle"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:candle"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:white_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "dyed_candle",
+		"key": "minecraft:white_candle",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:white_candle"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:white_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:white_wool"
+				],
+				"type": "material"
+			}
+		},
+		"group": "carpet",
+		"key": "minecraft:white_carpet",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:white_carpet"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:white_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			}
+		],
+		"group": "concrete_powder",
+		"key": "minecraft:white_concrete_powder",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:white_concrete_powder"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:bone_meal"
+				],
+				"type": "material"
+			}
+		],
+		"group": "white_dye",
+		"key": "minecraft:white_dye",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:white_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:lily_of_the_valley"
+				],
+				"type": "material"
+			}
+		],
+		"group": "white_dye",
+		"key": "minecraft:white_dye_from_lily_of_the_valley",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:white_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_shulker_box",
+				"minecraft:blue_shulker_box",
+				"minecraft:brown_shulker_box",
+				"minecraft:cyan_shulker_box",
+				"minecraft:gray_shulker_box",
+				"minecraft:green_shulker_box",
+				"minecraft:light_blue_shulker_box",
+				"minecraft:light_gray_shulker_box",
+				"minecraft:lime_shulker_box",
+				"minecraft:magenta_shulker_box",
+				"minecraft:orange_shulker_box",
+				"minecraft:pink_shulker_box",
+				"minecraft:purple_shulker_box",
+				"minecraft:red_shulker_box",
+				"minecraft:shulker_box",
+				"minecraft:white_shulker_box",
+				"minecraft:yellow_shulker_box"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:white_shulker_box",
+		"material": {
+			"choices": [
+				"minecraft:white_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:white_shulker_box"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:white_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass",
+		"key": "minecraft:white_stained_glass",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:white_stained_glass"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:white_stained_glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:white_stained_glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:white_stained_glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:white_stained_glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:white_stained_glass"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:white_stained_glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:white_stained_glass_pane",
+		"result": {
+			"amount": 16,
+			"type": "minecraft:white_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:white_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:white_stained_glass_pane_from_glass_pane",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:white_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:white_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_terracotta",
+		"key": "minecraft:white_terracotta",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:white_terracotta"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:string"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:string"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:string"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:string"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:white_wool_from_string",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:white_wool"
+		},
+		"shape": [
+			"ab",
+			"cd"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:wild_armor_trim_smithing_template"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:mossy_cobblestone"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:diamond"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:wild_armor_trim_smithing_template",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:wild_armor_trim_smithing_template"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:breeze_rod"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:wind_charge",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:wind_charge"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:armadillo_scute"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:armadillo_scute"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:armadillo_scute"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:armadillo_scute"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:armadillo_scute"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:armadillo_scute"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:wolf_armor",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:wolf_armor"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:wooden_axe",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:wooden_axe"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:wooden_hoe",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:wooden_hoe"
+		},
+		"shape": [
+			"ab",
+			"cd",
+			"ef"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:wooden_pickaxe",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:wooden_pickaxe"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:wooden_shovel",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:wooden_shovel"
+		},
+		"shape": [
+			"a",
+			"b",
+			"c"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "EQUIPMENT",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "",
+		"key": "minecraft:wooden_sword",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:wooden_sword"
+		},
+		"shape": [
+			"a",
+			"b",
+			"c"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:book"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:ink_sac"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:feather"
+				],
+				"type": "material"
+			}
+		],
+		"group": "",
+		"key": "minecraft:writable_book",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:writable_book"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:stick"
+				],
+				"type": "material"
+			}
+		},
+		"group": "banner",
+		"key": "minecraft:yellow_banner",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:yellow_banner"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:acacia_planks",
+					"minecraft:bamboo_planks",
+					"minecraft:birch_planks",
+					"minecraft:cherry_planks",
+					"minecraft:crimson_planks",
+					"minecraft:dark_oak_planks",
+					"minecraft:jungle_planks",
+					"minecraft:mangrove_planks",
+					"minecraft:oak_planks",
+					"minecraft:pale_oak_planks",
+					"minecraft:spruce_planks",
+					"minecraft:warped_planks"
+				],
+				"type": "material"
+			}
+		},
+		"group": "bed",
+		"key": "minecraft:yellow_bed",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:yellow_bed"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_bundle",
+				"minecraft:blue_bundle",
+				"minecraft:brown_bundle",
+				"minecraft:bundle",
+				"minecraft:cyan_bundle",
+				"minecraft:gray_bundle",
+				"minecraft:green_bundle",
+				"minecraft:light_blue_bundle",
+				"minecraft:light_gray_bundle",
+				"minecraft:lime_bundle",
+				"minecraft:magenta_bundle",
+				"minecraft:orange_bundle",
+				"minecraft:pink_bundle",
+				"minecraft:purple_bundle",
+				"minecraft:red_bundle",
+				"minecraft:white_bundle",
+				"minecraft:yellow_bundle"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:yellow_bundle",
+		"material": {
+			"choices": [
+				"minecraft:yellow_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:yellow_bundle"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:candle"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:yellow_dye"
+				],
+				"type": "material"
+			}
+		],
+		"group": "dyed_candle",
+		"key": "minecraft:yellow_candle",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:yellow_candle"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:yellow_wool"
+				],
+				"type": "material"
+			}
+		},
+		"group": "carpet",
+		"key": "minecraft:yellow_carpet",
+		"result": {
+			"amount": 3,
+			"type": "minecraft:yellow_carpet"
+		},
+		"shape": [
+			"ab"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:yellow_dye"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:sand"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			},
+			{
+				"choices": [
+					"minecraft:gravel"
+				],
+				"type": "material"
+			}
+		],
+		"group": "concrete_powder",
+		"key": "minecraft:yellow_concrete_powder",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:yellow_concrete_powder"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:dandelion"
+				],
+				"type": "material"
+			}
+		],
+		"group": "yellow_dye",
+		"key": "minecraft:yellow_dye_from_dandelion",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:yellow_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"choices": [
+			{
+				"choices": [
+					"minecraft:sunflower"
+				],
+				"type": "material"
+			}
+		],
+		"group": "yellow_dye",
+		"key": "minecraft:yellow_dye_from_sunflower",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:yellow_dye"
+		},
+		"type": "shapeless"
+	},
+	{
+		"category": "MISC",
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_shulker_box",
+				"minecraft:blue_shulker_box",
+				"minecraft:brown_shulker_box",
+				"minecraft:cyan_shulker_box",
+				"minecraft:gray_shulker_box",
+				"minecraft:green_shulker_box",
+				"minecraft:light_blue_shulker_box",
+				"minecraft:light_gray_shulker_box",
+				"minecraft:lime_shulker_box",
+				"minecraft:magenta_shulker_box",
+				"minecraft:orange_shulker_box",
+				"minecraft:pink_shulker_box",
+				"minecraft:purple_shulker_box",
+				"minecraft:red_shulker_box",
+				"minecraft:shulker_box",
+				"minecraft:white_shulker_box",
+				"minecraft:yellow_shulker_box"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:yellow_shulker_box",
+		"material": {
+			"choices": [
+				"minecraft:yellow_dye"
+			],
+			"type": "material"
+		},
+		"result": {
+			"amount": 1,
+			"type": "minecraft:yellow_shulker_box"
+		},
+		"type": "transmute"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:yellow_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass",
+		"key": "minecraft:yellow_stained_glass",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:yellow_stained_glass"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:yellow_stained_glass"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:yellow_stained_glass"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:yellow_stained_glass"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:yellow_stained_glass"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:yellow_stained_glass"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:yellow_stained_glass"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:yellow_stained_glass_pane",
+		"result": {
+			"amount": 16,
+			"type": "minecraft:yellow_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "MISC",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:yellow_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:glass_pane"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_glass_pane",
+		"key": "minecraft:yellow_stained_glass_pane_from_glass_pane",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:yellow_stained_glass_pane"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	},
+	{
+		"category": "BUILDING",
+		"choiceMap": {
+			"a": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"b": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"c": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"d": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"e": {
+				"choices": [
+					"minecraft:yellow_dye"
+				],
+				"type": "material"
+			},
+			"f": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"g": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"h": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			},
+			"i": {
+				"choices": [
+					"minecraft:terracotta"
+				],
+				"type": "material"
+			}
+		},
+		"group": "stained_terracotta",
+		"key": "minecraft:yellow_terracotta",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:yellow_terracotta"
+		},
+		"shape": [
+			"abc",
+			"def",
+			"ghi"
+		],
+		"type": "shaped"
+	}
+]

--- a/src/main/resources/recipes/smelting.json
+++ b/src/main/resources/recipes/smelting.json
@@ -1,0 +1,1267 @@
+[
+	{
+		"category": "FOOD",
+		"cookingTime": 200,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:potato"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:baked_potato",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:baked_potato"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:black_terracotta"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:black_glazed_terracotta",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:black_glazed_terracotta"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:blue_terracotta"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:blue_glazed_terracotta",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:blue_glazed_terracotta"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 0.3,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:clay_ball"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:brick",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:brick"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:brown_terracotta"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:brown_glazed_terracotta",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:brown_glazed_terracotta"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 0.15,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:acacia_log",
+				"minecraft:acacia_wood",
+				"minecraft:birch_log",
+				"minecraft:birch_wood",
+				"minecraft:cherry_log",
+				"minecraft:cherry_wood",
+				"minecraft:dark_oak_log",
+				"minecraft:dark_oak_wood",
+				"minecraft:jungle_log",
+				"minecraft:jungle_wood",
+				"minecraft:mangrove_log",
+				"minecraft:mangrove_wood",
+				"minecraft:oak_log",
+				"minecraft:oak_wood",
+				"minecraft:pale_oak_log",
+				"minecraft:pale_oak_wood",
+				"minecraft:spruce_log",
+				"minecraft:spruce_wood",
+				"minecraft:stripped_acacia_log",
+				"minecraft:stripped_acacia_wood",
+				"minecraft:stripped_birch_log",
+				"minecraft:stripped_birch_wood",
+				"minecraft:stripped_cherry_log",
+				"minecraft:stripped_cherry_wood",
+				"minecraft:stripped_dark_oak_log",
+				"minecraft:stripped_dark_oak_wood",
+				"minecraft:stripped_jungle_log",
+				"minecraft:stripped_jungle_wood",
+				"minecraft:stripped_mangrove_log",
+				"minecraft:stripped_mangrove_wood",
+				"minecraft:stripped_oak_log",
+				"minecraft:stripped_oak_wood",
+				"minecraft:stripped_pale_oak_log",
+				"minecraft:stripped_pale_oak_wood",
+				"minecraft:stripped_spruce_log",
+				"minecraft:stripped_spruce_wood"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:charcoal",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:charcoal"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "coal",
+		"input": {
+			"choices": [
+				"minecraft:coal_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:coal_from_smelting_coal_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:coal"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "coal",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_coal_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:coal_from_smelting_deepslate_coal_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:coal"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 200,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:beef"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cooked_beef",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cooked_beef"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 200,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:chicken"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cooked_chicken",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cooked_chicken"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 200,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cod"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cooked_cod",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cooked_cod"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 200,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:mutton"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cooked_mutton",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cooked_mutton"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 200,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:porkchop"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cooked_porkchop",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cooked_porkchop"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 200,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:rabbit"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cooked_rabbit",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cooked_rabbit"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 200,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:salmon"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cooked_salmon",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cooked_salmon"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 0.7,
+		"group": "copper_ingot",
+		"input": {
+			"choices": [
+				"minecraft:copper_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:copper_ingot_from_smelting_copper_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:copper_ingot"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 0.7,
+		"group": "copper_ingot",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_copper_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:copper_ingot_from_smelting_deepslate_copper_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:copper_ingot"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 0.7,
+		"group": "copper_ingot",
+		"input": {
+			"choices": [
+				"minecraft:raw_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:copper_ingot_from_smelting_raw_copper",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:copper_ingot"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cracked_deepslate_bricks",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cracked_deepslate_bricks"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_tiles"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cracked_deepslate_tiles",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cracked_deepslate_tiles"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:nether_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cracked_nether_bricks",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cracked_nether_bricks"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_blackstone_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cracked_polished_blackstone_bricks",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cracked_polished_blackstone_bricks"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:stone_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cracked_stone_bricks",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cracked_stone_bricks"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cyan_terracotta"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cyan_glazed_terracotta",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cyan_glazed_terracotta"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cobbled_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:deepslate"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 1.0,
+		"group": "diamond",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_diamond_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:diamond_from_smelting_deepslate_diamond_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:diamond"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 1.0,
+		"group": "diamond",
+		"input": {
+			"choices": [
+				"minecraft:diamond_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:diamond_from_smelting_diamond_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:diamond"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:kelp"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:dried_kelp_from_smelting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:dried_kelp"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 1.0,
+		"group": "emerald",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_emerald_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:emerald_from_smelting_deepslate_emerald_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:emerald"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 1.0,
+		"group": "emerald",
+		"input": {
+			"choices": [
+				"minecraft:emerald_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:emerald_from_smelting_emerald_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:emerald"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:red_sand",
+				"minecraft:sand"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:glass",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:glass"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 1.0,
+		"group": "gold_ingot",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_gold_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:gold_ingot_from_smelting_deepslate_gold_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:gold_ingot"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 1.0,
+		"group": "gold_ingot",
+		"input": {
+			"choices": [
+				"minecraft:gold_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:gold_ingot_from_smelting_gold_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:gold_ingot"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 1.0,
+		"group": "gold_ingot",
+		"input": {
+			"choices": [
+				"minecraft:nether_gold_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:gold_ingot_from_smelting_nether_gold_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:gold_ingot"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 1.0,
+		"group": "gold_ingot",
+		"input": {
+			"choices": [
+				"minecraft:raw_gold"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:gold_ingot_from_smelting_raw_gold",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:gold_ingot"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:golden_axe",
+				"minecraft:golden_boots",
+				"minecraft:golden_chestplate",
+				"minecraft:golden_helmet",
+				"minecraft:golden_hoe",
+				"minecraft:golden_horse_armor",
+				"minecraft:golden_leggings",
+				"minecraft:golden_pickaxe",
+				"minecraft:golden_shovel",
+				"minecraft:golden_sword"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:gold_nugget_from_smelting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:gold_nugget"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:gray_terracotta"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:gray_glazed_terracotta",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:gray_glazed_terracotta"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 1.0,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cactus"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:green_dye",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:green_dye"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:green_terracotta"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:green_glazed_terracotta",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:green_glazed_terracotta"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 0.7,
+		"group": "iron_ingot",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_iron_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:iron_ingot_from_smelting_deepslate_iron_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:iron_ingot"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 0.7,
+		"group": "iron_ingot",
+		"input": {
+			"choices": [
+				"minecraft:iron_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:iron_ingot_from_smelting_iron_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:iron_ingot"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 0.7,
+		"group": "iron_ingot",
+		"input": {
+			"choices": [
+				"minecraft:raw_iron"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:iron_ingot_from_smelting_raw_iron",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:iron_ingot"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:chainmail_boots",
+				"minecraft:chainmail_chestplate",
+				"minecraft:chainmail_helmet",
+				"minecraft:chainmail_leggings",
+				"minecraft:iron_axe",
+				"minecraft:iron_boots",
+				"minecraft:iron_chestplate",
+				"minecraft:iron_helmet",
+				"minecraft:iron_hoe",
+				"minecraft:iron_horse_armor",
+				"minecraft:iron_leggings",
+				"minecraft:iron_pickaxe",
+				"minecraft:iron_shovel",
+				"minecraft:iron_sword"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:iron_nugget_from_smelting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:iron_nugget"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 0.2,
+		"group": "lapis_lazuli",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_lapis_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:lapis_lazuli_from_smelting_deepslate_lapis_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:lapis_lazuli"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 0.2,
+		"group": "lapis_lazuli",
+		"input": {
+			"choices": [
+				"minecraft:lapis_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:lapis_lazuli_from_smelting_lapis_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:lapis_lazuli"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:light_blue_terracotta"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:light_blue_glazed_terracotta",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_blue_glazed_terracotta"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:light_gray_terracotta"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:light_gray_glazed_terracotta",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:light_gray_glazed_terracotta"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:sea_pickle"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:lime_dye_from_smelting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:lime_dye"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:lime_terracotta"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:lime_glazed_terracotta",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:lime_glazed_terracotta"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:magenta_terracotta"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:magenta_glazed_terracotta",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:magenta_glazed_terracotta"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:netherrack"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:nether_brick",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:nether_brick"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 2.0,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:ancient_debris"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:netherite_scrap",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:netherite_scrap"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:orange_terracotta"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:orange_glazed_terracotta",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:orange_glazed_terracotta"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:pink_terracotta"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:pink_glazed_terracotta",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:pink_glazed_terracotta"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:chorus_fruit"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:popped_chorus_fruit",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:popped_chorus_fruit"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:purple_terracotta"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:purple_glazed_terracotta",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:purple_glazed_terracotta"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 0.2,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:nether_quartz_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:quartz",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:quartz"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:red_terracotta"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:red_glazed_terracotta",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:red_glazed_terracotta"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.7,
+		"group": "redstone",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_redstone_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:redstone_from_smelting_deepslate_redstone_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:redstone"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.7,
+		"group": "redstone",
+		"input": {
+			"choices": [
+				"minecraft:redstone_ore"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:redstone_from_smelting_redstone_ore",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:redstone"
+		}
+	},
+	{
+		"category": "MISC",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:resin_clump"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:resin_brick",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:resin_brick"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:basalt"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:smooth_basalt",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:smooth_basalt"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:quartz_block"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:smooth_quartz",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:smooth_quartz"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:red_sandstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:smooth_red_sandstone",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:smooth_red_sandstone"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:sandstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:smooth_sandstone",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:smooth_sandstone"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:stone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:smooth_stone",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:smooth_stone"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.15,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:wet_sponge"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:sponge",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:sponge"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cobblestone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:stone",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:stone"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:clay"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:terracotta",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:terracotta"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:white_terracotta"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:white_glazed_terracotta",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:white_glazed_terracotta"
+		}
+	},
+	{
+		"category": "BLOCKS",
+		"cookingTime": 200,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:yellow_terracotta"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:yellow_glazed_terracotta",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:yellow_glazed_terracotta"
+		}
+	}
+]

--- a/src/main/resources/recipes/smithing.json
+++ b/src/main/resources/recipes/smithing.json
@@ -1,0 +1,1154 @@
+[
+	{
+		"addition": {
+			"choices": [
+				"minecraft:amethyst_shard",
+				"minecraft:copper_ingot",
+				"minecraft:diamond",
+				"minecraft:emerald",
+				"minecraft:gold_ingot",
+				"minecraft:iron_ingot",
+				"minecraft:lapis_lazuli",
+				"minecraft:netherite_ingot",
+				"minecraft:quartz",
+				"minecraft:redstone",
+				"minecraft:resin_brick"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:chainmail_boots",
+				"minecraft:chainmail_chestplate",
+				"minecraft:chainmail_helmet",
+				"minecraft:chainmail_leggings",
+				"minecraft:diamond_boots",
+				"minecraft:diamond_chestplate",
+				"minecraft:diamond_helmet",
+				"minecraft:diamond_leggings",
+				"minecraft:golden_boots",
+				"minecraft:golden_chestplate",
+				"minecraft:golden_helmet",
+				"minecraft:golden_leggings",
+				"minecraft:iron_boots",
+				"minecraft:iron_chestplate",
+				"minecraft:iron_helmet",
+				"minecraft:iron_leggings",
+				"minecraft:leather_boots",
+				"minecraft:leather_chestplate",
+				"minecraft:leather_helmet",
+				"minecraft:leather_leggings",
+				"minecraft:netherite_boots",
+				"minecraft:netherite_chestplate",
+				"minecraft:netherite_helmet",
+				"minecraft:netherite_leggings",
+				"minecraft:turtle_helmet"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:bolt_armor_trim_smithing_template_smithing_trim",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:amethyst_shard",
+				"minecraft:copper_ingot",
+				"minecraft:diamond",
+				"minecraft:emerald",
+				"minecraft:gold_ingot",
+				"minecraft:iron_ingot",
+				"minecraft:lapis_lazuli",
+				"minecraft:netherite_ingot",
+				"minecraft:quartz",
+				"minecraft:redstone",
+				"minecraft:resin_brick"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:chainmail_boots",
+				"minecraft:chainmail_chestplate",
+				"minecraft:chainmail_helmet",
+				"minecraft:chainmail_leggings",
+				"minecraft:diamond_boots",
+				"minecraft:diamond_chestplate",
+				"minecraft:diamond_helmet",
+				"minecraft:diamond_leggings",
+				"minecraft:golden_boots",
+				"minecraft:golden_chestplate",
+				"minecraft:golden_helmet",
+				"minecraft:golden_leggings",
+				"minecraft:iron_boots",
+				"minecraft:iron_chestplate",
+				"minecraft:iron_helmet",
+				"minecraft:iron_leggings",
+				"minecraft:leather_boots",
+				"minecraft:leather_chestplate",
+				"minecraft:leather_helmet",
+				"minecraft:leather_leggings",
+				"minecraft:netherite_boots",
+				"minecraft:netherite_chestplate",
+				"minecraft:netherite_helmet",
+				"minecraft:netherite_leggings",
+				"minecraft:turtle_helmet"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:coast_armor_trim_smithing_template_smithing_trim",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:amethyst_shard",
+				"minecraft:copper_ingot",
+				"minecraft:diamond",
+				"minecraft:emerald",
+				"minecraft:gold_ingot",
+				"minecraft:iron_ingot",
+				"minecraft:lapis_lazuli",
+				"minecraft:netherite_ingot",
+				"minecraft:quartz",
+				"minecraft:redstone",
+				"minecraft:resin_brick"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:chainmail_boots",
+				"minecraft:chainmail_chestplate",
+				"minecraft:chainmail_helmet",
+				"minecraft:chainmail_leggings",
+				"minecraft:diamond_boots",
+				"minecraft:diamond_chestplate",
+				"minecraft:diamond_helmet",
+				"minecraft:diamond_leggings",
+				"minecraft:golden_boots",
+				"minecraft:golden_chestplate",
+				"minecraft:golden_helmet",
+				"minecraft:golden_leggings",
+				"minecraft:iron_boots",
+				"minecraft:iron_chestplate",
+				"minecraft:iron_helmet",
+				"minecraft:iron_leggings",
+				"minecraft:leather_boots",
+				"minecraft:leather_chestplate",
+				"minecraft:leather_helmet",
+				"minecraft:leather_leggings",
+				"minecraft:netherite_boots",
+				"minecraft:netherite_chestplate",
+				"minecraft:netherite_helmet",
+				"minecraft:netherite_leggings",
+				"minecraft:turtle_helmet"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:dune_armor_trim_smithing_template_smithing_trim",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:amethyst_shard",
+				"minecraft:copper_ingot",
+				"minecraft:diamond",
+				"minecraft:emerald",
+				"minecraft:gold_ingot",
+				"minecraft:iron_ingot",
+				"minecraft:lapis_lazuli",
+				"minecraft:netherite_ingot",
+				"minecraft:quartz",
+				"minecraft:redstone",
+				"minecraft:resin_brick"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:chainmail_boots",
+				"minecraft:chainmail_chestplate",
+				"minecraft:chainmail_helmet",
+				"minecraft:chainmail_leggings",
+				"minecraft:diamond_boots",
+				"minecraft:diamond_chestplate",
+				"minecraft:diamond_helmet",
+				"minecraft:diamond_leggings",
+				"minecraft:golden_boots",
+				"minecraft:golden_chestplate",
+				"minecraft:golden_helmet",
+				"minecraft:golden_leggings",
+				"minecraft:iron_boots",
+				"minecraft:iron_chestplate",
+				"minecraft:iron_helmet",
+				"minecraft:iron_leggings",
+				"minecraft:leather_boots",
+				"minecraft:leather_chestplate",
+				"minecraft:leather_helmet",
+				"minecraft:leather_leggings",
+				"minecraft:netherite_boots",
+				"minecraft:netherite_chestplate",
+				"minecraft:netherite_helmet",
+				"minecraft:netherite_leggings",
+				"minecraft:turtle_helmet"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:eye_armor_trim_smithing_template_smithing_trim",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:amethyst_shard",
+				"minecraft:copper_ingot",
+				"minecraft:diamond",
+				"minecraft:emerald",
+				"minecraft:gold_ingot",
+				"minecraft:iron_ingot",
+				"minecraft:lapis_lazuli",
+				"minecraft:netherite_ingot",
+				"minecraft:quartz",
+				"minecraft:redstone",
+				"minecraft:resin_brick"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:chainmail_boots",
+				"minecraft:chainmail_chestplate",
+				"minecraft:chainmail_helmet",
+				"minecraft:chainmail_leggings",
+				"minecraft:diamond_boots",
+				"minecraft:diamond_chestplate",
+				"minecraft:diamond_helmet",
+				"minecraft:diamond_leggings",
+				"minecraft:golden_boots",
+				"minecraft:golden_chestplate",
+				"minecraft:golden_helmet",
+				"minecraft:golden_leggings",
+				"minecraft:iron_boots",
+				"minecraft:iron_chestplate",
+				"minecraft:iron_helmet",
+				"minecraft:iron_leggings",
+				"minecraft:leather_boots",
+				"minecraft:leather_chestplate",
+				"minecraft:leather_helmet",
+				"minecraft:leather_leggings",
+				"minecraft:netherite_boots",
+				"minecraft:netherite_chestplate",
+				"minecraft:netherite_helmet",
+				"minecraft:netherite_leggings",
+				"minecraft:turtle_helmet"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:flow_armor_trim_smithing_template_smithing_trim",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:amethyst_shard",
+				"minecraft:copper_ingot",
+				"minecraft:diamond",
+				"minecraft:emerald",
+				"minecraft:gold_ingot",
+				"minecraft:iron_ingot",
+				"minecraft:lapis_lazuli",
+				"minecraft:netherite_ingot",
+				"minecraft:quartz",
+				"minecraft:redstone",
+				"minecraft:resin_brick"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:chainmail_boots",
+				"minecraft:chainmail_chestplate",
+				"minecraft:chainmail_helmet",
+				"minecraft:chainmail_leggings",
+				"minecraft:diamond_boots",
+				"minecraft:diamond_chestplate",
+				"minecraft:diamond_helmet",
+				"minecraft:diamond_leggings",
+				"minecraft:golden_boots",
+				"minecraft:golden_chestplate",
+				"minecraft:golden_helmet",
+				"minecraft:golden_leggings",
+				"minecraft:iron_boots",
+				"minecraft:iron_chestplate",
+				"minecraft:iron_helmet",
+				"minecraft:iron_leggings",
+				"minecraft:leather_boots",
+				"minecraft:leather_chestplate",
+				"minecraft:leather_helmet",
+				"minecraft:leather_leggings",
+				"minecraft:netherite_boots",
+				"minecraft:netherite_chestplate",
+				"minecraft:netherite_helmet",
+				"minecraft:netherite_leggings",
+				"minecraft:turtle_helmet"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:host_armor_trim_smithing_template_smithing_trim",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:netherite_ingot"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:diamond_axe"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:netherite_axe_smithing",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:netherite_axe"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:netherite_ingot"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:diamond_boots"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:netherite_boots_smithing",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:netherite_boots"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:netherite_ingot"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:diamond_chestplate"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:netherite_chestplate_smithing",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:netherite_chestplate"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:netherite_ingot"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:diamond_helmet"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:netherite_helmet_smithing",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:netherite_helmet"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:netherite_ingot"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:diamond_hoe"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:netherite_hoe_smithing",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:netherite_hoe"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:netherite_ingot"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:diamond_leggings"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:netherite_leggings_smithing",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:netherite_leggings"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:netherite_ingot"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:diamond_pickaxe"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:netherite_pickaxe_smithing",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:netherite_pickaxe"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:netherite_ingot"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:diamond_shovel"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:netherite_shovel_smithing",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:netherite_shovel"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:netherite_ingot"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:diamond_sword"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:netherite_sword_smithing",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:netherite_sword"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:amethyst_shard",
+				"minecraft:copper_ingot",
+				"minecraft:diamond",
+				"minecraft:emerald",
+				"minecraft:gold_ingot",
+				"minecraft:iron_ingot",
+				"minecraft:lapis_lazuli",
+				"minecraft:netherite_ingot",
+				"minecraft:quartz",
+				"minecraft:redstone",
+				"minecraft:resin_brick"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:chainmail_boots",
+				"minecraft:chainmail_chestplate",
+				"minecraft:chainmail_helmet",
+				"minecraft:chainmail_leggings",
+				"minecraft:diamond_boots",
+				"minecraft:diamond_chestplate",
+				"minecraft:diamond_helmet",
+				"minecraft:diamond_leggings",
+				"minecraft:golden_boots",
+				"minecraft:golden_chestplate",
+				"minecraft:golden_helmet",
+				"minecraft:golden_leggings",
+				"minecraft:iron_boots",
+				"minecraft:iron_chestplate",
+				"minecraft:iron_helmet",
+				"minecraft:iron_leggings",
+				"minecraft:leather_boots",
+				"minecraft:leather_chestplate",
+				"minecraft:leather_helmet",
+				"minecraft:leather_leggings",
+				"minecraft:netherite_boots",
+				"minecraft:netherite_chestplate",
+				"minecraft:netherite_helmet",
+				"minecraft:netherite_leggings",
+				"minecraft:turtle_helmet"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:raiser_armor_trim_smithing_template_smithing_trim",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:amethyst_shard",
+				"minecraft:copper_ingot",
+				"minecraft:diamond",
+				"minecraft:emerald",
+				"minecraft:gold_ingot",
+				"minecraft:iron_ingot",
+				"minecraft:lapis_lazuli",
+				"minecraft:netherite_ingot",
+				"minecraft:quartz",
+				"minecraft:redstone",
+				"minecraft:resin_brick"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:chainmail_boots",
+				"minecraft:chainmail_chestplate",
+				"minecraft:chainmail_helmet",
+				"minecraft:chainmail_leggings",
+				"minecraft:diamond_boots",
+				"minecraft:diamond_chestplate",
+				"minecraft:diamond_helmet",
+				"minecraft:diamond_leggings",
+				"minecraft:golden_boots",
+				"minecraft:golden_chestplate",
+				"minecraft:golden_helmet",
+				"minecraft:golden_leggings",
+				"minecraft:iron_boots",
+				"minecraft:iron_chestplate",
+				"minecraft:iron_helmet",
+				"minecraft:iron_leggings",
+				"minecraft:leather_boots",
+				"minecraft:leather_chestplate",
+				"minecraft:leather_helmet",
+				"minecraft:leather_leggings",
+				"minecraft:netherite_boots",
+				"minecraft:netherite_chestplate",
+				"minecraft:netherite_helmet",
+				"minecraft:netherite_leggings",
+				"minecraft:turtle_helmet"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:rib_armor_trim_smithing_template_smithing_trim",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:amethyst_shard",
+				"minecraft:copper_ingot",
+				"minecraft:diamond",
+				"minecraft:emerald",
+				"minecraft:gold_ingot",
+				"minecraft:iron_ingot",
+				"minecraft:lapis_lazuli",
+				"minecraft:netherite_ingot",
+				"minecraft:quartz",
+				"minecraft:redstone",
+				"minecraft:resin_brick"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:chainmail_boots",
+				"minecraft:chainmail_chestplate",
+				"minecraft:chainmail_helmet",
+				"minecraft:chainmail_leggings",
+				"minecraft:diamond_boots",
+				"minecraft:diamond_chestplate",
+				"minecraft:diamond_helmet",
+				"minecraft:diamond_leggings",
+				"minecraft:golden_boots",
+				"minecraft:golden_chestplate",
+				"minecraft:golden_helmet",
+				"minecraft:golden_leggings",
+				"minecraft:iron_boots",
+				"minecraft:iron_chestplate",
+				"minecraft:iron_helmet",
+				"minecraft:iron_leggings",
+				"minecraft:leather_boots",
+				"minecraft:leather_chestplate",
+				"minecraft:leather_helmet",
+				"minecraft:leather_leggings",
+				"minecraft:netherite_boots",
+				"minecraft:netherite_chestplate",
+				"minecraft:netherite_helmet",
+				"minecraft:netherite_leggings",
+				"minecraft:turtle_helmet"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:sentry_armor_trim_smithing_template_smithing_trim",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:amethyst_shard",
+				"minecraft:copper_ingot",
+				"minecraft:diamond",
+				"minecraft:emerald",
+				"minecraft:gold_ingot",
+				"minecraft:iron_ingot",
+				"minecraft:lapis_lazuli",
+				"minecraft:netherite_ingot",
+				"minecraft:quartz",
+				"minecraft:redstone",
+				"minecraft:resin_brick"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:chainmail_boots",
+				"minecraft:chainmail_chestplate",
+				"minecraft:chainmail_helmet",
+				"minecraft:chainmail_leggings",
+				"minecraft:diamond_boots",
+				"minecraft:diamond_chestplate",
+				"minecraft:diamond_helmet",
+				"minecraft:diamond_leggings",
+				"minecraft:golden_boots",
+				"minecraft:golden_chestplate",
+				"minecraft:golden_helmet",
+				"minecraft:golden_leggings",
+				"minecraft:iron_boots",
+				"minecraft:iron_chestplate",
+				"minecraft:iron_helmet",
+				"minecraft:iron_leggings",
+				"minecraft:leather_boots",
+				"minecraft:leather_chestplate",
+				"minecraft:leather_helmet",
+				"minecraft:leather_leggings",
+				"minecraft:netherite_boots",
+				"minecraft:netherite_chestplate",
+				"minecraft:netherite_helmet",
+				"minecraft:netherite_leggings",
+				"minecraft:turtle_helmet"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:shaper_armor_trim_smithing_template_smithing_trim",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:amethyst_shard",
+				"minecraft:copper_ingot",
+				"minecraft:diamond",
+				"minecraft:emerald",
+				"minecraft:gold_ingot",
+				"minecraft:iron_ingot",
+				"minecraft:lapis_lazuli",
+				"minecraft:netherite_ingot",
+				"minecraft:quartz",
+				"minecraft:redstone",
+				"minecraft:resin_brick"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:chainmail_boots",
+				"minecraft:chainmail_chestplate",
+				"minecraft:chainmail_helmet",
+				"minecraft:chainmail_leggings",
+				"minecraft:diamond_boots",
+				"minecraft:diamond_chestplate",
+				"minecraft:diamond_helmet",
+				"minecraft:diamond_leggings",
+				"minecraft:golden_boots",
+				"minecraft:golden_chestplate",
+				"minecraft:golden_helmet",
+				"minecraft:golden_leggings",
+				"minecraft:iron_boots",
+				"minecraft:iron_chestplate",
+				"minecraft:iron_helmet",
+				"minecraft:iron_leggings",
+				"minecraft:leather_boots",
+				"minecraft:leather_chestplate",
+				"minecraft:leather_helmet",
+				"minecraft:leather_leggings",
+				"minecraft:netherite_boots",
+				"minecraft:netherite_chestplate",
+				"minecraft:netherite_helmet",
+				"minecraft:netherite_leggings",
+				"minecraft:turtle_helmet"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:silence_armor_trim_smithing_template_smithing_trim",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:amethyst_shard",
+				"minecraft:copper_ingot",
+				"minecraft:diamond",
+				"minecraft:emerald",
+				"minecraft:gold_ingot",
+				"minecraft:iron_ingot",
+				"minecraft:lapis_lazuli",
+				"minecraft:netherite_ingot",
+				"minecraft:quartz",
+				"minecraft:redstone",
+				"minecraft:resin_brick"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:chainmail_boots",
+				"minecraft:chainmail_chestplate",
+				"minecraft:chainmail_helmet",
+				"minecraft:chainmail_leggings",
+				"minecraft:diamond_boots",
+				"minecraft:diamond_chestplate",
+				"minecraft:diamond_helmet",
+				"minecraft:diamond_leggings",
+				"minecraft:golden_boots",
+				"minecraft:golden_chestplate",
+				"minecraft:golden_helmet",
+				"minecraft:golden_leggings",
+				"minecraft:iron_boots",
+				"minecraft:iron_chestplate",
+				"minecraft:iron_helmet",
+				"minecraft:iron_leggings",
+				"minecraft:leather_boots",
+				"minecraft:leather_chestplate",
+				"minecraft:leather_helmet",
+				"minecraft:leather_leggings",
+				"minecraft:netherite_boots",
+				"minecraft:netherite_chestplate",
+				"minecraft:netherite_helmet",
+				"minecraft:netherite_leggings",
+				"minecraft:turtle_helmet"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:snout_armor_trim_smithing_template_smithing_trim",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:amethyst_shard",
+				"minecraft:copper_ingot",
+				"minecraft:diamond",
+				"minecraft:emerald",
+				"minecraft:gold_ingot",
+				"minecraft:iron_ingot",
+				"minecraft:lapis_lazuli",
+				"minecraft:netherite_ingot",
+				"minecraft:quartz",
+				"minecraft:redstone",
+				"minecraft:resin_brick"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:chainmail_boots",
+				"minecraft:chainmail_chestplate",
+				"minecraft:chainmail_helmet",
+				"minecraft:chainmail_leggings",
+				"minecraft:diamond_boots",
+				"minecraft:diamond_chestplate",
+				"minecraft:diamond_helmet",
+				"minecraft:diamond_leggings",
+				"minecraft:golden_boots",
+				"minecraft:golden_chestplate",
+				"minecraft:golden_helmet",
+				"minecraft:golden_leggings",
+				"minecraft:iron_boots",
+				"minecraft:iron_chestplate",
+				"minecraft:iron_helmet",
+				"minecraft:iron_leggings",
+				"minecraft:leather_boots",
+				"minecraft:leather_chestplate",
+				"minecraft:leather_helmet",
+				"minecraft:leather_leggings",
+				"minecraft:netherite_boots",
+				"minecraft:netherite_chestplate",
+				"minecraft:netherite_helmet",
+				"minecraft:netherite_leggings",
+				"minecraft:turtle_helmet"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:spire_armor_trim_smithing_template_smithing_trim",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:amethyst_shard",
+				"minecraft:copper_ingot",
+				"minecraft:diamond",
+				"minecraft:emerald",
+				"minecraft:gold_ingot",
+				"minecraft:iron_ingot",
+				"minecraft:lapis_lazuli",
+				"minecraft:netherite_ingot",
+				"minecraft:quartz",
+				"minecraft:redstone",
+				"minecraft:resin_brick"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:chainmail_boots",
+				"minecraft:chainmail_chestplate",
+				"minecraft:chainmail_helmet",
+				"minecraft:chainmail_leggings",
+				"minecraft:diamond_boots",
+				"minecraft:diamond_chestplate",
+				"minecraft:diamond_helmet",
+				"minecraft:diamond_leggings",
+				"minecraft:golden_boots",
+				"minecraft:golden_chestplate",
+				"minecraft:golden_helmet",
+				"minecraft:golden_leggings",
+				"minecraft:iron_boots",
+				"minecraft:iron_chestplate",
+				"minecraft:iron_helmet",
+				"minecraft:iron_leggings",
+				"minecraft:leather_boots",
+				"minecraft:leather_chestplate",
+				"minecraft:leather_helmet",
+				"minecraft:leather_leggings",
+				"minecraft:netherite_boots",
+				"minecraft:netherite_chestplate",
+				"minecraft:netherite_helmet",
+				"minecraft:netherite_leggings",
+				"minecraft:turtle_helmet"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:tide_armor_trim_smithing_template_smithing_trim",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:amethyst_shard",
+				"minecraft:copper_ingot",
+				"minecraft:diamond",
+				"minecraft:emerald",
+				"minecraft:gold_ingot",
+				"minecraft:iron_ingot",
+				"minecraft:lapis_lazuli",
+				"minecraft:netherite_ingot",
+				"minecraft:quartz",
+				"minecraft:redstone",
+				"minecraft:resin_brick"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:chainmail_boots",
+				"minecraft:chainmail_chestplate",
+				"minecraft:chainmail_helmet",
+				"minecraft:chainmail_leggings",
+				"minecraft:diamond_boots",
+				"minecraft:diamond_chestplate",
+				"minecraft:diamond_helmet",
+				"minecraft:diamond_leggings",
+				"minecraft:golden_boots",
+				"minecraft:golden_chestplate",
+				"minecraft:golden_helmet",
+				"minecraft:golden_leggings",
+				"minecraft:iron_boots",
+				"minecraft:iron_chestplate",
+				"minecraft:iron_helmet",
+				"minecraft:iron_leggings",
+				"minecraft:leather_boots",
+				"minecraft:leather_chestplate",
+				"minecraft:leather_helmet",
+				"minecraft:leather_leggings",
+				"minecraft:netherite_boots",
+				"minecraft:netherite_chestplate",
+				"minecraft:netherite_helmet",
+				"minecraft:netherite_leggings",
+				"minecraft:turtle_helmet"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:vex_armor_trim_smithing_template_smithing_trim",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:amethyst_shard",
+				"minecraft:copper_ingot",
+				"minecraft:diamond",
+				"minecraft:emerald",
+				"minecraft:gold_ingot",
+				"minecraft:iron_ingot",
+				"minecraft:lapis_lazuli",
+				"minecraft:netherite_ingot",
+				"minecraft:quartz",
+				"minecraft:redstone",
+				"minecraft:resin_brick"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:chainmail_boots",
+				"minecraft:chainmail_chestplate",
+				"minecraft:chainmail_helmet",
+				"minecraft:chainmail_leggings",
+				"minecraft:diamond_boots",
+				"minecraft:diamond_chestplate",
+				"minecraft:diamond_helmet",
+				"minecraft:diamond_leggings",
+				"minecraft:golden_boots",
+				"minecraft:golden_chestplate",
+				"minecraft:golden_helmet",
+				"minecraft:golden_leggings",
+				"minecraft:iron_boots",
+				"minecraft:iron_chestplate",
+				"minecraft:iron_helmet",
+				"minecraft:iron_leggings",
+				"minecraft:leather_boots",
+				"minecraft:leather_chestplate",
+				"minecraft:leather_helmet",
+				"minecraft:leather_leggings",
+				"minecraft:netherite_boots",
+				"minecraft:netherite_chestplate",
+				"minecraft:netherite_helmet",
+				"minecraft:netherite_leggings",
+				"minecraft:turtle_helmet"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:ward_armor_trim_smithing_template_smithing_trim",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:amethyst_shard",
+				"minecraft:copper_ingot",
+				"minecraft:diamond",
+				"minecraft:emerald",
+				"minecraft:gold_ingot",
+				"minecraft:iron_ingot",
+				"minecraft:lapis_lazuli",
+				"minecraft:netherite_ingot",
+				"minecraft:quartz",
+				"minecraft:redstone",
+				"minecraft:resin_brick"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:chainmail_boots",
+				"minecraft:chainmail_chestplate",
+				"minecraft:chainmail_helmet",
+				"minecraft:chainmail_leggings",
+				"minecraft:diamond_boots",
+				"minecraft:diamond_chestplate",
+				"minecraft:diamond_helmet",
+				"minecraft:diamond_leggings",
+				"minecraft:golden_boots",
+				"minecraft:golden_chestplate",
+				"minecraft:golden_helmet",
+				"minecraft:golden_leggings",
+				"minecraft:iron_boots",
+				"minecraft:iron_chestplate",
+				"minecraft:iron_helmet",
+				"minecraft:iron_leggings",
+				"minecraft:leather_boots",
+				"minecraft:leather_chestplate",
+				"minecraft:leather_helmet",
+				"minecraft:leather_leggings",
+				"minecraft:netherite_boots",
+				"minecraft:netherite_chestplate",
+				"minecraft:netherite_helmet",
+				"minecraft:netherite_leggings",
+				"minecraft:turtle_helmet"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:wayfinder_armor_trim_smithing_template_smithing_trim",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		}
+	},
+	{
+		"addition": {
+			"choices": [
+				"minecraft:amethyst_shard",
+				"minecraft:copper_ingot",
+				"minecraft:diamond",
+				"minecraft:emerald",
+				"minecraft:gold_ingot",
+				"minecraft:iron_ingot",
+				"minecraft:lapis_lazuli",
+				"minecraft:netherite_ingot",
+				"minecraft:quartz",
+				"minecraft:redstone",
+				"minecraft:resin_brick"
+			],
+			"type": "material"
+		},
+		"base": {
+			"choices": [
+				"minecraft:chainmail_boots",
+				"minecraft:chainmail_chestplate",
+				"minecraft:chainmail_helmet",
+				"minecraft:chainmail_leggings",
+				"minecraft:diamond_boots",
+				"minecraft:diamond_chestplate",
+				"minecraft:diamond_helmet",
+				"minecraft:diamond_leggings",
+				"minecraft:golden_boots",
+				"minecraft:golden_chestplate",
+				"minecraft:golden_helmet",
+				"minecraft:golden_leggings",
+				"minecraft:iron_boots",
+				"minecraft:iron_chestplate",
+				"minecraft:iron_helmet",
+				"minecraft:iron_leggings",
+				"minecraft:leather_boots",
+				"minecraft:leather_chestplate",
+				"minecraft:leather_helmet",
+				"minecraft:leather_leggings",
+				"minecraft:netherite_boots",
+				"minecraft:netherite_chestplate",
+				"minecraft:netherite_helmet",
+				"minecraft:netherite_leggings",
+				"minecraft:turtle_helmet"
+			],
+			"type": "material"
+		},
+		"copyDataComponents": true,
+		"key": "minecraft:wild_armor_trim_smithing_template_smithing_trim",
+		"result": {
+			"amount": 0,
+			"type": "minecraft:air"
+		}
+	}
+]

--- a/src/main/resources/recipes/smoking.json
+++ b/src/main/resources/recipes/smoking.json
@@ -1,0 +1,155 @@
+[
+	{
+		"category": "FOOD",
+		"cookingTime": 100,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:potato"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:baked_potato_from_smoking",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:baked_potato"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 100,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:beef"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cooked_beef_from_smoking",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cooked_beef"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 100,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:chicken"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cooked_chicken_from_smoking",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cooked_chicken"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 100,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cod"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cooked_cod_from_smoking",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cooked_cod"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 100,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:mutton"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cooked_mutton_from_smoking",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cooked_mutton"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 100,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:porkchop"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cooked_porkchop_from_smoking",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cooked_porkchop"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 100,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:rabbit"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cooked_rabbit_from_smoking",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cooked_rabbit"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 100,
+		"experience": 0.35,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:salmon"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cooked_salmon_from_smoking",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cooked_salmon"
+		}
+	},
+	{
+		"category": "FOOD",
+		"cookingTime": 100,
+		"experience": 0.1,
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:kelp"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:dried_kelp_from_smoking",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:dried_kelp"
+		}
+	}
+]

--- a/src/main/resources/recipes/stonecutting.json
+++ b/src/main/resources/recipes/stonecutting.json
@@ -1,0 +1,3558 @@
+[
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:andesite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:andesite_slab_from_andesite_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:andesite_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:andesite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:andesite_stairs_from_andesite_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:andesite_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:andesite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:andesite_wall_from_andesite_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:andesite_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:blackstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:blackstone_slab_from_blackstone_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:blackstone_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:blackstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:blackstone_stairs_from_blackstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:blackstone_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:blackstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:blackstone_wall_from_blackstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:blackstone_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:brick_slab_from_bricks_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:brick_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:brick_stairs_from_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:brick_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:brick_wall_from_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:brick_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:copper_block"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:chiseled_copper_from_copper_block_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:chiseled_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:chiseled_copper_from_cut_copper_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cobbled_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:chiseled_deepslate_from_cobbled_deepslate_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_deepslate"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:nether_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:chiseled_nether_bricks_from_nether_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_nether_bricks"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:blackstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:chiseled_polished_blackstone_from_blackstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_polished_blackstone"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_blackstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:chiseled_polished_blackstone_from_polished_blackstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_polished_blackstone"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:quartz_block"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:chiseled_quartz_block_from_quartz_block_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_quartz_block"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:red_sandstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:chiseled_red_sandstone_from_red_sandstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_red_sandstone"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:resin_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:chiseled_resin_bricks_from_resin_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_resin_bricks"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:sandstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:chiseled_sandstone_from_sandstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_sandstone"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:stone_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:chiseled_stone_bricks_from_stone_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_stone_bricks"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:stone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:chiseled_stone_bricks_stone_from_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_stone_bricks"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_tuff"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:chiseled_tuff_bricks_from_polished_tuff_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_tuff_bricks"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:tuff_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:chiseled_tuff_bricks_from_tuff_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_tuff_bricks"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:tuff"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:chiseled_tuff_bricks_from_tuff_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_tuff_bricks"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:tuff"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:chiseled_tuff_from_tuff_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:chiseled_tuff"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cobbled_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cobbled_deepslate_slab_from_cobbled_deepslate_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:cobbled_deepslate_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cobbled_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cobbled_deepslate_stairs_from_cobbled_deepslate_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cobbled_deepslate_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cobbled_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cobbled_deepslate_wall_from_cobbled_deepslate_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cobbled_deepslate_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cobblestone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cobblestone_slab_from_cobblestone_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:cobblestone_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cobblestone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cobblestone_stairs_from_cobblestone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cobblestone_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cobblestone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cobblestone_wall_from_cobblestone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cobblestone_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:copper_block"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:copper_grate_from_copper_block_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:copper_grate"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:copper_block"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cut_copper_from_copper_block_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:cut_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:copper_block"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cut_copper_slab_from_copper_block_stonecutting",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:cut_copper_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cut_copper_slab_from_cut_copper_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:cut_copper_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:copper_block"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cut_copper_stairs_from_copper_block_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:cut_copper_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cut_copper_stairs_from_cut_copper_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cut_copper_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:red_sandstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cut_red_sandstone_from_red_sandstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cut_red_sandstone"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cut_red_sandstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cut_red_sandstone_slab_from_cut_red_sandstone_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:cut_red_sandstone_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:red_sandstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cut_red_sandstone_slab_from_red_sandstone_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:cut_red_sandstone_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:sandstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cut_sandstone_from_sandstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:cut_sandstone"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cut_sandstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cut_sandstone_slab_from_cut_sandstone_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:cut_sandstone_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:sandstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:cut_sandstone_slab_from_sandstone_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:cut_sandstone_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:dark_prismarine"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:dark_prismarine_slab_from_dark_prismarine_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:dark_prismarine_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:dark_prismarine"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:dark_prismarine_stairs_from_dark_prismarine_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:dark_prismarine_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cobbled_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_brick_slab_from_cobbled_deepslate_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:deepslate_brick_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_brick_slab_from_deepslate_bricks_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:deepslate_brick_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_brick_slab_from_polished_deepslate_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:deepslate_brick_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cobbled_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_brick_stairs_from_cobbled_deepslate_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:deepslate_brick_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_brick_stairs_from_deepslate_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:deepslate_brick_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_brick_stairs_from_polished_deepslate_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:deepslate_brick_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cobbled_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_brick_wall_from_cobbled_deepslate_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:deepslate_brick_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_brick_wall_from_deepslate_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:deepslate_brick_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_brick_wall_from_polished_deepslate_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:deepslate_brick_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cobbled_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_bricks_from_cobbled_deepslate_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:deepslate_bricks"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_bricks_from_polished_deepslate_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:deepslate_bricks"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cobbled_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_tile_slab_from_cobbled_deepslate_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:deepslate_tile_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_tile_slab_from_deepslate_bricks_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:deepslate_tile_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_tiles"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_tile_slab_from_deepslate_tiles_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:deepslate_tile_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_tile_slab_from_polished_deepslate_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:deepslate_tile_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cobbled_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_tile_stairs_from_cobbled_deepslate_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:deepslate_tile_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_tile_stairs_from_deepslate_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:deepslate_tile_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_tiles"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_tile_stairs_from_deepslate_tiles_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:deepslate_tile_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_tile_stairs_from_polished_deepslate_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:deepslate_tile_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cobbled_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_tile_wall_from_cobbled_deepslate_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:deepslate_tile_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_tile_wall_from_deepslate_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:deepslate_tile_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_tiles"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_tile_wall_from_deepslate_tiles_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:deepslate_tile_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_tile_wall_from_polished_deepslate_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:deepslate_tile_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cobbled_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_tiles_from_cobbled_deepslate_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:deepslate_tiles"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:deepslate_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_tiles_from_deepslate_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:deepslate_tiles"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:deepslate_tiles_from_polished_deepslate_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:deepslate_tiles"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:diorite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:diorite_slab_from_diorite_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:diorite_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:diorite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:diorite_stairs_from_diorite_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:diorite_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:diorite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:diorite_wall_from_diorite_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:diorite_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:end_stone_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:end_stone_brick_slab_from_end_stone_brick_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:end_stone_brick_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:end_stone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:end_stone_brick_slab_from_end_stone_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:end_stone_brick_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:end_stone_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:end_stone_brick_stairs_from_end_stone_brick_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:end_stone_brick_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:end_stone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:end_stone_brick_stairs_from_end_stone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:end_stone_brick_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:end_stone_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:end_stone_brick_wall_from_end_stone_brick_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:end_stone_brick_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:end_stone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:end_stone_brick_wall_from_end_stone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:end_stone_brick_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:end_stone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:end_stone_bricks_from_end_stone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:end_stone_bricks"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:exposed_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:exposed_chiseled_copper_from_exposed_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:exposed_chiseled_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:exposed_cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:exposed_chiseled_copper_from_exposed_cut_copper_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:exposed_chiseled_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:exposed_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:exposed_copper_grate_from_exposed_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:exposed_copper_grate"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:exposed_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:exposed_cut_copper_from_exposed_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:exposed_cut_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:exposed_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:exposed_cut_copper_slab_from_exposed_copper_stonecutting",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:exposed_cut_copper_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:exposed_cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:exposed_cut_copper_slab_from_exposed_cut_copper_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:exposed_cut_copper_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:exposed_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:exposed_cut_copper_stairs_from_exposed_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:exposed_cut_copper_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:exposed_cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:exposed_cut_copper_stairs_from_exposed_cut_copper_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:exposed_cut_copper_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:granite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:granite_slab_from_granite_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:granite_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:granite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:granite_stairs_from_granite_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:granite_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:granite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:granite_wall_from_granite_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:granite_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:mossy_cobblestone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:mossy_cobblestone_slab_from_mossy_cobblestone_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:mossy_cobblestone_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:mossy_cobblestone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:mossy_cobblestone_stairs_from_mossy_cobblestone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:mossy_cobblestone_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:mossy_cobblestone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:mossy_cobblestone_wall_from_mossy_cobblestone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:mossy_cobblestone_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:mossy_stone_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:mossy_stone_brick_slab_from_mossy_stone_brick_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:mossy_stone_brick_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:mossy_stone_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:mossy_stone_brick_stairs_from_mossy_stone_brick_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:mossy_stone_brick_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:mossy_stone_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:mossy_stone_brick_wall_from_mossy_stone_brick_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:mossy_stone_brick_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:mud_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:mud_brick_slab_from_mud_bricks_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:mud_brick_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:mud_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:mud_brick_stairs_from_mud_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:mud_brick_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:mud_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:mud_brick_wall_from_mud_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:mud_brick_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:nether_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:nether_brick_slab_from_nether_bricks_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:nether_brick_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:nether_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:nether_brick_stairs_from_nether_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:nether_brick_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:nether_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:nether_brick_wall_from_nether_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:nether_brick_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:oxidized_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:oxidized_chiseled_copper_from_oxidized_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:oxidized_chiseled_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:oxidized_cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:oxidized_chiseled_copper_from_oxidized_cut_copper_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:oxidized_chiseled_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:oxidized_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:oxidized_copper_grate_from_oxidized_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:oxidized_copper_grate"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:oxidized_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:oxidized_cut_copper_from_oxidized_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:oxidized_cut_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:oxidized_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:oxidized_cut_copper_slab_from_oxidized_copper_stonecutting",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:oxidized_cut_copper_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:oxidized_cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:oxidized_cut_copper_slab_from_oxidized_cut_copper_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:oxidized_cut_copper_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:oxidized_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:oxidized_cut_copper_stairs_from_oxidized_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:oxidized_cut_copper_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:oxidized_cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:oxidized_cut_copper_stairs_from_oxidized_cut_copper_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:oxidized_cut_copper_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:andesite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_andesite_from_andesite_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_andesite"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:andesite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_andesite_slab_from_andesite_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:polished_andesite_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_andesite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_andesite_slab_from_polished_andesite_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:polished_andesite_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:andesite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_andesite_stairs_from_andesite_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_andesite_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_andesite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_andesite_stairs_from_polished_andesite_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_andesite_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:basalt"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_basalt_from_basalt_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_basalt"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:blackstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_blackstone_brick_slab_from_blackstone_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:polished_blackstone_brick_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_blackstone_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_blackstone_brick_slab_from_polished_blackstone_bricks_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:polished_blackstone_brick_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_blackstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_blackstone_brick_slab_from_polished_blackstone_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:polished_blackstone_brick_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:blackstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_blackstone_brick_stairs_from_blackstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_blackstone_brick_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_blackstone_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_blackstone_brick_stairs_from_polished_blackstone_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_blackstone_brick_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_blackstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_blackstone_brick_stairs_from_polished_blackstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_blackstone_brick_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:blackstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_blackstone_brick_wall_from_blackstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_blackstone_brick_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_blackstone_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_blackstone_brick_wall_from_polished_blackstone_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_blackstone_brick_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_blackstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_blackstone_brick_wall_from_polished_blackstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_blackstone_brick_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:blackstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_blackstone_bricks_from_blackstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_blackstone_bricks"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_blackstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_blackstone_bricks_from_polished_blackstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_blackstone_bricks"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:blackstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_blackstone_from_blackstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_blackstone"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:blackstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_blackstone_slab_from_blackstone_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:polished_blackstone_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_blackstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_blackstone_slab_from_polished_blackstone_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:polished_blackstone_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:blackstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_blackstone_stairs_from_blackstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_blackstone_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_blackstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_blackstone_stairs_from_polished_blackstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_blackstone_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:blackstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_blackstone_wall_from_blackstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_blackstone_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_blackstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_blackstone_wall_from_polished_blackstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_blackstone_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cobbled_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_deepslate_from_cobbled_deepslate_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_deepslate"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cobbled_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_deepslate_slab_from_cobbled_deepslate_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:polished_deepslate_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_deepslate_slab_from_polished_deepslate_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:polished_deepslate_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cobbled_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_deepslate_stairs_from_cobbled_deepslate_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_deepslate_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_deepslate_stairs_from_polished_deepslate_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_deepslate_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:cobbled_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_deepslate_wall_from_cobbled_deepslate_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_deepslate_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_deepslate"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_deepslate_wall_from_polished_deepslate_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_deepslate_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:diorite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_diorite_from_diorite_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_diorite"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:diorite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_diorite_slab_from_diorite_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:polished_diorite_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_diorite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_diorite_slab_from_polished_diorite_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:polished_diorite_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:diorite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_diorite_stairs_from_diorite_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_diorite_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_diorite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_diorite_stairs_from_polished_diorite_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_diorite_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:granite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_granite_from_granite_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_granite"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:granite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_granite_slab_from_granite_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:polished_granite_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_granite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_granite_slab_from_polished_granite_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:polished_granite_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:granite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_granite_stairs_from_granite_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_granite_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_granite"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_granite_stairs_from_polished_granite_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_granite_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:tuff"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_tuff_from_tuff_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_tuff"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_tuff"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_tuff_slab_from_polished_tuff_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:polished_tuff_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:tuff"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_tuff_slab_from_tuff_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:polished_tuff_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_tuff"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_tuff_stairs_from_polished_tuff_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_tuff_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:tuff"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_tuff_stairs_from_tuff_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_tuff_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_tuff"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_tuff_wall_from_polished_tuff_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_tuff_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:tuff"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:polished_tuff_wall_from_tuff_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:polished_tuff_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:prismarine_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:prismarine_brick_slab_from_prismarine_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:prismarine_brick_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:prismarine_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:prismarine_brick_stairs_from_prismarine_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:prismarine_brick_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:prismarine"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:prismarine_slab_from_prismarine_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:prismarine_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:prismarine"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:prismarine_stairs_from_prismarine_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:prismarine_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:prismarine"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:prismarine_wall_from_prismarine_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:prismarine_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:purpur_block"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:purpur_pillar_from_purpur_block_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:purpur_pillar"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:purpur_block"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:purpur_slab_from_purpur_block_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:purpur_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:purpur_block"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:purpur_stairs_from_purpur_block_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:purpur_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:quartz_block"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:quartz_bricks_from_quartz_block_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:quartz_bricks"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:quartz_block"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:quartz_pillar_from_quartz_block_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:quartz_pillar"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:quartz_block"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:quartz_slab_from_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:quartz_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:quartz_block"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:quartz_stairs_from_quartz_block_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:quartz_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:red_nether_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:red_nether_brick_slab_from_red_nether_bricks_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:red_nether_brick_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:red_nether_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:red_nether_brick_stairs_from_red_nether_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:red_nether_brick_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:red_nether_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:red_nether_brick_wall_from_red_nether_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:red_nether_brick_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:red_sandstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:red_sandstone_slab_from_red_sandstone_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:red_sandstone_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:red_sandstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:red_sandstone_stairs_from_red_sandstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:red_sandstone_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:red_sandstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:red_sandstone_wall_from_red_sandstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:red_sandstone_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:resin_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:resin_brick_slab_from_resin_bricks_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:resin_brick_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:resin_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:resin_brick_stairs_from_resin_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:resin_brick_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:resin_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:resin_brick_wall_from_resin_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:resin_brick_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:sandstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:sandstone_slab_from_sandstone_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:sandstone_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:sandstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:sandstone_stairs_from_sandstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:sandstone_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:sandstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:sandstone_wall_from_sandstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:sandstone_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:smooth_quartz"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:smooth_quartz_slab_from_smooth_quartz_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:smooth_quartz_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:smooth_quartz"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:smooth_quartz_stairs_from_smooth_quartz_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:smooth_quartz_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:smooth_red_sandstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:smooth_red_sandstone_slab_from_smooth_red_sandstone_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:smooth_red_sandstone_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:smooth_red_sandstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:smooth_red_sandstone_stairs_from_smooth_red_sandstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:smooth_red_sandstone_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:smooth_sandstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:smooth_sandstone_slab_from_smooth_sandstone_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:smooth_sandstone_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:smooth_sandstone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:smooth_sandstone_stairs_from_smooth_sandstone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:smooth_sandstone_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:smooth_stone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:smooth_stone_slab_from_smooth_stone_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:smooth_stone_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:stone_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:stone_brick_slab_from_stone_bricks_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:stone_brick_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:stone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:stone_brick_slab_from_stone_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:stone_brick_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:stone_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:stone_brick_stairs_from_stone_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:stone_brick_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:stone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:stone_brick_stairs_from_stone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:stone_brick_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:stone_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:stone_brick_wall_from_stone_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:stone_brick_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:stone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:stone_brick_walls_from_stone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:stone_brick_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:stone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:stone_bricks_from_stone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:stone_bricks"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:stone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:stone_slab_from_stone_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:stone_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:stone"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:stone_stairs_from_stone_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:stone_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_tuff"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:tuff_brick_slab_from_polished_tuff_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:tuff_brick_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:tuff_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:tuff_brick_slab_from_tuff_bricks_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:tuff_brick_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:tuff"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:tuff_brick_slab_from_tuff_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:tuff_brick_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_tuff"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:tuff_brick_stairs_from_polished_tuff_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:tuff_brick_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:tuff_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:tuff_brick_stairs_from_tuff_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:tuff_brick_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:tuff"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:tuff_brick_stairs_from_tuff_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:tuff_brick_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_tuff"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:tuff_brick_wall_from_polished_tuff_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:tuff_brick_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:tuff_bricks"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:tuff_brick_wall_from_tuff_bricks_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:tuff_brick_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:tuff"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:tuff_brick_wall_from_tuff_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:tuff_brick_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:polished_tuff"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:tuff_bricks_from_polished_tuff_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:tuff_bricks"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:tuff"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:tuff_bricks_from_tuff_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:tuff_bricks"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:tuff"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:tuff_slab_from_tuff_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:tuff_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:tuff"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:tuff_stairs_from_tuff_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:tuff_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:tuff"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:tuff_wall_from_tuff_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:tuff_wall"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_copper_block"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_chiseled_copper_from_waxed_copper_block_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_chiseled_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_chiseled_copper_from_waxed_cut_copper_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_chiseled_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_copper_block"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_copper_grate_from_waxed_copper_block_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_copper_grate"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_copper_block"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_cut_copper_from_waxed_copper_block_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_cut_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_copper_block"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_cut_copper_slab_from_waxed_copper_block_stonecutting",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:waxed_cut_copper_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_cut_copper_slab_from_waxed_cut_copper_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:waxed_cut_copper_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_copper_block"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_cut_copper_stairs_from_waxed_copper_block_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_cut_copper_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_cut_copper_stairs_from_waxed_cut_copper_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_cut_copper_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_exposed_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_exposed_chiseled_copper_from_waxed_exposed_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_exposed_chiseled_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_exposed_cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_exposed_chiseled_copper_from_waxed_exposed_cut_copper_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_exposed_chiseled_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_exposed_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_exposed_copper_grate_from_waxed_exposed_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_exposed_copper_grate"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_exposed_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_exposed_cut_copper_from_waxed_exposed_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_exposed_cut_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_exposed_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_exposed_cut_copper_slab_from_waxed_exposed_copper_stonecutting",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:waxed_exposed_cut_copper_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_exposed_cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_exposed_cut_copper_slab_from_waxed_exposed_cut_copper_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:waxed_exposed_cut_copper_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_exposed_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_exposed_cut_copper_stairs_from_waxed_exposed_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_exposed_cut_copper_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_exposed_cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_exposed_cut_copper_stairs_from_waxed_exposed_cut_copper_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_exposed_cut_copper_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_oxidized_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_oxidized_chiseled_copper_from_waxed_oxidized_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_oxidized_chiseled_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_oxidized_cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_oxidized_chiseled_copper_from_waxed_oxidized_cut_copper_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_oxidized_chiseled_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_oxidized_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_oxidized_copper_grate_from_waxed_oxidized_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_oxidized_copper_grate"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_oxidized_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_oxidized_cut_copper_from_waxed_oxidized_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_oxidized_cut_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_oxidized_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_oxidized_cut_copper_slab_from_waxed_oxidized_copper_stonecutting",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:waxed_oxidized_cut_copper_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_oxidized_cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_oxidized_cut_copper_slab_from_waxed_oxidized_cut_copper_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:waxed_oxidized_cut_copper_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_oxidized_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_oxidized_cut_copper_stairs_from_waxed_oxidized_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_oxidized_cut_copper_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_oxidized_cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_oxidized_cut_copper_stairs_from_waxed_oxidized_cut_copper_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_oxidized_cut_copper_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_weathered_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_weathered_chiseled_copper_from_waxed_weathered_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_weathered_chiseled_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_weathered_cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_weathered_chiseled_copper_from_waxed_weathered_cut_copper_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_weathered_chiseled_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_weathered_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_weathered_copper_grate_from_waxed_weathered_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_weathered_copper_grate"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_weathered_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_weathered_cut_copper_from_waxed_weathered_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_weathered_cut_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_weathered_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_weathered_cut_copper_slab_from_waxed_weathered_copper_stonecutting",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:waxed_weathered_cut_copper_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_weathered_cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_weathered_cut_copper_slab_from_waxed_weathered_cut_copper_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:waxed_weathered_cut_copper_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_weathered_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_weathered_cut_copper_stairs_from_waxed_weathered_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:waxed_weathered_cut_copper_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:waxed_weathered_cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:waxed_weathered_cut_copper_stairs_from_waxed_weathered_cut_copper_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:waxed_weathered_cut_copper_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:weathered_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:weathered_chiseled_copper_from_weathered_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:weathered_chiseled_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:weathered_cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:weathered_chiseled_copper_from_weathered_cut_copper_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:weathered_chiseled_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:weathered_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:weathered_copper_grate_from_weathered_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:weathered_copper_grate"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:weathered_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:weathered_cut_copper_from_weathered_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:weathered_cut_copper"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:weathered_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:weathered_cut_copper_slab_from_weathered_copper_stonecutting",
+		"result": {
+			"amount": 8,
+			"type": "minecraft:weathered_cut_copper_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:weathered_cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:weathered_cut_copper_slab_from_weathered_cut_copper_stonecutting",
+		"result": {
+			"amount": 2,
+			"type": "minecraft:weathered_cut_copper_slab"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:weathered_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:weathered_cut_copper_stairs_from_weathered_copper_stonecutting",
+		"result": {
+			"amount": 4,
+			"type": "minecraft:weathered_cut_copper_stairs"
+		}
+	},
+	{
+		"group": "",
+		"input": {
+			"choices": [
+				"minecraft:weathered_cut_copper"
+			],
+			"type": "material"
+		},
+		"key": "minecraft:weathered_cut_copper_stairs_from_weathered_cut_copper_stonecutting",
+		"result": {
+			"amount": 1,
+			"type": "minecraft:weathered_cut_copper_stairs"
+		}
+	}
+]

--- a/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
@@ -38,6 +38,7 @@ import static org.mockbukkit.mockbukkit.matcher.plugin.PluginManagerFiredEventFi
 import com.destroystokyo.paper.event.player.PlayerConnectionCloseEvent;
 import com.destroystokyo.paper.event.server.WhitelistToggleEvent;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
 import com.google.common.net.InetAddresses;
@@ -428,6 +429,7 @@ class ServerMockTest
 	@Test
 	void addRecipe_AddsRecipe_ReturnsTrue()
 	{
+		server.clearRecipes();
 		TestRecipe recipe1 = new TestRecipe();
 		TestRecipe recipe2 = new TestRecipe();
 		server.addRecipe(recipe1);
@@ -446,6 +448,13 @@ class ServerMockTest
 		assumeTrue(server.recipeIterator().hasNext());
 		server.clearRecipes();
 		assertFalse(server.recipeIterator().hasNext());
+	}
+
+	@Test
+	void recipeIterator_HasDefaultCraftingRecipes()
+	{
+		Iterator<Recipe> actual = server.recipeIterator();
+		assertEquals(976, Iterators.size(actual));
 	}
 
 	@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
@@ -38,7 +38,6 @@ import static org.mockbukkit.mockbukkit.matcher.plugin.PluginManagerFiredEventFi
 import com.destroystokyo.paper.event.player.PlayerConnectionCloseEvent;
 import com.destroystokyo.paper.event.server.WhitelistToggleEvent;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
 import com.google.common.net.InetAddresses;
@@ -52,6 +51,7 @@ import org.bukkit.GameEvent;
 import org.bukkit.GameMode;
 import org.bukkit.Keyed;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.Registry;
 import org.bukkit.Sound;
@@ -90,6 +90,7 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scoreboard.ScoreboardManager;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -450,11 +451,43 @@ class ServerMockTest
 		assertFalse(server.recipeIterator().hasNext());
 	}
 
-	@Test
-	void recipeIterator_HasDefaultCraftingRecipes()
+	@Nested
+	class GetRecipe
 	{
-		Iterator<Recipe> actual = server.recipeIterator();
-		assertEquals(976, Iterators.size(actual));
+
+		@ParameterizedTest
+		@ValueSource(strings = {
+			"minecraft:bamboo_block",
+			"minecraft:bamboo_door",
+			"minecraft:decorated_pot",
+			"minecraft:gray_bundle"
+		})
+		void givenValidValues(String expectedKey)
+		{
+			NamespacedKey key = NamespacedKey.fromString(expectedKey);
+			assertNotNull(key);
+
+			@Nullable Recipe actual = server.getRecipe(key);
+
+			assertNotNull(actual);
+			Keyed actualKeyed = assertInstanceOf(Keyed.class, actual);
+			assertEquals(expectedKey, actualKeyed.getKey().asString());
+		}
+
+		@ParameterizedTest
+		@ValueSource(strings = {
+			"minecraft:non_existing_recipe",
+			"other_namespace:bamboo_door"
+		})
+		void givenInvalidValues(String expectedKey)
+		{
+			NamespacedKey key = NamespacedKey.fromString(expectedKey);
+			assertNotNull(key);
+
+			@Nullable Recipe actual = server.getRecipe(key);
+			assertNull(actual);
+		}
+
 	}
 
 	@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/CraftingRecipeFactoryTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/CraftingRecipeFactoryTest.java
@@ -1,0 +1,222 @@
+package org.mockbukkit.mockbukkit.inventory;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.bukkit.Material;
+import org.bukkit.inventory.ComplexRecipe;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.ShapelessRecipe;
+import org.bukkit.inventory.TransmuteRecipe;
+import org.bukkit.inventory.recipe.CraftingBookCategory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+@ExtendWith(MockBukkitExtension.class)
+class CraftingRecipeFactoryTest
+{
+
+	@Test
+	void createShapedRecipe()
+	{
+		String text = """
+				{
+				  		"category": "MISC",
+				  		"choiceMap": {
+				  			"a": {
+				  				"choices": [
+				  					"minecraft:acacia_planks"
+				  				],
+				  				"type": "material"
+				  			},
+				  			"b": {
+				  				"choices": [
+				  					"minecraft:stick"
+				  				],
+				  				"type": "material"
+				  			},
+				  			"c": {
+				  				"choices": [
+				  					"minecraft:acacia_planks"
+				  				],
+				  				"type": "material"
+				  			},
+				  			"d": {
+				  				"choices": [
+				  					"minecraft:acacia_planks"
+				  				],
+				  				"type": "material"
+				  			},
+				  			"e": {
+				  				"choices": [
+				  					"minecraft:stick"
+				  				],
+				  				"type": "material"
+				  			},
+				  			"f": {
+				  				"choices": [
+				  					"minecraft:acacia_planks"
+				  				],
+				  				"type": "material"
+				  			}
+				  		},
+				  		"group": "wooden_fence",
+				  		"key": "minecraft:acacia_fence",
+				  		"result": {
+				  			"amount": 3,
+				  			"type": "minecraft:acacia_fence"
+				  		},
+				  		"shape": [
+				  			"abc",
+				  			"def"
+				  		],
+				  		"type": "shaped"
+				  	}
+
+				""";
+		JsonObject jsonObject = JsonParser.parseString(text).getAsJsonObject();
+		ShapedRecipe recipe = CraftingRecipeFactory.createShapedRecipe(jsonObject);
+
+		assertNotNull(recipe);
+		assertEquals("minecraft:acacia_fence", recipe.getKey().asString());
+		assertEquals(3, recipe.getResult().getAmount());
+		assertEquals(Material.ACACIA_FENCE, recipe.getResult().getType());
+		assertEquals("wooden_fence", recipe.getGroup());
+		assertEquals(CraftingBookCategory.MISC, recipe.getCategory());
+		assertArrayEquals(new String[] {"abc", "def"}, recipe.getShape());
+		assertEquals(6, recipe.getChoiceMap().size());
+	}
+
+	@Test
+	void createShapelessRecipe()
+	{
+		String text = """
+				{
+					"category": "BUILDING",
+					"choices": [
+						{
+							"choices": [
+								"minecraft:diorite"
+							],
+							"type": "material"
+						},
+						{
+							"choices": [
+								"minecraft:cobblestone"
+							],
+							"type": "material"
+						}
+					],
+					"group": "",
+					"key": "minecraft:andesite",
+					"result": {
+						"amount": 2,
+						"type": "minecraft:andesite"
+					},
+					"type": "shapeless"
+				}
+				""";
+		JsonObject jsonObject = JsonParser.parseString(text).getAsJsonObject();
+		ShapelessRecipe recipe = CraftingRecipeFactory.createShapelessRecipe(jsonObject);
+
+		assertNotNull(recipe);
+		assertEquals("minecraft:andesite", recipe.getKey().asString());
+		assertEquals(2, recipe.getResult().getAmount());
+		assertEquals(Material.ANDESITE, recipe.getResult().getType());
+		assertEquals("", recipe.getGroup());
+		assertEquals(CraftingBookCategory.BUILDING, recipe.getCategory());
+		assertEquals(2, recipe.getChoiceList().size());
+	}
+
+	@Test
+	void createTransmuteRecipe()
+	{
+		String text = """
+				{
+					"category": "MISC",
+					"group": "",
+					"input": {
+						"choices": [
+							"minecraft:black_bundle",
+							"minecraft:blue_bundle",
+							"minecraft:brown_bundle",
+							"minecraft:bundle",
+							"minecraft:cyan_bundle",
+							"minecraft:gray_bundle",
+							"minecraft:green_bundle",
+							"minecraft:light_blue_bundle",
+							"minecraft:light_gray_bundle",
+							"minecraft:lime_bundle",
+							"minecraft:magenta_bundle",
+							"minecraft:orange_bundle",
+							"minecraft:pink_bundle",
+							"minecraft:purple_bundle",
+							"minecraft:red_bundle",
+							"minecraft:white_bundle",
+							"minecraft:yellow_bundle"
+						],
+						"type": "material"
+					},
+					"key": "minecraft:black_bundle",
+					"material": {
+						"choices": [
+							"minecraft:black_dye"
+						],
+						"type": "material"
+					},
+					"result": {
+						"amount": 1,
+						"type": "minecraft:black_bundle"
+					},
+					"type": "transmute"
+				}
+				""";
+		JsonObject jsonObject = JsonParser.parseString(text).getAsJsonObject();
+		TransmuteRecipe recipe = CraftingRecipeFactory.createTransmuteRecipe(jsonObject);
+
+		assertNotNull(recipe);
+		assertEquals("minecraft:black_bundle", recipe.getKey().asString());
+		assertEquals(1, recipe.getResult().getAmount());
+		assertEquals(Material.BLACK_BUNDLE, recipe.getResult().getType());
+		assertEquals("", recipe.getGroup());
+		assertEquals(CraftingBookCategory.MISC, recipe.getCategory());
+
+		assertTrue(recipe.getInput().test(ItemStack.of(Material.BLUE_BUNDLE)));
+		assertFalse(recipe.getInput().test(ItemStack.of(Material.STONE)));
+
+		assertTrue(recipe.getMaterial().test(ItemStack.of(Material.BLACK_DYE)));
+		assertFalse(recipe.getMaterial().test(ItemStack.of(Material.CYAN_DYE)));
+	}
+
+	@Test
+	void createComplexRecipe()
+	{
+		String text = """
+				{
+					"category": "MISC",
+					"group": "",
+					"key": "minecraft:armor_dye",
+					"result": {
+						"amount": 0,
+						"type": "minecraft:air"
+					},
+					"type": "complex"
+				}
+				""";
+		JsonObject jsonObject = JsonParser.parseString(text).getAsJsonObject();
+		ComplexRecipe recipe = CraftingRecipeFactory.createComplexRecipe(jsonObject);
+
+		assertNotNull(recipe);
+		assertEquals("minecraft:armor_dye", recipe.getKey().asString());
+		assertEquals(0, recipe.getResult().getAmount());
+		assertEquals(Material.AIR, recipe.getResult().getType());
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/RecipeManagerTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/RecipeManagerTest.java
@@ -1,0 +1,40 @@
+package org.mockbukkit.mockbukkit.inventory;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+@ExtendWith(MockBukkitExtension.class)
+class RecipeManagerTest
+{
+	private final RecipeManager manager = new RecipeManager();
+
+	@Nested
+	class Clear
+	{
+		@Test
+		void clearOnlyOneSingleRecipeType()
+		{
+			assertFalse(manager.getRecipes(RecipeType.CRAFTING).isEmpty());
+
+			manager.getRecipes(RecipeType.CRAFTING).clear();
+
+			assertTrue(manager.getRecipes(RecipeType.CRAFTING).isEmpty());
+		}
+
+		@Test
+		void clearAllRecipeType()
+		{
+			assertFalse(manager.getRecipes(RecipeType.CRAFTING).isEmpty());
+
+			manager.getRecipes().clear();
+
+			assertTrue(manager.getRecipes(RecipeType.CRAFTING).isEmpty());
+		}
+	}
+
+}


### PR DESCRIPTION
# Description
This PR includes the base code to import the crafting recipes into MockBukkit.
The data is mined from the Paper API into a internal JSON format, that can be read by MockBukkit.
The main focus of this PR are the crafting recipes, but the source code can be reused for the other recipes.

Related with https://github.com/MockBukkit/MockBukkit/issues/1233.

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
