### PR TITLE
Implement `getCraftingRecipe`, `craftItem` and `resetRecipes` in ServerMock

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
@@ -1108,15 +1108,13 @@ public class ServerMock extends Server.Spigot implements Server
 	@Override
 	public @NotNull ItemStack craftItem(@NotNull ItemStack[] craftingMatrix, @NotNull World world, @NotNull Player player)
 	{
-		Preconditions.checkArgument(player != null, "player cannot be null");
-		return craftItem(craftingMatrix, world);
+		// TODO Auto-generated method stub
+		throw new UnimplementedOperationException();
 	}
 
 	@Override
 	public @NotNull ItemCraftResult craftItemResult(@NotNull ItemStack[] craftingMatrix, @NotNull World world)
 	{
-		Preconditions.checkArgument(world != null, "world must not be null");
-
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
 	}
@@ -1124,9 +1122,6 @@ public class ServerMock extends Server.Spigot implements Server
 	@Override
 	public @NotNull ItemCraftResult craftItemResult(@NotNull ItemStack[] craftingMatrix, @NotNull World world, @NotNull Player player)
 	{
-		Preconditions.checkArgument(world != null, "world cannot be null");
-		Preconditions.checkArgument(player != null, "player cannot be null");
-
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
 	}

--- a/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
@@ -1084,25 +1084,39 @@ public class ServerMock extends Server.Spigot implements Server
 		return this.recipeManager.getRecipeByKey(RecipeType.CRAFTING, key);
 	}
 
-	@Nullable
 	@Override
-	public Recipe getCraftingRecipe(@NotNull ItemStack[] craftingMatrix, @NotNull World world)
+	public @Nullable Recipe getCraftingRecipe(@NotNull ItemStack[] craftingMatrix, @NotNull World world)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkArgument(craftingMatrix != null, "craftingMatrix must not be null");
+		Preconditions.checkArgument(craftingMatrix.length == 9, "craftingMatrix must be an array of length 9");
+		Preconditions.checkArgument(world != null, "world must not be null");
+		return this.recipeManager.getCraftingRecipe(craftingMatrix);
 	}
 
-	@NotNull
 	@Override
-	public ItemStack craftItem(@NotNull ItemStack[] craftingMatrix, @NotNull World world, @NotNull Player player)
+	public @NotNull ItemStack craftItem(@NotNull ItemStack[] craftingMatrix, @NotNull World world)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		@Nullable Recipe recipe = getCraftingRecipe(craftingMatrix, world);
+		if (recipe == null)
+		{
+			return ItemStack.empty();
+		}
+
+		return recipe.getResult();
+	}
+
+	@Override
+	public @NotNull ItemStack craftItem(@NotNull ItemStack[] craftingMatrix, @NotNull World world, @NotNull Player player)
+	{
+		Preconditions.checkArgument(player != null, "player cannot be null");
+		return craftItem(craftingMatrix, world);
 	}
 
 	@Override
 	public @NotNull ItemCraftResult craftItemResult(@NotNull ItemStack[] craftingMatrix, @NotNull World world)
 	{
+		Preconditions.checkArgument(world != null, "world must not be null");
+
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
 	}
@@ -1110,13 +1124,9 @@ public class ServerMock extends Server.Spigot implements Server
 	@Override
 	public @NotNull ItemCraftResult craftItemResult(@NotNull ItemStack[] craftingMatrix, @NotNull World world, @NotNull Player player)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
+		Preconditions.checkArgument(world != null, "world cannot be null");
+		Preconditions.checkArgument(player != null, "player cannot be null");
 
-	@Override
-	public @NotNull ItemStack craftItem(@NotNull ItemStack[] craftingMatrix, @NotNull World world)
-	{
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
 	}
@@ -1647,8 +1657,7 @@ public class ServerMock extends Server.Spigot implements Server
 	@Override
 	public void resetRecipes()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.recipeManager.reset(RecipeType.CRAFTING);
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryMock.java
@@ -1,5 +1,18 @@
 package org.mockbukkit.mockbukkit.inventory;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import net.kyori.adventure.text.Component;
@@ -18,19 +31,6 @@ import org.jetbrains.annotations.Nullable;
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.entity.EntityMock;
 import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Objects;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Mock implementation of an {@link Inventory}.
@@ -319,7 +319,8 @@ public class InventoryMock implements Inventory
 	@Override
 	public ItemStack @NotNull [] getContents()
 	{
-		return Arrays.stream(items).map(item -> item == null ? null : item.clone())
+		return Arrays.stream(items)
+				.map(item -> (item == null || item.isEmpty()) ? null : item.clone())
 				.toArray(ItemStack[]::new);
 	}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
