### PR TITLE
Added Entity Phantom and Lightning Strike

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/EntityMock.java
@@ -128,7 +128,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	private CreatureSpawnEvent.SpawnReason spawnReason = CreatureSpawnEvent.SpawnReason.CUSTOM;
 
 	/**
-	 * Constructs a new EntityMock on the provided {@link ServerMock} with a specified {@link UUID}.
+	 * Constructs a new {@link EntityMock} on the provided {@link ServerMock} with a specified {@link UUID}.
 	 *
 	 * @param server The server to create the entity on.
 	 * @param uuid   The UUID of the entity.

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/EntityTypesMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/EntityTypesMock.java
@@ -73,6 +73,7 @@ import org.bukkit.entity.Ocelot;
 import org.bukkit.entity.Painting;
 import org.bukkit.entity.Panda;
 import org.bukkit.entity.Parrot;
+import org.bukkit.entity.Phantom;
 import org.bukkit.entity.Pig;
 import org.bukkit.entity.PigZombie;
 import org.bukkit.entity.Piglin;
@@ -290,6 +291,7 @@ public final class EntityTypesMock
 			.register(PaleOakChestBoat.class, PaleOakChestBoatMock.class, PaleOakChestBoatMock::new)
 			.register(Panda.class, PandaMock.class, PandaMock::new)
 			.register(Parrot.class, ParrotMock.class, ParrotMock::new)
+			.register(Phantom.class, PhantomMock.class, PhantomMock::new)
 			.register(Pig.class, PigMock.class, PigMock::new)
 			.register(Piglin.class, PiglinMock.class, PiglinMock::new)
 			.register(PiglinBrute.class, PiglinBruteMock.class, PiglinBruteMock::new)

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/EntityTypesMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/EntityTypesMock.java
@@ -62,6 +62,7 @@ import org.bukkit.entity.ItemDisplay;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.LargeFireball;
 import org.bukkit.entity.LeashHitch;
+import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.Llama;
 import org.bukkit.entity.LlamaSpit;
 import org.bukkit.entity.MagmaCube;
@@ -272,6 +273,7 @@ public final class EntityTypesMock
 			.register(JungleChestBoat.class, JungleChestBoatMock.class, JungleChestBoatMock::new)
 			.register(LargeFireball.class, LargeFireballMock.class, LargeFireballMock::new)
 			.register(LeashHitch.class, LeashHitchMock.class, LeashHitchMock::new)
+			.register(LightningStrike.class, LightningStrikeMock.class, LightningStrikeMock::new)
 			.register(Llama.class, LlamaMock.class, LlamaMock::new)
 			.register(LlamaSpit.class, LlamaSpitMock.class, LlamaSpitMock::new)
 			.register(MagmaCube.class, MagmaCubeMock.class, MagmaCubeMock::new)

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LightningStrikeMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LightningStrikeMock.java
@@ -1,0 +1,125 @@
+package org.mockbukkit.mockbukkit.entity;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LightningStrike;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
+
+import java.util.UUID;
+
+/**
+ * Mock implementation of a {@link LightningStrike}.
+ *
+ * @see EntityMock
+ */
+public class LightningStrikeMock extends EntityMock implements LightningStrike
+{
+	private boolean isEffect = false;
+	private int numberOfFlashes = 3;
+	private int ticksLived = 0;
+
+	private @Nullable Player causingPlayer = null;
+
+	/**
+	 * Constructs a new {@link LightningStrikeMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
+	public LightningStrikeMock(@NotNull ServerMock server, @NotNull UUID uuid)
+	{
+		super(server, uuid);
+	}
+
+	@Override
+	public boolean isEffect()
+	{
+		return this.isEffect;
+	}
+
+	/**
+	 * Set whether the strike is an effect that does no damage.
+	 *
+	 * @param effect {@code true} if the strike is an effect, otherwise {@code false}
+	 */
+	public void setEffect(boolean effect)
+	{
+		this.isEffect = effect;
+	}
+
+	@Override
+	@Deprecated(forRemoval = true)
+	public int getFlashes()
+	{
+		return this.getFlashCount();
+	}
+
+	@Override
+	@Deprecated(forRemoval = true)
+	public void setFlashes(int flashes)
+	{
+		this.setFlashCount(flashes);
+	}
+
+	@Override
+	public int getLifeTicks()
+	{
+		return this.ticksLived;
+	}
+
+	@Override
+	public void setLifeTicks(int ticks)
+	{
+		this.ticksLived = ticks;
+	}
+
+	@Override
+	public @Nullable Player getCausingPlayer()
+	{
+		return this.causingPlayer;
+	}
+
+	@Override
+	public void setCausingPlayer(@Nullable Player player)
+	{
+		this.causingPlayer = player;
+	}
+
+	@Override
+	public int getFlashCount()
+	{
+		return this.numberOfFlashes;
+	}
+
+	@Override
+	public void setFlashCount(int flashes)
+	{
+		Preconditions.checkArgument(flashes >= 1, "flashes must be >= 1");
+		this.numberOfFlashes = flashes;
+	}
+
+	@Override
+	public @Nullable Entity getCausingEntity()
+	{
+		return this.getCausingPlayer();
+	}
+
+	@Override
+	public @NotNull EntityType getType()
+	{
+		return EntityType.LIGHTNING_BOLT;
+	}
+
+	@Override
+	@Deprecated(forRemoval = true)
+	public @NotNull LightningStrike.Spigot spigot()
+	{
+		throw new UnimplementedOperationException("spigot() method is not implemented in LightningStrikeMock");
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/PhantomMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/PhantomMock.java
@@ -1,0 +1,96 @@
+package org.mockbukkit.mockbukkit.entity;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Location;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Phantom;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+import java.util.UUID;
+
+/**
+ * Mock implementation of a {@link Phantom}.
+ *
+ * @see FlyingMock
+ */
+public class PhantomMock extends FlyingMock implements Phantom
+{
+	private int size = 0;
+	private boolean shouldBurnInDay = true;
+
+	private @Nullable UUID spawningEntity = null;
+	private @NotNull Location anchorLocation = new Location(null, 0, 0, 0);
+
+	/**
+	 * Constructs a new {@link PhantomMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
+	public PhantomMock(@NotNull ServerMock server, @NotNull UUID uuid)
+	{
+		super(server, uuid);
+	}
+
+	@Override
+	public int getSize()
+	{
+		return this.size;
+	}
+
+	@Override
+	public void setSize(int size)
+	{
+		this.size = Math.clamp(size, 0, 64);
+	}
+
+	@Override
+	public @Nullable UUID getSpawningEntity()
+	{
+		return this.spawningEntity;
+	}
+
+	/**
+	 * Set the UUID of the entity that caused this phantom to spawn.
+	 *
+	 * @param spawningEntity The UUID of the spawning entity.
+	 */
+	public void setSpawningEntity(@Nullable UUID spawningEntity)
+	{
+		this.spawningEntity = spawningEntity;
+	}
+
+	@Override
+	public boolean shouldBurnInDay()
+	{
+		return this.shouldBurnInDay;
+	}
+
+	@Override
+	public void setShouldBurnInDay(boolean shouldBurnInDay)
+	{
+		this.shouldBurnInDay = shouldBurnInDay;
+	}
+
+	@Override
+	public @NotNull Location getAnchorLocation()
+	{
+		return this.anchorLocation.clone();
+	}
+
+	@Override
+	public void setAnchorLocation(@NotNull Location location)
+	{
+		Preconditions.checkArgument(location != null, "location cannot be null");
+		this.anchorLocation = location.toBlockLocation();
+	}
+
+	@Override
+	public @NotNull EntityType getType()
+	{
+		return EntityType.PHANTOM;
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/LightningStrikeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/LightningStrikeMockTest.java
@@ -1,0 +1,152 @@
+package org.mockbukkit.mockbukkit.entity;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+import org.mockbukkit.mockbukkit.MockBukkitInject;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockBukkitExtension.class)
+class LightningStrikeMockTest
+{
+
+	@MockBukkitInject
+	private ServerMock server;
+	private LightningStrikeMock lightning;
+
+	@BeforeEach
+	void setUp()
+	{
+		lightning = new LightningStrikeMock(server, UUID.randomUUID());
+	}
+
+	@Nested
+	class SetEffect
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertFalse(lightning.isEffect());
+		}
+
+		@ParameterizedTest
+		@ValueSource(booleans = {true, false})
+		void givenPossibleValues(boolean expectedValue)
+		{
+			lightning.setEffect(expectedValue);
+			assertEquals(expectedValue, lightning.isEffect());
+		}
+
+	}
+
+	@Nested
+	class SetFlashes
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(3, lightning.getFlashes());
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = {1, 2, 3})
+		void givenPossibleValues(int expectedValue)
+		{
+			lightning.setFlashes(expectedValue);
+			assertEquals(expectedValue, lightning.getFlashes());
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = {-5, -4, -3, -2, -1, 0})
+		void givenImpossibleValues(int expectedValue)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () ->lightning.setFlashes(expectedValue));
+			assertEquals("flashes must be >= 1", e.getMessage());
+		}
+
+	}
+
+	@Nested
+	class SetLifeTicks
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(0, lightning.getLifeTicks());
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
+		void givenPossibleValues(int expectedValue)
+		{
+			lightning.setLifeTicks(expectedValue);
+			assertEquals(expectedValue, lightning.getLifeTicks());
+		}
+
+	}
+
+	@Nested
+	class SetCausingPlayer
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertNull(lightning.getCausingPlayer());
+			assertNull(lightning.getCausingEntity());
+		}
+
+		@Test
+		void givenChangeInValue()
+		{
+			PlayerMock player = server.addPlayer("test");
+			lightning.setCausingPlayer(player);
+			assertEquals(player, lightning.getCausingPlayer());
+			assertEquals(player, lightning.getCausingEntity());
+		}
+
+	}
+
+	@Nested
+	class SetFlashCount
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(3, lightning.getFlashCount());
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = {1, 2, 3})
+		void givenPossibleValues(int expectedValue)
+		{
+			lightning.setFlashCount(expectedValue);
+			assertEquals(expectedValue, lightning.getFlashCount());
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = {-5, -4, -3, -2, -1, 0})
+		void givenImpossibleValues(int expectedValue)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () ->lightning.setFlashCount(expectedValue));
+			assertEquals("flashes must be >= 1", e.getMessage());
+		}
+
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/PhantomMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/PhantomMockTest.java
@@ -1,0 +1,173 @@
+package org.mockbukkit.mockbukkit.entity;
+
+import org.bukkit.Location;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+import org.mockbukkit.mockbukkit.MockBukkitInject;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockBukkitExtension.class)
+class PhantomMockTest
+{
+
+	@MockBukkitInject
+	private ServerMock server;
+	private PhantomMock phantom;
+
+	@BeforeEach
+	void setUp()
+	{
+		phantom = new PhantomMock(server, UUID.randomUUID());
+	}
+
+	@Nested
+	class SetSize
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(0, phantom.getSize());
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = {
+			0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+			10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+			20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+			30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+			40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+			50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+			60, 61, 62, 63, 64
+		})
+		void givenPossibleValues(int expectedSize)
+		{
+			phantom.setSize(expectedSize);
+			assertEquals(expectedSize, phantom.getSize());
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = {
+			-5, -4, -3, -2, -1
+		})
+		void givenClampValuesBelow(int expectedSize)
+		{
+			phantom.setSize(expectedSize);
+			assertEquals(0, phantom.getSize());
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = {
+			65, 66, 67, 68, 69
+		})
+		void givenClampValuesUpper(int expectedSize)
+		{
+			phantom.setSize(expectedSize);
+			assertEquals(64, phantom.getSize());
+		}
+
+	}
+
+	@Nested
+	class SetSpawningEntity
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertNull(phantom.getSpawningEntity());
+		}
+
+		@Test
+		void givenChangeInValueValue()
+		{
+			UUID spawningEntity = UUID.randomUUID();
+
+			phantom.setSpawningEntity(spawningEntity);
+			assertEquals(spawningEntity, phantom.getSpawningEntity());
+
+			phantom.setSpawningEntity(null);
+			assertNull(phantom.getSpawningEntity());
+		}
+
+	}
+
+	@Nested
+	class ShouldBurnInDay
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertTrue(phantom.shouldBurnInDay());
+		}
+
+		@ParameterizedTest
+		@ValueSource(booleans = {true, false})
+		void givenChangeInValue(boolean expectedValue)
+		{
+			phantom.setShouldBurnInDay(expectedValue);
+			assertEquals(expectedValue, phantom.shouldBurnInDay());
+		}
+
+	}
+
+	@Nested
+	class SetAnchorLocation
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			Location location = phantom.getAnchorLocation();
+
+			assertNotNull(location);
+			assertNull(location.getWorld());
+			assertEquals(0.0, location.x());
+			assertEquals(0.0, location.y());
+			assertEquals(0.0, location.z());
+		}
+
+		@Test
+		void givenNullLocation()
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> phantom.setAnchorLocation(null));
+			assertEquals("location cannot be null", e.getMessage());
+		}
+
+		@Test
+		void givenChangeInValue()
+		{
+			Location location = new Location(null,  3.1, 1.5, 2.7);
+
+			phantom.setAnchorLocation(location);
+
+			Location actual = phantom.getAnchorLocation();
+
+			assertNotNull(actual);
+			assertNull(actual.getWorld());
+			assertEquals(3.0, actual.x());
+			assertEquals(1.0, actual.y());
+			assertEquals(2.0, actual.z());
+
+			assertEquals(actual, phantom.getAnchorLocation());
+			assertNotSame(actual, phantom.getAnchorLocation());
+		}
+
+	}
+
+}


### PR DESCRIPTION
# Description
Implemented mocks for [Phantom](https://jd.papermc.io/paper/1.21.4/org/bukkit/entity/Phantom.html) and [LightningStrike](https://jd.papermc.io/paper/1.21.4/org/bukkit/entity/LightningStrike.html).

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [X] Unit tests added (if applicable).

# Relates
- https://github.com/MockBukkit/MockBukkit/issues/825