### PR TITLE
Improved InventoryMock to mirror items properly

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/block/BlockMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/BlockMock.java
@@ -1,10 +1,5 @@
 package org.mockbukkit.mockbukkit.block;
 
-import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
-import org.mockbukkit.mockbukkit.block.data.BlockDataMock;
-import org.mockbukkit.mockbukkit.block.state.BlockStateMock;
-import org.mockbukkit.mockbukkit.metadata.MetadataTable;
-import org.mockbukkit.mockbukkit.tags.internal.InternalTag;
 import com.destroystokyo.paper.block.BlockSoundGroup;
 import com.google.common.base.Preconditions;
 import org.bukkit.Chunk;
@@ -30,6 +25,11 @@ import org.bukkit.util.Vector;
 import org.bukkit.util.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mockbukkit.mockbukkit.block.data.BlockDataMock;
+import org.mockbukkit.mockbukkit.block.state.BlockStateMock;
+import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
+import org.mockbukkit.mockbukkit.metadata.MetadataTable;
+import org.mockbukkit.mockbukkit.tags.internal.InternalTag;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -311,9 +311,7 @@ public class BlockMock implements Block
 	@Override
 	public @NotNull BlockState getState()
 	{
-		// This will always return a snapshot of the BlockState, not the actual state.
-		// This is optional with Paper but for Spigot it simply works like that.
-		return state.getSnapshot();
+		return this.state;
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/ContainerStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/ContainerStateMock.java
@@ -53,7 +53,7 @@ public abstract class ContainerStateMock extends LockableTileStateMock implement
 	protected ContainerStateMock(@NotNull ContainerStateMock state)
 	{
 		super(state);
-		this.inventory = state.getInventory();
+		this.inventory = state.getSnapshotInventory();
 		this.customName = state.customName();
 	}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryMock.java
@@ -250,7 +250,7 @@ public class InventoryMock implements Inventory
 	@Override
 	public ItemStack getItem(int index)
 	{
-		return items[index] == null ? null : items[index].clone();
+		return items[index] == null ? null : ItemStackMirror.create(items[index]);
 	}
 
 	@Override
@@ -320,7 +320,7 @@ public class InventoryMock implements Inventory
 	public ItemStack @NotNull [] getContents()
 	{
 		return Arrays.stream(items)
-				.map(item -> (item == null || item.isEmpty()) ? null : item.clone())
+				.map(item -> (item == null || item.isEmpty()) ? null : ItemStackMirror.create(item))
 				.toArray(ItemStack[]::new);
 	}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMirror.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMirror.java
@@ -1,0 +1,610 @@
+package org.mockbukkit.mockbukkit.inventory;
+
+import com.google.common.base.Preconditions;
+import io.papermc.paper.datacomponent.DataComponentBuilder;
+import io.papermc.paper.datacomponent.DataComponentType;
+import io.papermc.paper.inventory.ItemRarity;
+import io.papermc.paper.inventory.tooltip.TooltipContext;
+import io.papermc.paper.persistence.PersistentDataContainerView;
+import io.papermc.paper.registry.set.RegistryKeySet;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.HoverEvent;
+import org.bukkit.Material;
+import org.bukkit.UndefinedNullability;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.material.MaterialData;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
+/**
+ * Helper class that emulates the Bukkit mirror behaviour at CraftItemStack#asCraftMirror(net.minecraft.world.item.ItemStack original).
+ *
+ * @see ItemStack
+ */
+public final class ItemStackMirror extends ItemStack
+{
+
+	/**
+	 * Creates a mirror of the {@link ItemStack}. Any change applied to this {@link ItemStack} will also
+	 * affect the original {@link ItemStack}.
+	 * <p/>
+	 * This emulates the behaviour from <code>CraftItemStack#asCraftMirror(net.minecraft.world.item.ItemStack original)</code>.
+	 *
+	 * @param item The original item.
+	 *
+	 * @return The mirror item.
+	 */
+	@NotNull
+	public static ItemStack create(@NonNull ItemStack item)
+	{
+		Preconditions.checkArgument(item != null, "item cannot be null");
+
+		if (item instanceof ItemStackMirror mirror)
+		{
+			return mirror;
+		}
+		return new ItemStackMirror(item);
+	}
+
+	private final ItemStack itemStack;
+
+	private ItemStackMirror(@NotNull ItemStack item)
+	{
+		Preconditions.checkArgument(item != null, "item cannot be null");
+		this.itemStack = item;
+	}
+
+	@Override
+	public @NotNull ItemStack add()
+	{
+		return itemStack.add();
+	}
+
+	@Override
+	public @NotNull ItemStack add(int qty)
+	{
+		return itemStack.add(qty);
+	}
+
+	@Override
+	public void addEnchantment(@NotNull Enchantment ench, int level)
+	{
+		itemStack.addEnchantment(ench, level);
+	}
+
+	@Override
+	public void addEnchantments(@NotNull Map<Enchantment, Integer> enchantments)
+	{
+		itemStack.addEnchantments(enchantments);
+	}
+
+	@Override
+	public void addItemFlags(@NotNull ItemFlag... itemFlags)
+	{
+		itemStack.addItemFlags(itemFlags);
+	}
+
+	@Override
+	public void addUnsafeEnchantment(@NotNull Enchantment ench, int level)
+	{
+		itemStack.addUnsafeEnchantment(ench, level);
+	}
+
+	@Override
+	public void addUnsafeEnchantments(@NotNull Map<Enchantment, Integer> enchantments)
+	{
+		itemStack.addUnsafeEnchantments(enchantments);
+	}
+
+	@Override
+	public @NotNull HoverEvent<HoverEvent.ShowItem> asHoverEvent(@NotNull UnaryOperator<HoverEvent.ShowItem> op)
+	{
+		return itemStack.asHoverEvent(op);
+	}
+
+	@Override
+	public @NotNull ItemStack asOne()
+	{
+		return itemStack.asOne();
+	}
+
+	@Override
+	public @NotNull ItemStack asQuantity(int qty)
+	{
+		return itemStack.asQuantity(qty);
+	}
+
+	@Override
+	public boolean canRepair(@NotNull ItemStack toBeRepaired)
+	{
+		return itemStack.canRepair(toBeRepaired);
+	}
+
+	@Override
+	public @NotNull ItemStack clone()
+	{
+		return itemStack.clone();
+	}
+
+	@Override
+	public @NotNull @Unmodifiable List<Component> computeTooltipLines(@NotNull TooltipContext tooltipContext, @Nullable Player player)
+	{
+		return itemStack.computeTooltipLines(tooltipContext, player);
+	}
+
+	@Override
+	public boolean containsEnchantment(@NotNull Enchantment ench)
+	{
+		return itemStack.containsEnchantment(ench);
+	}
+
+	@ApiStatus.Experimental
+	@Override
+	public void copyDataFrom(@NotNull ItemStack source, @NotNull Predicate<@NotNull DataComponentType> filter)
+	{
+		itemStack.copyDataFrom(source, filter);
+	}
+
+	@Override
+	public @NotNull ItemStack damage(int amount, @NotNull LivingEntity livingEntity)
+	{
+		return itemStack.damage(amount, livingEntity);
+	}
+
+	public static @NotNull ItemStack deserialize(@NotNull Map<String, Object> args)
+	{
+		return ItemStack.deserialize(args);
+	}
+
+	public static @NotNull ItemStack deserializeBytes(byte @NotNull [] bytes)
+	{
+		return ItemStack.deserializeBytes(bytes);
+	}
+
+	public static @NotNull ItemStack @NotNull [] deserializeItemsFromBytes(byte @NotNull [] bytes)
+	{
+		return ItemStack.deserializeItemsFromBytes(bytes);
+	}
+
+	@Override
+	public @NotNull Component displayName()
+	{
+		return itemStack.displayName();
+	}
+
+	@Override
+	public boolean editMeta(@NotNull Consumer<? super ItemMeta> consumer)
+	{
+		return itemStack.editMeta(consumer);
+	}
+
+	@Override
+	public <M extends ItemMeta> boolean editMeta(@NotNull Class<M> metaClass, @NotNull Consumer<? super M> consumer)
+	{
+		return itemStack.editMeta(metaClass, consumer);
+	}
+
+	@Override
+	public boolean editPersistentDataContainer(@NotNull Consumer<PersistentDataContainer> consumer)
+	{
+		return itemStack.editPersistentDataContainer(consumer);
+	}
+
+	@Override
+	public @NotNull Component effectiveName()
+	{
+		return itemStack.effectiveName();
+	}
+
+	public static @NotNull ItemStack empty()
+	{
+		return ItemStack.empty();
+	}
+
+	@Override
+	public @NotNull ItemStack enchantWithLevels(int levels, boolean allowTreasure, @NotNull Random random)
+	{
+		return itemStack.enchantWithLevels(levels, allowTreasure, random);
+	}
+
+	@Override
+	public @NotNull ItemStack enchantWithLevels(int levels, @NotNull RegistryKeySet<@NotNull Enchantment> keySet, @NotNull Random random)
+	{
+		return itemStack.enchantWithLevels(levels, keySet, random);
+	}
+
+	@Override
+	public @NotNull ItemStack ensureServerConversions()
+	{
+		return itemStack.ensureServerConversions();
+	}
+
+	@Override
+	public boolean equals(Object obj)
+	{
+		return itemStack.equals(obj);
+	}
+
+	@Override
+	public int getAmount()
+	{
+		return itemStack.getAmount();
+	}
+
+	@Deprecated(forRemoval = true, since = "1.13")
+	@Override
+	public @Nullable MaterialData getData()
+	{
+		return itemStack.getData();
+	}
+
+	@Contract(pure = true)
+	@ApiStatus.Experimental
+	@Override
+	public <T> @Nullable T getData(DataComponentType.@NotNull Valued<T> type)
+	{
+		return itemStack.getData(type);
+	}
+
+	@Contract(value = "_, !null -> !null", pure = true)
+	@ApiStatus.Experimental
+	@Override
+	public <T> @Nullable T getDataOrDefault(DataComponentType.@NotNull Valued<? extends T> type, @Nullable T fallback)
+	{
+		return itemStack.getDataOrDefault(type, fallback);
+	}
+
+	@Contract("-> new")
+	@ApiStatus.Experimental
+	@Override
+	public @Unmodifiable Set<@NotNull DataComponentType> getDataTypes()
+	{
+		return itemStack.getDataTypes();
+	}
+
+	@Deprecated(since = "1.13")
+	@Override
+	public short getDurability()
+	{
+		return itemStack.getDurability();
+	}
+
+	@Override
+	public int getEnchantmentLevel(@NotNull Enchantment ench)
+	{
+		return itemStack.getEnchantmentLevel(ench);
+	}
+
+	@Override
+	public @NotNull Map<Enchantment, Integer> getEnchantments()
+	{
+		return itemStack.getEnchantments();
+	}
+
+	@Deprecated
+	@Override
+	public @Nullable String getI18NDisplayName()
+	{
+		return itemStack.getI18NDisplayName();
+	}
+
+	@Override
+	public @NotNull Set<ItemFlag> getItemFlags()
+	{
+		return itemStack.getItemFlags();
+	}
+
+	@UndefinedNullability
+	@Override
+	public ItemMeta getItemMeta()
+	{
+		return itemStack.getItemMeta();
+	}
+
+	@Deprecated
+	@Override
+	public @Nullable List<String> getLore()
+	{
+		return itemStack.getLore();
+	}
+
+	@Deprecated(forRemoval = true)
+	@Override
+	public int getMaxItemUseDuration()
+	{
+		return itemStack.getMaxItemUseDuration();
+	}
+
+	@Override
+	public int getMaxItemUseDuration(@NotNull LivingEntity entity)
+	{
+		return itemStack.getMaxItemUseDuration(entity);
+	}
+
+	@Override
+	public int getMaxStackSize()
+	{
+		return itemStack.getMaxStackSize();
+	}
+
+	@Override
+	public @NotNull PersistentDataContainerView getPersistentDataContainer()
+	{
+		return itemStack.getPersistentDataContainer();
+	}
+
+	@Deprecated(forRemoval = true, since = "1.20.5")
+	@Override
+	public @NotNull ItemRarity getRarity()
+	{
+		return itemStack.getRarity();
+	}
+
+	@Deprecated(forRemoval = true)
+	@Override
+	public @NotNull String getTranslationKey()
+	{
+		return itemStack.getTranslationKey();
+	}
+
+	@Override
+	public @NotNull Material getType()
+	{
+		return itemStack.getType();
+	}
+
+	@Contract(pure = true)
+	@ApiStatus.Experimental
+	@Override
+	public boolean hasData(@NotNull DataComponentType type)
+	{
+		return itemStack.hasData(type);
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return itemStack.hashCode();
+	}
+
+	@Override
+	public boolean hasItemFlag(@NotNull ItemFlag flag)
+	{
+		return itemStack.hasItemFlag(flag);
+	}
+
+	@Override
+	public boolean hasItemMeta()
+	{
+		return itemStack.hasItemMeta();
+	}
+
+	@ApiStatus.Experimental
+	@Override
+	public boolean isDataOverridden(@NotNull DataComponentType type)
+	{
+		return itemStack.isDataOverridden(type);
+	}
+
+	@Override
+	public boolean isEmpty()
+	{
+		return itemStack.isEmpty();
+	}
+
+	@Override
+	public boolean isRepairableBy(@NotNull ItemStack repairMaterial)
+	{
+		return itemStack.isRepairableBy(repairMaterial);
+	}
+
+	@Override
+	public boolean isSimilar(@Nullable ItemStack stack)
+	{
+		return itemStack.isSimilar(stack);
+	}
+
+	@Override
+	public @Nullable List<Component> lore()
+	{
+		return itemStack.lore();
+	}
+
+	@Override
+	public void lore(@Nullable List<? extends Component> lore)
+	{
+		itemStack.lore(lore);
+	}
+
+	@ApiStatus.Experimental
+	@Override
+	public boolean matchesWithoutData(@NotNull ItemStack item, @NotNull Set<@NotNull DataComponentType> excludeTypes)
+	{
+		return itemStack.matchesWithoutData(item, excludeTypes);
+	}
+
+	@ApiStatus.Experimental
+	@Override
+	public boolean matchesWithoutData(@NotNull ItemStack item, @NotNull Set<@NotNull DataComponentType> excludeTypes, boolean ignoreCount)
+	{
+		return itemStack.matchesWithoutData(item, excludeTypes, ignoreCount);
+	}
+
+	@Contract(value = "_ -> new", pure = true)
+	public static @NotNull ItemStack of(@NotNull Material type)
+	{
+		return ItemStack.of(type);
+	}
+
+	@Contract(value = "_, _ -> new", pure = true)
+	public static @NotNull ItemStack of(@NotNull Material type, int amount)
+	{
+		return ItemStack.of(type, amount);
+	}
+
+	@Override
+	public int removeEnchantment(@NotNull Enchantment ench)
+	{
+		return itemStack.removeEnchantment(ench);
+	}
+
+	@Override
+	public void removeEnchantments()
+	{
+		itemStack.removeEnchantments();
+	}
+
+	@Override
+	public void removeItemFlags(@NotNull ItemFlag... itemFlags)
+	{
+		itemStack.removeItemFlags(itemFlags);
+	}
+
+	@ApiStatus.Experimental
+	@Override
+	public void resetData(@NotNull DataComponentType type)
+	{
+		itemStack.resetData(type);
+	}
+
+	@Override
+	public @NotNull Map<String, Object> serialize()
+	{
+		return itemStack.serialize();
+	}
+
+	@Override
+	public byte @NotNull [] serializeAsBytes()
+	{
+		return itemStack.serializeAsBytes();
+	}
+
+	public static byte @NotNull [] serializeItemsAsBytes(@NotNull Collection<ItemStack> items)
+	{
+		return ItemStack.serializeItemsAsBytes(items);
+	}
+
+	public static byte @NotNull [] serializeItemsAsBytes(@Nullable ItemStack @NotNull [] items)
+	{
+		return ItemStack.serializeItemsAsBytes(items);
+	}
+
+	@Override
+	public void setAmount(int amount)
+	{
+		itemStack.setAmount(amount);
+	}
+
+	@Deprecated(forRemoval = true, since = "1.13")
+	@Override
+	public void setData(@Nullable MaterialData data)
+	{
+		itemStack.setData(data);
+	}
+
+	@ApiStatus.Experimental
+	@Override
+	public void setData(DataComponentType.@NotNull NonValued type)
+	{
+		itemStack.setData(type);
+	}
+
+	@ApiStatus.Experimental
+	@Override
+	public <T> void setData(DataComponentType.@NotNull Valued<T> type, @NotNull T value)
+	{
+		itemStack.setData(type, value);
+	}
+
+	@ApiStatus.Experimental
+	@Override
+	public <T> void setData(DataComponentType.@NotNull Valued<T> type, @NotNull DataComponentBuilder<T> valueBuilder)
+	{
+		itemStack.setData(type, valueBuilder);
+	}
+
+	@Deprecated(since = "1.13")
+	@Override
+	public void setDurability(short durability)
+	{
+		itemStack.setDurability(durability);
+	}
+
+	@Override
+	public boolean setItemMeta(@Nullable ItemMeta itemMeta)
+	{
+		return itemStack.setItemMeta(itemMeta);
+	}
+
+	@Deprecated
+	@Override
+	public void setLore(@Nullable List<String> lore)
+	{
+		itemStack.setLore(lore);
+	}
+
+	@Deprecated
+	@Override
+	public void setType(@NotNull Material type)
+	{
+		itemStack.setType(type);
+	}
+
+	@Override
+	public @NotNull ItemStack subtract()
+	{
+		return itemStack.subtract();
+	}
+
+	@Override
+	public @NotNull ItemStack subtract(int qty)
+	{
+		return itemStack.subtract(qty);
+	}
+
+	@Override
+	public String toString()
+	{
+		return itemStack.toString();
+	}
+
+	@Override
+	public @NotNull String translationKey()
+	{
+		return itemStack.translationKey();
+	}
+
+	@ApiStatus.Experimental
+	@Override
+	public void unsetData(@NotNull DataComponentType type)
+	{
+		itemStack.unsetData(type);
+	}
+
+	@Contract(value = "_ -> new", pure = true)
+	@Override
+	public @NotNull ItemStack withType(@NotNull Material type)
+	{
+		return itemStack.withType(type);
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMirror.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMirror.java
@@ -40,6 +40,7 @@ import java.util.function.UnaryOperator;
  *
  * @see ItemStack
  */
+@ApiStatus.Internal
 public final class ItemStackMirror extends ItemStack
 {
 

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMirror.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMirror.java
@@ -300,7 +300,7 @@ public final class ItemStackMirror extends ItemStack
 		return itemStack.getEnchantments();
 	}
 
-	@Deprecated
+	@Deprecated(forRemoval = true)
 	@Override
 	public @Nullable String getI18NDisplayName()
 	{
@@ -320,7 +320,7 @@ public final class ItemStackMirror extends ItemStack
 		return itemStack.getItemMeta();
 	}
 
-	@Deprecated
+	@Deprecated(forRemoval = true)
 	@Override
 	public @Nullable List<String> getLore()
 	{
@@ -555,14 +555,14 @@ public final class ItemStackMirror extends ItemStack
 		return itemStack.setItemMeta(itemMeta);
 	}
 
-	@Deprecated
+	@Deprecated(forRemoval = true)
 	@Override
 	public void setLore(@Nullable List<String> lore)
 	{
 		itemStack.setLore(lore);
 	}
 
-	@Deprecated
+	@Deprecated(forRemoval = true)
 	@Override
 	public void setType(@NotNull Material type)
 	{

--- a/src/test/java/org/mockbukkit/mockbukkit/block/state/ChestStateMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/state/ChestStateMockTest.java
@@ -1,15 +1,5 @@
 package org.mockbukkit.mockbukkit.block.state;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -21,6 +11,16 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockbukkit.mockbukkit.block.BlockMock;
 import org.mockbukkit.mockbukkit.world.WorldMock;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 class ChestStateMockTest extends ContainerStateMockTest
@@ -167,5 +167,25 @@ class ChestStateMockTest extends ContainerStateMockTest
 
 		// Assert that the old state was also updated
 		assertTrue(chestState.getBlockInventory().contains(ItemStack.of(Material.DIAMOND)));
+	}
+
+	@Nested
+	class Copy
+	{
+		@Test
+		void shouldCloneInventory()
+		{
+			chest.getBlockInventory().setItem(0, ItemStack.of(Material.DIAMOND));
+
+			ChestStateMock newState = chest.copy();
+
+			assertEquals(chest, newState);
+			assertNotSame(chest, newState);
+
+			chest.getBlockInventory().setItem(0, ItemStack.of(Material.EMERALD));
+			assertNotEquals(chest, newState);
+			assertNotSame(chest, newState);
+		}
+
 	}
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryMockTest.java
@@ -100,7 +100,7 @@ class InventoryMockTest
 	}
 
 	@Test
-	void getItem_IsCloned()
+	void getItem_IsMirrored()
 	{
 		inventory.setItem(0, new ItemStackMock(Material.DIAMOND, 1));
 		ItemStack item = inventory.getItem(0);
@@ -109,8 +109,9 @@ class InventoryMockTest
 		assertEquals(item, clone);
 
 		item.setAmount(2);
+
 		assertEquals(2, item.getAmount());
-		assertEquals(1, clone.getAmount());
+		assertEquals(2, clone.getAmount());
 	}
 
 	@Test
@@ -352,8 +353,9 @@ class InventoryMockTest
 		assertArrayEquals(contents, clone);
 
 		contents[0].setAmount(1);
+
 		assertEquals(1, contents[0].getAmount());
-		assertEquals(2, clone[0].getAmount());
+		assertEquals(1, clone[0].getAmount());
 	}
 
 	@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryMockTest.java
@@ -344,7 +344,7 @@ class InventoryMockTest
 	}
 
 	@Test