@@ -33,10 +33,6 @@ import org.mockbukkit.mockbukkit.MockBukkit;
 public class RecipeManager
 {
 
-	private static final String RECIPE_TYPE_CANNOT_BE_NULL = "Recipe type cannot be null";
-	private static final String THE_RECIPE_CANNOT_BE_NULL = "The recipe cannot be null";
-	private static final String THE_CRAFTING_MATRIX_CANNOT_BE_NULL = "The craftingMatrix cannot be null";
-
 	/**
 	 * This field is used as cache. The values are lazy loaded with method {@link #getRecipes()}.
 	 * This field should not be accessed directly, it's preferred to use the method {@link #getRecipes()} instead.
@@ -58,7 +54,7 @@ public class RecipeManager
 	 */
 	public void reset(@NotNull RecipeType recipeType)
 	{
-		Preconditions.checkArgument(recipeType != null, RECIPE_TYPE_CANNOT_BE_NULL);
+		Preconditions.checkArgument(recipeType != null, "Recipe type cannot be null");
 		Preconditions.checkState(this.recipes != null, "Recipes has not been initialized yet.");
 		this.recipes.put(recipeType, RecipeManager.loadDefaultRecipes(recipeType));
 	}
@@ -89,7 +85,7 @@ public class RecipeManager
 	@NotNull
 	public List<Recipe> getRecipes(@NotNull RecipeType recipeType)
 	{
-		Preconditions.checkArgument(recipeType != null, RECIPE_TYPE_CANNOT_BE_NULL);
+		Preconditions.checkArgument(recipeType != null, "Recipe type cannot be null");
 		return getRecipes().getOrDefault(recipeType, Collections.emptyList());
 	}
 
@@ -104,7 +100,7 @@ public class RecipeManager
 	@Nullable
 	public Recipe getRecipeByKey(@NotNull RecipeType recipeType, @NotNull NamespacedKey recipeKey)
 	{
-		Preconditions.checkArgument(recipeType != null, RECIPE_TYPE_CANNOT_BE_NULL);
+		Preconditions.checkArgument(recipeType != null, "Recipe type cannot be null");
 		Preconditions.checkArgument(recipeKey != null, "Recipe key cannot be null");
 
 		List<Recipe> recipesToSearch = getRecipes().get(recipeType);
@@ -130,7 +126,7 @@ public class RecipeManager
 	@NotNull
 	public List<Recipe> getRecipesFor(@NotNull RecipeType recipeType, @NotNull ItemStack itemStack)
 	{
-		Preconditions.checkArgument(recipeType != null, RECIPE_TYPE_CANNOT_BE_NULL);
+		Preconditions.checkArgument(recipeType != null, "Recipe type cannot be null");
 		return getRecipes(recipeType).stream()
 				.filter(recipe -> itemStack.isSimilar(recipe.getResult()))
 				.toList();
@@ -185,7 +181,7 @@ public class RecipeManager
 	public boolean addRecipe(@NotNull RecipeType recipeType, @NotNull Recipe recipe)
 	{
 		Preconditions.checkArgument(recipeType != null, "The recipe type cannot be null");
-		Preconditions.checkArgument(recipe != null, THE_RECIPE_CANNOT_BE_NULL);
+		Preconditions.checkArgument(recipe != null, "The recipe cannot be null");
 		return getRecipes(recipeType).add(recipe);
 	}
 
@@ -200,7 +196,7 @@ public class RecipeManager
 	public boolean removeRecipe(@NotNull RecipeType recipeType, @NotNull Recipe recipe)
 	{
 		Preconditions.checkArgument(recipeType != null, "The recipe type cannot be null");
-		Preconditions.checkArgument(recipe != null, THE_RECIPE_CANNOT_BE_NULL);
+		Preconditions.checkArgument(recipe != null, "The recipe cannot be null");
 		return getRecipes(recipeType).remove(recipe);
 	}
 
@@ -292,8 +288,8 @@ public class RecipeManager
 
 	static boolean matches(@NotNull ShapelessRecipe shapelessRecipe, @NotNull ItemStack @NotNull [] craftingMatrix)
 	{
-		Preconditions.checkArgument(shapelessRecipe != null, THE_RECIPE_CANNOT_BE_NULL);
-		Preconditions.checkArgument(craftingMatrix != null, THE_CRAFTING_MATRIX_CANNOT_BE_NULL);
+		Preconditions.checkArgument(shapelessRecipe != null, "The recipe cannot be null");
+		Preconditions.checkArgument(craftingMatrix != null, "The craftingMatrix cannot be null");
 
 		long itemCount = Stream.of(craftingMatrix).filter(item -> !item.isEmpty()).count();
 
@@ -319,8 +315,8 @@ public class RecipeManager
 
 	static boolean matches(@NotNull ShapedRecipe shapedRecipe, @NotNull ItemStack @NotNull [] craftingMatrix)
 	{
-		Preconditions.checkArgument(shapedRecipe != null, THE_RECIPE_CANNOT_BE_NULL);
-		Preconditions.checkArgument(craftingMatrix != null, THE_CRAFTING_MATRIX_CANNOT_BE_NULL);
+		Preconditions.checkArgument(shapedRecipe != null, "The recipe cannot be null");
+		Preconditions.checkArgument(craftingMatrix != null, "The craftingMatrix cannot be null");
 
 		// TODO: Logic for shaped recipes
 
@@ -329,8 +325,8 @@ public class RecipeManager
 
 	static boolean matches(@NotNull ComplexRecipe complexRecipe, @NotNull ItemStack @NotNull [] items)
 	{
-		Preconditions.checkArgument(complexRecipe != null, THE_RECIPE_CANNOT_BE_NULL);
-		Preconditions.checkArgument(items != null, THE_CRAFTING_MATRIX_CANNOT_BE_NULL);
+		Preconditions.checkArgument(complexRecipe != null, "The recipe cannot be null");
+		Preconditions.checkArgument(items != null, "The craftingMatrix cannot be null");
 
 		// TODO: Logic for complex recipes
 

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.JsonArray;
@@ -19,8 +20,12 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ComplexRecipe;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
+import org.bukkit.inventory.RecipeChoice;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.ShapelessRecipe;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mockbukkit.mockbukkit.MockBukkit;
@@ -34,7 +39,33 @@ public class RecipeManager
 	 * This field is used as cache. The values are lazy loaded with method {@link #getRecipes()}.
 	 * This field should not be accessed directly, it's preferred to use the method {@link #getRecipes()} instead.
 	 */
-	private Map<RecipeType, List<Recipe>> recipes = null;
+	private @Nullable Map<RecipeType, List<Recipe>> recipes = null;
+
+	/**
+	 * Resets the list of recipes to the default.
+	 */
+	public void reset()
+	{
+		this.recipes = new EnumMap<>(RecipeManager.loadDefaultRecipes());
+	}
+
+	/**
+	 * Resets the list of recipes to the default for a given recipe type.
+	 *
+	 * @param recipeType The recipe type to reset.
+	 */
+	public void reset(@NotNull RecipeType recipeType)
+	{
+		Preconditions.checkArgument(recipeType != null, "Recipe type cannot be null");
+
+		if (this.recipes == null)
+		{
+			reset();
+		} else
+		{
+			this.recipes.put(recipeType, RecipeManager.loadDefaultRecipes(recipeType));
+		}
+	}
 
 	/**
 	 * Get the list of recipes available.
@@ -46,7 +77,7 @@ public class RecipeManager
 	{
 		if (this.recipes == null)
 		{
-			this.recipes = new EnumMap<>(RecipeManager.loadDefaultRecipes());
+			this.reset();
 		}
 
 		return this.recipes;
@@ -107,6 +138,44 @@ public class RecipeManager
 		return getRecipes(recipeType).stream()
 				.filter(recipe -> itemStack.isSimilar(recipe.getResult()))
 				.toList();
+	}
+
+	@Nullable
+	public Recipe getCraftingRecipe(@NotNull ItemStack[] craftingMatrix)
+	{
+		Preconditions.checkArgument(craftingMatrix != null, "craftingMatrix must not be null");
+		Preconditions.checkArgument(craftingMatrix.length == 9, "craftingMatrix must be an array of length 9");
+
+		List<Recipe> possibleRecipes = getRecipes(RecipeType.CRAFTING);
+		for (Recipe recipe : possibleRecipes)
+		{
+			if (recipe instanceof ShapelessRecipe shapelessRecipe)
+			{
+				if (matches(shapelessRecipe, craftingMatrix))
+				{
+					return recipe;
+				}
+			}
+			else if (recipe instanceof ShapedRecipe shapedRecipe)
+			{
+				if (matches(shapedRecipe, craftingMatrix))
+				{
+					return recipe;
+				}
+			}
+			else if (recipe instanceof ComplexRecipe complexRecipe)
+			{
+				if (matches(complexRecipe, craftingMatrix))
+				{
+					return recipe;
+				}
+			} else
+			{
+				throw new UnsupportedOperationException("Unknown recipe type: " + recipe.getClass().getName());
+			}
+		}
+
+		return null;
 	}
 
 	/**
@@ -223,6 +292,53 @@ public class RecipeManager
 		}
 
 		return recipesList;
+	}
+
+	private static boolean matches(@NotNull ShapelessRecipe shapelessRecipe, @NotNull ItemStack @NotNull [] craftingMatrix)
+	{
+		Preconditions.checkArgument(shapelessRecipe != null, "The recipe cannot be null");
+		Preconditions.checkArgument(craftingMatrix != null, "The craftingMatrix cannot be null");
+
+		long itemCount = Stream.of(craftingMatrix).filter(item -> !item.isEmpty()).count();
+
+		@NotNull List<RecipeChoice> choices = shapelessRecipe.getChoiceList();
+		if (choices.size() != itemCount)
+		{
+			// If number of items in the recipe does not match the amount of items required, we skip
+			return false;
+		}
+
+		for (RecipeChoice choice : choices)
+		{
+			boolean anyMatches = Stream.of(craftingMatrix).anyMatch(choice);
+			if (!anyMatches)
+			{
+				// If at least one item does not have matching items we exit
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private static boolean matches(@NotNull ShapedRecipe shapedRecipe, @NotNull ItemStack @NotNull [] items)
+	{
+		Preconditions.checkArgument(shapedRecipe != null, "The recipe cannot be null");
+		Preconditions.checkArgument(items != null, "The items cannot be null");
+
+		// TODO: Logic for shaped recipes
+
+		return false;
+	}
+
+	private static boolean matches(@NotNull ComplexRecipe complexRecipe, @NotNull ItemStack @NotNull [] items)
+	{
+		Preconditions.checkArgument(complexRecipe != null, "The recipe cannot be null");
+		Preconditions.checkArgument(items != null, "The items cannot be null");
+
+		// TODO: Logic for complex recipes
+
+		return false;
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
@@ -57,14 +57,8 @@ public class RecipeManager
 	public void reset(@NotNull RecipeType recipeType)
 	{
 		Preconditions.checkArgument(recipeType != null, "Recipe type cannot be null");
-
-		if (this.recipes == null)
-		{
-			reset();
-		} else
-		{
-			this.recipes.put(recipeType, RecipeManager.loadDefaultRecipes(recipeType));
-		}
+		Preconditions.checkState(this.recipes != null, "Recipes has not been initialized yet.");
+		this.recipes.put(recipeType, RecipeManager.loadDefaultRecipes(recipeType));
 	}
 
 	/**

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
@@ -34,6 +34,8 @@ public class RecipeManager
 {
 
 	private static final String RECIPE_TYPE_CANNOT_BE_NULL = "Recipe type cannot be null";
+	private static final String THE_RECIPE_CANNOT_BE_NULL = "The recipe cannot be null";
+	private static final String THE_CRAFTING_MATRIX_CANNOT_BE_NULL = "The craftingMatrix cannot be null";
 
 	/**
 	 * This field is used as cache. The values are lazy loaded with method {@link #getRecipes()}.
@@ -56,7 +58,7 @@ public class RecipeManager
 	 */
 	public void reset(@NotNull RecipeType recipeType)
 	{
-		Preconditions.checkArgument(recipeType != null, "Recipe type cannot be null");
+		Preconditions.checkArgument(recipeType != null, RECIPE_TYPE_CANNOT_BE_NULL);
 		Preconditions.checkState(this.recipes != null, "Recipes has not been initialized yet.");
 		this.recipes.put(recipeType, RecipeManager.loadDefaultRecipes(recipeType));
 	}
@@ -183,7 +185,7 @@ public class RecipeManager
 	public boolean addRecipe(@NotNull RecipeType recipeType, @NotNull Recipe recipe)
 	{
 		Preconditions.checkArgument(recipeType != null, "The recipe type cannot be null");
-		Preconditions.checkArgument(recipe != null, "The recipe cannot be null");
+		Preconditions.checkArgument(recipe != null, THE_RECIPE_CANNOT_BE_NULL);
 		return getRecipes(recipeType).add(recipe);
 	}
 
@@ -198,7 +200,7 @@ public class RecipeManager
 	public boolean removeRecipe(@NotNull RecipeType recipeType, @NotNull Recipe recipe)
 	{
 		Preconditions.checkArgument(recipeType != null, "The recipe type cannot be null");
-		Preconditions.checkArgument(recipe != null, "The recipe cannot be null");
+		Preconditions.checkArgument(recipe != null, THE_RECIPE_CANNOT_BE_NULL);
 		return getRecipes(recipeType).remove(recipe);
 	}
 
@@ -290,8 +292,8 @@ public class RecipeManager
 
 	static boolean matches(@NotNull ShapelessRecipe shapelessRecipe, @NotNull ItemStack @NotNull [] craftingMatrix)
 	{
-		Preconditions.checkArgument(shapelessRecipe != null, "The recipe cannot be null");
-		Preconditions.checkArgument(craftingMatrix != null, "The craftingMatrix cannot be null");
+		Preconditions.checkArgument(shapelessRecipe != null, THE_RECIPE_CANNOT_BE_NULL);
+		Preconditions.checkArgument(craftingMatrix != null, THE_CRAFTING_MATRIX_CANNOT_BE_NULL);
 
 		long itemCount = Stream.of(craftingMatrix).filter(item -> !item.isEmpty()).count();
 
@@ -317,8 +319,8 @@ public class RecipeManager
 
 	static boolean matches(@NotNull ShapedRecipe shapedRecipe, @NotNull ItemStack @NotNull [] craftingMatrix)
 	{
-		Preconditions.checkArgument(shapedRecipe != null, "The recipe cannot be null");
-		Preconditions.checkArgument(craftingMatrix != null, "The craftingMatrix cannot be null");
+		Preconditions.checkArgument(shapedRecipe != null, THE_RECIPE_CANNOT_BE_NULL);
+		Preconditions.checkArgument(craftingMatrix != null, THE_CRAFTING_MATRIX_CANNOT_BE_NULL);
 
 		// TODO: Logic for shaped recipes
 
@@ -327,8 +329,8 @@ public class RecipeManager
 
 	static boolean matches(@NotNull ComplexRecipe complexRecipe, @NotNull ItemStack @NotNull [] items)
 	{
-		Preconditions.checkArgument(complexRecipe != null, "The recipe cannot be null");
-		Preconditions.checkArgument(items != null, "The craftingMatrix cannot be null");
+		Preconditions.checkArgument(complexRecipe != null, THE_RECIPE_CANNOT_BE_NULL);
+		Preconditions.checkArgument(items != null, THE_CRAFTING_MATRIX_CANNOT_BE_NULL);
 
 		// TODO: Logic for complex recipes
 

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
@@ -288,7 +288,7 @@ public class RecipeManager
 		return recipesList;
 	}
 
-	private static boolean matches(@NotNull ShapelessRecipe shapelessRecipe, @NotNull ItemStack @NotNull [] craftingMatrix)
+	static boolean matches(@NotNull ShapelessRecipe shapelessRecipe, @NotNull ItemStack @NotNull [] craftingMatrix)
 	{
 		Preconditions.checkArgument(shapelessRecipe != null, "The recipe cannot be null");
 		Preconditions.checkArgument(craftingMatrix != null, "The craftingMatrix cannot be null");
@@ -315,20 +315,20 @@ public class RecipeManager
 		return true;
 	}
 
-	private static boolean matches(@NotNull ShapedRecipe shapedRecipe, @NotNull ItemStack @NotNull [] items)
+	static boolean matches(@NotNull ShapedRecipe shapedRecipe, @NotNull ItemStack @NotNull [] craftingMatrix)
 	{
 		Preconditions.checkArgument(shapedRecipe != null, "The recipe cannot be null");
-		Preconditions.checkArgument(items != null, "The items cannot be null");
+		Preconditions.checkArgument(craftingMatrix != null, "The craftingMatrix cannot be null");
 
 		// TODO: Logic for shaped recipes
 
 		return false;
 	}
 
-	private static boolean matches(@NotNull ComplexRecipe complexRecipe, @NotNull ItemStack @NotNull [] items)
+	static boolean matches(@NotNull ComplexRecipe complexRecipe, @NotNull ItemStack @NotNull [] items)
 	{
 		Preconditions.checkArgument(complexRecipe != null, "The recipe cannot be null");
-		Preconditions.checkArgument(items != null, "The items cannot be null");
+		Preconditions.checkArgument(items != null, "The craftingMatrix cannot be null");
 
 		// TODO: Logic for complex recipes
 

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/WorkbenchInventoryMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/WorkbenchInventoryMock.java
@@ -1,7 +1,8 @@
 package org.mockbukkit.mockbukkit.inventory;
 
-import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 import com.google.common.base.Preconditions;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.CraftingInventory;
 import org.bukkit.inventory.InventoryHolder;
@@ -59,8 +60,10 @@ public class WorkbenchInventoryMock extends InventoryMock implements CraftingInv
 	@Override
 	public @Nullable Recipe getRecipe()
 	{
-		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Location location = this.getLocation();
+		Preconditions.checkState(location != null, "The location can't be null!");
+		Preconditions.checkState(location.getWorld() != null, "The world can't be null!");
+		return Bukkit.getCraftingRecipe(this.getContents(), location.getWorld());
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/WorkbenchInventoryMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/WorkbenchInventoryMock.java
@@ -54,7 +54,23 @@ public class WorkbenchInventoryMock extends InventoryMock implements CraftingInv
 	{
 		Preconditions.checkNotNull(contents);
 		Preconditions.checkArgument(contents.length <= super.getSize(), "Invalid inventory size. Expected " + super.getSize() + " or less, got " + contents.length);
-		super.setContents(contents);
+		for (int i = 0; i < this.getSize(); i++)
+		{
+			if (i < contents.length)
+			{
+				ItemStack content = contents[i];
+				if (content == null)
+				{
+					this.setItem(i, ItemStack.empty());
+				} else
+				{
+					this.setItem(i, contents[i]);
+				}
+			} else
+			{
+				this.setItem(i, ItemStack.empty());
+			}
+		}
 	}
 
 	@Override
@@ -63,7 +79,19 @@ public class WorkbenchInventoryMock extends InventoryMock implements CraftingInv
 		Location location = this.getLocation();
 		Preconditions.checkState(location != null, "The location can't be null!");
 		Preconditions.checkState(location.getWorld() != null, "The world can't be null!");
-		return Bukkit.getCraftingRecipe(this.getContents(), location.getWorld());
+
+		ItemStack[] craftingItems = new ItemStack[] {
+			this.getItem(0),
+			this.getItem(1),
+			this.getItem(2),
+			this.getItem(3),
+			this.getItem(4),
+			this.getItem(5),
+			this.getItem(6),
+			this.getItem(7),
+			this.getItem(8),
+		};
+		return Bukkit.getCraftingRecipe(craftingItems, location.getWorld());
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
@@ -38,6 +38,7 @@ import static org.mockbukkit.mockbukkit.matcher.plugin.PluginManagerFiredEventFi
 import com.destroystokyo.paper.event.player.PlayerConnectionCloseEvent;
 import com.destroystokyo.paper.event.server.WhitelistToggleEvent;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
 import com.google.common.net.InetAddresses;
@@ -84,6 +85,7 @@ import org.bukkit.event.server.MapInitializeEvent;
 import org.bukkit.event.server.ServerLoadEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
+import org.bukkit.inventory.ShapelessRecipe;
 import org.bukkit.loot.LootTables;
 import org.bukkit.map.MapView;
 import org.bukkit.plugin.Plugin;
@@ -451,6 +453,22 @@ class ServerMockTest
 		assertFalse(server.recipeIterator().hasNext());
 	}
 
+	@Test
+	void resetRecipes()
+	{
+		int initialSize = Iterators.size(server.recipeIterator());
+		ShapelessRecipe shapelessRecipe = new ShapelessRecipe(
+				NamespacedKey.fromString("mockbukkit:test_recipe"), ItemStack.of(Material.DIAMOND));
+		server.addRecipe(shapelessRecipe);
+		int newSize = Iterators.size(server.recipeIterator());
+		assertEquals(initialSize + 1, newSize);
+
+		server.resetRecipes();
+
+		int actualSize = Iterators.size(server.recipeIterator());
+		assertEquals(initialSize, actualSize);
+	}
+
 	@Nested
 	class GetRecipe
 	{
@@ -486,6 +504,123 @@ class ServerMockTest
 
 			@Nullable Recipe actual = server.getRecipe(key);
 			assertNull(actual);
+		}
+
+	}
+
+	@Nested
+	class GetCraftingRecipe
+	{
+		private final World world = new WorldMock();
+
+		@Test
+		void givenNullCraftMatrix()
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> server.getCraftingRecipe(null, world));
+			assertEquals("craftingMatrix must not be null", e.getMessage());
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = {
+			0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 14, 15
+		})
+		void givenCraftMatrixWithout9Slots(int itemsAmount)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> server.getCraftingRecipe(new ItemStack[itemsAmount], world));
+			assertEquals("craftingMatrix must be an array of length 9", e.getMessage());
+		}
+
+		@Test
+		void givenNullWorld()
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> server.getCraftingRecipe(new ItemStack[9], null));
+			assertEquals("world must not be null", e.getMessage());
+		}
+
+		@Test
+		void givenNonExistingRecipe()
+		{
+			ItemStack[] craftingItems = new ItemStack[] {
+					ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.STONE),
+					ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
+					ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.DIAMOND),
+			};
+			@Nullable Recipe recipe = server.getCraftingRecipe(craftingItems, world);
+
+			assertNull(recipe);
+		}
+
+		@Test
+		void givenShapelessRecipe()
+		{
+			ItemStack[] craftingItems = new ItemStack[] {
+				ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
+				ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
+				ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.OAK_PLANKS),
+			};
+			@Nullable Recipe recipe = server.getCraftingRecipe(craftingItems, world);
+
+			assertNotNull(recipe);
+			assertEquals(Material.OAK_BUTTON, recipe.getResult().getType());
+		}
+
+	}
+
+	@Nested
+	class CraftItem
+	{
+		private final World world = new WorldMock();
+
+		@Test
+		void givenNullCraftMatrix()
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> server.craftItem(null, world));
+			assertEquals("craftingMatrix must not be null", e.getMessage());
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = {
+				0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 14, 15
+		})
+		void givenCraftMatrixWithout9Slots(int itemsAmount)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> server.craftItem(new ItemStack[itemsAmount], world));
+			assertEquals("craftingMatrix must be an array of length 9", e.getMessage());
+		}
+
+		@Test
+		void givenNullWorld()
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> server.craftItem(new ItemStack[9], null));
+			assertEquals("world must not be null", e.getMessage());
+		}
+
+		@Test
+		void givenNonExistingRecipe()
+		{
+			ItemStack[] craftingItems = new ItemStack[] {
+					ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.STONE),
+					ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
+					ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.DIAMOND),
+			};
+			ItemStack output = server.craftItem(craftingItems, world);
+
+			assertNotNull(output);
+			assertTrue(output.isEmpty());
+		}
+
+		@Test
+		void givenShapelessRecipe()
+		{
+			ItemStack[] craftingItems = new ItemStack[] {
+					ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
+					ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
+					ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.OAK_PLANKS),
+			};
+			ItemStack output = server.craftItem(craftingItems, world);
+
+			assertNotNull(output);
+			assertEquals(Material.OAK_BUTTON, output.getType());
 		}
 
 	}

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/RecipeManagerTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/RecipeManagerTest.java
@@ -1,11 +1,19 @@
 package org.mockbukkit.mockbukkit.inventory;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.Recipe;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockbukkit.mockbukkit.MockBukkitExtension;
 
 @ExtendWith(MockBukkitExtension.class)
