### PR TITLE
Start migration of ItemEntityMock to ItemMock

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/ItemEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/ItemEntityMock.java
@@ -1,0 +1,33 @@
+package org.mockbukkit.mockbukkit.entity;
+
+import org.bukkit.entity.Item;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+import java.util.UUID;
+
+/**
+ * Mock implementation of an {@link Item}.
+ *
+ * @see ItemMock
+ *
+ * @deprecated {@link ItemEntityMock} is deprecated in favor of {@link ItemMock} to match the other entities pattern.
+ */
+@Deprecated(forRemoval = true)
+public class ItemEntityMock extends ItemMock
+{
+
+	/**
+	 * Constructs a new {@link ItemMock} on the provided {@link ServerMock} with a specified {@link UUID} and {@link ItemStack}.
+	 *
+	 * @param server The server to create the entity on.
+	 * @param uuid   The UUID of the entity.
+	 * @param item   The item this entity represents.
+	 */
+	public ItemEntityMock(@NotNull ServerMock server, @NotNull UUID uuid, @NotNull ItemStack item)
+	{
+		super(server, uuid, item);
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/ItemMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/ItemMock.java
@@ -17,7 +17,7 @@ import java.util.UUID;
  *
  * @see EntityMock
  */
-public class ItemEntityMock extends EntityMock implements Item
+public class ItemMock extends EntityMock implements Item
 {
 
 	private ItemStack item;
@@ -27,13 +27,13 @@ public class ItemEntityMock extends EntityMock implements Item
 	private TriState frictionState = TriState.NOT_SET;
 
 	/**
-	 * Constructs a new {@link ItemEntityMock} on the provided {@link ServerMock} with a specified {@link UUID} and {@link ItemStack}.
+	 * Constructs a new {@link ItemMock} on the provided {@link ServerMock} with a specified {@link UUID} and {@link ItemStack}.
 	 *
 	 * @param server The server to create the entity on.
 	 * @param uuid   The UUID of the entity.
 	 * @param item   The item this entity represents.
 	 */
-	public ItemEntityMock(@NotNull ServerMock server, @NotNull UUID uuid, @NotNull ItemStack item)
+	public ItemMock(@NotNull ServerMock server, @NotNull UUID uuid, @NotNull ItemStack item)
 	{
 		super(server, uuid);
 		Preconditions.checkNotNull(item, "Item cannot be null");

--- a/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
@@ -107,7 +107,7 @@ import org.mockbukkit.mockbukkit.block.BlockMock;
 import org.mockbukkit.mockbukkit.block.data.BlockDataMock;
 import org.mockbukkit.mockbukkit.entity.EntityMock;
 import org.mockbukkit.mockbukkit.entity.EntityTypesMock;
-import org.mockbukkit.mockbukkit.entity.ItemEntityMock;
+import org.mockbukkit.mockbukkit.entity.ItemMock;
 import org.mockbukkit.mockbukkit.entity.MobMock;
 import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 import org.mockbukkit.mockbukkit.generator.BiomeProviderMock;
@@ -812,7 +812,7 @@ public class WorldMock implements World
 		Preconditions.checkNotNull(item, "Cannot drop items that are null.");
 		Preconditions.checkArgument(!item.getType().isAir(), "Cannot drop air.");
 
-		ItemEntityMock entity = new ItemEntityMock(server, UUID.randomUUID(), item);
+		ItemMock entity = new ItemMock(server, UUID.randomUUID(), item);
 		entity.setLocation(location);
 
 		if (function != null)

--- a/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
@@ -107,7 +107,7 @@ import org.mockbukkit.mockbukkit.block.BlockMock;
 import org.mockbukkit.mockbukkit.block.data.BlockDataMock;
 import org.mockbukkit.mockbukkit.entity.EntityMock;
 import org.mockbukkit.mockbukkit.entity.EntityTypesMock;
-import org.mockbukkit.mockbukkit.entity.ItemMock;
+import org.mockbukkit.mockbukkit.entity.ItemEntityMock;
 import org.mockbukkit.mockbukkit.entity.MobMock;
 import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 import org.mockbukkit.mockbukkit.generator.BiomeProviderMock;
@@ -812,7 +812,8 @@ public class WorldMock implements World
 		Preconditions.checkNotNull(item, "Cannot drop items that are null.");
 		Preconditions.checkArgument(!item.getType().isAir(), "Cannot drop air.");
 
-		ItemMock entity = new ItemMock(server, UUID.randomUUID(), item);
+		// To avoid breaking changes, this should be kept until we decide to remove the ItemEntityMock class
+		ItemEntityMock entity = new ItemEntityMock(server, UUID.randomUUID(), item);
 		entity.setLocation(location);
 
 		if (function != null)

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/ItemMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/ItemMockTest.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class ItemEntityMockTest
+class ItemMockTest
 {
 
 	private ServerMock server;
@@ -49,7 +49,7 @@ class ItemEntityMockTest
 	@Test
 	void testEntityType()
 	{
-		Item item = new ItemEntityMock(server, UUID.randomUUID(), new ItemStackMock(Material.STONE));
+		Item item = new ItemMock(server, UUID.randomUUID(), new ItemStackMock(Material.STONE));
 		assertEquals(EntityType.ITEM, item.getType());
 	}
 

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMockTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.ItemEntityMock;
 import org.mockbukkit.mockbukkit.entity.ItemMock;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
@@ -251,11 +252,14 @@ class InventoryViewMockTest
 		List<Entity> entities = player.getWorld().getEntities().stream().filter(p -> !(p instanceof Player)).toList();
 		assertEquals(1, entities.size());
 		assertInstanceOf(ItemMock.class, entities.getFirst());
+		assertInstanceOf(ItemEntityMock.class, entities.getFirst());
 
 		assertEquals(sword, ((ItemMock) entities.getFirst()).getItemStack());
+		assertEquals(sword, ((ItemEntityMock) entities.getFirst()).getItemStack());
 
 		sword.setAmount(2);
 		assertNotEquals(sword, ((ItemMock) entities.getFirst()).getItemStack());
+		assertNotEquals(sword, ((ItemEntityMock) entities.getFirst()).getItemStack());
 	}
 
 	@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMockTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.ServerMock;
-import org.mockbukkit.mockbukkit.entity.ItemEntityMock;
+import org.mockbukkit.mockbukkit.entity.ItemMock;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
 import java.util.List;
@@ -250,12 +250,12 @@ class InventoryViewMockTest
 
 		List<Entity> entities = player.getWorld().getEntities().stream().filter(p -> !(p instanceof Player)).toList();
 		assertEquals(1, entities.size());
-		assertInstanceOf(ItemEntityMock.class, entities.getFirst());
+		assertInstanceOf(ItemMock.class, entities.getFirst());
 
-		assertEquals(sword, ((ItemEntityMock) entities.getFirst()).getItemStack());
+		assertEquals(sword, ((ItemMock) entities.getFirst()).getItemStack());
 
 		sword.setAmount(2);
-		assertNotEquals(sword, ((ItemEntityMock) entities.getFirst()).getItemStack());
+		assertNotEquals(sword, ((ItemMock) entities.getFirst()).getItemStack());
 	}
 
 	@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
@@ -132,8 +132,9 @@ import org.mockbukkit.mockbukkit.entity.IllusionerMock;
 import org.mockbukkit.mockbukkit.entity.InteractionMock;
 import org.mockbukkit.mockbukkit.entity.IronGolemMock;
 import org.mockbukkit.mockbukkit.entity.ItemDisplayMock;
-import org.mockbukkit.mockbukkit.entity.ItemMock;
+import org.mockbukkit.mockbukkit.entity.ItemEntityMock;
 import org.mockbukkit.mockbukkit.entity.ItemFrameMock;
+import org.mockbukkit.mockbukkit.entity.ItemMock;
 import org.mockbukkit.mockbukkit.entity.LeashHitchMock;
 import org.mockbukkit.mockbukkit.entity.LlamaMock;
 import org.mockbukkit.mockbukkit.entity.LlamaSpitMock;
@@ -394,6 +395,7 @@ class WorldMockTest
 		world.dropItem(new Location(world, 0, 0, 0), new ItemStackMock(Material.STONE));
 		assertEquals(1, world.getEntitiesByClass(ZombieMock.class).size());
 		assertEquals(1, world.getEntitiesByClass(ItemMock.class).size());
+		assertEquals(1, world.getEntitiesByClass(ItemEntityMock.class).size());
 	}
 
 	@Test
@@ -404,7 +406,8 @@ class WorldMockTest
 		world.dropItem(new Location(world, 0, 0, 0), new ItemStackMock(Material.STONE));
 		assertEquals(1, world.getEntitiesByClasses(ZombieMock.class).size());
 		assertEquals(1, world.getEntitiesByClasses(ItemMock.class).size());
-		assertEquals(2, world.getEntitiesByClasses(ZombieMock.class, ItemMock.class).size());
+		assertEquals(1, world.getEntitiesByClasses(ItemEntityMock.class).size());
+		assertEquals(2, world.getEntitiesByClasses(ZombieMock.class, ItemEntityMock.class).size());
 	}
 
 	@Test
@@ -416,7 +419,8 @@ class WorldMockTest
 		world.dropItem(new Location(world, 0, 0, 0), new ItemStackMock(Material.STONE));
 		assertEquals(1, world.getEntitiesByClass(new Class[]{ ZombieMock.class }).size());
 		assertEquals(1, world.getEntitiesByClass(new Class[]{ ItemMock.class }).size());
-		assertEquals(2, world.getEntitiesByClass(new Class[]{ ZombieMock.class, ItemMock.class }).size());
+		assertEquals(1, world.getEntitiesByClass(new Class[]{ ItemEntityMock.class }).size());
+		assertEquals(2, world.getEntitiesByClass(new Class[]{ ZombieMock.class, ItemEntityMock.class }).size());
 	}
 
 	@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