-	void getContents_IsCloned()
+	void getContents_IsMirrored()
 	{
 		inventory.addItem(new ItemStackMock(Material.STONE, 2));
 		ItemStack[] contents = inventory.getContents();

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/InventoryMockTest.java
@@ -12,6 +12,7 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -864,6 +865,21 @@ class InventoryMockTest
 			{
 				assertFalse(inventoryA.isIdentical(inventoryB));
 			}
+		}
+
+	}
+
+	@Nested
+	class Issues
+	{
+
+		@Test
+		@DisplayName("ItemStacks should not be cloned, they should be mirrored.")
+		void issue1322()
+		{
+			inventory.setItem(0, ItemStack.of(Material.DIAMOND, 3));
+			inventory.getItem(0).setAmount(15);
+			assertEquals(15, inventory.getItem(0).getAmount());
 		}
 
 	}

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/ItemStackMirrorTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/ItemStackMirrorTest.java
@@ -26,6 +26,7 @@ class ItemStackMirrorTest
 			ItemStack mirror = ItemStackMirror.create(originalItem);
 
 			assertEquals(originalItem, mirror);
+			assertEquals(mirror, originalItem);
 			assertNotSame(originalItem, mirror);
 		}
 
@@ -39,6 +40,7 @@ class ItemStackMirrorTest
 
 			assertEquals(5, originalItem.getAmount());
 			assertEquals(originalItem, mirror);
