### PR TITLE
Adding player-on-player damage and ability to retrieve the killer

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -72,6 +72,7 @@ import java.util.function.Consumer;
  */
 public abstract class LivingEntityMock extends EntityMock implements LivingEntity
 {
+
 	private final BrainMock brain = new BrainMock();
 	/**
 	 * How much health the entity has.
@@ -268,7 +269,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	 */
 	public EntityDamageEvent simulateDamage(double amount, @NotNull DamageSource source)
 	{
-		return new LivingEntitySimulation(this).simulateDamage(amount,source);
+		return new LivingEntitySimulation(this).simulateDamage(amount, source);
 	}
 
 	/**
@@ -686,7 +687,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	 * Adds multiple potion effects. If one event is canceled, the effect from that event won't be added.
 	 *
 	 * @param effects The Potion Effects to add.
-	 * @param cause The cause.
+	 * @param cause   The cause.
 	 * @return A list of events containing details about adding the potion effects.
 	 */
 	public List<EntityPotionEffectEvent> addPotionEffects(@NotNull Collection<PotionEffect> effects, EntityPotionEffectEvent.Cause cause)

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -168,10 +168,10 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		}
 
 		DamageSource dmg;
-		if (getLastDamageCause() != null && getLastDamageCause().getDamageSource().getDirectEntity() instanceof Player killer)
+		if (getLastDamageCause() != null && getLastDamageCause().getDamageSource().getDirectEntity() instanceof Player player)
 		{
 			dmg = DamageSource.builder(DamageType.PLAYER_ATTACK).build();
-			setKiller(killer);
+			setKiller(player);
 		}
 		else
 		{

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -269,7 +269,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	 */
 	public EntityDamageEvent simulateDamage(double amount, @NotNull DamageSource source)
 	{
-		return new LivingEntitySimulation(this).simulateDamage(amount, source);
+		return new LivingEntitySimulation(this).simulateDamage(amount,source);
 	}
 
 	/**

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -166,12 +166,30 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 			return;
 		}
 
+		DamageSource dmg;
+		if (getLastDamageCause() != null && getLastDamageCause().getDamageSource().getDirectEntity() instanceof Player killer)
+		{
+			dmg = DamageSource.builder(DamageType.PLAYER_ATTACK).build();
+			setKiller(killer);
+		}
+		else
+		{
+			dmg = DamageSource.builder(DamageType.GENERIC).build();
+		}
+
 		this.health = 0;
 
-		EntityDeathEvent event = new EntityDeathEvent(this, DamageSource.builder(DamageType.GENERIC).build(), new ArrayList<>());
-		Bukkit.getPluginManager().callEvent(event);
-
-		this.alive = false;
+		EntityDeathEvent event = new EntityDeathEvent(this, dmg, new ArrayList<>());
+		if (!event.callEvent())
+		{
+			setKiller(null);
+			this.health = event.getReviveHealth();
+			this.alive = true;
+		}
+		else
+		{
+			this.alive = false;
+		}
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
@@ -2362,11 +2362,11 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 
 		DamageSource dmg;
 		String msg;
-		if (getLastDamageCause() != null && getLastDamageCause().getDamageSource().getDirectEntity() instanceof Player killer)
+		if (getLastDamageCause() != null && getLastDamageCause().getDamageSource().getDirectEntity() instanceof Player player)
 		{
 			dmg = DamageSource.builder(DamageType.PLAYER_ATTACK).build();
-			setKiller(killer);
-			msg = getName() + " was slain by " + killer.getName();
+			setKiller(player);
+			msg = getName() + " was slain by " + player.getName();
 		}
 		else
 		{

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
@@ -2360,28 +2360,49 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 			return;
 		}
 
+		DamageSource dmg;
+		String msg;
+		if (getLastDamageCause() != null && getLastDamageCause().getDamageSource().getDirectEntity() instanceof Player killer)
+		{
+			dmg = DamageSource.builder(DamageType.PLAYER_ATTACK).build();
+			setKiller(killer);
+			msg = getName() + " was slain by " + killer.getName();
+		}
+		else
+		{
+			dmg = DamageSource.builder(DamageType.GENERIC).build();
+			msg = getName() + " got killed";
+		}
+
 		this.health = 0;
 
 		List<ItemStack> drops = new ArrayList<>(Arrays.asList(getInventory().getContents()));
-		PlayerDeathEvent event = new PlayerDeathEvent(this, DamageSource.builder(DamageType.GENERIC).build(), drops, 0, getName() + " got killed");
-		Bukkit.getPluginManager().callEvent(event);
-
-		// Terminate any InventoryView and the cursor item
-		closeInventory();
-
-		// Clear the Inventory if keep-inventory is not enabled
-		if (!getWorld().getGameRuleValue(GameRule.KEEP_INVENTORY))
+		PlayerDeathEvent event = new PlayerDeathEvent(this, dmg, drops, 0, msg);
+		if (!event.callEvent())
 		{
-			getInventory().clear();
-			// Should someone try to provoke a RespawnEvent, they will now find the Inventory to be empty
+			setKiller(null);
+			this.health = event.getReviveHealth();
+			this.alive = true;
 		}
+		else
+		{
+			// Terminate any InventoryView and the cursor item
+			closeInventory();
 
-		setLevel(0);
-		setExp(0);
-		setFoodLevel(0);
+			// Clear the Inventory if keep-inventory is not enabled
+			if (!getWorld().getGameRuleValue(GameRule.KEEP_INVENTORY))
+			{
+				getInventory().clear();
+				// Should someone try to provoke a RespawnEvent, they will now find the Inventory to be empty
+			}
 
-		setBlocking(false);
-		alive = false;
+			setLevel(0);
+			setExp(0);
+			setFoodLevel(0);
+
+			setBlocking(false);
+			alive = false;
+		}
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/simulate/entity/LivingEntitySimulation.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/simulate/entity/LivingEntitySimulation.java
@@ -38,11 +38,12 @@ public class LivingEntitySimulation
 		{
 			event = new EntityDamageEvent(livingEntityMock, EntityDamageEvent.DamageCause.CUSTOM, source, amount);
 		}
+
 		if (event.callEvent())
 		{
 			livingEntityMock.setLastDamageCause(event);
 			amount = event.getDamage();
-			livingEntityMock.damage(amount);
+			livingEntityMock.damage(amount, source.getDirectEntity());
 		}
 		return event;
 	}

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
@@ -1,10 +1,5 @@
 package org.mockbukkit.mockbukkit.entity;
 
-import org.bukkit.entity.memory.MemoryKey;
-import org.mockbukkit.mockbukkit.MockBukkit;
-import org.mockbukkit.mockbukkit.ServerMock;
-import org.mockbukkit.mockbukkit.world.WorldMock;
-import org.mockbukkit.mockbukkit.entity.data.EntityState;
 import net.kyori.adventure.util.TriState;
 import org.bukkit.Location;
 import org.bukkit.entity.Arrow;
@@ -29,6 +24,9 @@ import org.bukkit.entity.TippedArrow;
 import org.bukkit.entity.Trident;
 import org.bukkit.entity.WindCharge;
 import org.bukkit.entity.WitherSkull;
+import org.bukkit.entity.memory.MemoryKey;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityPotionEffectEvent;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -39,12 +37,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.data.EntityState;
+import org.mockbukkit.mockbukkit.world.WorldMock;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -53,6 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockbukkit.mockbukkit.matcher.plugin.PluginManagerFiredEventClassMatcher.hasFiredEventInstance;
 
 class LivingEntityMockTest
 {
@@ -352,25 +356,25 @@ class LivingEntityMockTest
 
 	@ParameterizedTest
 	@ValueSource(classes = {
-		Arrow.class,
-		DragonFireball.class,
-		Egg.class,
-		EnderPearl.class,
-		Firework.class,
-		FishHook.class,
-		LargeFireball.class,
-		LingeringPotion.class,
-		LlamaSpit.class,
-		ShulkerBullet.class,
-		SmallFireball.class,
-		Snowball.class,
-		SpectralArrow.class,
-		ThrownExpBottle.class,
-		ThrownPotion.class,
-		TippedArrow.class,
-		Trident.class,
-		WindCharge.class,
-		WitherSkull.class,
+			Arrow.class,
+			DragonFireball.class,
+			Egg.class,
+			EnderPearl.class,
+			Firework.class,
+			FishHook.class,
+			LargeFireball.class,
+			LingeringPotion.class,
+			LlamaSpit.class,
+			ShulkerBullet.class,
+			SmallFireball.class,
+			Snowball.class,
+			SpectralArrow.class,
+			ThrownExpBottle.class,
+			ThrownPotion.class,
+			TippedArrow.class,
+			Trident.class,
+			WindCharge.class,
+			WitherSkull.class,
 	})
 	<T extends Projectile> void launchProjectile_GivenProjectileAndVelocityAndFunctionAsArgument(Class<T> tClass)
 	{
@@ -432,6 +436,18 @@ class LivingEntityMockTest
 
 		livingEntity.setMemory(MemoryKey.HUNTED_RECENTLY, null);
 		assertNull(livingEntity.getMemory(MemoryKey.HUNTED_RECENTLY));
+	}
+
+	@Test
+	void damage_ExactlyHealth_ZeroAndDeathEvent()
+	{
+		var player = server.addPlayer();
+		livingEntity.simulateDamage(livingEntity.getHealth(), player);
+		assertEquals(0, livingEntity.getHealth(), 0);
+		assertTrue(livingEntity.isDead());
+		assertThat(server.getPluginManager(), hasFiredEventInstance(EntityDamageEvent.class));
+		assertThat(server.getPluginManager(), hasFiredEventInstance(EntityDeathEvent.class));
+		assertEquals(player, livingEntity.getKiller());
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
@@ -25,6 +25,9 @@ import org.bukkit.entity.Trident;
 import org.bukkit.entity.WindCharge;
 import org.bukkit.entity.WitherSkull;
 import org.bukkit.entity.memory.MemoryKey;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.CreeperPowerEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityPotionEffectEvent;
@@ -448,6 +451,36 @@ class LivingEntityMockTest
 		assertThat(server.getPluginManager(), hasFiredEventInstance(EntityDamageEvent.class));
 		assertThat(server.getPluginManager(), hasFiredEventInstance(EntityDeathEvent.class));
 		assertEquals(player, livingEntity.getKiller());
+	}
+
+	@Test
+	void damage_JustKilled()
+	{
+		livingEntity.simulateDamage(livingEntity.getHealth(), (Entity) null);
+		assertEquals(0, livingEntity.getHealth(), 0);
+		assertTrue(livingEntity.isDead());
+		assertThat(server.getPluginManager(), hasFiredEventInstance(EntityDamageEvent.class));
+		assertThat(server.getPluginManager(), hasFiredEventInstance(EntityDeathEvent.class));
+	}
+
+	@Test
+	void damage_CancelDeathEvent()
+	{
+		server.getPluginManager().registerEvents(new Listener()
+		{
+			@EventHandler
+			void onEntityDeathEvent(EntityDeathEvent event)
+			{
+				event.setReviveHealth(10);
+				event.setCancelled(true);
+			}
+		}, MockBukkit.createMockPlugin());
+
+		var player = server.addPlayer();
+		livingEntity.simulateDamage(livingEntity.getHealth(), player);
+		assertEquals(10, livingEntity.getHealth(), 0);
+		assertFalse(livingEntity.isDead());
+		assertNull(livingEntity.getKiller());
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
@@ -36,6 +36,7 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockDamageEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityTeleportEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.ClickType;
@@ -345,8 +346,33 @@ class PlayerMockTest
 		assertEquals(0, player.getHealth(), 0);
 		assertTrue(player.isDead());
 		assertEquals(killer, player.getKiller());
+		assertTrue(player.getInventory().isEmpty());
 	}
 
+	@Test
+	void damage_CancelDeathEvent()
+	{
+		server.getPluginManager().registerEvents(new Listener()
+		{
+			@EventHandler
+			void onPlayerDeathEvent(PlayerDeathEvent event)
+			{
+				event.setReviveHealth(10);
+				event.setCancelled(true);
+			}
+		}, MockBukkit.createMockPlugin());
+
+		assertTrue(player.getInventory().isEmpty());
+		player.setItemInHand(new ItemStackMock(Material.STONE_SWORD));
+		assertFalse(player.getInventory().isEmpty());
+
+		var killer = server.addPlayer();
+		player.simulateDamage(player.getHealth(), killer);
+		assertEquals(10, player.getHealth(), 0);
+		assertFalse(player.isDead());
+		assertNull(player.getKiller());
+		assertFalse(player.getInventory().isEmpty());
+	}
 	@Test
 	void getAttribute_HealthAttribute_IsMaximumHealth()
 	{

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
@@ -338,6 +338,16 @@ class PlayerMockTest
 	}
 
 	@Test
+	void damage_Player_Kills_OtherPlayer()
+	{
+		var killer = server.addPlayer();
+		player.simulateDamage(player.getHealth(), killer);
+		assertEquals(0, player.getHealth(), 0);
+		assertTrue(player.isDead());
+		assertEquals(killer, player.getKiller());
+	}
+
+	@Test
 	void getAttribute_HealthAttribute_IsMaximumHealth()
 	{
 		assertEquals(20.0, player.getAttribute(Attribute.MAX_HEALTH).getDefaultValue(), 0);

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
@@ -78,13 +78,10 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockbukkit.mockbukkit.MockBukkit;
-import org.mockbukkit.mockbukkit.block.state.ChestStateMock;
-import org.mockbukkit.mockbukkit.plugin.PluginMock;
 import org.mockbukkit.mockbukkit.ServerMock;
-import org.mockbukkit.mockbukkit.plugin.TestPlugin;
-import org.mockbukkit.mockbukkit.world.WorldMock;
 import org.mockbukkit.mockbukkit.block.BlockMock;
 import org.mockbukkit.mockbukkit.block.data.BlockDataMock;
+import org.mockbukkit.mockbukkit.block.state.ChestStateMock;
 import org.mockbukkit.mockbukkit.block.state.TileStateMock;
 import org.mockbukkit.mockbukkit.entity.data.EntityState;
 import org.mockbukkit.mockbukkit.inventory.EnderChestInventoryMock;
@@ -93,6 +90,9 @@ import org.mockbukkit.mockbukkit.inventory.ItemStackMock;
 import org.mockbukkit.mockbukkit.map.MapViewMock;
 import org.mockbukkit.mockbukkit.matcher.sound.SoundReceiverSoundHeardMatcher;
 import org.mockbukkit.mockbukkit.plugin.PluginManagerMock;
+import org.mockbukkit.mockbukkit.plugin.PluginMock;
+import org.mockbukkit.mockbukkit.plugin.TestPlugin;
+import org.mockbukkit.mockbukkit.world.WorldMock;
 
 import java.net.InetSocketAddress;
 import java.util.Collections;
@@ -2723,4 +2723,5 @@ class PlayerMockTest
 		assertEquals(player.nextActionBar(), textComponent2);
 		assertEquals(player.nextActionBar(), textComponent3);
 	}
+
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
@@ -341,12 +341,21 @@ class PlayerMockTest
 	@Test
 	void damage_Player_Kills_OtherPlayer()
 	{
+		player.setItemInHand(new ItemStackMock(Material.STONE_SWORD));
+		player.setLevel(11);
+		player.setExp(0.5f);
+		player.setFoodLevel(13);
+
 		var killer = server.addPlayer();
+
 		player.simulateDamage(player.getHealth(), killer);
 		assertEquals(0, player.getHealth(), 0);
 		assertTrue(player.isDead());
 		assertEquals(killer, player.getKiller());
 		assertTrue(player.getInventory().isEmpty());
+		assertEquals(0, player.getLevel());
+		assertEquals(0, player.getExp(), 1e-6);
+		assertEquals(0, player.getFoodLevel());
 	}
 
 	@Test
@@ -364,6 +373,9 @@ class PlayerMockTest
 
 		assertTrue(player.getInventory().isEmpty());
 		player.setItemInHand(new ItemStackMock(Material.STONE_SWORD));
+		player.setLevel(11);
+		player.setExp(0.5f);
+		player.setFoodLevel(13);
 		assertFalse(player.getInventory().isEmpty());
 
 		var killer = server.addPlayer();
@@ -372,6 +384,9 @@ class PlayerMockTest
 		assertFalse(player.isDead());
 		assertNull(player.getKiller());
 		assertFalse(player.getInventory().isEmpty());
+		assertEquals(11, player.getLevel());
+		assertEquals(0.5f, player.getExp(), 1e-6);
+		assertEquals(13, player.getFoodLevel());
 	}
 	@Test
 	void getAttribute_HealthAttribute_IsMaximumHealth()


### PR DESCRIPTION
# Description
I added this test:
```java
    @Test
    void damage_Player_Kills_OtherPlayer()
    {
        var killer = server.addPlayer();
        player.simulateDamage(player.getHealth(), killer);
        assertEquals(0, player.getHealth(), 0);
        assertTrue(player.isDead());
        assertEquals(killer, player.getKiller());
    }
```
And it fails:
Expected :org.mockbukkit.mockbukkit.entity.PlayerMock@d3f6027e
Actual   :null

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