@@ -35,6 +43,229 @@ class RecipeManagerTest
 
 			assertTrue(manager.getRecipes(RecipeType.CRAFTING).isEmpty());
 		}
+	}
+
+	@Nested
+	class GetCraftingRecipe
+	{
+
+		@Nested
+		class ShapelessRecipe
+		{
+			@ParameterizedTest
+			@CsvSource({
+				"OAK_LOG, OAK_PLANKS",
+				"SPRUCE_LOG, SPRUCE_PLANKS",
+				"BIRCH_LOG, BIRCH_PLANKS",
+				"JUNGLE_LOG, JUNGLE_PLANKS",
+				"ACACIA_LOG, ACACIA_PLANKS",
+				"CHERRY_LOG, CHERRY_PLANKS",
+				"PALE_OAK_LOG, PALE_OAK_PLANKS",
+				"DARK_OAK_LOG, DARK_OAK_PLANKS",
+				"MANGROVE_LOG, MANGROVE_PLANKS"
+			})
+			void givenLogs(Material log, Material planks)
+			{
+				Recipe recipe = manager.getCraftingRecipe(new ItemStack[]
+						{
+								ItemStack.empty(), ItemStack.of(log), ItemStack.empty(),
+								ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
+								ItemStack.empty(), ItemStack.empty(), ItemStack.empty()
+						});
+
+				assertNotNull(recipe);
+				assertEquals(planks, recipe.getResult().getType());
+			}
+
+			@ParameterizedTest
+			@CsvSource({
+				"OAK_PLANKS, OAK_BUTTON",
+				"SPRUCE_PLANKS, SPRUCE_BUTTON",
+				"BIRCH_PLANKS, BIRCH_BUTTON",
+				"JUNGLE_PLANKS, JUNGLE_BUTTON",
+				"ACACIA_PLANKS, ACACIA_BUTTON",
+				"CHERRY_PLANKS, CHERRY_BUTTON",
+				"DARK_OAK_PLANKS, DARK_OAK_BUTTON",
+				"PALE_OAK_PLANKS, PALE_OAK_BUTTON",
+				"MANGROVE_PLANKS, MANGROVE_BUTTON",
+				"BAMBOO_PLANKS, BAMBOO_BUTTON",
+				"CRIMSON_PLANKS, CRIMSON_BUTTON",
+				"WARPED_PLANKS, WARPED_BUTTON",
+			})
+			void givenButton(Material planks, Material button)
+			{
+				Recipe recipe = manager.getCraftingRecipe(new ItemStack[]
+						{
+								ItemStack.empty(), ItemStack.empty(), 		ItemStack.empty(),
+								ItemStack.empty(), ItemStack.of(planks), 	ItemStack.empty(),
+								ItemStack.empty(), ItemStack.empty(), 		ItemStack.empty()
+						});
+
+				assertNotNull(recipe);
+				assertEquals(button, recipe.getResult().getType());
+			}
+
+			@Test
+			void givenSugar()
+			{
+				Recipe recipe = manager.getCraftingRecipe(new ItemStack[]
+						{
+								ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
+								ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
+								ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.SUGAR_CANE)
+						});
+
+				assertNotNull(recipe);
+				assertEquals(Material.SUGAR, recipe.getResult().getType());
+			}
+
+			@Test
+			void givenSuspiciousStew()
+			{
+				Recipe recipe = manager.getCraftingRecipe(new ItemStack[]
+						{
+								ItemStack.of(Material.RED_MUSHROOM), 	ItemStack.empty(), ItemStack.of(Material.BOWL),
+								ItemStack.empty(), 						ItemStack.empty(), ItemStack.empty(),
+								ItemStack.of(Material.ALLIUM), 			ItemStack.empty(), ItemStack.of(Material.BROWN_MUSHROOM)
+						});
+
+				assertNotNull(recipe);
+				assertEquals(Material.SUSPICIOUS_STEW, recipe.getResult().getType());
+			}
+
+			@Test
+			void givenTntMinecart()
+			{
+				Recipe recipe = manager.getCraftingRecipe(new ItemStack[]
+						{
+								ItemStack.empty(), 				ItemStack.empty(), ItemStack.empty(),
+								ItemStack.of(Material.TNT), 	ItemStack.empty(), ItemStack.empty(),
+								ItemStack.of(Material.MINECART),ItemStack.empty(), ItemStack.empty()
+						});
+
+				assertNotNull(recipe);
+				assertEquals(Material.TNT_MINECART, recipe.getResult().getType());
+			}
+
+			@Test
+			void givenTrappedChest()
+			{
+				Recipe recipe = manager.getCraftingRecipe(new ItemStack[]
+						{
+								ItemStack.empty(), ItemStack.of(Material.TRIPWIRE_HOOK),ItemStack.of(Material.CHEST),
+								ItemStack.empty(), ItemStack.empty(), 					ItemStack.empty(),
+								ItemStack.empty(), ItemStack.empty(), 					ItemStack.empty()
+						});
+
+				assertNotNull(recipe);
+				assertEquals(Material.TRAPPED_CHEST, recipe.getResult().getType());
+			}
+
+			@Test
+			void givenWaxedCopper()
+			{
+				Recipe recipe = manager.getCraftingRecipe(new ItemStack[]
+						{
+								ItemStack.empty(), 					ItemStack.empty(), 						ItemStack.empty(),
+								ItemStack.empty(), 					ItemStack.of(Material.COPPER_BLOCK), 	ItemStack.empty(),
+								ItemStack.of(Material.HONEYCOMB),	ItemStack.empty(), 						ItemStack.empty()
+						});
+
+				assertNotNull(recipe);
+				assertEquals(Material.WAXED_COPPER_BLOCK, recipe.getResult().getType());
+			}
+
+			@ParameterizedTest
+			@CsvSource({
+				"WHITE_DYE, WHITE_CANDLE",
+				"ORANGE_DYE, ORANGE_CANDLE",
+				"MAGENTA_DYE, MAGENTA_CANDLE",
+				"LIGHT_BLUE_DYE, LIGHT_BLUE_CANDLE",
+				"YELLOW_DYE, YELLOW_CANDLE",
+				"LIME_DYE, LIME_CANDLE",
+				"PINK_DYE, PINK_CANDLE",
+				"GRAY_DYE, GRAY_CANDLE",
+				"LIGHT_GRAY_DYE, LIGHT_GRAY_CANDLE",
+				"CYAN_DYE, CYAN_CANDLE",
+				"PURPLE_DYE, PURPLE_CANDLE",
+				"BLUE_DYE, BLUE_CANDLE",
+				"BROWN_DYE, BROWN_CANDLE",
+				"GREEN_DYE, GREEN_CANDLE",
+				"RED_DYE, RED_CANDLE",
+				"BLACK_DYE, BLACK_CANDLE",
+			})
+			void givenCandle(Material color, Material expectedOutput)
+			{
+				Recipe recipe = manager.getCraftingRecipe(new ItemStack[]
+						{
+								ItemStack.empty(), 					ItemStack.empty(), 	ItemStack.of(color),
+								ItemStack.empty(), 					ItemStack.empty(), 	ItemStack.empty(),
+								ItemStack.of(Material.CANDLE),		ItemStack.empty(), 	ItemStack.empty()
+						});
+
+				assertNotNull(recipe);
+				assertEquals(expectedOutput, recipe.getResult().getType());
+			}
+
+		}
+
+		@Nested
+		@Disabled("Shaped recipes have not been implemented yet")
+		class ShapedRecipe
+		{
+
+			@ParameterizedTest
+			@CsvSource({
+				"IRON_INGOT, IRON_DOOR",
+				"OAK_PLANKS, OAK_DOOR",
+				"SPRUCE_PLANKS, SPRUCE_DOOR",
+				"BIRCH_PLANKS, BIRCH_DOOR",
+				"JUNGLE_PLANKS, JUNGLE_DOOR",
+				"ACACIA_PLANKS, ACACIA_DOOR",
+				"CHERRY_PLANKS, CHERRY_DOOR",
+				"DARK_OAK_PLANKS, DARK_OAK_DOOR",
+				"PALE_OAK_PLANKS, PALE_OAK_DOOR",
+				"MANGROVE_PLANKS, MANGROVE_DOOR",
+				"BAMBOO_PLANKS, BAMBOO_DOOR",
+				"CRIMSON_PLANKS, CRIMSON_DOOR",
+				"WARPED_PLANKS, WARPED_DOOR",
+				"COPPER_INGOT, COPPER_DOOR",
+				"EXPOSED_COPPER, EXPOSED_COPPER_DOOR",
+				"WEATHERED_COPPER, WEATHERED_COPPER_DOOR",
+				"OXIDIZED_COPPER, OXIDIZED_COPPER_DOOR",
+				"WAXED_EXPOSED_COPPER, WAXED_EXPOSED_COPPER_DOOR",
+				"WAXED_WEATHERED_COPPER, WAXED_WEATHERED_COPPER_DOOR",
+				"WAXED_OXIDIZED_COPPER, WAXED_OXIDIZED_COPPER_DOOR"
+			})
+			void givenDoor(Material doorMaterial, Material expectedOutput)
+			{
+				Recipe recipe = manager.getCraftingRecipe(new ItemStack[]
+						{
+								ItemStack.of(doorMaterial), ItemStack.of(doorMaterial), ItemStack.empty(),
+								ItemStack.of(doorMaterial), ItemStack.of(doorMaterial), ItemStack.empty(),
+								ItemStack.of(doorMaterial), ItemStack.of(doorMaterial), ItemStack.empty()
+						});
+
+				assertNotNull(recipe);
+				assertEquals(expectedOutput, recipe.getResult().getType());
+			}
+
+			@Test
+			void givenSticks()
+			{
+				Recipe recipe = manager.getCraftingRecipe(new ItemStack[]
+						{
+								ItemStack.empty(), ItemStack.empty(), 					ItemStack.empty(),
+								ItemStack.empty(), ItemStack.of(Material.OAK_PLANKS), 	ItemStack.empty(),
+								ItemStack.empty(), ItemStack.of(Material.OAK_PLANKS), 	ItemStack.empty()
+						});
+
+				assertNotNull(recipe);
+				assertEquals(Material.STICK, recipe.getResult().getType());
+			}
+
+		}
+
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/RecipeManagerTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/RecipeManagerTest.java
@@ -1,25 +1,81 @@
 package org.mockbukkit.mockbukkit.inventory;
 
