### PR TITLE
Test leniency (v1.21.5)

### DIFF
--- a/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
@@ -1,40 +1,5 @@
 package org.mockbukkit.mockbukkit;
 
-import javax.imageio.ImageIO;
-import java.awt.Graphics2D;
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.net.InetAddress;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.Stream;
-
-import static org.bukkit.Bukkit.getPauseWhenEmptyTime;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.mockbukkit.mockbukkit.matcher.command.CommandResultSucceedMatcher.hasSucceeded;
-import static org.mockbukkit.mockbukkit.matcher.plugin.PluginManagerFiredEventClassMatcher.hasFiredEventInstance;
-import static org.mockbukkit.mockbukkit.matcher.plugin.PluginManagerFiredEventClassMatcher.hasNotFiredEventInstance;
-import static org.mockbukkit.mockbukkit.matcher.plugin.PluginManagerFiredEventFilterMatcher.hasFiredFilteredEvent;
-
 import com.destroystokyo.paper.event.player.PlayerConnectionCloseEvent;
 import com.destroystokyo.paper.event.server.WhitelistToggleEvent;
 import com.google.common.collect.Iterables;
@@ -138,6 +103,41 @@ import org.mockbukkit.mockbukkit.plugin.TestPlugin;
 import org.mockbukkit.mockbukkit.profile.PlayerProfileMock;
 import org.mockbukkit.mockbukkit.world.WorldMock;
 import org.spigotmc.event.player.PlayerSpawnLocationEvent;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Stream;
+
+import static org.bukkit.Bukkit.getPauseWhenEmptyTime;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockbukkit.mockbukkit.matcher.command.CommandResultSucceedMatcher.hasSucceeded;
+import static org.mockbukkit.mockbukkit.matcher.plugin.PluginManagerFiredEventClassMatcher.hasFiredEventInstance;
+import static org.mockbukkit.mockbukkit.matcher.plugin.PluginManagerFiredEventClassMatcher.hasNotFiredEventInstance;
+import static org.mockbukkit.mockbukkit.matcher.plugin.PluginManagerFiredEventFilterMatcher.hasFiredFilteredEvent;
 
 @ExtendWith(MockBukkitExtension.class)
 class ServerMockTest