+			assertEquals(mirror, originalItem);
 			assertNotSame(originalItem, mirror);
 		}
 
@@ -52,6 +54,7 @@ class ItemStackMirrorTest
 
 			assertEquals(5, mirror.getAmount());
 			assertEquals(originalItem, mirror);
+			assertEquals(mirror, originalItem);
 			assertNotSame(originalItem, mirror);
 		}
 

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/ItemStackMirrorTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/ItemStackMirrorTest.java
@@ -1,0 +1,60 @@
+package org.mockbukkit.mockbukkit.inventory;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+@ExtendWith(MockBukkitExtension.class)
+class ItemStackMirrorTest
+{
+
+	@Nested
+	class Create
+	{
+
+		@Test
+		void givenValidValue_ShouldNotBeTheSame()
+		{
+			ItemStack originalItem = new ItemStackMock(Material.DIAMOND, 1);
+
+			ItemStack mirror = ItemStackMirror.create(originalItem);
+
+			assertEquals(originalItem, mirror);
+			assertNotSame(originalItem, mirror);
+		}
+
+		@Test
+		void givenAnyChangeExecutedInTheOriginalItem_ShouldBeAppliedInTheMirror()
+		{
+			ItemStack originalItem = new ItemStackMock(Material.DIAMOND, 1);
+			ItemStack mirror = ItemStackMirror.create(originalItem);
+
+			originalItem.setAmount(5);
+
+			assertEquals(5, originalItem.getAmount());
+			assertEquals(originalItem, mirror);
+			assertNotSame(originalItem, mirror);
+		}
+
+		@Test
+		void givenAnyChangeExecutedInTheMirrorItem_ShouldBeAppliedInTheOriginal()
+		{
+			ItemStack originalItem = new ItemStackMock(Material.DIAMOND, 1);
+			ItemStack mirror = ItemStackMirror.create(originalItem);
+
+			mirror.setAmount(5);
+
+			assertEquals(5, mirror.getAmount());
+			assertEquals(originalItem, mirror);
+			assertNotSame(originalItem, mirror);
+		}
+
+	}
+
+}


### PR DESCRIPTION
# Description
This PR fixes the issue #1322. Paper implements the delegate pattern in the CraftItemStack to support the changes in the minecraft item. To emulate this implementation and respect that `getItem` and `getContent` are mirror and not same class, it was required to implement a classe named `ItemStackMirror`. This follows the delegate pattern so that we can emulate the "mirror" operation.

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
