### PR TITLE
Implemented method death screen score in Player

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
@@ -175,6 +175,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	private int expTotal = 0;
 	private float exp = 0;
 	private int expCooldown = 0;
+	private int deathScreenScore = 0;
 	private boolean sprinting = false;
 	private boolean allowFlight = false;
 	private boolean flying = false;
@@ -3480,6 +3481,18 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	{
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public int getDeathScreenScore()
+	{
+		return this.deathScreenScore;
+	}
+
+	@Override
+	public void setDeathScreenScore(int deathScreenScore)
+	{
+		this.deathScreenScore = deathScreenScore;
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
@@ -36,7 +36,6 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockDamageEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityTeleportEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.ClickType;
@@ -78,6 +77,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.ServerMock;
 import org.mockbukkit.mockbukkit.block.BlockMock;
@@ -2763,6 +2763,27 @@ class PlayerMockTest
 		assertEquals(player.nextActionBar(), textComponent);
 		assertEquals(player.nextActionBar(), textComponent2);
 		assertEquals(player.nextActionBar(), textComponent3);
+	}
+
+	@Nested
+	class DeathScreenScore
+	{
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(0, player.getDeathScreenScore());
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = {
+			0, 1, 2, 3, 4, 5, 10, 200, 3000
+		})
+		void givenPossibleValues(int value)
+		{
+			player.setDeathScreenScore(value);
+			assertEquals(value, player.getDeathScreenScore());
+		}
+
 	}
 
 }


### PR DESCRIPTION
# Description
Implemented method [getDeathScreenScore](https://jd.papermc.io/paper/1.21.4/org/bukkit/entity/Player.html#getDeathScreenScore()) and [setDeathScreenScore(int)](https://jd.papermc.io/paper/1.21.4/org/bukkit/entity/Player.html#setDeathScreenScore(int)).

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