+import java.util.EnumMap;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ComplexRecipe;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.ShapelessRecipe;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockbukkit.mockbukkit.MockBukkitExtension;
 
 @ExtendWith(MockBukkitExtension.class)
 class RecipeManagerTest
 {
 	private final RecipeManager manager = new RecipeManager();
+
+	@Nested
+	class Reset
+	{
+		@Test
+		void givenNullRecipeType()
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> manager.reset(null));
+			assertEquals("Recipe type cannot be null", e.getMessage());
+		}
+
+		@ParameterizedTest
+		@EnumSource(RecipeType.class)
+		void givenResetToRecipeType(RecipeType type)
+		{
+			int initialSize = manager.getRecipes(type).size();
+			manager.clearRecipes(type);
+			assertTrue(manager.getRecipes(type).isEmpty());
+
+			manager.reset(type);
+
+			assertEquals(initialSize, manager.getRecipes(type).size());
+		}
+
+		@Test
+		void givenGenericReset()
+		{
+			Map<RecipeType, Integer> initialSizes = new EnumMap<>(RecipeType.class);
+
+			for (RecipeType type : RecipeType.values())
+			{
+				initialSizes.put(type, manager.getRecipes(type).size());
+				manager.clearRecipes(type);
+				assertTrue(manager.getRecipes(type).isEmpty());
+			}
+
+			manager.reset();
+
+			for (RecipeType type : RecipeType.values())
+			{
+				assertEquals(initialSizes.get(type), manager.getRecipes(type).size());
+			}
+		}
+
+	}
 
 	@Nested
 	class Clear