@@ -475,10 +475,10 @@ class ServerMockTest
 
 		@ParameterizedTest
 		@ValueSource(strings = {
-			"minecraft:bamboo_block",
-			"minecraft:bamboo_door",
-			"minecraft:decorated_pot",
-			"minecraft:gray_bundle"
+				"minecraft:bamboo_block",
+				"minecraft:bamboo_door",
+				"minecraft:decorated_pot",
+				"minecraft:gray_bundle"
 		})
 		void givenValidValues(String expectedKey)
 		{
@@ -494,8 +494,8 @@ class ServerMockTest
 
 		@ParameterizedTest
 		@ValueSource(strings = {
-			"minecraft:non_existing_recipe",
-			"other_namespace:bamboo_door"
+				"minecraft:non_existing_recipe",
+				"other_namespace:bamboo_door"
 		})
 		void givenInvalidValues(String expectedKey)
 		{
@@ -511,6 +511,7 @@ class ServerMockTest
 	@Nested
 	class GetCraftingRecipe
 	{
+
 		private final World world = new WorldMock();
 
 		@Test
@@ -522,7 +523,7 @@ class ServerMockTest
 
 		@ParameterizedTest
 		@ValueSource(ints = {
-			0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 14, 15
+				0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 14, 15
 		})
 		void givenCraftMatrixWithout9Slots(int itemsAmount)
 		{
@@ -540,7 +541,7 @@ class ServerMockTest
 		@Test
 		void givenNonExistingRecipe()
 		{
-			ItemStack[] craftingItems = new ItemStack[] {
+			ItemStack[] craftingItems = new ItemStack[]{
 					ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.STONE),
 					ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
 					ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.DIAMOND),
@@ -553,10 +554,10 @@ class ServerMockTest
 		@Test
 		void givenShapelessRecipe()
 		{
-			ItemStack[] craftingItems = new ItemStack[] {
-				ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
-				ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
-				ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.OAK_PLANKS),
+			ItemStack[] craftingItems = new ItemStack[]{
+					ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
+					ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
+					ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.OAK_PLANKS),
 			};
 			@Nullable Recipe recipe = server.getCraftingRecipe(craftingItems, world);
 
@@ -569,6 +570,7 @@ class ServerMockTest
 	@Nested
 	class CraftItem
 	{
+
 		private final World world = new WorldMock();
 
 		@Test
@@ -598,7 +600,7 @@ class ServerMockTest
 		@Test
 		void givenNonExistingRecipe()
 		{
-			ItemStack[] craftingItems = new ItemStack[] {
+			ItemStack[] craftingItems = new ItemStack[]{
 					ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.STONE),
 					ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
 					ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.DIAMOND),
@@ -612,7 +614,7 @@ class ServerMockTest
 		@Test
 		void givenShapelessRecipe()
 		{
-			ItemStack[] craftingItems = new ItemStack[] {
+			ItemStack[] craftingItems = new ItemStack[]{
 					ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
 					ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
 					ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.OAK_PLANKS),
@@ -1735,7 +1737,7 @@ class ServerMockTest
 		{
 
 			@ParameterizedTest
-			@ValueSource(ints = {9, 18, 27, 36, 45, 54})
+			@ValueSource(ints = { 9, 18, 27, 36, 45, 54 })
 			void shouldSucceed(int size)
 			{
 				InventoryMock inventory = server.createInventory(null, size);
@@ -1758,7 +1760,7 @@ class ServerMockTest
 		{
 
 			@ParameterizedTest
-			@ValueSource(ints = {9, 18, 27, 36, 45, 54})
+			@ValueSource(ints = { 9, 18, 27, 36, 45, 54 })
 			void shouldSucceed(int size)
 			{
 				InventoryMock inventory = server.createInventory(null, size, Component.text("My inventory"));
@@ -1782,7 +1784,7 @@ class ServerMockTest
 		{
 
 			@ParameterizedTest
-			@ValueSource(ints = {9, 18, 27, 36, 45, 54})
+			@ValueSource(ints = { 9, 18, 27, 36, 45, 54 })
 			void shouldSucceed(int size)
 			{
 				InventoryMock inventory = server.createInventory(null, size, "My inventory");
@@ -1813,6 +1815,7 @@ class ServerMockTest
 			}
 
 		}
+
 	}
 
 	@Test
@@ -2145,9 +2148,11 @@ class ServerMockTest
 	@Nested
 	class GetTag
 	{
+
 		@Nested
 		class Block
 		{
+
 			@Test
 			void givenValidBlockTag()
 			{
@@ -2169,11 +2174,13 @@ class ServerMockTest
 						Tag.STONE_BRICKS.getKey(), EntityType.class));
 				assertEquals("Block namespace (org.bukkit.entity.EntityType) must have material type", e.getMessage());
 			}
+
 		}
 
 		@Nested
 		class Item
 		{
+
 			@Test
 			void givenValidItem()
 			{
@@ -2193,11 +2200,13 @@ class ServerMockTest
 				IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> server.getTag(Tag.REGISTRY_ITEMS, Tag.STONE_BRICKS.getKey(), EntityType.class));
 				assertEquals("Item namespace (org.bukkit.entity.EntityType) must have material type", e.getMessage());
 			}
+
 		}
 
 		@Nested
 		class Fluids
 		{
+
 			@Test
 			void givenValidItem()
 			{
@@ -2216,11 +2225,13 @@ class ServerMockTest
 				IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> server.getTag(Tag.REGISTRY_FLUIDS, Tag.STONE_BRICKS.getKey(), EntityType.class));
 				assertEquals("Fluid namespace (org.bukkit.entity.EntityType) must have fluid type", e.getMessage());
 			}
+
 		}
 
 		@Nested
 		class EntityTypes
 		{
+
 			@Test
 			void givenValidItem()
 			{
@@ -2239,11 +2250,13 @@ class ServerMockTest
 				IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> server.getTag(Tag.REGISTRY_ENTITY_TYPES, Tag.STONE_BRICKS.getKey(), Material.class));
 				assertEquals("Entity type namespace (org.bukkit.Material) must have entity type", e.getMessage());
 			}
+
 		}
 
 		@Nested
 		class GameEvents
 		{
+
 			@Test
 			void givenValidItem()
 			{
@@ -2261,22 +2274,26 @@ class ServerMockTest
 				IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> server.getTag(Tag.REGISTRY_GAME_EVENTS, Tag.STONE_BRICKS.getKey(), EntityType.class));
 				assertEquals("Game Event namespace must have GameEvent type", e.getMessage());
 			}
+
 		}
+
 	}
 
 	@Nested
 	class GetTags
 	{
+
 		@Nested
 		class Block
 		{
+
 			@Test
 			void givenValidBlockTag()
 			{
 				Iterable<Tag<Material>> blocks = server.getTags(Tag.REGISTRY_BLOCKS, Material.class);
 
 				assertNotNull(blocks);
-				assertEquals(182, Iterables.size(blocks));
+				assertTrue(182 < Iterables.size(blocks));
 			}
 
 			@Test
@@ -2285,18 +2302,20 @@ class ServerMockTest
 				IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> server.getTags(Tag.REGISTRY_BLOCKS, EntityType.class));
 				assertEquals("Block namespace (org.bukkit.entity.EntityType) must have material type", e.getMessage());
 			}
+
 		}
 
 		@Nested
 		class Item
 		{
+
 			@Test
 			void givenValidItem()
 			{
 				Iterable<Tag<Material>> itemsTag = server.getTags(Tag.REGISTRY_ITEMS, Material.class);
 
 				assertNotNull(itemsTag);
-				assertEquals(154, Iterables.size(itemsTag));
+				assertTrue(154 < Iterables.size(itemsTag));
 			}
 
 			@Test
@@ -2305,11 +2324,13 @@ class ServerMockTest
 				IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> server.getTags(Tag.REGISTRY_ITEMS, EntityType.class));
 				assertEquals("Item namespace (org.bukkit.entity.EntityType) must have material type", e.getMessage());
 			}
+
 		}
 
 		@Nested
 		class Fluids
 		{
+
 			@Test
 			void givenValidItem()
 			{
@@ -2325,18 +2346,20 @@ class ServerMockTest
 				IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> server.getTags(Tag.REGISTRY_FLUIDS, EntityType.class));
 				assertEquals("Fluid namespace (org.bukkit.entity.EntityType) must have fluid type", e.getMessage());
 			}
+
 		}
 
 		@Nested
 		class EntityTypes
 		{
+
 			@Test
 			void givenValidItem()
 			{
 				@NotNull Iterable<Tag<EntityType>> entityTypeTag = server.getTags(Tag.REGISTRY_ENTITY_TYPES, EntityType.class);
 
 				assertNotNull(entityTypeTag);
-				assertEquals(35, Iterables.size(entityTypeTag));
+				assertTrue(35 < Iterables.size(entityTypeTag));
 			}
 
 			@Test
@@ -2345,11 +2368,13 @@ class ServerMockTest
 				IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> server.getTag(Tag.REGISTRY_ENTITY_TYPES, Tag.STONE_BRICKS.getKey(), Material.class));
 				assertEquals("Entity type namespace (org.bukkit.Material) must have entity type", e.getMessage());
 			}
+
 		}
 
 		@Nested
 		class GameEvents
 		{
+
 			@Test
 			void givenValidItem()
 			{
@@ -2365,7 +2390,9 @@ class ServerMockTest
 				IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> server.getTag(Tag.REGISTRY_GAME_EVENTS, Tag.STONE_BRICKS.getKey(), EntityType.class));
 				assertEquals("Game Event namespace must have GameEvent type", e.getMessage());
 			}