@@ -132,7 +132,7 @@ import org.mockbukkit.mockbukkit.entity.IllusionerMock;
 import org.mockbukkit.mockbukkit.entity.InteractionMock;
 import org.mockbukkit.mockbukkit.entity.IronGolemMock;
 import org.mockbukkit.mockbukkit.entity.ItemDisplayMock;
-import org.mockbukkit.mockbukkit.entity.ItemEntityMock;
+import org.mockbukkit.mockbukkit.entity.ItemMock;
 import org.mockbukkit.mockbukkit.entity.ItemFrameMock;
 import org.mockbukkit.mockbukkit.entity.LeashHitchMock;
 import org.mockbukkit.mockbukkit.entity.LlamaMock;
@@ -393,7 +393,7 @@ class WorldMockTest
 		world.spawnEntity(new Location(world, 0, 0, 0), EntityType.ZOMBIE);
 		world.dropItem(new Location(world, 0, 0, 0), new ItemStackMock(Material.STONE));
 		assertEquals(1, world.getEntitiesByClass(ZombieMock.class).size());
-		assertEquals(1, world.getEntitiesByClass(ItemEntityMock.class).size());
+		assertEquals(1, world.getEntitiesByClass(ItemMock.class).size());
 	}
 
 	@Test
@@ -403,8 +403,8 @@ class WorldMockTest
 		world.spawnEntity(new Location(world, 0, 0, 0), EntityType.ZOMBIE);
 		world.dropItem(new Location(world, 0, 0, 0), new ItemStackMock(Material.STONE));
 		assertEquals(1, world.getEntitiesByClasses(ZombieMock.class).size());