@@ -48,6 +104,22 @@ class RecipeManagerTest
 	@Nested
 	class GetCraftingRecipe
 	{
+		@Test
+		void givenNullCraftMatrix()
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> manager.getCraftingRecipe(null));
+			assertEquals("craftingMatrix must not be null", e.getMessage());
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = {
+			0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 14, 15
+		})
+		void givenCraftMatrixWithout9Slots(int itemsAmount)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> manager.getCraftingRecipe(new ItemStack[itemsAmount]));
+			assertEquals("craftingMatrix must be an array of length 9", e.getMessage());
+		}
 
 		@Nested
 		class ShapelessRecipe
@@ -262,6 +334,126 @@ class RecipeManagerTest
 
 				assertNotNull(recipe);
 				assertEquals(Material.STICK, recipe.getResult().getType());
+			}
+
+		}
+
+	}
+
+	@Nested
+	class Matches
+	{
+
+		@Nested
+		class Shapeless
+		{
+			private final ShapelessRecipe recipe = (ShapelessRecipe) Bukkit.getRecipe(NamespacedKey.minecraft("oak_button"));
+
+			@Test
+			void givenNullRecipe()
+			{
+				IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> RecipeManager.matches((ShapelessRecipe) null, new ItemStack[0]));
+				assertEquals("The recipe cannot be null", e.getMessage());
+			}
+
+			@Test
+			void givenNullCraftMatrix()
+			{
+				IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> RecipeManager.matches(recipe, null));
+				assertEquals("The craftingMatrix cannot be null", e.getMessage());
+			}
+
+			@Test
+			void givenValidCraftMatrix()
+			{
+				ItemStack[] matrix = new ItemStack[] {
+					ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
+					ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
+					ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.OAK_PLANKS)
+				};
+				boolean result = RecipeManager.matches(recipe, matrix);
+				assertTrue(result);
+			}
+
+			@Test
+			void givenInvalidCraftMatrix()
+			{
+				ItemStack[] matrix = new ItemStack[] {
+						ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
+						ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
+						ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.BIRCH_PLANKS)
+				};
+				boolean result = RecipeManager.matches(recipe, matrix);
+				assertFalse(result);
+			}
+
+		}
+
+		@Nested
+		class Shaped
+		{
+
+			private final ShapedRecipe recipe = (ShapedRecipe) Bukkit.getRecipe(NamespacedKey.minecraft("stick"));
+
+			@Test
+			void givenNullRecipe()
+			{
+				IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> RecipeManager.matches((ShapedRecipe) null, new ItemStack[0]));
+				assertEquals("The recipe cannot be null", e.getMessage());
+			}
+
+			@Test
+			void givenNullCraftMatrix()
+			{
+				IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> RecipeManager.matches(recipe, null));
+				assertEquals("The craftingMatrix cannot be null", e.getMessage());
+			}
+
+			@Test
+			@Disabled("This was not implemented yet")
+			void givenValidCraftMatrix()
+			{
+				ItemStack[] matrix = new ItemStack[] {
+						ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
+						ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.OAK_PLANKS),
+						ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.OAK_PLANKS)
+				};
+				boolean result = RecipeManager.matches(recipe, matrix);
+				assertTrue(result);
+			}
+
+			@Test
+			void givenInvalidCraftMatrix()
+			{
+				ItemStack[] matrix = new ItemStack[] {
+						ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
+						ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.BIRCH_PLANKS),
+						ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.BIRCH_PLANKS)
+				};
+				boolean result = RecipeManager.matches(recipe, matrix);
+				assertFalse(result);
+			}
+
+		}
+
+		@Nested
+		class Complex
+		{
+
+			private final ComplexRecipe recipe = (ComplexRecipe) Bukkit.getRecipe(NamespacedKey.minecraft("shield_decoration"));
+
+			@Test
+			void givenNullRecipe()
+			{
+				IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> RecipeManager.matches((ComplexRecipe) null, new ItemStack[0]));
+				assertEquals("The recipe cannot be null", e.getMessage());
+			}
+
+			@Test
+			void givenNullCraftMatrix()
+			{
+				IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> RecipeManager.matches(recipe, null));
+				assertEquals("The craftingMatrix cannot be null", e.getMessage());
 			}
 
 		}

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/WorkbenchInventoryMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/WorkbenchInventoryMockTest.java
@@ -1,18 +1,20 @@
 package org.mockbukkit.mockbukkit.inventory;
 
