### PR TITLE
Fix two player xp functions not throwing

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
@@ -1959,8 +1959,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public void setExp(float exp)
 	{
-		if (exp < 0.0 || exp > 1.0)
-			throw new IllegalArgumentException("Experience progress must be between 0.0 and 1.0");
+		Preconditions.checkArgument(exp >= 0.0 && exp <= 1.0, "Experience progress must be between 0.0 and 1.0 (%s)", exp);
 		this.exp = exp;
 	}
 
@@ -1973,8 +1972,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public void setLevel(int level)
 	{
-		if (level < 0)
-			throw new IllegalArgumentException("Experience level must not be negative");
+		Preconditions.checkArgument(level >= 0, "Experience level must not be negative (%s)", level);
 		this.expLevel = level;
 	}
 
@@ -1987,8 +1985,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public void setTotalExperience(int exp)
 	{
-		if (exp < 0)
-			throw new IllegalArgumentException("Total experience points must not be negative");
+		Preconditions.checkArgument(exp >= 0, "Total experience points must not be negative (%s)", exp);
 		this.expTotal = exp;
 	}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
@@ -1973,6 +1973,8 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public void setLevel(int level)
 	{
+		if (level < 0)
+			throw new IllegalArgumentException("Experience level must not be negative");
 		this.expLevel = level;
 	}
 
@@ -1985,7 +1987,9 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public void setTotalExperience(int exp)
 	{
-		this.expTotal = Math.max(0, exp);
+		if (exp < 0)
+			throw new IllegalArgumentException("Total experience points must not be negative");
+		this.expTotal = exp;
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
@@ -388,6 +388,7 @@ class PlayerMockTest
 		assertEquals(0.5f, player.getExp(), 1e-6);
 		assertEquals(13, player.getFoodLevel());
 	}
+
 	@Test
 	void getAttribute_HealthAttribute_IsMaximumHealth()
 	{
@@ -758,6 +759,12 @@ class PlayerMockTest
 	}
 
 	@Test
+	void setLevel_LessThanZero_ExceptionThrown()
+	{
+		assertThrows(IllegalArgumentException.class, () -> player.setLevel(-1));
+	}
+
+	@Test
 	void setExp_SomeValue_LevelSetExactly()
 	{
 		player.setExp(0.5F);
@@ -784,10 +791,9 @@ class PlayerMockTest
 	}
 
 	@Test
-	void setTotalExperience_NegativeValue_ClampedAtZero()
+	void setTotalExperience_LessThanZero_ExceptionThrown()
 	{
-		player.setTotalExperience(-200);
-		assertEquals(0, player.getTotalExperience(), 0);
+		assertThrows(IllegalArgumentException.class, () -> player.setTotalExperience(-200));
 	}
 
 	@Test
@@ -2768,6 +2774,7 @@ class PlayerMockTest
 	@Nested
 	class DeathScreenScore
 	{
+
 		@Test
 		void givenDefaultValue()
 		{
@@ -2776,7 +2783,7 @@ class PlayerMockTest
 
 		@ParameterizedTest
 		@ValueSource(ints = {
-			0, 1, 2, 3, 4, 5, 10, 200, 3000
+				0, 1, 2, 3, 4, 5, 10, 200, 3000
 		})
 		void givenPossibleValues(int value)
 		{


### PR DESCRIPTION
# Description
small fix to better match paper behavior

Note: Paper use `Preconditions.checkArgument` instead of `new IllegalArgumentException`. But this copy how current setExp do

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
