### PR TITLE
Added Entity Vex and Ominous Item Spawner

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/EntityTypesMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/EntityTypesMock.java
@@ -69,6 +69,7 @@ import org.bukkit.entity.Marker;
 import org.bukkit.entity.Mule;
 import org.bukkit.entity.MushroomCow;
 import org.bukkit.entity.Ocelot;
+import org.bukkit.entity.OminousItemSpawner;
 import org.bukkit.entity.Painting;
 import org.bukkit.entity.Panda;
 import org.bukkit.entity.Parrot;
@@ -283,6 +284,7 @@ public final class EntityTypesMock
 			.register(OakBoat.class, OakBoatMock.class, OakBoatMock::new)
 			.register(OakChestBoat.class, OakChestBoatMock.class, OakChestBoatMock::new)
 			.register(Ocelot.class, OcelotMock.class, OcelotMock::new)
+			.register(OminousItemSpawner.class, OminousItemSpawnerMock.class, OminousItemSpawnerMock::new)
 			.register(Painting.class, PaintingMock.class, PaintingMock::new)
 			.register(PaleOakBoat.class, PaleOakBoatMock.class, PaleOakBoatMock::new)
 			.register(PaleOakChestBoat.class, PaleOakChestBoatMock.class, PaleOakChestBoatMock::new)

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/EntityTypesMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/EntityTypesMock.java
@@ -108,6 +108,7 @@ import org.bukkit.entity.TraderLlama;
 import org.bukkit.entity.Trident;
 import org.bukkit.entity.TropicalFish;
 import org.bukkit.entity.Turtle;
+import org.bukkit.entity.Vex;
 import org.bukkit.entity.Villager;
 import org.bukkit.entity.Vindicator;
 import org.bukkit.entity.Warden;
@@ -330,6 +331,7 @@ public final class EntityTypesMock
 			.register(Trident.class, TridentMock.class, TridentMock::new)
 			.register(TropicalFish.class, TropicalFishMock.class, TropicalFishMock::new)
 			.register(Turtle.class, TurtleMock.class, TurtleMock::new)