-		assertEquals(1, world.getEntitiesByClasses(ItemEntityMock.class).size());
-		assertEquals(2, world.getEntitiesByClasses(ZombieMock.class, ItemEntityMock.class).size());
+		assertEquals(1, world.getEntitiesByClasses(ItemMock.class).size());
+		assertEquals(2, world.getEntitiesByClasses(ZombieMock.class, ItemMock.class).size());
 	}
 
 	@Test
@@ -415,8 +415,8 @@ class WorldMockTest
 		world.spawnEntity(new Location(world, 0, 0, 0), EntityType.ZOMBIE);
 		world.dropItem(new Location(world, 0, 0, 0), new ItemStackMock(Material.STONE));
 		assertEquals(1, world.getEntitiesByClass(new Class[]{ ZombieMock.class }).size());
-		assertEquals(1, world.getEntitiesByClass(new Class[]{ ItemEntityMock.class }).size());
-		assertEquals(2, world.getEntitiesByClass(new Class[]{ ZombieMock.class, ItemEntityMock.class }).size());
+		assertEquals(1, world.getEntitiesByClass(new Class[]{ ItemMock.class }).size());
+		assertEquals(2, world.getEntitiesByClass(new Class[]{ ZombieMock.class, ItemMock.class }).size());
 	}
 
 	@Test


### PR DESCRIPTION
# Description
This PR is open for discussion.
I saw that the `Item` implementation was not following the same pattern as the other entities (`<NAME>Mock`), this was a little bit confusing for me, because i was thinking it did not exist yet.

In this PR I propose a solution to gradually migrate the users to the `ItemMock` and when we feel that the time is correct, we can remove the deprecated class.


# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