-import org.mockbukkit.mockbukkit.MockBukkitExtension;
-import org.bukkit.Material;
-import org.bukkit.inventory.ItemStack;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.Recipe;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
 
 @ExtendWith(MockBukkitExtension.class)
 class WorkbenchInventoryMockTest
@@ -46,46 +48,62 @@ class WorkbenchInventoryMockTest
 		assertNotNull(workbench.getMatrix());
 	}
 
-	@Test
-	void testSetMatrix()
+	@Nested
+	class SetMatrix
 	{
-		ItemStack[] matrix = new ItemStackMock[10];
-		matrix[4] = new ItemStackMock(Material.OAK_BOAT);
+		@Test
+		void testSetMatrix()
+		{
+			ItemStack[] matrix = new ItemStackMock[10];
+			matrix[4] = new ItemStackMock(Material.OAK_BOAT);
 
-		workbench.setMatrix(matrix);
+			workbench.setMatrix(matrix);
 
-		assertArrayEquals(matrix, workbench.getMatrix());
+			assertArrayEquals(matrix, workbench.getMatrix());
+		}
+
+		@Test
+		void givenMatrixUnderMaxSize()
+		{
+			ItemStack[] matrix = new ItemStack[5];
+			matrix[4] = new ItemStackMock(Material.OAK_BOAT);
+			assertDoesNotThrow(() -> workbench.setMatrix(matrix));
+		}
+
+		@Test
+		void givenMatrixOverMaxSize()
+		{
+			assertThrows(IllegalArgumentException.class, () -> workbench.setMatrix(new ItemStack[12]));
+		}
+
+		@Test
+		void givenNull()
+		{
+			assertThrows(NullPointerException.class, () -> workbench.setMatrix(null));
+		}
+
+		@Test
+		void testSetMatrix_SetsItems()
+		{
+			ItemStack[] matrix = new ItemStack[10];
+			matrix[4] = new ItemStackMock(Material.OAK_BOAT);
+
+			workbench.setMatrix(matrix);
+
+			assertArrayEquals(matrix, workbench.getContents());
+		}
 	}
 
 	@Test