+			.register(Vex.class, VexMock.class, VexMock::new)
 			.register(Villager.class, VillagerMock.class, VillagerMock::new)
 			.register(Vindicator.class, VindicatorMock.class, VindicatorMock::new)
 			.register(Warden.class, WardenMock.class, WardenMock::new)

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/OminousItemSpawnerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/OminousItemSpawnerMock.java
@@ -1,0 +1,64 @@
+package org.mockbukkit.mockbukkit.entity;
+
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.OminousItemSpawner;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+import java.util.UUID;
+
+/**
+ * Mock implementation of an {@link OminousItemSpawner}.
+ *
+ * @see EntityMock
+ */
+public class OminousItemSpawnerMock extends EntityMock implements OminousItemSpawner
+{
+	private long spawnItemAfterTicks = 60;
+
+	private @NotNull ItemStack item = ItemStack.empty();
+
+	/**
+	 * Constructs a new {@link OminousItemSpawnerMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
+	public OminousItemSpawnerMock(@NotNull ServerMock server, @NotNull UUID uuid)
+	{
+		super(server, uuid);
+	}
+
+	@Override
+	public @NotNull ItemStack getItem()
+	{
+		return this.item.clone();
+	}
+
+	@Override
+	public void setItem(@Nullable ItemStack item)
+	{
+		this.item = (item == null ? ItemStack.empty() : item.clone());
+	}
+
+	@Override
+	public long getSpawnItemAfterTicks()
+	{
+		return this.spawnItemAfterTicks;
+	}
+
+	@Override
+	public void setSpawnItemAfterTicks(long ticks)
+	{
+		this.spawnItemAfterTicks = ticks;
+	}
+
+	@Override
+	public @NotNull EntityType getType()
+	{
+		return EntityType.OMINOUS_ITEM_SPAWNER;
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/VexMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/VexMock.java
@@ -1,0 +1,136 @@
+package org.mockbukkit.mockbukkit.entity;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Location;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Mob;
+import org.bukkit.entity.Vex;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Mock implementation of a {@link Vex}.
+ *
+ * @see MonsterMock
+ */
+public class VexMock extends MonsterMock implements Vex
+{
+	private boolean isCharging = false;
+	private boolean hasLimitedLife = false;
+	private int limitedLifeTicks = -1;
+
+	private @Nullable Location boundLocation = null;
+	private @Nullable Mob summoner = null;
+
+	/**
+	 * Constructs a new {@link VexMock} on the provided {@link ServerMock} with a specified {@link UUID}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 */
+	public VexMock(@NotNull ServerMock server, @NotNull UUID uuid)
+	{
+		super(server, uuid);
+	}
+
+	@Override
+	public boolean isCharging()
+	{
+		return this.isCharging;
+	}
+
+	@Override
+	public void setCharging(boolean charging)
+	{
+		this.isCharging = charging;
+	}
+
+	@Override
+	public @Nullable Location getBound()
+	{
+		return this.boundLocation == null ? null : boundLocation.clone();
+	}
+
+	@Override
+	public void setBound(@Nullable Location location)
+	{
+		if (location == null)
+		{
+			this.boundLocation = null;
+		}
+		else
+		{
+			Preconditions.checkArgument(Objects.equals(this.getWorld(), location.getWorld()), "The bound world cannot be different to the entity's world.");
+			this.boundLocation = location.clone();
+		}
+	}
+
+	@Override
+	@Deprecated(forRemoval = true)
+	public int getLifeTicks()
+	{
+		return this.getLimitedLifetimeTicks();
+	}
+
+	@Override
+	@Deprecated(forRemoval = true)
+	public void setLifeTicks(int lifeTicks)
+	{
+		this.setLimitedLifetime(lifeTicks >= 0);
+		this.setLimitedLifetimeTicks(lifeTicks);
+	}
+
+	@Override
+	@Deprecated(forRemoval = true)
+	public boolean hasLimitedLife()
+	{
+		return this.hasLimitedLifetime();
+	}
+
+	@Override
+	public @Nullable Mob getSummoner()
+	{
+		return this.summoner;
+	}
+
+	@Override
+	public void setSummoner(@Nullable Mob summoner)
+	{
+		this.summoner = summoner;
+	}
+
+	@Override
+	public boolean hasLimitedLifetime()
+	{
+		return this.hasLimitedLife;
+	}
+
+	@Override
+	public void setLimitedLifetime(boolean hasLimitedLifetime)
+	{
+		this.hasLimitedLife = hasLimitedLifetime;
+	}
+
+	@Override
+	public int getLimitedLifetimeTicks()
+	{
+		return this.limitedLifeTicks;
+	}
+
+	@Override
+	public void setLimitedLifetimeTicks(int ticks)
+	{
+		this.limitedLifeTicks = ticks;
+	}
+
+	@Override
+	public @NotNull EntityType getType()
+	{
+		return EntityType.VEX;
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/OminousItemSpawnerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/OminousItemSpawnerMockTest.java
@@ -1,0 +1,79 @@
+package org.mockbukkit.mockbukkit.entity;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+import org.mockbukkit.mockbukkit.MockBukkitInject;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+@ExtendWith(MockBukkitExtension.class)
+class OminousItemSpawnerMockTest
+{
+
+	@MockBukkitInject
+	private ServerMock server;
+	private OminousItemSpawnerMock ominousSpawner;
+
+	@BeforeEach
+	void setUp()
+	{
+		ominousSpawner = new OminousItemSpawnerMock(server, UUID.randomUUID());
+	}
+
+	@Nested
+	class SetItem
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(ItemStack.empty(), ominousSpawner.getItem());
+		}
+
+		@Test
+		void givenItemChange()
+		{
+			ItemStack item = ItemStack.of(Material.DIAMOND);
+			ominousSpawner.setItem(item);
+
+			assertEquals(item, ominousSpawner.getItem());
+			assertNotSame(item, ominousSpawner.getItem());
+
+			ominousSpawner.setItem(null);
+			assertEquals(ItemStack.empty(), ominousSpawner.getItem());
+		}
+
+	}
+
+	@Nested
+	class SetSpawnItemAfterTicks
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(60, ominousSpawner.getSpawnItemAfterTicks());
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
+		void givenValueChange(int value)
+		{
+			ominousSpawner.setSpawnItemAfterTicks(value);
+			assertEquals(value, ominousSpawner.getSpawnItemAfterTicks());
+		}
+
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/VexMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/VexMockTest.java
@@ -1,0 +1,175 @@
+package org.mockbukkit.mockbukkit.entity;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Mob;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+import org.mockbukkit.mockbukkit.MockBukkitInject;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockBukkitExtension.class)
+class VexMockTest
+{
+
+	@MockBukkitInject
+	private ServerMock server;
+	private VexMock vex;
+
+	@BeforeEach
+	void setUp()
+	{
+		vex = new VexMock(server, UUID.randomUUID());
+	}
+
+	@Nested
+	class SetCharging
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertFalse(vex.isCharging());
+		}
+
+		@ParameterizedTest
+		@ValueSource(booleans = {true, false})
+		void givenValueChange(boolean expectedValue)
+		{
+			vex.setCharging(expectedValue);
+			assertEquals(expectedValue, vex.isCharging());
+		}
+
+	}
+
+	@Nested
+	class SetBound
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertNull(vex.getBound());
+		}
+
+		@Test
+		void givenLocationInDifferentWorld_ExceptionIsThrown()
+		{
+			World worldA = server.addSimpleWorld("A");
+			Location locationA = new Location(worldA, 0, 0, 0);
+			vex.setLocation(locationA);
+
+			World worldB = server.addSimpleWorld("B");
+			Location locationB = new Location(worldB, 0, 0, 0);
+
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> vex.setBound(locationB));
+			assertEquals("The bound world cannot be different to the entity's world.", e.getMessage());
+		}
+
+		@Test
+		void givenLocationInSameWorld_ShouldSucceed()
+		{
+			World worldA = server.addSimpleWorld("A");
+			Location locationA = new Location(worldA, 0, 0, 0);
+			vex.setLocation(locationA);
+
+			Location locationB = new Location(worldA, 1, 2, 3);
+			vex.setBound(locationB);
+
+			assertEquals(locationB, vex.getBound());
+			assertNotSame(locationB, vex.getBound());
+		}
+
+		@Test
+		void givenLocationInNullWorld_ShouldSucceed()
+		{
+			Location locationA = new Location(null, 0, 0, 0);
+			vex.setLocation(locationA);
+
+			Location locationB = new Location(null, 1, 2, 3);
+			vex.setBound(locationB);
+
+			assertEquals(locationB, vex.getBound());
+			assertNotSame(locationB, vex.getBound());
+
+			vex.setBound(null);
+			assertNull(vex.getBound());
+		}
+
+	}
+
+	@Nested
+	class SetSummoner
+	{
+		@Test
+		void givenDefaultValue()
+		{
+			assertNull(vex.getSummoner());
+		}
+
+		@Test
+		void givenChangeInValue()
+		{
+			Mob mob = new IllusionerMock(server, UUID.randomUUID());
+
+			vex.setSummoner(mob);
+			assertEquals(mob, vex.getSummoner());
+
+			vex.setSummoner(null);
+			assertNull(vex.getSummoner());
+		}
+
+	}
+
+	@Nested
+	class SetLimitedLifetime
+	{
+		@Test
+		void givenDefaultValue()
+		{
+			assertFalse(vex.hasLimitedLifetime());
+		}
+
+		@ParameterizedTest
+		@ValueSource(booleans = {true, false})
+		void givenChangeInValue(boolean expectedValue)
+		{
+			vex.setLimitedLifetime(expectedValue);
+			assertEquals(expectedValue, vex.hasLimitedLifetime());
+		}
+
+	}
+
+	@Nested
+	class SetLimitedLifetimeTicks
+	{
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(-1, vex.getLimitedLifetimeTicks());
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = {-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
+		void givenChangeInValue(int expectedValue)
+		{
+			vex.setLimitedLifetimeTicks(expectedValue);
+			assertEquals(expectedValue, vex.getLimitedLifetimeTicks());
+		}
+
+	}
+
+}


### PR DESCRIPTION
# Description
Implemented mocks for [Vex](https://jd.papermc.io/paper/1.21.4/org/bukkit/entity/Vex.html) and [Ominous Item Spawner](https://jd.papermc.io/paper/1.21.4/org/bukkit/entity/OminousItemSpawner.html).

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [X] Unit tests added (if applicable).

# Relates
- https://github.com/MockBukkit/MockBukkit/issues/825