+
 		}
+
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/variant/VillagerProfessionMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/variant/VillagerProfessionMockTest.java
@@ -15,7 +15,6 @@ class VillagerProfessionMockTest
 		Villager.Profession profession = Villager.Profession.BUTCHER;
 		assertEquals("BUTCHER", profession.name());
 		assertEquals(NamespacedKey.fromString("minecraft:butcher"), profession.getKey());
-		assertEquals(2, profession.ordinal());
 		assertEquals("entity.minecraft.villager.butcher", profession.translationKey());
 	}
 

--- a/src/test/java/org/mockbukkit/mockbukkit/tags/TagRegistryTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/tags/TagRegistryTest.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.bukkit.Fluid;
 import org.bukkit.GameEvent;
@@ -30,7 +31,7 @@ class TagRegistryTest
 		{
 			@NotNull Map<NamespacedKey, Tag<?>> actual = TagRegistry.BLOCKS.getTags();
 			assertNotNull(actual);
-			assertEquals(182, actual.size());
+			assertTrue(182 < actual.size());
 		}
 
 		@Test
@@ -56,7 +57,7 @@ class TagRegistryTest
 		{
 			@NotNull Map<NamespacedKey, Tag<?>> actual = TagRegistry.ENTITY_TYPES.getTags();
 			assertNotNull(actual);
-			assertEquals(35, actual.size());
+			assertTrue(35 < actual.size());
 		}
 
 		@Test
@@ -82,7 +83,7 @@ class TagRegistryTest
 		{
 			@NotNull Map<NamespacedKey, Tag<?>> actual = TagRegistry.ITEMS.getTags();
 			assertNotNull(actual);
-			assertEquals(154, actual.size());
+			assertTrue(154 < actual.size());
 		}
 
 		@Test


### PR DESCRIPTION
# Description
Adds leniency on some tests that are unstable and tests something that is not crucial. I.e. how many tags are there of blocks/items. This is going to change every update.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