-	void testSetMatrix_underMaxSize()
-	{
-		ItemStack[] matrix = new ItemStack[5];
-		matrix[4] = new ItemStackMock(Material.OAK_BOAT);
-		assertDoesNotThrow(() -> workbench.setMatrix(matrix));
-	}
-
-	@Test
-	void testSetMatrix_overMaxSize()
-	{
-		assertThrows(IllegalArgumentException.class, () -> workbench.setMatrix(new ItemStack[12]));
-	}
-
-	@Test
-	void testSetMatrix_null()
-	{
-		assertThrows(NullPointerException.class, () -> workbench.setMatrix(null));
-	}
-
-	@Test
-	void testSetMatrix_SetsItems()
+	void getRecipe()
 	{
 		ItemStack[] matrix = new ItemStack[10];
-		matrix[4] = new ItemStackMock(Material.OAK_BOAT);
-
+		matrix[5] = new ItemStackMock(Material.OAK_PLANKS);
 		workbench.setMatrix(matrix);
 
-		assertArrayEquals(matrix, workbench.getContents());
+		Recipe actual = workbench.getRecipe();
+		assertNotNull(actual);
+		assertEquals(ItemStack.of(Material.OAK_BUTTON), actual.getResult());
 	}
 
 }


### PR DESCRIPTION
# Description
Implemented some of the methods related with recipes in `ServerMock` .

We can now use the methods `getCraftingRecipe` and `craftItem` for `Shapeless` recipes.
I tried to develop the code for `Shaped` recipes but this part is so complex that I think it's better to do it in a separated pull request.

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
