### PR TITLE
Fix some issues for keyed data in metaminer (1.21.5)

### DIFF
--- a/metaminer/src/main/java/org/mockbukkit/metaminer/keyed/KeyedDataGenerator.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/keyed/KeyedDataGenerator.java
@@ -88,17 +88,6 @@ public class KeyedDataGenerator implements DataGenerator
 
 	private void addItemTypeProperties(JsonObject jsonObject, ItemType itemType)
 	{
-		jsonObject.add("maxStackSize", new JsonPrimitive(itemType.getMaxStackSize()));
-		jsonObject.add("maxDurability", new JsonPrimitive(itemType.getMaxDurability()));
-		jsonObject.add("edible", new JsonPrimitive(itemType.isEdible()));
-		jsonObject.add("record", new JsonPrimitive(itemType.isRecord()));
-		jsonObject.add("fuel", new JsonPrimitive(itemType.isFuel()));
-		jsonObject.add("blockType", new JsonPrimitive(itemType.hasBlockType()));
-		jsonObject.add("translationKey", new JsonPrimitive(itemType.getTranslationKey()));
-		jsonObject.add("material", new JsonPrimitive(itemType.asMaterial().name()));
-		jsonObject.add("rarity", new JsonPrimitive(itemType.getItemRarity().toString()));
-		jsonObject.add("creativeCategory", new JsonPrimitive(itemType.getCreativeCategory().toString()));
-		jsonObject.add("compostable", new JsonPrimitive(itemType.isCompostable()));
 		if (itemType.isCompostable())
 		{
 			jsonObject.add("compostChance", new JsonPrimitive("%sF".formatted(itemType.getCompostChance())));

--- a/metaminer/src/main/java/org/mockbukkit/metaminer/keyed/MethodDataScanner.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/keyed/MethodDataScanner.java
@@ -18,7 +18,7 @@ import java.util.regex.Pattern;
 public class MethodDataScanner
 {
 
-	private static final Pattern WORDS_TO_REPLACE = Pattern.compile("((^get)|(^has)|(^is))([A-Z])");
+	private static final Pattern WORDS_TO_REPLACE = Pattern.compile("((^get)|(^has)|(^is)|(as))([A-Z])");
 	private static final Set<String> METHOD_NAME_BLACKLIST = Set.of("hashCode", "toString", "getKeyOrNull", "implHashCode",
 			"implToString", "wait", "getDeclaringClass", "notify", "notifyAll", "getClass", "values");
 
@@ -59,6 +59,19 @@ public class MethodDataScanner
 		Preconditions.checkArgument(returnType != null, "The return type can't be null!");
 		Preconditions.checkArgument(method != null, "The method can't be null!");
 
+		if (method.getName().startsWith("has"))
+		{
+			try
+			{
+				object.getClass().getMethod(method.getName().replace("has", "get"));
+				return null;
+			}
+			catch (NoSuchMethodException e)
+			{
+				// continue
+			}
+		}
+
 		// Convert the primitive type into the respective wrapper
 		returnType = ClassUtils.primitiveToWrapper(returnType);
 
@@ -76,7 +89,7 @@ public class MethodDataScanner
 		Matcher matcher = WORDS_TO_REPLACE.matcher(name);
 		if (matcher.find())
 		{
-			return matcher.group(5).toLowerCase(Locale.ROOT) + matcher.replaceAll("");
+			return matcher.group(6).toLowerCase(Locale.ROOT) + matcher.replaceAll("");
 		}
 		return name;
 	}

--- a/src/main/java/org/mockbukkit/mockbukkit/block/BlockTypeMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/BlockTypeMock.java
@@ -23,7 +23,7 @@ public class BlockTypeMock<B extends BlockData> implements BlockType.Typed<B>
 {
 
 	private final NamespacedKey key;
-	private final boolean itemType;
+	private final NamespacedKey itemType;
 	private final boolean solid;
 	private final boolean flammable;
 	private final boolean burnable;
@@ -38,9 +38,9 @@ public class BlockTypeMock<B extends BlockData> implements BlockType.Typed<B>
 	private final String translationKey;
 
 	@ApiStatus.Internal
-	private BlockTypeMock(NamespacedKey key, boolean itemType, boolean solid, boolean flammable, boolean burnable,
-						 boolean occluding, boolean gravity, float hardness, float blastResistance, float slipperiness,
-						 boolean air, boolean interactable, boolean collision, String translationKey)
+	private BlockTypeMock(NamespacedKey key, @Nullable NamespacedKey itemType, boolean solid, boolean flammable, boolean burnable,
+						  boolean occluding, boolean gravity, float hardness, float blastResistance, float slipperiness,
+						  boolean air, boolean interactable, boolean collision, String translationKey)
 	{
 		this.key = key;
 		this.itemType = itemType;
@@ -62,7 +62,7 @@ public class BlockTypeMock<B extends BlockData> implements BlockType.Typed<B>
 	public static BlockTypeMock from(JsonObject jsonObject)
 	{
 		NamespacedKey key = NamespacedKey.fromString(jsonObject.get("key").getAsString());
-		boolean itemType = jsonObject.get("itemType").getAsBoolean();
+		NamespacedKey itemType = jsonObject.has("itemType") ? NamespacedKey.fromString(jsonObject.get("itemType").getAsString()) : null;
 		boolean solid = jsonObject.get("solid").getAsBoolean();
 		boolean flammable = jsonObject.get("flammable").getAsBoolean();
 		boolean burnable = jsonObject.get("burnable").getAsBoolean();
@@ -96,7 +96,7 @@ public class BlockTypeMock<B extends BlockData> implements BlockType.Typed<B>
 	@Override
 	public boolean hasItemType()
 	{
-		return this.itemType;
+		return this.itemType != null;
 	}
 
 	@Override
@@ -106,9 +106,9 @@ public class BlockTypeMock<B extends BlockData> implements BlockType.Typed<B>
 		{
 			return ItemType.AIR;
 		}
-
-		ItemType item = Registry.ITEM.get(this.key);
-		Preconditions.checkArgument(item != null && item != ItemType.AIR, "The block type %s has no corresponding item type", this.getKey());
+		Preconditions.checkArgument(this.itemType != null, "The block type %s has no corresponding item type", this.getKey());
+		ItemType item = Registry.ITEM.get(this.itemType);
+		Preconditions.checkState(item != null && item != ItemType.AIR, "The block type %s has no corresponding item type", this.getKey());
 		return item;
 	}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemTypeMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemTypeMock.java
@@ -1,11 +1,9 @@
 package org.mockbukkit.mockbukkit.inventory;
 
-import io.papermc.paper.datacomponent.DataComponentType;
-import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
-import org.mockbukkit.mockbukkit.inventory.meta.ItemMetaMock;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Multimap;
 import com.google.gson.JsonObject;
+import io.papermc.paper.datacomponent.DataComponentType;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
@@ -23,6 +21,8 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
+import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
+import org.mockbukkit.mockbukkit.inventory.meta.ItemMetaMock;
 
 import java.math.BigDecimal;
 import java.util.Set;
@@ -33,7 +33,7 @@ public class ItemTypeMock<M extends ItemMeta> implements ItemType.Typed<M>
 {
 
 	private final NamespacedKey namespacedKey;
-	private final boolean blockType;
+	private final @Nullable NamespacedKey blockType;
 	private final int maxStackSize;
 	private final short maxDurability;
 	private final boolean edible;
@@ -47,8 +47,8 @@ public class ItemTypeMock<M extends ItemMeta> implements ItemType.Typed<M>
 	private final BigDecimal compostChance;
 
 	private ItemTypeMock(NamespacedKey namespacedKey, int maxStackSize, short maxDurability,
-						 boolean edible, boolean hasRecord, boolean fuel, boolean blockType, String translationKey,
-						 Class<M> metaClass, ItemRarity rarity, CreativeCategory creativeCategory,boolean isCompostable,
+						 boolean edible, boolean hasRecord, boolean fuel, @Nullable NamespacedKey blockType, String translationKey,
+						 Class<M> metaClass, ItemRarity rarity, CreativeCategory creativeCategory, boolean isCompostable,
 						 BigDecimal compostChance)
 	{
 		this.namespacedKey = namespacedKey;
@@ -75,9 +75,9 @@ public class ItemTypeMock<M extends ItemMeta> implements ItemType.Typed<M>
 		boolean edible = jsonObject.get("edible").getAsBoolean();
 		boolean hasRecord = jsonObject.get("record").getAsBoolean();
 		boolean fuel = jsonObject.get("fuel").getAsBoolean();
-		boolean blockType = jsonObject.get("blockType").getAsBoolean();
+		NamespacedKey blockType = jsonObject.has("blockType") ? NamespacedKey.fromString(jsonObject.get("blockType").getAsString()) : null;
 		String translationKey = jsonObject.get("translationKey").getAsString();
-		ItemRarity rarity = ItemRarity.valueOf(jsonObject.get("rarity").getAsString());
+		ItemRarity rarity = ItemRarity.valueOf(jsonObject.get("itemRarity").getAsString());
 		CreativeCategory creativeCategory = CreativeCategory.valueOf(jsonObject.get("creativeCategory").getAsString());
 		boolean isCompostable = jsonObject.get("compostable").getAsBoolean();
 		BigDecimal compostChance = new BigDecimal(0);
@@ -160,13 +160,20 @@ public class ItemTypeMock<M extends ItemMeta> implements ItemType.Typed<M>
 	@Override
 	public boolean hasBlockType()
 	{
-		return this.blockType;
+		return this.blockType != null;
 	}
 
 	@Override
 	public @NotNull BlockType getBlockType()
 	{
-		throw new UnimplementedOperationException();
+		if (this == AIR)
+		{
+			return BlockType.AIR;
+		}
+		Preconditions.checkArgument(this.blockType != null, "The item type %s has no corresponding block type", this.getKey());
+		BlockType block = Registry.BLOCK.get(this.blockType);
+		Preconditions.checkState(block != null && block != ItemType.AIR, "The item type %s has no corresponding item type", this.getKey());
+		return block;
 	}
 
 	@Override

--- a/src/main/resources/keyed/attribute.json
+++ b/src/main/resources/keyed/attribute.json
@@ -3,55 +3,55 @@
 		{
 			"key": "minecraft:armor",
 			"name": "ARMOR",
-			"ordinal": 20,
+			"ordinal": 2,
 			"translationKey": "attribute.name.armor"
 		},
 		{
 			"key": "minecraft:armor_toughness",
 			"name": "ARMOR_TOUGHNESS",
-			"ordinal": 12,
+			"ordinal": 3,
 			"translationKey": "attribute.name.armor_toughness"
 		},
 		{
 			"key": "minecraft:attack_damage",
 			"name": "ATTACK_DAMAGE",
-			"ordinal": 27,
+			"ordinal": 0,
 			"translationKey": "attribute.name.attack_damage"
 		},
 		{
 			"key": "minecraft:attack_knockback",
 			"name": "ATTACK_KNOCKBACK",
-			"ordinal": 17,
+			"ordinal": 20,
 			"translationKey": "attribute.name.attack_knockback"
 		},
 		{
 			"key": "minecraft:attack_speed",
 			"name": "ATTACK_SPEED",
-			"ordinal": 3,
+			"ordinal": 1,
 			"translationKey": "attribute.name.attack_speed"
 		},
 		{
 			"key": "minecraft:block_break_speed",
 			"name": "BLOCK_BREAK_SPEED",
-			"ordinal": 26,
+			"ordinal": 27,
 			"translationKey": "attribute.name.block_break_speed"
 		},
 		{
 			"key": "minecraft:block_interaction_range",
 			"name": "BLOCK_INTERACTION_RANGE",
-			"ordinal": 23,
+			"ordinal": 24,
 			"translationKey": "attribute.name.block_interaction_range"
 		},
 		{
 			"key": "minecraft:burning_time",
 			"name": "BURNING_TIME",
-			"ordinal": 14,
+			"ordinal": 17,
 			"translationKey": "attribute.name.burning_time"
 		},
 		{
 			"key": "minecraft:entity_interaction_range",
 			"name": "ENTITY_INTERACTION_RANGE",
-			"ordinal": 5,
+			"ordinal": 9,
 			"translationKey": "attribute.name.entity_interaction_range"
 		},
 		{
@@ -63,85 +63,85 @@
 		{
 			"key": "minecraft:fall_damage_multiplier",
 			"name": "FALL_DAMAGE_MULTIPLIER",
-			"ordinal": 0,
+			"ordinal": 5,
 			"translationKey": "attribute.name.fall_damage_multiplier"
 		},
 		{
 			"key": "minecraft:flying_speed",
 			"name": "FLYING_SPEED",
-			"ordinal": 9,
+			"ordinal": 13,
 			"translationKey": "attribute.name.flying_speed"
 		},
 		{
 			"key": "minecraft:follow_range",
 			"name": "FOLLOW_RANGE",
-			"ordinal": 1,
+			"ordinal": 6,
 			"translationKey": "attribute.name.follow_range"
 		},
 		{
 			"key": "minecraft:gravity",
 			"name": "GRAVITY",
-			"ordinal": 13,
+			"ordinal": 16,
 			"translationKey": "attribute.name.gravity"
 		},
 		{
 			"key": "minecraft:jump_strength",
 			"name": "JUMP_STRENGTH",
-			"ordinal": 24,
+			"ordinal": 25,
 			"translationKey": "attribute.name.jump_strength"
 		},
 		{
 			"key": "minecraft:knockback_resistance",
 			"name": "KNOCKBACK_RESISTANCE",
-			"ordinal": 19,
+			"ordinal": 4,
 			"translationKey": "attribute.name.knockback_resistance"
 		},
 		{
 			"key": "minecraft:luck",
 			"name": "LUCK",
-			"ordinal": 11,
+			"ordinal": 15,
 			"translationKey": "attribute.name.luck"
 		},
 		{
 			"key": "minecraft:max_absorption",
 			"name": "MAX_ABSORPTION",
-			"ordinal": 15,
+			"ordinal": 18,
 			"translationKey": "attribute.name.max_absorption"
 		},
 		{
 			"key": "minecraft:max_health",
 			"name": "MAX_HEALTH",
-			"ordinal": 6,
+			"ordinal": 10,
 			"translationKey": "attribute.name.max_health"
 		},
 		{
 			"key": "minecraft:mining_efficiency",
 			"name": "MINING_EFFICIENCY",
-			"ordinal": 21,
+			"ordinal": 22,
 			"translationKey": "attribute.name.mining_efficiency"
 		},
 		{
 			"key": "minecraft:movement_efficiency",
 			"name": "MOVEMENT_EFFICIENCY",
-			"ordinal": 16,
+			"ordinal": 19,
 			"translationKey": "attribute.name.movement_efficiency"
 		},
 		{
 			"key": "minecraft:movement_speed",
 			"name": "MOVEMENT_SPEED",
-			"ordinal": 4,
+			"ordinal": 8,
 			"translationKey": "attribute.name.movement_speed"
 		},
 		{
 			"key": "minecraft:oxygen_bonus",
 			"name": "OXYGEN_BONUS",
-			"ordinal": 10,
+			"ordinal": 14,
 			"translationKey": "attribute.name.oxygen_bonus"
 		},
 		{
 			"key": "minecraft:safe_fall_distance",
 			"name": "SAFE_FALL_DISTANCE",
-			"ordinal": 22,
+			"ordinal": 23,
 			"translationKey": "attribute.name.safe_fall_distance"
 		},
 		{
@@ -153,13 +153,13 @@
 		{
 			"key": "minecraft:sneaking_speed",
 			"name": "SNEAKING_SPEED",
-			"ordinal": 18,
+			"ordinal": 21,
 			"translationKey": "attribute.name.sneaking_speed"
 		},
 		{
 			"key": "minecraft:spawn_reinforcements",
 			"name": "SPAWN_REINFORCEMENTS",
-			"ordinal": 2,
+			"ordinal": 7,
 			"translationKey": "attribute.name.spawn_reinforcements"
 		},
 		{
@@ -171,13 +171,13 @@
 		{
 			"key": "minecraft:submerged_mining_speed",
 			"name": "SUBMERGED_MINING_SPEED",
-			"ordinal": 8,
+			"ordinal": 12,
 			"translationKey": "attribute.name.submerged_mining_speed"
 		},
 		{
 			"key": "minecraft:sweeping_damage_ratio",
 			"name": "SWEEPING_DAMAGE_RATIO",
-			"ordinal": 7,
+			"ordinal": 11,
 			"translationKey": "attribute.name.sweeping_damage_ratio"
 		},
 		{
@@ -189,7 +189,7 @@
 		{
 			"key": "minecraft:water_movement_efficiency",
 			"name": "WATER_MOVEMENT_EFFICIENCY",
-			"ordinal": 25,
+			"ordinal": 26,
 			"translationKey": "attribute.name.water_movement_efficiency"
 		}
 	]

--- a/src/main/resources/keyed/block.json
+++ b/src/main/resources/keyed/block.json
@@ -2,7 +2,6 @@
 	"values": [
 		{
 			"air": false,
-			"asMaterial": "minecraft:acacia_button",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -12,6 +11,7 @@
 			"interactable": true,
 			"itemType": "minecraft:acacia_button",
 			"key": "minecraft:acacia_button",
+			"material": "minecraft:acacia_button",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23,7 +23,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:acacia_door",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -33,6 +32,7 @@
 			"interactable": true,
 			"itemType": "minecraft:acacia_door",
 			"key": "minecraft:acacia_door",
+			"material": "minecraft:acacia_door",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44,7 +44,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:acacia_fence",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -54,6 +53,7 @@
 			"interactable": true,
 			"itemType": "minecraft:acacia_fence",
 			"key": "minecraft:acacia_fence",
+			"material": "minecraft:acacia_fence",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -65,7 +65,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:acacia_fence_gate",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -75,6 +74,7 @@
 			"interactable": true,
 			"itemType": "minecraft:acacia_fence_gate",
 			"key": "minecraft:acacia_fence_gate",
+			"material": "minecraft:acacia_fence_gate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -86,7 +86,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:acacia_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -96,6 +95,7 @@
 			"interactable": true,
 			"itemType": "minecraft:acacia_hanging_sign",
 			"key": "minecraft:acacia_hanging_sign",
+			"material": "minecraft:acacia_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -107,7 +107,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:acacia_leaves",
 			"blastResistance": 0.2,
 			"burnable": true,
 			"collision": true,
@@ -117,6 +116,7 @@
 			"interactable": false,
 			"itemType": "minecraft:acacia_leaves",
 			"key": "minecraft:acacia_leaves",
+			"material": "minecraft:acacia_leaves",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -128,7 +128,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:acacia_log",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -138,6 +137,7 @@
 			"interactable": false,
 			"itemType": "minecraft:acacia_log",
 			"key": "minecraft:acacia_log",
+			"material": "minecraft:acacia_log",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -149,7 +149,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:acacia_planks",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -159,6 +158,7 @@
 			"interactable": false,
 			"itemType": "minecraft:acacia_planks",
 			"key": "minecraft:acacia_planks",
+			"material": "minecraft:acacia_planks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -170,7 +170,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:acacia_pressure_plate",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -180,6 +179,7 @@
 			"interactable": false,
 			"itemType": "minecraft:acacia_pressure_plate",
 			"key": "minecraft:acacia_pressure_plate",
+			"material": "minecraft:acacia_pressure_plate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -191,7 +191,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:acacia_sapling",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -201,6 +200,7 @@
 			"interactable": false,
 			"itemType": "minecraft:acacia_sapling",
 			"key": "minecraft:acacia_sapling",
+			"material": "minecraft:acacia_sapling",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -212,7 +212,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:acacia_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -222,6 +221,7 @@
 			"interactable": true,
 			"itemType": "minecraft:acacia_sign",
 			"key": "minecraft:acacia_sign",
+			"material": "minecraft:acacia_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -233,7 +233,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:acacia_slab",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -243,6 +242,7 @@
 			"interactable": false,
 			"itemType": "minecraft:acacia_slab",
 			"key": "minecraft:acacia_slab",
+			"material": "minecraft:acacia_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -254,7 +254,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:acacia_stairs",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -264,6 +263,7 @@
 			"interactable": false,
 			"itemType": "minecraft:acacia_stairs",
 			"key": "minecraft:acacia_stairs",
+			"material": "minecraft:acacia_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -275,7 +275,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:acacia_trapdoor",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -285,6 +284,7 @@
 			"interactable": true,
 			"itemType": "minecraft:acacia_trapdoor",
 			"key": "minecraft:acacia_trapdoor",
+			"material": "minecraft:acacia_trapdoor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -296,7 +296,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:acacia_wall_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -306,6 +305,7 @@
 			"interactable": true,
 			"itemType": "minecraft:acacia_hanging_sign",
 			"key": "minecraft:acacia_wall_hanging_sign",
+			"material": "minecraft:acacia_wall_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -317,7 +317,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:acacia_wall_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -327,6 +326,7 @@
 			"interactable": true,
 			"itemType": "minecraft:acacia_sign",
 			"key": "minecraft:acacia_wall_sign",
+			"material": "minecraft:acacia_wall_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -338,7 +338,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:acacia_wood",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -348,6 +347,7 @@
 			"interactable": false,
 			"itemType": "minecraft:acacia_wood",
 			"key": "minecraft:acacia_wood",
+			"material": "minecraft:acacia_wood",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -359,7 +359,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:activator_rail",
 			"blastResistance": 0.7,
 			"burnable": false,
 			"collision": false,
@@ -369,6 +368,7 @@
 			"interactable": false,
 			"itemType": "minecraft:activator_rail",
 			"key": "minecraft:activator_rail",
+			"material": "minecraft:activator_rail",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -380,7 +380,6 @@
 		},
 		{
 			"air": true,
-			"asMaterial": "minecraft:air",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -390,6 +389,7 @@
 			"interactable": false,
 			"itemType": "minecraft:air",
 			"key": "minecraft:air",
+			"material": "minecraft:air",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -401,7 +401,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:allium",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -411,6 +410,7 @@
 			"interactable": false,
 			"itemType": "minecraft:allium",
 			"key": "minecraft:allium",
+			"material": "minecraft:allium",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -422,7 +422,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:amethyst_block",
 			"blastResistance": 1.5,
 			"burnable": false,
 			"collision": true,
@@ -432,6 +431,7 @@
 			"interactable": false,
 			"itemType": "minecraft:amethyst_block",
 			"key": "minecraft:amethyst_block",
+			"material": "minecraft:amethyst_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -443,7 +443,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:amethyst_cluster",
 			"blastResistance": 1.5,
 			"burnable": false,
 			"collision": true,
@@ -453,6 +452,7 @@
 			"interactable": false,
 			"itemType": "minecraft:amethyst_cluster",
 			"key": "minecraft:amethyst_cluster",
+			"material": "minecraft:amethyst_cluster",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -464,7 +464,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:ancient_debris",
 			"blastResistance": 1200.0,
 			"burnable": false,
 			"collision": true,
@@ -474,6 +473,7 @@
 			"interactable": false,
 			"itemType": "minecraft:ancient_debris",
 			"key": "minecraft:ancient_debris",
+			"material": "minecraft:ancient_debris",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -485,7 +485,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:andesite",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -495,6 +494,7 @@
 			"interactable": false,
 			"itemType": "minecraft:andesite",
 			"key": "minecraft:andesite",
+			"material": "minecraft:andesite",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -506,7 +506,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:andesite_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -516,6 +515,7 @@
 			"interactable": false,
 			"itemType": "minecraft:andesite_slab",
 			"key": "minecraft:andesite_slab",
+			"material": "minecraft:andesite_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -527,7 +527,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:andesite_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -537,6 +536,7 @@
 			"interactable": false,
 			"itemType": "minecraft:andesite_stairs",
 			"key": "minecraft:andesite_stairs",
+			"material": "minecraft:andesite_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -548,7 +548,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:andesite_wall",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -558,6 +557,7 @@
 			"interactable": false,
 			"itemType": "minecraft:andesite_wall",
 			"key": "minecraft:andesite_wall",
+			"material": "minecraft:andesite_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -569,7 +569,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:anvil",
 			"blastResistance": 1200.0,
 			"burnable": false,
 			"collision": true,
@@ -579,6 +578,7 @@
 			"interactable": true,
 			"itemType": "minecraft:anvil",
 			"key": "minecraft:anvil",
+			"material": "minecraft:anvil",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -590,7 +590,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:attached_melon_stem",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -598,8 +597,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": false,
-			"itemType": false,
 			"key": "minecraft:attached_melon_stem",
+			"material": "minecraft:attached_melon_stem",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -611,7 +610,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:attached_pumpkin_stem",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -619,8 +617,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": false,
-			"itemType": false,
 			"key": "minecraft:attached_pumpkin_stem",
+			"material": "minecraft:attached_pumpkin_stem",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -632,7 +630,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:azalea",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": true,
@@ -642,6 +639,7 @@
 			"interactable": false,
 			"itemType": "minecraft:azalea",
 			"key": "minecraft:azalea",
+			"material": "minecraft:azalea",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -653,7 +651,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:azalea_leaves",
 			"blastResistance": 0.2,
 			"burnable": true,
 			"collision": true,
@@ -663,6 +660,7 @@
 			"interactable": false,
 			"itemType": "minecraft:azalea_leaves",
 			"key": "minecraft:azalea_leaves",
+			"material": "minecraft:azalea_leaves",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -674,7 +672,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:azure_bluet",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -684,6 +681,7 @@
 			"interactable": false,
 			"itemType": "minecraft:azure_bluet",
 			"key": "minecraft:azure_bluet",
+			"material": "minecraft:azure_bluet",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -695,7 +693,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bamboo",
 			"blastResistance": 1.0,
 			"burnable": true,
 			"collision": true,
@@ -705,6 +702,7 @@
 			"interactable": false,
 			"itemType": "minecraft:bamboo",
 			"key": "minecraft:bamboo",
+			"material": "minecraft:bamboo",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -716,7 +714,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bamboo_block",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -726,6 +723,7 @@
 			"interactable": false,
 			"itemType": "minecraft:bamboo_block",
 			"key": "minecraft:bamboo_block",
+			"material": "minecraft:bamboo_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -737,7 +735,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bamboo_button",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -747,6 +744,7 @@
 			"interactable": true,
 			"itemType": "minecraft:bamboo_button",
 			"key": "minecraft:bamboo_button",
+			"material": "minecraft:bamboo_button",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -758,7 +756,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bamboo_door",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -768,6 +765,7 @@
 			"interactable": true,
 			"itemType": "minecraft:bamboo_door",
 			"key": "minecraft:bamboo_door",
+			"material": "minecraft:bamboo_door",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -779,7 +777,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bamboo_fence",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -789,6 +786,7 @@
 			"interactable": true,
 			"itemType": "minecraft:bamboo_fence",
 			"key": "minecraft:bamboo_fence",
+			"material": "minecraft:bamboo_fence",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -800,7 +798,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bamboo_fence_gate",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -810,6 +807,7 @@
 			"interactable": true,
 			"itemType": "minecraft:bamboo_fence_gate",
 			"key": "minecraft:bamboo_fence_gate",
+			"material": "minecraft:bamboo_fence_gate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -821,7 +819,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bamboo_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -831,6 +828,7 @@
 			"interactable": true,
 			"itemType": "minecraft:bamboo_hanging_sign",
 			"key": "minecraft:bamboo_hanging_sign",
+			"material": "minecraft:bamboo_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -842,7 +840,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bamboo_mosaic",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -852,6 +849,7 @@
 			"interactable": false,
 			"itemType": "minecraft:bamboo_mosaic",
 			"key": "minecraft:bamboo_mosaic",
+			"material": "minecraft:bamboo_mosaic",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -863,7 +861,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bamboo_mosaic_slab",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -873,6 +870,7 @@
 			"interactable": false,
 			"itemType": "minecraft:bamboo_mosaic_slab",
 			"key": "minecraft:bamboo_mosaic_slab",
+			"material": "minecraft:bamboo_mosaic_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -884,7 +882,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bamboo_mosaic_stairs",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -894,6 +891,7 @@
 			"interactable": false,
 			"itemType": "minecraft:bamboo_mosaic_stairs",
 			"key": "minecraft:bamboo_mosaic_stairs",
+			"material": "minecraft:bamboo_mosaic_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -905,7 +903,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bamboo_planks",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -915,6 +912,7 @@
 			"interactable": false,
 			"itemType": "minecraft:bamboo_planks",
 			"key": "minecraft:bamboo_planks",
+			"material": "minecraft:bamboo_planks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -926,7 +924,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bamboo_pressure_plate",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -936,6 +933,7 @@
 			"interactable": false,
 			"itemType": "minecraft:bamboo_pressure_plate",
 			"key": "minecraft:bamboo_pressure_plate",
+			"material": "minecraft:bamboo_pressure_plate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -947,7 +945,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bamboo_sapling",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -955,8 +952,8 @@
 			"gravity": false,
 			"hardness": 1.0,
 			"interactable": false,
-			"itemType": false,
 			"key": "minecraft:bamboo_sapling",
+			"material": "minecraft:bamboo_sapling",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -968,7 +965,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bamboo_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -978,6 +974,7 @@
 			"interactable": true,
 			"itemType": "minecraft:bamboo_sign",
 			"key": "minecraft:bamboo_sign",
+			"material": "minecraft:bamboo_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -989,7 +986,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bamboo_slab",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -999,6 +995,7 @@
 			"interactable": false,
 			"itemType": "minecraft:bamboo_slab",
 			"key": "minecraft:bamboo_slab",
+			"material": "minecraft:bamboo_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1010,7 +1007,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bamboo_stairs",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -1020,6 +1016,7 @@
 			"interactable": false,
 			"itemType": "minecraft:bamboo_stairs",
 			"key": "minecraft:bamboo_stairs",
+			"material": "minecraft:bamboo_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1031,7 +1028,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bamboo_trapdoor",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -1041,6 +1037,7 @@
 			"interactable": true,
 			"itemType": "minecraft:bamboo_trapdoor",
 			"key": "minecraft:bamboo_trapdoor",
+			"material": "minecraft:bamboo_trapdoor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1052,7 +1049,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bamboo_wall_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -1062,6 +1058,7 @@
 			"interactable": true,
 			"itemType": "minecraft:bamboo_hanging_sign",
 			"key": "minecraft:bamboo_wall_hanging_sign",
+			"material": "minecraft:bamboo_wall_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1073,7 +1070,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bamboo_wall_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -1083,6 +1079,7 @@
 			"interactable": true,
 			"itemType": "minecraft:bamboo_sign",
 			"key": "minecraft:bamboo_wall_sign",
+			"material": "minecraft:bamboo_wall_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1094,7 +1091,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:barrel",
 			"blastResistance": 2.5,
 			"burnable": false,
 			"collision": true,
@@ -1104,6 +1100,7 @@
 			"interactable": true,
 			"itemType": "minecraft:barrel",
 			"key": "minecraft:barrel",
+			"material": "minecraft:barrel",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1115,7 +1112,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:barrier",
 			"blastResistance": 3600000.8,
 			"burnable": false,
 			"collision": true,
@@ -1125,6 +1121,7 @@
 			"interactable": false,
 			"itemType": "minecraft:barrier",
 			"key": "minecraft:barrier",
+			"material": "minecraft:barrier",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1136,7 +1133,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:basalt",
 			"blastResistance": 4.2,
 			"burnable": false,
 			"collision": true,
@@ -1146,6 +1142,7 @@
 			"interactable": false,
 			"itemType": "minecraft:basalt",
 			"key": "minecraft:basalt",
+			"material": "minecraft:basalt",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1157,7 +1154,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:beacon",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -1167,6 +1163,7 @@
 			"interactable": true,
 			"itemType": "minecraft:beacon",
 			"key": "minecraft:beacon",
+			"material": "minecraft:beacon",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1178,7 +1175,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bedrock",
 			"blastResistance": 3600000.0,
 			"burnable": false,
 			"collision": true,
@@ -1188,6 +1184,7 @@
 			"interactable": false,
 			"itemType": "minecraft:bedrock",
 			"key": "minecraft:bedrock",
+			"material": "minecraft:bedrock",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1199,7 +1196,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bee_nest",
 			"blastResistance": 0.3,
 			"burnable": true,
 			"collision": true,
@@ -1209,6 +1205,7 @@
 			"interactable": true,
 			"itemType": "minecraft:bee_nest",
 			"key": "minecraft:bee_nest",
+			"material": "minecraft:bee_nest",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1220,7 +1217,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:beehive",
 			"blastResistance": 0.6,
 			"burnable": true,
 			"collision": true,
@@ -1230,6 +1226,7 @@
 			"interactable": true,
 			"itemType": "minecraft:beehive",
 			"key": "minecraft:beehive",
+			"material": "minecraft:beehive",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1241,7 +1238,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:beetroots",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -1251,6 +1247,7 @@
 			"interactable": false,
 			"itemType": "minecraft:beetroot_seeds",
 			"key": "minecraft:beetroots",
+			"material": "minecraft:beetroots",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1262,7 +1259,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bell",
 			"blastResistance": 5.0,
 			"burnable": false,
 			"collision": true,
@@ -1272,6 +1268,7 @@
 			"interactable": true,
 			"itemType": "minecraft:bell",
 			"key": "minecraft:bell",
+			"material": "minecraft:bell",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1283,7 +1280,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:big_dripleaf",
 			"blastResistance": 0.1,
 			"burnable": true,
 			"collision": true,
@@ -1293,6 +1289,7 @@
 			"interactable": false,
 			"itemType": "minecraft:big_dripleaf",
 			"key": "minecraft:big_dripleaf",
+			"material": "minecraft:big_dripleaf",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1304,7 +1301,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:big_dripleaf_stem",
 			"blastResistance": 0.1,
 			"burnable": true,
 			"collision": false,
@@ -1314,6 +1310,7 @@
 			"interactable": false,
 			"itemType": "minecraft:big_dripleaf",
 			"key": "minecraft:big_dripleaf_stem",
+			"material": "minecraft:big_dripleaf_stem",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1325,7 +1322,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:birch_button",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -1335,6 +1331,7 @@
 			"interactable": true,
 			"itemType": "minecraft:birch_button",
 			"key": "minecraft:birch_button",
+			"material": "minecraft:birch_button",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1346,7 +1343,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:birch_door",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -1356,6 +1352,7 @@
 			"interactable": true,
 			"itemType": "minecraft:birch_door",
 			"key": "minecraft:birch_door",
+			"material": "minecraft:birch_door",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1367,7 +1364,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:birch_fence",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -1377,6 +1373,7 @@
 			"interactable": true,
 			"itemType": "minecraft:birch_fence",
 			"key": "minecraft:birch_fence",
+			"material": "minecraft:birch_fence",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1388,7 +1385,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:birch_fence_gate",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -1398,6 +1394,7 @@
 			"interactable": true,
 			"itemType": "minecraft:birch_fence_gate",
 			"key": "minecraft:birch_fence_gate",
+			"material": "minecraft:birch_fence_gate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1409,7 +1406,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:birch_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -1419,6 +1415,7 @@
 			"interactable": true,
 			"itemType": "minecraft:birch_hanging_sign",
 			"key": "minecraft:birch_hanging_sign",
+			"material": "minecraft:birch_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1430,7 +1427,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:birch_leaves",
 			"blastResistance": 0.2,
 			"burnable": true,
 			"collision": true,
@@ -1440,6 +1436,7 @@
 			"interactable": false,
 			"itemType": "minecraft:birch_leaves",
 			"key": "minecraft:birch_leaves",
+			"material": "minecraft:birch_leaves",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1451,7 +1448,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:birch_log",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -1461,6 +1457,7 @@
 			"interactable": false,
 			"itemType": "minecraft:birch_log",
 			"key": "minecraft:birch_log",
+			"material": "minecraft:birch_log",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1472,7 +1469,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:birch_planks",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -1482,6 +1478,7 @@
 			"interactable": false,
 			"itemType": "minecraft:birch_planks",
 			"key": "minecraft:birch_planks",
+			"material": "minecraft:birch_planks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1493,7 +1490,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:birch_pressure_plate",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -1503,6 +1499,7 @@
 			"interactable": false,
 			"itemType": "minecraft:birch_pressure_plate",
 			"key": "minecraft:birch_pressure_plate",
+			"material": "minecraft:birch_pressure_plate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1514,7 +1511,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:birch_sapling",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -1524,6 +1520,7 @@
 			"interactable": false,
 			"itemType": "minecraft:birch_sapling",
 			"key": "minecraft:birch_sapling",
+			"material": "minecraft:birch_sapling",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1535,7 +1532,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:birch_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -1545,6 +1541,7 @@
 			"interactable": true,
 			"itemType": "minecraft:birch_sign",
 			"key": "minecraft:birch_sign",
+			"material": "minecraft:birch_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1556,7 +1553,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:birch_slab",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -1566,6 +1562,7 @@
 			"interactable": false,
 			"itemType": "minecraft:birch_slab",
 			"key": "minecraft:birch_slab",
+			"material": "minecraft:birch_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1577,7 +1574,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:birch_stairs",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -1587,6 +1583,7 @@
 			"interactable": false,
 			"itemType": "minecraft:birch_stairs",
 			"key": "minecraft:birch_stairs",
+			"material": "minecraft:birch_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1598,7 +1595,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:birch_trapdoor",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -1608,6 +1604,7 @@
 			"interactable": true,
 			"itemType": "minecraft:birch_trapdoor",
 			"key": "minecraft:birch_trapdoor",
+			"material": "minecraft:birch_trapdoor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1619,7 +1616,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:birch_wall_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -1629,6 +1625,7 @@
 			"interactable": true,
 			"itemType": "minecraft:birch_hanging_sign",
 			"key": "minecraft:birch_wall_hanging_sign",
+			"material": "minecraft:birch_wall_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1640,7 +1637,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:birch_wall_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -1650,6 +1646,7 @@
 			"interactable": true,
 			"itemType": "minecraft:birch_sign",
 			"key": "minecraft:birch_wall_sign",
+			"material": "minecraft:birch_wall_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1661,7 +1658,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:birch_wood",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -1671,6 +1667,7 @@
 			"interactable": false,
 			"itemType": "minecraft:birch_wood",
 			"key": "minecraft:birch_wood",
+			"material": "minecraft:birch_wood",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1682,7 +1679,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:black_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -1692,6 +1688,7 @@
 			"interactable": false,
 			"itemType": "minecraft:black_banner",
 			"key": "minecraft:black_banner",
+			"material": "minecraft:black_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1703,7 +1700,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:black_bed",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": true,
@@ -1713,6 +1709,7 @@
 			"interactable": true,
 			"itemType": "minecraft:black_bed",
 			"key": "minecraft:black_bed",
+			"material": "minecraft:black_bed",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1724,7 +1721,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:black_candle",
 			"blastResistance": 0.1,
 			"burnable": false,
 			"collision": true,
@@ -1734,6 +1730,7 @@
 			"interactable": true,
 			"itemType": "minecraft:black_candle",
 			"key": "minecraft:black_candle",
+			"material": "minecraft:black_candle",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1745,7 +1742,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:black_candle_cake",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -1753,8 +1749,8 @@
 			"gravity": false,
 			"hardness": 0.5,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:black_candle_cake",
+			"material": "minecraft:black_candle_cake",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1766,7 +1762,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:black_carpet",
 			"blastResistance": 0.1,
 			"burnable": true,
 			"collision": true,
@@ -1776,6 +1771,7 @@
 			"interactable": false,
 			"itemType": "minecraft:black_carpet",
 			"key": "minecraft:black_carpet",
+			"material": "minecraft:black_carpet",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1787,7 +1783,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:black_concrete",
 			"blastResistance": 1.8,
 			"burnable": false,
 			"collision": true,
@@ -1797,6 +1792,7 @@
 			"interactable": false,
 			"itemType": "minecraft:black_concrete",
 			"key": "minecraft:black_concrete",
+			"material": "minecraft:black_concrete",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1808,7 +1804,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:black_concrete_powder",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -1818,6 +1813,7 @@
 			"interactable": false,
 			"itemType": "minecraft:black_concrete_powder",
 			"key": "minecraft:black_concrete_powder",
+			"material": "minecraft:black_concrete_powder",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1829,7 +1825,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:black_glazed_terracotta",
 			"blastResistance": 1.4,
 			"burnable": false,
 			"collision": true,
@@ -1839,6 +1834,7 @@
 			"interactable": false,
 			"itemType": "minecraft:black_glazed_terracotta",
 			"key": "minecraft:black_glazed_terracotta",
+			"material": "minecraft:black_glazed_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1850,7 +1846,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:black_shulker_box",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -1860,6 +1855,7 @@
 			"interactable": true,
 			"itemType": "minecraft:black_shulker_box",
 			"key": "minecraft:black_shulker_box",
+			"material": "minecraft:black_shulker_box",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1871,7 +1867,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:black_stained_glass",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -1881,6 +1876,7 @@
 			"interactable": false,
 			"itemType": "minecraft:black_stained_glass",
 			"key": "minecraft:black_stained_glass",
+			"material": "minecraft:black_stained_glass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1892,7 +1888,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:black_stained_glass_pane",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -1902,6 +1897,7 @@
 			"interactable": false,
 			"itemType": "minecraft:black_stained_glass_pane",
 			"key": "minecraft:black_stained_glass_pane",
+			"material": "minecraft:black_stained_glass_pane",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1913,7 +1909,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:black_terracotta",
 			"blastResistance": 4.2,
 			"burnable": false,
 			"collision": true,
@@ -1923,6 +1918,7 @@
 			"interactable": false,
 			"itemType": "minecraft:black_terracotta",
 			"key": "minecraft:black_terracotta",
+			"material": "minecraft:black_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1934,7 +1930,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:black_wall_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -1944,6 +1939,7 @@
 			"interactable": false,
 			"itemType": "minecraft:black_banner",
 			"key": "minecraft:black_wall_banner",
+			"material": "minecraft:black_wall_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1955,7 +1951,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:black_wool",
 			"blastResistance": 0.8,
 			"burnable": true,
 			"collision": true,
@@ -1965,6 +1960,7 @@
 			"interactable": false,
 			"itemType": "minecraft:black_wool",
 			"key": "minecraft:black_wool",
+			"material": "minecraft:black_wool",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1976,7 +1972,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:blackstone",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -1986,6 +1981,7 @@
 			"interactable": false,
 			"itemType": "minecraft:blackstone",
 			"key": "minecraft:blackstone",
+			"material": "minecraft:blackstone",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1997,7 +1993,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:blackstone_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -2007,6 +2002,7 @@
 			"interactable": false,
 			"itemType": "minecraft:blackstone_slab",
 			"key": "minecraft:blackstone_slab",
+			"material": "minecraft:blackstone_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2018,7 +2014,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:blackstone_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -2028,6 +2023,7 @@
 			"interactable": false,
 			"itemType": "minecraft:blackstone_stairs",
 			"key": "minecraft:blackstone_stairs",
+			"material": "minecraft:blackstone_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2039,7 +2035,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:blackstone_wall",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -2049,6 +2044,7 @@
 			"interactable": false,
 			"itemType": "minecraft:blackstone_wall",
 			"key": "minecraft:blackstone_wall",
+			"material": "minecraft:blackstone_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2060,7 +2056,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:blast_furnace",
 			"blastResistance": 3.5,
 			"burnable": false,
 			"collision": true,
@@ -2070,6 +2065,7 @@
 			"interactable": true,
 			"itemType": "minecraft:blast_furnace",
 			"key": "minecraft:blast_furnace",
+			"material": "minecraft:blast_furnace",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2081,7 +2077,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:blue_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -2091,6 +2086,7 @@
 			"interactable": false,
 			"itemType": "minecraft:blue_banner",
 			"key": "minecraft:blue_banner",
+			"material": "minecraft:blue_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2102,7 +2098,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:blue_bed",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": true,
@@ -2112,6 +2107,7 @@
 			"interactable": true,
 			"itemType": "minecraft:blue_bed",
 			"key": "minecraft:blue_bed",
+			"material": "minecraft:blue_bed",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2123,7 +2119,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:blue_candle",
 			"blastResistance": 0.1,
 			"burnable": false,
 			"collision": true,
@@ -2133,6 +2128,7 @@
 			"interactable": true,
 			"itemType": "minecraft:blue_candle",
 			"key": "minecraft:blue_candle",
+			"material": "minecraft:blue_candle",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2144,7 +2140,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:blue_candle_cake",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -2152,8 +2147,8 @@
 			"gravity": false,
 			"hardness": 0.5,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:blue_candle_cake",
+			"material": "minecraft:blue_candle_cake",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2165,7 +2160,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:blue_carpet",
 			"blastResistance": 0.1,
 			"burnable": true,
 			"collision": true,
@@ -2175,6 +2169,7 @@
 			"interactable": false,
 			"itemType": "minecraft:blue_carpet",
 			"key": "minecraft:blue_carpet",
+			"material": "minecraft:blue_carpet",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2186,7 +2181,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:blue_concrete",
 			"blastResistance": 1.8,
 			"burnable": false,
 			"collision": true,
@@ -2196,6 +2190,7 @@
 			"interactable": false,
 			"itemType": "minecraft:blue_concrete",
 			"key": "minecraft:blue_concrete",
+			"material": "minecraft:blue_concrete",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2207,7 +2202,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:blue_concrete_powder",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -2217,6 +2211,7 @@
 			"interactable": false,
 			"itemType": "minecraft:blue_concrete_powder",
 			"key": "minecraft:blue_concrete_powder",
+			"material": "minecraft:blue_concrete_powder",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2228,7 +2223,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:blue_glazed_terracotta",
 			"blastResistance": 1.4,
 			"burnable": false,
 			"collision": true,
@@ -2238,6 +2232,7 @@
 			"interactable": false,
 			"itemType": "minecraft:blue_glazed_terracotta",
 			"key": "minecraft:blue_glazed_terracotta",
+			"material": "minecraft:blue_glazed_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2249,7 +2244,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:blue_ice",
 			"blastResistance": 2.8,
 			"burnable": false,
 			"collision": true,
@@ -2259,6 +2253,7 @@
 			"interactable": false,
 			"itemType": "minecraft:blue_ice",
 			"key": "minecraft:blue_ice",
+			"material": "minecraft:blue_ice",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2270,7 +2265,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:blue_orchid",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -2280,6 +2274,7 @@
 			"interactable": false,
 			"itemType": "minecraft:blue_orchid",
 			"key": "minecraft:blue_orchid",
+			"material": "minecraft:blue_orchid",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2291,7 +2286,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:blue_shulker_box",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -2301,6 +2295,7 @@
 			"interactable": true,
 			"itemType": "minecraft:blue_shulker_box",
 			"key": "minecraft:blue_shulker_box",
+			"material": "minecraft:blue_shulker_box",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2312,7 +2307,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:blue_stained_glass",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -2322,6 +2316,7 @@
 			"interactable": false,
 			"itemType": "minecraft:blue_stained_glass",
 			"key": "minecraft:blue_stained_glass",
+			"material": "minecraft:blue_stained_glass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2333,7 +2328,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:blue_stained_glass_pane",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -2343,6 +2337,7 @@
 			"interactable": false,
 			"itemType": "minecraft:blue_stained_glass_pane",
 			"key": "minecraft:blue_stained_glass_pane",
+			"material": "minecraft:blue_stained_glass_pane",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2354,7 +2349,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:blue_terracotta",
 			"blastResistance": 4.2,
 			"burnable": false,
 			"collision": true,
@@ -2364,6 +2358,7 @@
 			"interactable": false,
 			"itemType": "minecraft:blue_terracotta",
 			"key": "minecraft:blue_terracotta",
+			"material": "minecraft:blue_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2375,7 +2370,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:blue_wall_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -2385,6 +2379,7 @@
 			"interactable": false,
 			"itemType": "minecraft:blue_banner",
 			"key": "minecraft:blue_wall_banner",
+			"material": "minecraft:blue_wall_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2396,7 +2391,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:blue_wool",
 			"blastResistance": 0.8,
 			"burnable": true,
 			"collision": true,
@@ -2406,6 +2400,7 @@
 			"interactable": false,
 			"itemType": "minecraft:blue_wool",
 			"key": "minecraft:blue_wool",
+			"material": "minecraft:blue_wool",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2417,7 +2412,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bone_block",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -2427,6 +2421,7 @@
 			"interactable": false,
 			"itemType": "minecraft:bone_block",
 			"key": "minecraft:bone_block",
+			"material": "minecraft:bone_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2438,7 +2433,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bookshelf",
 			"blastResistance": 1.5,
 			"burnable": true,
 			"collision": true,
@@ -2448,6 +2442,7 @@
 			"interactable": false,
 			"itemType": "minecraft:bookshelf",
 			"key": "minecraft:bookshelf",
+			"material": "minecraft:bookshelf",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2459,7 +2454,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brain_coral",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -2469,6 +2463,7 @@
 			"interactable": false,
 			"itemType": "minecraft:brain_coral",
 			"key": "minecraft:brain_coral",
+			"material": "minecraft:brain_coral",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2480,7 +2475,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brain_coral_block",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -2490,6 +2484,7 @@
 			"interactable": false,
 			"itemType": "minecraft:brain_coral_block",
 			"key": "minecraft:brain_coral_block",
+			"material": "minecraft:brain_coral_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2501,7 +2496,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brain_coral_fan",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -2511,6 +2505,7 @@
 			"interactable": false,
 			"itemType": "minecraft:brain_coral_fan",
 			"key": "minecraft:brain_coral_fan",
+			"material": "minecraft:brain_coral_fan",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2522,7 +2517,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brain_coral_wall_fan",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -2532,6 +2526,7 @@
 			"interactable": false,
 			"itemType": "minecraft:brain_coral_fan",
 			"key": "minecraft:brain_coral_wall_fan",
+			"material": "minecraft:brain_coral_wall_fan",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2543,7 +2538,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brewing_stand",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -2553,6 +2547,7 @@
 			"interactable": true,
 			"itemType": "minecraft:brewing_stand",
 			"key": "minecraft:brewing_stand",
+			"material": "minecraft:brewing_stand",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2564,7 +2559,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brick_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -2574,6 +2568,7 @@
 			"interactable": false,
 			"itemType": "minecraft:brick_slab",
 			"key": "minecraft:brick_slab",
+			"material": "minecraft:brick_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2585,7 +2580,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brick_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -2595,6 +2589,7 @@
 			"interactable": false,
 			"itemType": "minecraft:brick_stairs",
 			"key": "minecraft:brick_stairs",
+			"material": "minecraft:brick_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2606,7 +2601,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brick_wall",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -2616,6 +2610,7 @@
 			"interactable": false,
 			"itemType": "minecraft:brick_wall",
 			"key": "minecraft:brick_wall",
+			"material": "minecraft:brick_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2627,7 +2622,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bricks",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -2637,6 +2631,7 @@
 			"interactable": false,
 			"itemType": "minecraft:bricks",
 			"key": "minecraft:bricks",
+			"material": "minecraft:bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2648,7 +2643,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brown_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -2658,6 +2652,7 @@
 			"interactable": false,
 			"itemType": "minecraft:brown_banner",
 			"key": "minecraft:brown_banner",
+			"material": "minecraft:brown_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2669,7 +2664,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brown_bed",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": true,
@@ -2679,6 +2673,7 @@
 			"interactable": true,
 			"itemType": "minecraft:brown_bed",
 			"key": "minecraft:brown_bed",
+			"material": "minecraft:brown_bed",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2690,7 +2685,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brown_candle",
 			"blastResistance": 0.1,
 			"burnable": false,
 			"collision": true,
@@ -2700,6 +2694,7 @@
 			"interactable": true,
 			"itemType": "minecraft:brown_candle",
 			"key": "minecraft:brown_candle",
+			"material": "minecraft:brown_candle",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2711,7 +2706,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brown_candle_cake",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -2719,8 +2713,8 @@
 			"gravity": false,
 			"hardness": 0.5,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:brown_candle_cake",
+			"material": "minecraft:brown_candle_cake",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2732,7 +2726,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brown_carpet",
 			"blastResistance": 0.1,
 			"burnable": true,
 			"collision": true,
@@ -2742,6 +2735,7 @@
 			"interactable": false,
 			"itemType": "minecraft:brown_carpet",
 			"key": "minecraft:brown_carpet",
+			"material": "minecraft:brown_carpet",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2753,7 +2747,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brown_concrete",
 			"blastResistance": 1.8,
 			"burnable": false,
 			"collision": true,
@@ -2763,6 +2756,7 @@
 			"interactable": false,
 			"itemType": "minecraft:brown_concrete",
 			"key": "minecraft:brown_concrete",
+			"material": "minecraft:brown_concrete",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2774,7 +2768,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brown_concrete_powder",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -2784,6 +2777,7 @@
 			"interactable": false,
 			"itemType": "minecraft:brown_concrete_powder",
 			"key": "minecraft:brown_concrete_powder",
+			"material": "minecraft:brown_concrete_powder",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2795,7 +2789,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brown_glazed_terracotta",
 			"blastResistance": 1.4,
 			"burnable": false,
 			"collision": true,
@@ -2805,6 +2798,7 @@
 			"interactable": false,
 			"itemType": "minecraft:brown_glazed_terracotta",
 			"key": "minecraft:brown_glazed_terracotta",
+			"material": "minecraft:brown_glazed_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2816,7 +2810,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brown_mushroom",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -2826,6 +2819,7 @@
 			"interactable": false,
 			"itemType": "minecraft:brown_mushroom",
 			"key": "minecraft:brown_mushroom",
+			"material": "minecraft:brown_mushroom",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2837,7 +2831,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brown_mushroom_block",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": true,
@@ -2847,6 +2840,7 @@
 			"interactable": false,
 			"itemType": "minecraft:brown_mushroom_block",
 			"key": "minecraft:brown_mushroom_block",
+			"material": "minecraft:brown_mushroom_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2858,7 +2852,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brown_shulker_box",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -2868,6 +2861,7 @@
 			"interactable": true,
 			"itemType": "minecraft:brown_shulker_box",
 			"key": "minecraft:brown_shulker_box",
+			"material": "minecraft:brown_shulker_box",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2879,7 +2873,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brown_stained_glass",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -2889,6 +2882,7 @@
 			"interactable": false,
 			"itemType": "minecraft:brown_stained_glass",
 			"key": "minecraft:brown_stained_glass",
+			"material": "minecraft:brown_stained_glass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2900,7 +2894,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brown_stained_glass_pane",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -2910,6 +2903,7 @@
 			"interactable": false,
 			"itemType": "minecraft:brown_stained_glass_pane",
 			"key": "minecraft:brown_stained_glass_pane",
+			"material": "minecraft:brown_stained_glass_pane",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2921,7 +2915,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brown_terracotta",
 			"blastResistance": 4.2,
 			"burnable": false,
 			"collision": true,
@@ -2931,6 +2924,7 @@
 			"interactable": false,
 			"itemType": "minecraft:brown_terracotta",
 			"key": "minecraft:brown_terracotta",
+			"material": "minecraft:brown_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2942,7 +2936,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brown_wall_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -2952,6 +2945,7 @@
 			"interactable": false,
 			"itemType": "minecraft:brown_banner",
 			"key": "minecraft:brown_wall_banner",
+			"material": "minecraft:brown_wall_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2963,7 +2957,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:brown_wool",
 			"blastResistance": 0.8,
 			"burnable": true,
 			"collision": true,
@@ -2973,6 +2966,7 @@
 			"interactable": false,
 			"itemType": "minecraft:brown_wool",
 			"key": "minecraft:brown_wool",
+			"material": "minecraft:brown_wool",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2984,7 +2978,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bubble_column",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -2992,8 +2985,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": false,
-			"itemType": false,
 			"key": "minecraft:bubble_column",
+			"material": "minecraft:bubble_column",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3005,7 +2998,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bubble_coral",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -3015,6 +3007,7 @@
 			"interactable": false,
 			"itemType": "minecraft:bubble_coral",
 			"key": "minecraft:bubble_coral",
+			"material": "minecraft:bubble_coral",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3026,7 +3019,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bubble_coral_block",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -3036,6 +3028,7 @@
 			"interactable": false,
 			"itemType": "minecraft:bubble_coral_block",
 			"key": "minecraft:bubble_coral_block",
+			"material": "minecraft:bubble_coral_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3047,7 +3040,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bubble_coral_fan",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -3057,6 +3049,7 @@
 			"interactable": false,
 			"itemType": "minecraft:bubble_coral_fan",
 			"key": "minecraft:bubble_coral_fan",
+			"material": "minecraft:bubble_coral_fan",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3068,7 +3061,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bubble_coral_wall_fan",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -3078,6 +3070,7 @@
 			"interactable": false,
 			"itemType": "minecraft:bubble_coral_fan",
 			"key": "minecraft:bubble_coral_wall_fan",
+			"material": "minecraft:bubble_coral_wall_fan",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3089,7 +3082,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:budding_amethyst",
 			"blastResistance": 1.5,
 			"burnable": false,
 			"collision": true,
@@ -3099,6 +3091,7 @@
 			"interactable": false,
 			"itemType": "minecraft:budding_amethyst",
 			"key": "minecraft:budding_amethyst",
+			"material": "minecraft:budding_amethyst",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3110,7 +3103,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:bush",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -3120,6 +3112,7 @@
 			"interactable": false,
 			"itemType": "minecraft:bush",
 			"key": "minecraft:bush",
+			"material": "minecraft:bush",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3131,7 +3124,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cactus",
 			"blastResistance": 0.4,
 			"burnable": false,
 			"collision": true,
@@ -3141,6 +3133,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cactus",
 			"key": "minecraft:cactus",
+			"material": "minecraft:cactus",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3152,7 +3145,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cactus_flower",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -3162,6 +3154,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cactus_flower",
 			"key": "minecraft:cactus_flower",
+			"material": "minecraft:cactus_flower",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3173,7 +3166,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cake",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -3183,6 +3175,7 @@
 			"interactable": true,
 			"itemType": "minecraft:cake",
 			"key": "minecraft:cake",
+			"material": "minecraft:cake",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3194,7 +3187,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:calcite",
 			"blastResistance": 0.75,
 			"burnable": false,
 			"collision": true,
@@ -3204,6 +3196,7 @@
 			"interactable": false,
 			"itemType": "minecraft:calcite",
 			"key": "minecraft:calcite",
+			"material": "minecraft:calcite",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3215,7 +3208,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:calibrated_sculk_sensor",
 			"blastResistance": 1.5,
 			"burnable": false,
 			"collision": true,
@@ -3225,6 +3217,7 @@
 			"interactable": false,
 			"itemType": "minecraft:calibrated_sculk_sensor",
 			"key": "minecraft:calibrated_sculk_sensor",
+			"material": "minecraft:calibrated_sculk_sensor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3236,7 +3229,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:campfire",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -3246,6 +3238,7 @@
 			"interactable": true,
 			"itemType": "minecraft:campfire",
 			"key": "minecraft:campfire",
+			"material": "minecraft:campfire",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3257,7 +3250,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:candle",
 			"blastResistance": 0.1,
 			"burnable": false,
 			"collision": true,
@@ -3267,6 +3259,7 @@
 			"interactable": true,
 			"itemType": "minecraft:candle",
 			"key": "minecraft:candle",
+			"material": "minecraft:candle",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3278,7 +3271,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:candle_cake",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -3286,8 +3278,8 @@
 			"gravity": false,
 			"hardness": 0.5,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:candle_cake",
+			"material": "minecraft:candle_cake",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3299,7 +3291,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:carrots",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -3309,6 +3300,7 @@
 			"interactable": false,
 			"itemType": "minecraft:carrot",
 			"key": "minecraft:carrots",
+			"material": "minecraft:carrots",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3320,7 +3312,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cartography_table",
 			"blastResistance": 2.5,
 			"burnable": false,
 			"collision": true,
@@ -3330,6 +3321,7 @@
 			"interactable": true,
 			"itemType": "minecraft:cartography_table",
 			"key": "minecraft:cartography_table",
+			"material": "minecraft:cartography_table",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3341,7 +3333,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:carved_pumpkin",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": true,
@@ -3351,6 +3342,7 @@
 			"interactable": false,
 			"itemType": "minecraft:carved_pumpkin",
 			"key": "minecraft:carved_pumpkin",
+			"material": "minecraft:carved_pumpkin",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3362,7 +3354,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cauldron",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -3372,6 +3363,7 @@
 			"interactable": true,
 			"itemType": "minecraft:cauldron",
 			"key": "minecraft:cauldron",
+			"material": "minecraft:cauldron",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3383,7 +3375,6 @@
 		},
 		{
 			"air": true,
-			"asMaterial": "minecraft:cave_air",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -3391,8 +3382,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": false,
-			"itemType": false,
 			"key": "minecraft:cave_air",
+			"material": "minecraft:cave_air",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3404,7 +3395,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cave_vines",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -3414,6 +3404,7 @@
 			"interactable": true,
 			"itemType": "minecraft:glow_berries",
 			"key": "minecraft:cave_vines",
+			"material": "minecraft:cave_vines",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3425,7 +3416,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cave_vines_plant",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -3433,8 +3423,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:cave_vines_plant",
+			"material": "minecraft:cave_vines_plant",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3446,7 +3436,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:chain",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -3456,6 +3445,7 @@
 			"interactable": false,
 			"itemType": "minecraft:chain",
 			"key": "minecraft:chain",
+			"material": "minecraft:chain",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3467,7 +3457,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:chain_command_block",
 			"blastResistance": 3600000.0,
 			"burnable": false,
 			"collision": true,
@@ -3477,6 +3466,7 @@
 			"interactable": true,
 			"itemType": "minecraft:chain_command_block",
 			"key": "minecraft:chain_command_block",
+			"material": "minecraft:chain_command_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3488,7 +3478,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cherry_button",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -3498,6 +3487,7 @@
 			"interactable": true,
 			"itemType": "minecraft:cherry_button",
 			"key": "minecraft:cherry_button",
+			"material": "minecraft:cherry_button",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3509,7 +3499,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cherry_door",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -3519,6 +3508,7 @@
 			"interactable": true,
 			"itemType": "minecraft:cherry_door",
 			"key": "minecraft:cherry_door",
+			"material": "minecraft:cherry_door",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3530,7 +3520,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cherry_fence",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -3540,6 +3529,7 @@
 			"interactable": true,
 			"itemType": "minecraft:cherry_fence",
 			"key": "minecraft:cherry_fence",
+			"material": "minecraft:cherry_fence",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3551,7 +3541,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cherry_fence_gate",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -3561,6 +3550,7 @@
 			"interactable": true,
 			"itemType": "minecraft:cherry_fence_gate",
 			"key": "minecraft:cherry_fence_gate",
+			"material": "minecraft:cherry_fence_gate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3572,7 +3562,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cherry_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -3582,6 +3571,7 @@
 			"interactable": true,
 			"itemType": "minecraft:cherry_hanging_sign",
 			"key": "minecraft:cherry_hanging_sign",
+			"material": "minecraft:cherry_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3593,7 +3583,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cherry_leaves",
 			"blastResistance": 0.2,
 			"burnable": true,
 			"collision": true,
@@ -3603,6 +3592,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cherry_leaves",
 			"key": "minecraft:cherry_leaves",
+			"material": "minecraft:cherry_leaves",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3614,7 +3604,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cherry_log",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -3624,6 +3613,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cherry_log",
 			"key": "minecraft:cherry_log",
+			"material": "minecraft:cherry_log",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3635,7 +3625,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cherry_planks",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -3645,6 +3634,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cherry_planks",
 			"key": "minecraft:cherry_planks",
+			"material": "minecraft:cherry_planks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3656,7 +3646,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cherry_pressure_plate",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -3666,6 +3655,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cherry_pressure_plate",
 			"key": "minecraft:cherry_pressure_plate",
+			"material": "minecraft:cherry_pressure_plate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3677,7 +3667,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cherry_sapling",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -3687,6 +3676,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cherry_sapling",
 			"key": "minecraft:cherry_sapling",
+			"material": "minecraft:cherry_sapling",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3698,7 +3688,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cherry_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -3708,6 +3697,7 @@
 			"interactable": true,
 			"itemType": "minecraft:cherry_sign",
 			"key": "minecraft:cherry_sign",
+			"material": "minecraft:cherry_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3719,7 +3709,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cherry_slab",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -3729,6 +3718,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cherry_slab",
 			"key": "minecraft:cherry_slab",
+			"material": "minecraft:cherry_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3740,7 +3730,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cherry_stairs",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -3750,6 +3739,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cherry_stairs",
 			"key": "minecraft:cherry_stairs",
+			"material": "minecraft:cherry_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3761,7 +3751,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cherry_trapdoor",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -3771,6 +3760,7 @@
 			"interactable": true,
 			"itemType": "minecraft:cherry_trapdoor",
 			"key": "minecraft:cherry_trapdoor",
+			"material": "minecraft:cherry_trapdoor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3782,7 +3772,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cherry_wall_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -3792,6 +3781,7 @@
 			"interactable": true,
 			"itemType": "minecraft:cherry_hanging_sign",
 			"key": "minecraft:cherry_wall_hanging_sign",
+			"material": "minecraft:cherry_wall_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3803,7 +3793,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cherry_wall_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -3813,6 +3802,7 @@
 			"interactable": true,
 			"itemType": "minecraft:cherry_sign",
 			"key": "minecraft:cherry_wall_sign",
+			"material": "minecraft:cherry_wall_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3824,7 +3814,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cherry_wood",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -3834,6 +3823,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cherry_wood",
 			"key": "minecraft:cherry_wood",
+			"material": "minecraft:cherry_wood",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3845,7 +3835,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:chest",
 			"blastResistance": 2.5,
 			"burnable": false,
 			"collision": true,
@@ -3855,6 +3844,7 @@
 			"interactable": true,
 			"itemType": "minecraft:chest",
 			"key": "minecraft:chest",
+			"material": "minecraft:chest",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3866,7 +3856,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:chipped_anvil",
 			"blastResistance": 1200.0,
 			"burnable": false,
 			"collision": true,
@@ -3876,6 +3865,7 @@
 			"interactable": true,
 			"itemType": "minecraft:chipped_anvil",
 			"key": "minecraft:chipped_anvil",
+			"material": "minecraft:chipped_anvil",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3887,7 +3877,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:chiseled_bookshelf",
 			"blastResistance": 1.5,
 			"burnable": false,
 			"collision": true,
@@ -3897,6 +3886,7 @@
 			"interactable": true,
 			"itemType": "minecraft:chiseled_bookshelf",
 			"key": "minecraft:chiseled_bookshelf",
+			"material": "minecraft:chiseled_bookshelf",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3908,7 +3898,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:chiseled_copper",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -3918,6 +3907,7 @@
 			"interactable": false,
 			"itemType": "minecraft:chiseled_copper",
 			"key": "minecraft:chiseled_copper",
+			"material": "minecraft:chiseled_copper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3929,7 +3919,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:chiseled_deepslate",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -3939,6 +3928,7 @@
 			"interactable": false,
 			"itemType": "minecraft:chiseled_deepslate",
 			"key": "minecraft:chiseled_deepslate",
+			"material": "minecraft:chiseled_deepslate",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3950,7 +3940,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:chiseled_nether_bricks",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -3960,6 +3949,7 @@
 			"interactable": false,
 			"itemType": "minecraft:chiseled_nether_bricks",
 			"key": "minecraft:chiseled_nether_bricks",
+			"material": "minecraft:chiseled_nether_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3971,7 +3961,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:chiseled_polished_blackstone",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -3981,6 +3970,7 @@
 			"interactable": false,
 			"itemType": "minecraft:chiseled_polished_blackstone",
 			"key": "minecraft:chiseled_polished_blackstone",
+			"material": "minecraft:chiseled_polished_blackstone",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3992,7 +3982,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:chiseled_quartz_block",
 			"blastResistance": 0.8,
 			"burnable": false,
 			"collision": true,
@@ -4002,6 +3991,7 @@
 			"interactable": false,
 			"itemType": "minecraft:chiseled_quartz_block",
 			"key": "minecraft:chiseled_quartz_block",
+			"material": "minecraft:chiseled_quartz_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4013,7 +4003,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:chiseled_red_sandstone",
 			"blastResistance": 0.8,
 			"burnable": false,
 			"collision": true,
@@ -4023,6 +4012,7 @@
 			"interactable": false,
 			"itemType": "minecraft:chiseled_red_sandstone",
 			"key": "minecraft:chiseled_red_sandstone",
+			"material": "minecraft:chiseled_red_sandstone",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4034,7 +4024,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:chiseled_resin_bricks",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -4044,6 +4033,7 @@
 			"interactable": false,
 			"itemType": "minecraft:chiseled_resin_bricks",
 			"key": "minecraft:chiseled_resin_bricks",
+			"material": "minecraft:chiseled_resin_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4055,7 +4045,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:chiseled_sandstone",
 			"blastResistance": 0.8,
 			"burnable": false,
 			"collision": true,
@@ -4065,6 +4054,7 @@
 			"interactable": false,
 			"itemType": "minecraft:chiseled_sandstone",
 			"key": "minecraft:chiseled_sandstone",
+			"material": "minecraft:chiseled_sandstone",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4076,7 +4066,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:chiseled_stone_bricks",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -4086,6 +4075,7 @@
 			"interactable": false,
 			"itemType": "minecraft:chiseled_stone_bricks",
 			"key": "minecraft:chiseled_stone_bricks",
+			"material": "minecraft:chiseled_stone_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4097,7 +4087,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:chiseled_tuff",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -4107,6 +4096,7 @@
 			"interactable": false,
 			"itemType": "minecraft:chiseled_tuff",
 			"key": "minecraft:chiseled_tuff",
+			"material": "minecraft:chiseled_tuff",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4118,7 +4108,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:chiseled_tuff_bricks",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -4128,6 +4117,7 @@
 			"interactable": false,
 			"itemType": "minecraft:chiseled_tuff_bricks",
 			"key": "minecraft:chiseled_tuff_bricks",
+			"material": "minecraft:chiseled_tuff_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4139,7 +4129,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:chorus_flower",
 			"blastResistance": 0.4,
 			"burnable": false,
 			"collision": true,
@@ -4149,6 +4138,7 @@
 			"interactable": false,
 			"itemType": "minecraft:chorus_flower",
 			"key": "minecraft:chorus_flower",
+			"material": "minecraft:chorus_flower",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4160,7 +4150,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:chorus_plant",
 			"blastResistance": 0.4,
 			"burnable": false,
 			"collision": true,
@@ -4170,6 +4159,7 @@
 			"interactable": false,
 			"itemType": "minecraft:chorus_plant",
 			"key": "minecraft:chorus_plant",
+			"material": "minecraft:chorus_plant",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4181,7 +4171,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:clay",
 			"blastResistance": 0.6,
 			"burnable": false,
 			"collision": true,
@@ -4191,6 +4180,7 @@
 			"interactable": false,
 			"itemType": "minecraft:clay",
 			"key": "minecraft:clay",
+			"material": "minecraft:clay",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4202,7 +4192,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:closed_eyeblossom",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -4212,6 +4201,7 @@
 			"interactable": false,
 			"itemType": "minecraft:closed_eyeblossom",
 			"key": "minecraft:closed_eyeblossom",
+			"material": "minecraft:closed_eyeblossom",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4223,7 +4213,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:coal_block",
 			"blastResistance": 6.0,
 			"burnable": true,
 			"collision": true,
@@ -4233,6 +4222,7 @@
 			"interactable": false,
 			"itemType": "minecraft:coal_block",
 			"key": "minecraft:coal_block",
+			"material": "minecraft:coal_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4244,7 +4234,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:coal_ore",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -4254,6 +4243,7 @@
 			"interactable": false,
 			"itemType": "minecraft:coal_ore",
 			"key": "minecraft:coal_ore",
+			"material": "minecraft:coal_ore",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4265,7 +4255,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:coarse_dirt",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -4275,6 +4264,7 @@
 			"interactable": false,
 			"itemType": "minecraft:coarse_dirt",
 			"key": "minecraft:coarse_dirt",
+			"material": "minecraft:coarse_dirt",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4286,7 +4276,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cobbled_deepslate",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -4296,6 +4285,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cobbled_deepslate",
 			"key": "minecraft:cobbled_deepslate",
+			"material": "minecraft:cobbled_deepslate",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4307,7 +4297,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cobbled_deepslate_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -4317,6 +4306,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cobbled_deepslate_slab",
 			"key": "minecraft:cobbled_deepslate_slab",
+			"material": "minecraft:cobbled_deepslate_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4328,7 +4318,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cobbled_deepslate_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -4338,6 +4327,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cobbled_deepslate_stairs",
 			"key": "minecraft:cobbled_deepslate_stairs",
+			"material": "minecraft:cobbled_deepslate_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4349,7 +4339,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cobbled_deepslate_wall",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -4359,6 +4348,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cobbled_deepslate_wall",
 			"key": "minecraft:cobbled_deepslate_wall",
+			"material": "minecraft:cobbled_deepslate_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4370,7 +4360,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cobblestone",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -4380,6 +4369,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cobblestone",
 			"key": "minecraft:cobblestone",
+			"material": "minecraft:cobblestone",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4391,7 +4381,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cobblestone_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -4401,6 +4390,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cobblestone_slab",
 			"key": "minecraft:cobblestone_slab",
+			"material": "minecraft:cobblestone_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4412,7 +4402,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cobblestone_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -4422,6 +4411,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cobblestone_stairs",
 			"key": "minecraft:cobblestone_stairs",
+			"material": "minecraft:cobblestone_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4433,7 +4423,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cobblestone_wall",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -4443,6 +4432,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cobblestone_wall",
 			"key": "minecraft:cobblestone_wall",
+			"material": "minecraft:cobblestone_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4454,7 +4444,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cobweb",
 			"blastResistance": 4.0,
 			"burnable": false,
 			"collision": false,
@@ -4464,6 +4453,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cobweb",
 			"key": "minecraft:cobweb",
+			"material": "minecraft:cobweb",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4475,7 +4465,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cocoa",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -4485,6 +4474,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cocoa_beans",
 			"key": "minecraft:cocoa",
+			"material": "minecraft:cocoa",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4496,7 +4486,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:command_block",
 			"blastResistance": 3600000.0,
 			"burnable": false,
 			"collision": true,
@@ -4506,6 +4495,7 @@
 			"interactable": true,
 			"itemType": "minecraft:command_block",
 			"key": "minecraft:command_block",
+			"material": "minecraft:command_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4517,7 +4507,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:comparator",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -4527,6 +4516,7 @@
 			"interactable": true,
 			"itemType": "minecraft:comparator",
 			"key": "minecraft:comparator",
+			"material": "minecraft:comparator",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4538,7 +4528,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:composter",
 			"blastResistance": 0.6,
 			"burnable": true,
 			"collision": true,
@@ -4548,6 +4537,7 @@
 			"interactable": true,
 			"itemType": "minecraft:composter",
 			"key": "minecraft:composter",
+			"material": "minecraft:composter",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4559,7 +4549,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:conduit",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -4569,6 +4558,7 @@
 			"interactable": false,
 			"itemType": "minecraft:conduit",
 			"key": "minecraft:conduit",
+			"material": "minecraft:conduit",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4580,7 +4570,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:copper_block",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -4590,6 +4579,7 @@
 			"interactable": false,
 			"itemType": "minecraft:copper_block",
 			"key": "minecraft:copper_block",
+			"material": "minecraft:copper_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4601,7 +4591,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:copper_bulb",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -4611,6 +4600,7 @@
 			"interactable": false,
 			"itemType": "minecraft:copper_bulb",
 			"key": "minecraft:copper_bulb",
+			"material": "minecraft:copper_bulb",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4622,7 +4612,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:copper_door",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -4632,6 +4621,7 @@
 			"interactable": true,
 			"itemType": "minecraft:copper_door",
 			"key": "minecraft:copper_door",
+			"material": "minecraft:copper_door",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4643,7 +4633,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:copper_grate",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -4653,6 +4642,7 @@
 			"interactable": false,
 			"itemType": "minecraft:copper_grate",
 			"key": "minecraft:copper_grate",
+			"material": "minecraft:copper_grate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4664,7 +4654,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:copper_ore",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -4674,6 +4663,7 @@
 			"interactable": false,
 			"itemType": "minecraft:copper_ore",
 			"key": "minecraft:copper_ore",
+			"material": "minecraft:copper_ore",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4685,7 +4675,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:copper_trapdoor",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -4695,6 +4684,7 @@
 			"interactable": true,
 			"itemType": "minecraft:copper_trapdoor",
 			"key": "minecraft:copper_trapdoor",
+			"material": "minecraft:copper_trapdoor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4706,7 +4696,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cornflower",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -4716,6 +4705,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cornflower",
 			"key": "minecraft:cornflower",
+			"material": "minecraft:cornflower",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4727,7 +4717,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cracked_deepslate_bricks",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -4737,6 +4726,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cracked_deepslate_bricks",
 			"key": "minecraft:cracked_deepslate_bricks",
+			"material": "minecraft:cracked_deepslate_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4748,7 +4738,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cracked_deepslate_tiles",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -4758,6 +4747,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cracked_deepslate_tiles",
 			"key": "minecraft:cracked_deepslate_tiles",
+			"material": "minecraft:cracked_deepslate_tiles",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4769,7 +4759,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cracked_nether_bricks",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -4779,6 +4768,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cracked_nether_bricks",
 			"key": "minecraft:cracked_nether_bricks",
+			"material": "minecraft:cracked_nether_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4790,7 +4780,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cracked_polished_blackstone_bricks",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -4800,6 +4789,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cracked_polished_blackstone_bricks",
 			"key": "minecraft:cracked_polished_blackstone_bricks",
+			"material": "minecraft:cracked_polished_blackstone_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4811,7 +4801,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cracked_stone_bricks",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -4821,6 +4810,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cracked_stone_bricks",
 			"key": "minecraft:cracked_stone_bricks",
+			"material": "minecraft:cracked_stone_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4832,7 +4822,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:crafter",
 			"blastResistance": 3.5,
 			"burnable": false,
 			"collision": true,
@@ -4842,6 +4831,7 @@
 			"interactable": true,
 			"itemType": "minecraft:crafter",
 			"key": "minecraft:crafter",
+			"material": "minecraft:crafter",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4853,7 +4843,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:crafting_table",
 			"blastResistance": 2.5,
 			"burnable": false,
 			"collision": true,
@@ -4863,6 +4852,7 @@
 			"interactable": true,
 			"itemType": "minecraft:crafting_table",
 			"key": "minecraft:crafting_table",
+			"material": "minecraft:crafting_table",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4874,7 +4864,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:creaking_heart",
 			"blastResistance": 10.0,
 			"burnable": false,
 			"collision": true,
@@ -4884,6 +4873,7 @@
 			"interactable": false,
 			"itemType": "minecraft:creaking_heart",
 			"key": "minecraft:creaking_heart",
+			"material": "minecraft:creaking_heart",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4895,7 +4885,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:creeper_head",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": true,
@@ -4905,6 +4894,7 @@
 			"interactable": false,
 			"itemType": "minecraft:creeper_head",
 			"key": "minecraft:creeper_head",
+			"material": "minecraft:creeper_head",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4916,7 +4906,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:creeper_wall_head",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": true,
@@ -4926,6 +4915,7 @@
 			"interactable": false,
 			"itemType": "minecraft:creeper_head",
 			"key": "minecraft:creeper_wall_head",
+			"material": "minecraft:creeper_wall_head",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4937,7 +4927,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:crimson_button",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -4947,6 +4936,7 @@
 			"interactable": true,
 			"itemType": "minecraft:crimson_button",
 			"key": "minecraft:crimson_button",
+			"material": "minecraft:crimson_button",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4958,7 +4948,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:crimson_door",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -4968,6 +4957,7 @@
 			"interactable": true,
 			"itemType": "minecraft:crimson_door",
 			"key": "minecraft:crimson_door",
+			"material": "minecraft:crimson_door",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4979,7 +4969,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:crimson_fence",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -4989,6 +4978,7 @@
 			"interactable": true,
 			"itemType": "minecraft:crimson_fence",
 			"key": "minecraft:crimson_fence",
+			"material": "minecraft:crimson_fence",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5000,7 +4990,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:crimson_fence_gate",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -5010,6 +4999,7 @@
 			"interactable": true,
 			"itemType": "minecraft:crimson_fence_gate",
 			"key": "minecraft:crimson_fence_gate",
+			"material": "minecraft:crimson_fence_gate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5021,7 +5011,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:crimson_fungus",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -5031,6 +5020,7 @@
 			"interactable": false,
 			"itemType": "minecraft:crimson_fungus",
 			"key": "minecraft:crimson_fungus",
+			"material": "minecraft:crimson_fungus",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5042,7 +5032,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:crimson_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -5052,6 +5041,7 @@
 			"interactable": true,
 			"itemType": "minecraft:crimson_hanging_sign",
 			"key": "minecraft:crimson_hanging_sign",
+			"material": "minecraft:crimson_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5063,7 +5053,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:crimson_hyphae",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -5073,6 +5062,7 @@
 			"interactable": false,
 			"itemType": "minecraft:crimson_hyphae",
 			"key": "minecraft:crimson_hyphae",
+			"material": "minecraft:crimson_hyphae",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5084,7 +5074,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:crimson_nylium",
 			"blastResistance": 0.4,
 			"burnable": false,
 			"collision": true,
@@ -5094,6 +5083,7 @@
 			"interactable": false,
 			"itemType": "minecraft:crimson_nylium",
 			"key": "minecraft:crimson_nylium",
+			"material": "minecraft:crimson_nylium",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5105,7 +5095,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:crimson_planks",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -5115,6 +5104,7 @@
 			"interactable": false,
 			"itemType": "minecraft:crimson_planks",
 			"key": "minecraft:crimson_planks",
+			"material": "minecraft:crimson_planks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5126,7 +5116,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:crimson_pressure_plate",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -5136,6 +5125,7 @@
 			"interactable": false,
 			"itemType": "minecraft:crimson_pressure_plate",
 			"key": "minecraft:crimson_pressure_plate",
+			"material": "minecraft:crimson_pressure_plate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5147,7 +5137,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:crimson_roots",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -5157,6 +5146,7 @@
 			"interactable": false,
 			"itemType": "minecraft:crimson_roots",
 			"key": "minecraft:crimson_roots",
+			"material": "minecraft:crimson_roots",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5168,7 +5158,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:crimson_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -5178,6 +5167,7 @@
 			"interactable": true,
 			"itemType": "minecraft:crimson_sign",
 			"key": "minecraft:crimson_sign",
+			"material": "minecraft:crimson_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5189,7 +5179,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:crimson_slab",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -5199,6 +5188,7 @@
 			"interactable": false,
 			"itemType": "minecraft:crimson_slab",
 			"key": "minecraft:crimson_slab",
+			"material": "minecraft:crimson_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5210,7 +5200,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:crimson_stairs",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -5220,6 +5209,7 @@
 			"interactable": false,
 			"itemType": "minecraft:crimson_stairs",
 			"key": "minecraft:crimson_stairs",
+			"material": "minecraft:crimson_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5231,7 +5221,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:crimson_stem",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -5241,6 +5230,7 @@
 			"interactable": false,
 			"itemType": "minecraft:crimson_stem",
 			"key": "minecraft:crimson_stem",
+			"material": "minecraft:crimson_stem",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5252,7 +5242,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:crimson_trapdoor",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -5262,6 +5251,7 @@
 			"interactable": true,
 			"itemType": "minecraft:crimson_trapdoor",
 			"key": "minecraft:crimson_trapdoor",
+			"material": "minecraft:crimson_trapdoor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5273,7 +5263,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:crimson_wall_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -5283,6 +5272,7 @@
 			"interactable": true,
 			"itemType": "minecraft:crimson_hanging_sign",
 			"key": "minecraft:crimson_wall_hanging_sign",
+			"material": "minecraft:crimson_wall_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5294,7 +5284,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:crimson_wall_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -5304,6 +5293,7 @@
 			"interactable": true,
 			"itemType": "minecraft:crimson_sign",
 			"key": "minecraft:crimson_wall_sign",
+			"material": "minecraft:crimson_wall_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5315,7 +5305,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:crying_obsidian",
 			"blastResistance": 1200.0,
 			"burnable": false,
 			"collision": true,
@@ -5325,6 +5314,7 @@
 			"interactable": false,
 			"itemType": "minecraft:crying_obsidian",
 			"key": "minecraft:crying_obsidian",
+			"material": "minecraft:crying_obsidian",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5336,7 +5326,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cut_copper",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -5346,6 +5335,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cut_copper",
 			"key": "minecraft:cut_copper",
+			"material": "minecraft:cut_copper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5357,7 +5347,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cut_copper_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -5367,6 +5356,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cut_copper_slab",
 			"key": "minecraft:cut_copper_slab",
+			"material": "minecraft:cut_copper_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5378,7 +5368,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cut_copper_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -5388,6 +5377,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cut_copper_stairs",
 			"key": "minecraft:cut_copper_stairs",
+			"material": "minecraft:cut_copper_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5399,7 +5389,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cut_red_sandstone",
 			"blastResistance": 0.8,
 			"burnable": false,
 			"collision": true,
@@ -5409,6 +5398,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cut_red_sandstone",
 			"key": "minecraft:cut_red_sandstone",
+			"material": "minecraft:cut_red_sandstone",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5420,7 +5410,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cut_red_sandstone_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -5430,6 +5419,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cut_red_sandstone_slab",
 			"key": "minecraft:cut_red_sandstone_slab",
+			"material": "minecraft:cut_red_sandstone_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5441,7 +5431,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cut_sandstone",
 			"blastResistance": 0.8,
 			"burnable": false,
 			"collision": true,
@@ -5451,6 +5440,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cut_sandstone",
 			"key": "minecraft:cut_sandstone",
+			"material": "minecraft:cut_sandstone",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5462,7 +5452,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cut_sandstone_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -5472,6 +5461,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cut_sandstone_slab",
 			"key": "minecraft:cut_sandstone_slab",
+			"material": "minecraft:cut_sandstone_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5483,7 +5473,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cyan_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -5493,6 +5482,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cyan_banner",
 			"key": "minecraft:cyan_banner",
+			"material": "minecraft:cyan_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5504,7 +5494,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cyan_bed",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": true,
@@ -5514,6 +5503,7 @@
 			"interactable": true,
 			"itemType": "minecraft:cyan_bed",
 			"key": "minecraft:cyan_bed",
+			"material": "minecraft:cyan_bed",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5525,7 +5515,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cyan_candle",
 			"blastResistance": 0.1,
 			"burnable": false,
 			"collision": true,
@@ -5535,6 +5524,7 @@
 			"interactable": true,
 			"itemType": "minecraft:cyan_candle",
 			"key": "minecraft:cyan_candle",
+			"material": "minecraft:cyan_candle",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5546,7 +5536,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cyan_candle_cake",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -5554,8 +5543,8 @@
 			"gravity": false,
 			"hardness": 0.5,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:cyan_candle_cake",
+			"material": "minecraft:cyan_candle_cake",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5567,7 +5556,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cyan_carpet",
 			"blastResistance": 0.1,
 			"burnable": true,
 			"collision": true,
@@ -5577,6 +5565,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cyan_carpet",
 			"key": "minecraft:cyan_carpet",
+			"material": "minecraft:cyan_carpet",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5588,7 +5577,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cyan_concrete",
 			"blastResistance": 1.8,
 			"burnable": false,
 			"collision": true,
@@ -5598,6 +5586,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cyan_concrete",
 			"key": "minecraft:cyan_concrete",
+			"material": "minecraft:cyan_concrete",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5609,7 +5598,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cyan_concrete_powder",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -5619,6 +5607,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cyan_concrete_powder",
 			"key": "minecraft:cyan_concrete_powder",
+			"material": "minecraft:cyan_concrete_powder",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5630,7 +5619,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cyan_glazed_terracotta",
 			"blastResistance": 1.4,
 			"burnable": false,
 			"collision": true,
@@ -5640,6 +5628,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cyan_glazed_terracotta",
 			"key": "minecraft:cyan_glazed_terracotta",
+			"material": "minecraft:cyan_glazed_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5651,7 +5640,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cyan_shulker_box",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -5661,6 +5649,7 @@
 			"interactable": true,
 			"itemType": "minecraft:cyan_shulker_box",
 			"key": "minecraft:cyan_shulker_box",
+			"material": "minecraft:cyan_shulker_box",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5672,7 +5661,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cyan_stained_glass",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -5682,6 +5670,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cyan_stained_glass",
 			"key": "minecraft:cyan_stained_glass",
+			"material": "minecraft:cyan_stained_glass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5693,7 +5682,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cyan_stained_glass_pane",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -5703,6 +5691,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cyan_stained_glass_pane",
 			"key": "minecraft:cyan_stained_glass_pane",
+			"material": "minecraft:cyan_stained_glass_pane",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5714,7 +5703,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cyan_terracotta",
 			"blastResistance": 4.2,
 			"burnable": false,
 			"collision": true,
@@ -5724,6 +5712,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cyan_terracotta",
 			"key": "minecraft:cyan_terracotta",
+			"material": "minecraft:cyan_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5735,7 +5724,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cyan_wall_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -5745,6 +5733,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cyan_banner",
 			"key": "minecraft:cyan_wall_banner",
+			"material": "minecraft:cyan_wall_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5756,7 +5745,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:cyan_wool",
 			"blastResistance": 0.8,
 			"burnable": true,
 			"collision": true,
@@ -5766,6 +5754,7 @@
 			"interactable": false,
 			"itemType": "minecraft:cyan_wool",
 			"key": "minecraft:cyan_wool",
+			"material": "minecraft:cyan_wool",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5777,7 +5766,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:damaged_anvil",
 			"blastResistance": 1200.0,
 			"burnable": false,
 			"collision": true,
@@ -5787,6 +5775,7 @@
 			"interactable": true,
 			"itemType": "minecraft:damaged_anvil",
 			"key": "minecraft:damaged_anvil",
+			"material": "minecraft:damaged_anvil",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5798,7 +5787,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dandelion",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -5808,6 +5796,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dandelion",
 			"key": "minecraft:dandelion",
+			"material": "minecraft:dandelion",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5819,7 +5808,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dark_oak_button",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -5829,6 +5817,7 @@
 			"interactable": true,
 			"itemType": "minecraft:dark_oak_button",
 			"key": "minecraft:dark_oak_button",
+			"material": "minecraft:dark_oak_button",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5840,7 +5829,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dark_oak_door",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -5850,6 +5838,7 @@
 			"interactable": true,
 			"itemType": "minecraft:dark_oak_door",
 			"key": "minecraft:dark_oak_door",
+			"material": "minecraft:dark_oak_door",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5861,7 +5850,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dark_oak_fence",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -5871,6 +5859,7 @@
 			"interactable": true,
 			"itemType": "minecraft:dark_oak_fence",
 			"key": "minecraft:dark_oak_fence",
+			"material": "minecraft:dark_oak_fence",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5882,7 +5871,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dark_oak_fence_gate",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -5892,6 +5880,7 @@
 			"interactable": true,
 			"itemType": "minecraft:dark_oak_fence_gate",
 			"key": "minecraft:dark_oak_fence_gate",
+			"material": "minecraft:dark_oak_fence_gate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5903,7 +5892,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dark_oak_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -5913,6 +5901,7 @@
 			"interactable": true,
 			"itemType": "minecraft:dark_oak_hanging_sign",
 			"key": "minecraft:dark_oak_hanging_sign",
+			"material": "minecraft:dark_oak_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5924,7 +5913,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dark_oak_leaves",
 			"blastResistance": 0.2,
 			"burnable": true,
 			"collision": true,
@@ -5934,6 +5922,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dark_oak_leaves",
 			"key": "minecraft:dark_oak_leaves",
+			"material": "minecraft:dark_oak_leaves",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5945,7 +5934,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dark_oak_log",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -5955,6 +5943,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dark_oak_log",
 			"key": "minecraft:dark_oak_log",
+			"material": "minecraft:dark_oak_log",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5966,7 +5955,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dark_oak_planks",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -5976,6 +5964,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dark_oak_planks",
 			"key": "minecraft:dark_oak_planks",
+			"material": "minecraft:dark_oak_planks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5987,7 +5976,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dark_oak_pressure_plate",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -5997,6 +5985,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dark_oak_pressure_plate",
 			"key": "minecraft:dark_oak_pressure_plate",
+			"material": "minecraft:dark_oak_pressure_plate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6008,7 +5997,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dark_oak_sapling",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -6018,6 +6006,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dark_oak_sapling",
 			"key": "minecraft:dark_oak_sapling",
+			"material": "minecraft:dark_oak_sapling",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6029,7 +6018,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dark_oak_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -6039,6 +6027,7 @@
 			"interactable": true,
 			"itemType": "minecraft:dark_oak_sign",
 			"key": "minecraft:dark_oak_sign",
+			"material": "minecraft:dark_oak_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6050,7 +6039,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dark_oak_slab",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -6060,6 +6048,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dark_oak_slab",
 			"key": "minecraft:dark_oak_slab",
+			"material": "minecraft:dark_oak_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6071,7 +6060,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dark_oak_stairs",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -6081,6 +6069,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dark_oak_stairs",
 			"key": "minecraft:dark_oak_stairs",
+			"material": "minecraft:dark_oak_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6092,7 +6081,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dark_oak_trapdoor",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -6102,6 +6090,7 @@
 			"interactable": true,
 			"itemType": "minecraft:dark_oak_trapdoor",
 			"key": "minecraft:dark_oak_trapdoor",
+			"material": "minecraft:dark_oak_trapdoor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6113,7 +6102,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dark_oak_wall_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -6123,6 +6111,7 @@
 			"interactable": true,
 			"itemType": "minecraft:dark_oak_hanging_sign",
 			"key": "minecraft:dark_oak_wall_hanging_sign",
+			"material": "minecraft:dark_oak_wall_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6134,7 +6123,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dark_oak_wall_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -6144,6 +6132,7 @@
 			"interactable": true,
 			"itemType": "minecraft:dark_oak_sign",
 			"key": "minecraft:dark_oak_wall_sign",
+			"material": "minecraft:dark_oak_wall_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6155,7 +6144,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dark_oak_wood",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -6165,6 +6153,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dark_oak_wood",
 			"key": "minecraft:dark_oak_wood",
+			"material": "minecraft:dark_oak_wood",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6176,7 +6165,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dark_prismarine",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -6186,6 +6174,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dark_prismarine",
 			"key": "minecraft:dark_prismarine",
+			"material": "minecraft:dark_prismarine",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6197,7 +6186,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dark_prismarine_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -6207,6 +6195,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dark_prismarine_slab",
 			"key": "minecraft:dark_prismarine_slab",
+			"material": "minecraft:dark_prismarine_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6218,7 +6207,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dark_prismarine_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -6228,6 +6216,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dark_prismarine_stairs",
 			"key": "minecraft:dark_prismarine_stairs",
+			"material": "minecraft:dark_prismarine_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6239,7 +6228,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:daylight_detector",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": true,
@@ -6249,6 +6237,7 @@
 			"interactable": true,
 			"itemType": "minecraft:daylight_detector",
 			"key": "minecraft:daylight_detector",
+			"material": "minecraft:daylight_detector",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6260,7 +6249,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dead_brain_coral",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -6270,6 +6258,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dead_brain_coral",
 			"key": "minecraft:dead_brain_coral",
+			"material": "minecraft:dead_brain_coral",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6281,7 +6270,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dead_brain_coral_block",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -6291,6 +6279,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dead_brain_coral_block",
 			"key": "minecraft:dead_brain_coral_block",
+			"material": "minecraft:dead_brain_coral_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6302,7 +6291,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dead_brain_coral_fan",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -6312,6 +6300,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dead_brain_coral_fan",
 			"key": "minecraft:dead_brain_coral_fan",
+			"material": "minecraft:dead_brain_coral_fan",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6323,7 +6312,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dead_brain_coral_wall_fan",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -6333,6 +6321,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dead_brain_coral_fan",
 			"key": "minecraft:dead_brain_coral_wall_fan",
+			"material": "minecraft:dead_brain_coral_wall_fan",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6344,7 +6333,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dead_bubble_coral",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -6354,6 +6342,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dead_bubble_coral",
 			"key": "minecraft:dead_bubble_coral",
+			"material": "minecraft:dead_bubble_coral",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6365,7 +6354,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dead_bubble_coral_block",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -6375,6 +6363,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dead_bubble_coral_block",
 			"key": "minecraft:dead_bubble_coral_block",
+			"material": "minecraft:dead_bubble_coral_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6386,7 +6375,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dead_bubble_coral_fan",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -6396,6 +6384,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dead_bubble_coral_fan",
 			"key": "minecraft:dead_bubble_coral_fan",
+			"material": "minecraft:dead_bubble_coral_fan",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6407,7 +6396,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dead_bubble_coral_wall_fan",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -6417,6 +6405,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dead_bubble_coral_fan",
 			"key": "minecraft:dead_bubble_coral_wall_fan",
+			"material": "minecraft:dead_bubble_coral_wall_fan",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6428,7 +6417,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dead_bush",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -6438,6 +6426,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dead_bush",
 			"key": "minecraft:dead_bush",
+			"material": "minecraft:dead_bush",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6449,7 +6438,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dead_fire_coral",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -6459,6 +6447,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dead_fire_coral",
 			"key": "minecraft:dead_fire_coral",
+			"material": "minecraft:dead_fire_coral",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6470,7 +6459,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dead_fire_coral_block",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -6480,6 +6468,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dead_fire_coral_block",
 			"key": "minecraft:dead_fire_coral_block",
+			"material": "minecraft:dead_fire_coral_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6491,7 +6480,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dead_fire_coral_fan",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -6501,6 +6489,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dead_fire_coral_fan",
 			"key": "minecraft:dead_fire_coral_fan",
+			"material": "minecraft:dead_fire_coral_fan",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6512,7 +6501,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dead_fire_coral_wall_fan",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -6522,6 +6510,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dead_fire_coral_fan",
 			"key": "minecraft:dead_fire_coral_wall_fan",
+			"material": "minecraft:dead_fire_coral_wall_fan",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6533,7 +6522,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dead_horn_coral",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -6543,6 +6531,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dead_horn_coral",
 			"key": "minecraft:dead_horn_coral",
+			"material": "minecraft:dead_horn_coral",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6554,7 +6543,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dead_horn_coral_block",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -6564,6 +6552,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dead_horn_coral_block",
 			"key": "minecraft:dead_horn_coral_block",
+			"material": "minecraft:dead_horn_coral_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6575,7 +6564,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dead_horn_coral_fan",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -6585,6 +6573,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dead_horn_coral_fan",
 			"key": "minecraft:dead_horn_coral_fan",
+			"material": "minecraft:dead_horn_coral_fan",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6596,7 +6585,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dead_horn_coral_wall_fan",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -6606,6 +6594,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dead_horn_coral_fan",
 			"key": "minecraft:dead_horn_coral_wall_fan",
+			"material": "minecraft:dead_horn_coral_wall_fan",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6617,7 +6606,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dead_tube_coral",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -6627,6 +6615,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dead_tube_coral",
 			"key": "minecraft:dead_tube_coral",
+			"material": "minecraft:dead_tube_coral",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6638,7 +6627,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dead_tube_coral_block",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -6648,6 +6636,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dead_tube_coral_block",
 			"key": "minecraft:dead_tube_coral_block",
+			"material": "minecraft:dead_tube_coral_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6659,7 +6648,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dead_tube_coral_fan",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -6669,6 +6657,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dead_tube_coral_fan",
 			"key": "minecraft:dead_tube_coral_fan",
+			"material": "minecraft:dead_tube_coral_fan",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6680,7 +6669,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dead_tube_coral_wall_fan",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -6690,6 +6678,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dead_tube_coral_fan",
 			"key": "minecraft:dead_tube_coral_wall_fan",
+			"material": "minecraft:dead_tube_coral_wall_fan",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6701,7 +6690,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:decorated_pot",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -6711,6 +6699,7 @@
 			"interactable": true,
 			"itemType": "minecraft:decorated_pot",
 			"key": "minecraft:decorated_pot",
+			"material": "minecraft:decorated_pot",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6722,7 +6711,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:deepslate",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -6732,6 +6720,7 @@
 			"interactable": false,
 			"itemType": "minecraft:deepslate",
 			"key": "minecraft:deepslate",
+			"material": "minecraft:deepslate",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6743,7 +6732,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:deepslate_brick_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -6753,6 +6741,7 @@
 			"interactable": false,
 			"itemType": "minecraft:deepslate_brick_slab",
 			"key": "minecraft:deepslate_brick_slab",
+			"material": "minecraft:deepslate_brick_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6764,7 +6753,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:deepslate_brick_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -6774,6 +6762,7 @@
 			"interactable": false,
 			"itemType": "minecraft:deepslate_brick_stairs",
 			"key": "minecraft:deepslate_brick_stairs",
+			"material": "minecraft:deepslate_brick_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6785,7 +6774,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:deepslate_brick_wall",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -6795,6 +6783,7 @@
 			"interactable": false,
 			"itemType": "minecraft:deepslate_brick_wall",
 			"key": "minecraft:deepslate_brick_wall",
+			"material": "minecraft:deepslate_brick_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6806,7 +6795,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:deepslate_bricks",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -6816,6 +6804,7 @@
 			"interactable": false,
 			"itemType": "minecraft:deepslate_bricks",
 			"key": "minecraft:deepslate_bricks",
+			"material": "minecraft:deepslate_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6827,7 +6816,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:deepslate_coal_ore",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -6837,6 +6825,7 @@
 			"interactable": false,
 			"itemType": "minecraft:deepslate_coal_ore",
 			"key": "minecraft:deepslate_coal_ore",
+			"material": "minecraft:deepslate_coal_ore",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6848,7 +6837,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:deepslate_copper_ore",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -6858,6 +6846,7 @@
 			"interactable": false,
 			"itemType": "minecraft:deepslate_copper_ore",
 			"key": "minecraft:deepslate_copper_ore",
+			"material": "minecraft:deepslate_copper_ore",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6869,7 +6858,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:deepslate_diamond_ore",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -6879,6 +6867,7 @@
 			"interactable": false,
 			"itemType": "minecraft:deepslate_diamond_ore",
 			"key": "minecraft:deepslate_diamond_ore",
+			"material": "minecraft:deepslate_diamond_ore",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6890,7 +6879,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:deepslate_emerald_ore",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -6900,6 +6888,7 @@
 			"interactable": false,
 			"itemType": "minecraft:deepslate_emerald_ore",
 			"key": "minecraft:deepslate_emerald_ore",
+			"material": "minecraft:deepslate_emerald_ore",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6911,7 +6900,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:deepslate_gold_ore",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -6921,6 +6909,7 @@
 			"interactable": false,
 			"itemType": "minecraft:deepslate_gold_ore",
 			"key": "minecraft:deepslate_gold_ore",
+			"material": "minecraft:deepslate_gold_ore",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6932,7 +6921,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:deepslate_iron_ore",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -6942,6 +6930,7 @@
 			"interactable": false,
 			"itemType": "minecraft:deepslate_iron_ore",
 			"key": "minecraft:deepslate_iron_ore",
+			"material": "minecraft:deepslate_iron_ore",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6953,7 +6942,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:deepslate_lapis_ore",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -6963,6 +6951,7 @@
 			"interactable": false,
 			"itemType": "minecraft:deepslate_lapis_ore",
 			"key": "minecraft:deepslate_lapis_ore",
+			"material": "minecraft:deepslate_lapis_ore",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6974,7 +6963,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:deepslate_redstone_ore",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -6984,6 +6972,7 @@
 			"interactable": true,
 			"itemType": "minecraft:deepslate_redstone_ore",
 			"key": "minecraft:deepslate_redstone_ore",
+			"material": "minecraft:deepslate_redstone_ore",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6995,7 +6984,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:deepslate_tile_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -7005,6 +6993,7 @@
 			"interactable": false,
 			"itemType": "minecraft:deepslate_tile_slab",
 			"key": "minecraft:deepslate_tile_slab",
+			"material": "minecraft:deepslate_tile_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7016,7 +7005,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:deepslate_tile_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -7026,6 +7014,7 @@
 			"interactable": false,
 			"itemType": "minecraft:deepslate_tile_stairs",
 			"key": "minecraft:deepslate_tile_stairs",
+			"material": "minecraft:deepslate_tile_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7037,7 +7026,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:deepslate_tile_wall",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -7047,6 +7035,7 @@
 			"interactable": false,
 			"itemType": "minecraft:deepslate_tile_wall",
 			"key": "minecraft:deepslate_tile_wall",
+			"material": "minecraft:deepslate_tile_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7058,7 +7047,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:deepslate_tiles",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -7068,6 +7056,7 @@
 			"interactable": false,
 			"itemType": "minecraft:deepslate_tiles",
 			"key": "minecraft:deepslate_tiles",
+			"material": "minecraft:deepslate_tiles",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7079,7 +7068,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:detector_rail",
 			"blastResistance": 0.7,
 			"burnable": false,
 			"collision": false,
@@ -7089,6 +7077,7 @@
 			"interactable": false,
 			"itemType": "minecraft:detector_rail",
 			"key": "minecraft:detector_rail",
+			"material": "minecraft:detector_rail",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7100,7 +7089,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:diamond_block",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -7110,6 +7098,7 @@
 			"interactable": false,
 			"itemType": "minecraft:diamond_block",
 			"key": "minecraft:diamond_block",
+			"material": "minecraft:diamond_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7121,7 +7110,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:diamond_ore",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -7131,6 +7119,7 @@
 			"interactable": false,
 			"itemType": "minecraft:diamond_ore",
 			"key": "minecraft:diamond_ore",
+			"material": "minecraft:diamond_ore",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7142,7 +7131,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:diorite",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -7152,6 +7140,7 @@
 			"interactable": false,
 			"itemType": "minecraft:diorite",
 			"key": "minecraft:diorite",
+			"material": "minecraft:diorite",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7163,7 +7152,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:diorite_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -7173,6 +7161,7 @@
 			"interactable": false,
 			"itemType": "minecraft:diorite_slab",
 			"key": "minecraft:diorite_slab",
+			"material": "minecraft:diorite_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7184,7 +7173,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:diorite_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -7194,6 +7182,7 @@
 			"interactable": false,
 			"itemType": "minecraft:diorite_stairs",
 			"key": "minecraft:diorite_stairs",
+			"material": "minecraft:diorite_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7205,7 +7194,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:diorite_wall",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -7215,6 +7203,7 @@
 			"interactable": false,
 			"itemType": "minecraft:diorite_wall",
 			"key": "minecraft:diorite_wall",
+			"material": "minecraft:diorite_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7226,7 +7215,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dirt",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -7236,6 +7224,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dirt",
 			"key": "minecraft:dirt",
+			"material": "minecraft:dirt",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7247,7 +7236,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dirt_path",
 			"blastResistance": 0.65,
 			"burnable": false,
 			"collision": true,
@@ -7257,6 +7245,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dirt_path",
 			"key": "minecraft:dirt_path",
+			"material": "minecraft:dirt_path",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7268,7 +7257,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dispenser",
 			"blastResistance": 3.5,
 			"burnable": false,
 			"collision": true,
@@ -7278,6 +7266,7 @@
 			"interactable": true,
 			"itemType": "minecraft:dispenser",
 			"key": "minecraft:dispenser",
+			"material": "minecraft:dispenser",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7289,7 +7278,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dragon_egg",
 			"blastResistance": 9.0,
 			"burnable": false,
 			"collision": true,
@@ -7299,6 +7287,7 @@
 			"interactable": true,
 			"itemType": "minecraft:dragon_egg",
 			"key": "minecraft:dragon_egg",
+			"material": "minecraft:dragon_egg",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7310,7 +7299,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dragon_head",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": true,
@@ -7320,6 +7308,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dragon_head",
 			"key": "minecraft:dragon_head",
+			"material": "minecraft:dragon_head",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7331,7 +7320,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dragon_wall_head",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": true,
@@ -7341,6 +7329,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dragon_head",
 			"key": "minecraft:dragon_wall_head",
+			"material": "minecraft:dragon_wall_head",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7352,7 +7341,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dried_kelp_block",
 			"blastResistance": 2.5,
 			"burnable": true,
 			"collision": true,
@@ -7362,6 +7350,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dried_kelp_block",
 			"key": "minecraft:dried_kelp_block",
+			"material": "minecraft:dried_kelp_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7373,7 +7362,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dripstone_block",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": true,
@@ -7383,6 +7371,7 @@
 			"interactable": false,
 			"itemType": "minecraft:dripstone_block",
 			"key": "minecraft:dripstone_block",
+			"material": "minecraft:dripstone_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7394,7 +7383,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:dropper",
 			"blastResistance": 3.5,
 			"burnable": false,
 			"collision": true,
@@ -7404,6 +7392,7 @@
 			"interactable": true,
 			"itemType": "minecraft:dropper",
 			"key": "minecraft:dropper",
+			"material": "minecraft:dropper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7415,7 +7404,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:emerald_block",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -7425,6 +7413,7 @@
 			"interactable": false,
 			"itemType": "minecraft:emerald_block",
 			"key": "minecraft:emerald_block",
+			"material": "minecraft:emerald_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7436,7 +7425,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:emerald_ore",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -7446,6 +7434,7 @@
 			"interactable": false,
 			"itemType": "minecraft:emerald_ore",
 			"key": "minecraft:emerald_ore",
+			"material": "minecraft:emerald_ore",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7457,7 +7446,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:enchanting_table",
 			"blastResistance": 1200.0,
 			"burnable": false,
 			"collision": true,
@@ -7467,6 +7455,7 @@
 			"interactable": true,
 			"itemType": "minecraft:enchanting_table",
 			"key": "minecraft:enchanting_table",
+			"material": "minecraft:enchanting_table",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7478,7 +7467,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:end_gateway",
 			"blastResistance": 3600000.0,
 			"burnable": false,
 			"collision": false,
@@ -7486,8 +7474,8 @@
 			"gravity": false,
 			"hardness": -1.0,
 			"interactable": false,
-			"itemType": false,
 			"key": "minecraft:end_gateway",
+			"material": "minecraft:end_gateway",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7499,7 +7487,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:end_portal",
 			"blastResistance": 3600000.0,
 			"burnable": false,
 			"collision": false,
@@ -7507,8 +7494,8 @@
 			"gravity": false,
 			"hardness": -1.0,
 			"interactable": false,
-			"itemType": false,
 			"key": "minecraft:end_portal",
+			"material": "minecraft:end_portal",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7520,7 +7507,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:end_portal_frame",
 			"blastResistance": 3600000.0,
 			"burnable": false,
 			"collision": true,
@@ -7530,6 +7516,7 @@
 			"interactable": false,
 			"itemType": "minecraft:end_portal_frame",
 			"key": "minecraft:end_portal_frame",
+			"material": "minecraft:end_portal_frame",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7541,7 +7528,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:end_rod",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -7551,6 +7537,7 @@
 			"interactable": false,
 			"itemType": "minecraft:end_rod",
 			"key": "minecraft:end_rod",
+			"material": "minecraft:end_rod",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7562,7 +7549,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:end_stone",
 			"blastResistance": 9.0,
 			"burnable": false,
 			"collision": true,
@@ -7572,6 +7558,7 @@
 			"interactable": false,
 			"itemType": "minecraft:end_stone",
 			"key": "minecraft:end_stone",
+			"material": "minecraft:end_stone",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7583,7 +7570,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:end_stone_brick_slab",
 			"blastResistance": 9.0,
 			"burnable": false,
 			"collision": true,
@@ -7593,6 +7579,7 @@
 			"interactable": false,
 			"itemType": "minecraft:end_stone_brick_slab",
 			"key": "minecraft:end_stone_brick_slab",
+			"material": "minecraft:end_stone_brick_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7604,7 +7591,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:end_stone_brick_stairs",
 			"blastResistance": 9.0,
 			"burnable": false,
 			"collision": true,
@@ -7614,6 +7600,7 @@
 			"interactable": false,
 			"itemType": "minecraft:end_stone_brick_stairs",
 			"key": "minecraft:end_stone_brick_stairs",
+			"material": "minecraft:end_stone_brick_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7625,7 +7612,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:end_stone_brick_wall",
 			"blastResistance": 9.0,
 			"burnable": false,
 			"collision": true,
@@ -7635,6 +7621,7 @@
 			"interactable": false,
 			"itemType": "minecraft:end_stone_brick_wall",
 			"key": "minecraft:end_stone_brick_wall",
+			"material": "minecraft:end_stone_brick_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7646,7 +7633,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:end_stone_bricks",
 			"blastResistance": 9.0,
 			"burnable": false,
 			"collision": true,
@@ -7656,6 +7642,7 @@
 			"interactable": false,
 			"itemType": "minecraft:end_stone_bricks",
 			"key": "minecraft:end_stone_bricks",
+			"material": "minecraft:end_stone_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7667,7 +7654,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:ender_chest",
 			"blastResistance": 600.0,
 			"burnable": false,
 			"collision": true,
@@ -7677,6 +7663,7 @@
 			"interactable": true,
 			"itemType": "minecraft:ender_chest",
 			"key": "minecraft:ender_chest",
+			"material": "minecraft:ender_chest",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7688,7 +7675,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:exposed_chiseled_copper",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -7698,6 +7684,7 @@
 			"interactable": false,
 			"itemType": "minecraft:exposed_chiseled_copper",
 			"key": "minecraft:exposed_chiseled_copper",
+			"material": "minecraft:exposed_chiseled_copper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7709,7 +7696,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:exposed_copper",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -7719,6 +7705,7 @@
 			"interactable": false,
 			"itemType": "minecraft:exposed_copper",
 			"key": "minecraft:exposed_copper",
+			"material": "minecraft:exposed_copper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7730,7 +7717,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:exposed_copper_bulb",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -7740,6 +7726,7 @@
 			"interactable": false,
 			"itemType": "minecraft:exposed_copper_bulb",
 			"key": "minecraft:exposed_copper_bulb",
+			"material": "minecraft:exposed_copper_bulb",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7751,7 +7738,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:exposed_copper_door",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -7761,6 +7747,7 @@
 			"interactable": true,
 			"itemType": "minecraft:exposed_copper_door",
 			"key": "minecraft:exposed_copper_door",
+			"material": "minecraft:exposed_copper_door",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7772,7 +7759,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:exposed_copper_grate",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -7782,6 +7768,7 @@
 			"interactable": false,
 			"itemType": "minecraft:exposed_copper_grate",
 			"key": "minecraft:exposed_copper_grate",
+			"material": "minecraft:exposed_copper_grate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7793,7 +7780,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:exposed_copper_trapdoor",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -7803,6 +7789,7 @@
 			"interactable": true,
 			"itemType": "minecraft:exposed_copper_trapdoor",
 			"key": "minecraft:exposed_copper_trapdoor",
+			"material": "minecraft:exposed_copper_trapdoor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7814,7 +7801,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:exposed_cut_copper",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -7824,6 +7810,7 @@
 			"interactable": false,
 			"itemType": "minecraft:exposed_cut_copper",
 			"key": "minecraft:exposed_cut_copper",
+			"material": "minecraft:exposed_cut_copper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7835,7 +7822,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:exposed_cut_copper_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -7845,6 +7831,7 @@
 			"interactable": false,
 			"itemType": "minecraft:exposed_cut_copper_slab",
 			"key": "minecraft:exposed_cut_copper_slab",
+			"material": "minecraft:exposed_cut_copper_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7856,7 +7843,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:exposed_cut_copper_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -7866,6 +7852,7 @@
 			"interactable": false,
 			"itemType": "minecraft:exposed_cut_copper_stairs",
 			"key": "minecraft:exposed_cut_copper_stairs",
+			"material": "minecraft:exposed_cut_copper_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7877,7 +7864,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:farmland",
 			"blastResistance": 0.6,
 			"burnable": false,
 			"collision": true,
@@ -7887,6 +7873,7 @@
 			"interactable": false,
 			"itemType": "minecraft:farmland",
 			"key": "minecraft:farmland",
+			"material": "minecraft:farmland",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7898,7 +7885,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:fern",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -7908,6 +7894,7 @@
 			"interactable": false,
 			"itemType": "minecraft:fern",
 			"key": "minecraft:fern",
+			"material": "minecraft:fern",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7919,7 +7906,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:fire",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -7927,8 +7913,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": false,
-			"itemType": false,
 			"key": "minecraft:fire",
+			"material": "minecraft:fire",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7940,7 +7926,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:fire_coral",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -7950,6 +7935,7 @@
 			"interactable": false,
 			"itemType": "minecraft:fire_coral",
 			"key": "minecraft:fire_coral",
+			"material": "minecraft:fire_coral",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7961,7 +7947,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:fire_coral_block",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -7971,6 +7956,7 @@
 			"interactable": false,
 			"itemType": "minecraft:fire_coral_block",
 			"key": "minecraft:fire_coral_block",
+			"material": "minecraft:fire_coral_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7982,7 +7968,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:fire_coral_fan",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -7992,6 +7977,7 @@
 			"interactable": false,
 			"itemType": "minecraft:fire_coral_fan",
 			"key": "minecraft:fire_coral_fan",
+			"material": "minecraft:fire_coral_fan",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8003,7 +7989,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:fire_coral_wall_fan",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -8013,6 +7998,7 @@
 			"interactable": false,
 			"itemType": "minecraft:fire_coral_fan",
 			"key": "minecraft:fire_coral_wall_fan",
+			"material": "minecraft:fire_coral_wall_fan",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8024,7 +8010,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:firefly_bush",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -8034,6 +8019,7 @@
 			"interactable": false,
 			"itemType": "minecraft:firefly_bush",
 			"key": "minecraft:firefly_bush",
+			"material": "minecraft:firefly_bush",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8045,7 +8031,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:fletching_table",
 			"blastResistance": 2.5,
 			"burnable": false,
 			"collision": true,
@@ -8055,6 +8040,7 @@
 			"interactable": true,
 			"itemType": "minecraft:fletching_table",
 			"key": "minecraft:fletching_table",
+			"material": "minecraft:fletching_table",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8066,7 +8052,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:flower_pot",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -8076,6 +8061,7 @@
 			"interactable": true,
 			"itemType": "minecraft:flower_pot",
 			"key": "minecraft:flower_pot",
+			"material": "minecraft:flower_pot",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8087,7 +8073,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:flowering_azalea",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": true,
@@ -8097,6 +8082,7 @@
 			"interactable": false,
 			"itemType": "minecraft:flowering_azalea",
 			"key": "minecraft:flowering_azalea",
+			"material": "minecraft:flowering_azalea",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8108,7 +8094,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:flowering_azalea_leaves",
 			"blastResistance": 0.2,
 			"burnable": true,
 			"collision": true,
@@ -8118,6 +8103,7 @@
 			"interactable": false,
 			"itemType": "minecraft:flowering_azalea_leaves",
 			"key": "minecraft:flowering_azalea_leaves",
+			"material": "minecraft:flowering_azalea_leaves",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8129,7 +8115,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:frogspawn",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -8139,6 +8124,7 @@
 			"interactable": false,
 			"itemType": "minecraft:frogspawn",
 			"key": "minecraft:frogspawn",
+			"material": "minecraft:frogspawn",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8150,7 +8136,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:frosted_ice",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -8158,8 +8143,8 @@
 			"gravity": false,
 			"hardness": 0.5,
 			"interactable": false,
-			"itemType": false,
 			"key": "minecraft:frosted_ice",
+			"material": "minecraft:frosted_ice",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8171,7 +8156,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:furnace",
 			"blastResistance": 3.5,
 			"burnable": false,
 			"collision": true,
@@ -8181,6 +8165,7 @@
 			"interactable": true,
 			"itemType": "minecraft:furnace",
 			"key": "minecraft:furnace",
+			"material": "minecraft:furnace",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8192,7 +8177,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:gilded_blackstone",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -8202,6 +8186,7 @@
 			"interactable": false,
 			"itemType": "minecraft:gilded_blackstone",
 			"key": "minecraft:gilded_blackstone",
+			"material": "minecraft:gilded_blackstone",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8213,7 +8198,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:glass",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -8223,6 +8207,7 @@
 			"interactable": false,
 			"itemType": "minecraft:glass",
 			"key": "minecraft:glass",
+			"material": "minecraft:glass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8234,7 +8219,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:glass_pane",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -8244,6 +8228,7 @@
 			"interactable": false,
 			"itemType": "minecraft:glass_pane",
 			"key": "minecraft:glass_pane",
+			"material": "minecraft:glass_pane",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8255,7 +8240,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:glow_lichen",
 			"blastResistance": 0.2,
 			"burnable": true,
 			"collision": false,
@@ -8265,6 +8249,7 @@
 			"interactable": false,
 			"itemType": "minecraft:glow_lichen",
 			"key": "minecraft:glow_lichen",
+			"material": "minecraft:glow_lichen",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8276,7 +8261,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:glowstone",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -8286,6 +8270,7 @@
 			"interactable": false,
 			"itemType": "minecraft:glowstone",
 			"key": "minecraft:glowstone",
+			"material": "minecraft:glowstone",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8297,7 +8282,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:gold_block",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -8307,6 +8291,7 @@
 			"interactable": false,
 			"itemType": "minecraft:gold_block",
 			"key": "minecraft:gold_block",
+			"material": "minecraft:gold_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8318,7 +8303,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:gold_ore",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -8328,6 +8312,7 @@
 			"interactable": false,
 			"itemType": "minecraft:gold_ore",
 			"key": "minecraft:gold_ore",
+			"material": "minecraft:gold_ore",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8339,7 +8324,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:granite",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -8349,6 +8333,7 @@
 			"interactable": false,
 			"itemType": "minecraft:granite",
 			"key": "minecraft:granite",
+			"material": "minecraft:granite",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8360,7 +8345,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:granite_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -8370,6 +8354,7 @@
 			"interactable": false,
 			"itemType": "minecraft:granite_slab",
 			"key": "minecraft:granite_slab",
+			"material": "minecraft:granite_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8381,7 +8366,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:granite_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -8391,6 +8375,7 @@
 			"interactable": false,
 			"itemType": "minecraft:granite_stairs",
 			"key": "minecraft:granite_stairs",
+			"material": "minecraft:granite_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8402,7 +8387,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:granite_wall",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -8412,6 +8396,7 @@
 			"interactable": false,
 			"itemType": "minecraft:granite_wall",
 			"key": "minecraft:granite_wall",
+			"material": "minecraft:granite_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8423,7 +8408,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:grass_block",
 			"blastResistance": 0.6,
 			"burnable": false,
 			"collision": true,
@@ -8433,6 +8417,7 @@
 			"interactable": false,
 			"itemType": "minecraft:grass_block",
 			"key": "minecraft:grass_block",
+			"material": "minecraft:grass_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8444,7 +8429,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:gravel",
 			"blastResistance": 0.6,
 			"burnable": false,
 			"collision": true,
@@ -8454,6 +8438,7 @@
 			"interactable": false,
 			"itemType": "minecraft:gravel",
 			"key": "minecraft:gravel",
+			"material": "minecraft:gravel",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8465,7 +8450,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:gray_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -8475,6 +8459,7 @@
 			"interactable": false,
 			"itemType": "minecraft:gray_banner",
 			"key": "minecraft:gray_banner",
+			"material": "minecraft:gray_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8486,7 +8471,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:gray_bed",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": true,
@@ -8496,6 +8480,7 @@
 			"interactable": true,
 			"itemType": "minecraft:gray_bed",
 			"key": "minecraft:gray_bed",
+			"material": "minecraft:gray_bed",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8507,7 +8492,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:gray_candle",
 			"blastResistance": 0.1,
 			"burnable": false,
 			"collision": true,
@@ -8517,6 +8501,7 @@
 			"interactable": true,
 			"itemType": "minecraft:gray_candle",
 			"key": "minecraft:gray_candle",
+			"material": "minecraft:gray_candle",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8528,7 +8513,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:gray_candle_cake",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -8536,8 +8520,8 @@
 			"gravity": false,
 			"hardness": 0.5,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:gray_candle_cake",
+			"material": "minecraft:gray_candle_cake",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8549,7 +8533,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:gray_carpet",
 			"blastResistance": 0.1,
 			"burnable": true,
 			"collision": true,
@@ -8559,6 +8542,7 @@
 			"interactable": false,
 			"itemType": "minecraft:gray_carpet",
 			"key": "minecraft:gray_carpet",
+			"material": "minecraft:gray_carpet",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8570,7 +8554,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:gray_concrete",
 			"blastResistance": 1.8,
 			"burnable": false,
 			"collision": true,
@@ -8580,6 +8563,7 @@
 			"interactable": false,
 			"itemType": "minecraft:gray_concrete",
 			"key": "minecraft:gray_concrete",
+			"material": "minecraft:gray_concrete",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8591,7 +8575,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:gray_concrete_powder",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -8601,6 +8584,7 @@
 			"interactable": false,
 			"itemType": "minecraft:gray_concrete_powder",
 			"key": "minecraft:gray_concrete_powder",
+			"material": "minecraft:gray_concrete_powder",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8612,7 +8596,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:gray_glazed_terracotta",
 			"blastResistance": 1.4,
 			"burnable": false,
 			"collision": true,
@@ -8622,6 +8605,7 @@
 			"interactable": false,
 			"itemType": "minecraft:gray_glazed_terracotta",
 			"key": "minecraft:gray_glazed_terracotta",
+			"material": "minecraft:gray_glazed_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8633,7 +8617,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:gray_shulker_box",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -8643,6 +8626,7 @@
 			"interactable": true,
 			"itemType": "minecraft:gray_shulker_box",
 			"key": "minecraft:gray_shulker_box",
+			"material": "minecraft:gray_shulker_box",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8654,7 +8638,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:gray_stained_glass",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -8664,6 +8647,7 @@
 			"interactable": false,
 			"itemType": "minecraft:gray_stained_glass",
 			"key": "minecraft:gray_stained_glass",
+			"material": "minecraft:gray_stained_glass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8675,7 +8659,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:gray_stained_glass_pane",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -8685,6 +8668,7 @@
 			"interactable": false,
 			"itemType": "minecraft:gray_stained_glass_pane",
 			"key": "minecraft:gray_stained_glass_pane",
+			"material": "minecraft:gray_stained_glass_pane",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8696,7 +8680,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:gray_terracotta",
 			"blastResistance": 4.2,
 			"burnable": false,
 			"collision": true,
@@ -8706,6 +8689,7 @@
 			"interactable": false,
 			"itemType": "minecraft:gray_terracotta",
 			"key": "minecraft:gray_terracotta",
+			"material": "minecraft:gray_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8717,7 +8701,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:gray_wall_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -8727,6 +8710,7 @@
 			"interactable": false,
 			"itemType": "minecraft:gray_banner",
 			"key": "minecraft:gray_wall_banner",
+			"material": "minecraft:gray_wall_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8738,7 +8722,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:gray_wool",
 			"blastResistance": 0.8,
 			"burnable": true,
 			"collision": true,
@@ -8748,6 +8731,7 @@
 			"interactable": false,
 			"itemType": "minecraft:gray_wool",
 			"key": "minecraft:gray_wool",
+			"material": "minecraft:gray_wool",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8759,7 +8743,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:green_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -8769,6 +8752,7 @@
 			"interactable": false,
 			"itemType": "minecraft:green_banner",
 			"key": "minecraft:green_banner",
+			"material": "minecraft:green_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8780,7 +8764,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:green_bed",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": true,
@@ -8790,6 +8773,7 @@
 			"interactable": true,
 			"itemType": "minecraft:green_bed",
 			"key": "minecraft:green_bed",
+			"material": "minecraft:green_bed",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8801,7 +8785,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:green_candle",
 			"blastResistance": 0.1,
 			"burnable": false,
 			"collision": true,
@@ -8811,6 +8794,7 @@
 			"interactable": true,
 			"itemType": "minecraft:green_candle",
 			"key": "minecraft:green_candle",
+			"material": "minecraft:green_candle",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8822,7 +8806,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:green_candle_cake",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -8830,8 +8813,8 @@
 			"gravity": false,
 			"hardness": 0.5,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:green_candle_cake",
+			"material": "minecraft:green_candle_cake",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8843,7 +8826,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:green_carpet",
 			"blastResistance": 0.1,
 			"burnable": true,
 			"collision": true,
@@ -8853,6 +8835,7 @@
 			"interactable": false,
 			"itemType": "minecraft:green_carpet",
 			"key": "minecraft:green_carpet",
+			"material": "minecraft:green_carpet",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8864,7 +8847,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:green_concrete",
 			"blastResistance": 1.8,
 			"burnable": false,
 			"collision": true,
@@ -8874,6 +8856,7 @@
 			"interactable": false,
 			"itemType": "minecraft:green_concrete",
 			"key": "minecraft:green_concrete",
+			"material": "minecraft:green_concrete",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8885,7 +8868,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:green_concrete_powder",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -8895,6 +8877,7 @@
 			"interactable": false,
 			"itemType": "minecraft:green_concrete_powder",
 			"key": "minecraft:green_concrete_powder",
+			"material": "minecraft:green_concrete_powder",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8906,7 +8889,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:green_glazed_terracotta",
 			"blastResistance": 1.4,
 			"burnable": false,
 			"collision": true,
@@ -8916,6 +8898,7 @@
 			"interactable": false,
 			"itemType": "minecraft:green_glazed_terracotta",
 			"key": "minecraft:green_glazed_terracotta",
+			"material": "minecraft:green_glazed_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8927,7 +8910,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:green_shulker_box",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -8937,6 +8919,7 @@
 			"interactable": true,
 			"itemType": "minecraft:green_shulker_box",
 			"key": "minecraft:green_shulker_box",
+			"material": "minecraft:green_shulker_box",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8948,7 +8931,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:green_stained_glass",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -8958,6 +8940,7 @@
 			"interactable": false,
 			"itemType": "minecraft:green_stained_glass",
 			"key": "minecraft:green_stained_glass",
+			"material": "minecraft:green_stained_glass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8969,7 +8952,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:green_stained_glass_pane",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -8979,6 +8961,7 @@
 			"interactable": false,
 			"itemType": "minecraft:green_stained_glass_pane",
 			"key": "minecraft:green_stained_glass_pane",
+			"material": "minecraft:green_stained_glass_pane",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8990,7 +8973,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:green_terracotta",
 			"blastResistance": 4.2,
 			"burnable": false,
 			"collision": true,
@@ -9000,6 +8982,7 @@
 			"interactable": false,
 			"itemType": "minecraft:green_terracotta",
 			"key": "minecraft:green_terracotta",
+			"material": "minecraft:green_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9011,7 +8994,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:green_wall_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -9021,6 +9003,7 @@
 			"interactable": false,
 			"itemType": "minecraft:green_banner",
 			"key": "minecraft:green_wall_banner",
+			"material": "minecraft:green_wall_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9032,7 +9015,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:green_wool",
 			"blastResistance": 0.8,
 			"burnable": true,
 			"collision": true,
@@ -9042,6 +9024,7 @@
 			"interactable": false,
 			"itemType": "minecraft:green_wool",
 			"key": "minecraft:green_wool",
+			"material": "minecraft:green_wool",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9053,7 +9036,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:grindstone",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -9063,6 +9045,7 @@
 			"interactable": true,
 			"itemType": "minecraft:grindstone",
 			"key": "minecraft:grindstone",
+			"material": "minecraft:grindstone",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9074,7 +9057,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:hanging_roots",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -9084,6 +9066,7 @@
 			"interactable": false,
 			"itemType": "minecraft:hanging_roots",
 			"key": "minecraft:hanging_roots",
+			"material": "minecraft:hanging_roots",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9095,7 +9078,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:hay_block",
 			"blastResistance": 0.5,
 			"burnable": true,
 			"collision": true,
@@ -9105,6 +9087,7 @@
 			"interactable": false,
 			"itemType": "minecraft:hay_block",
 			"key": "minecraft:hay_block",
+			"material": "minecraft:hay_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9116,7 +9099,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:heavy_core",
 			"blastResistance": 1200.0,
 			"burnable": false,
 			"collision": true,
@@ -9126,6 +9108,7 @@
 			"interactable": false,
 			"itemType": "minecraft:heavy_core",
 			"key": "minecraft:heavy_core",
+			"material": "minecraft:heavy_core",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9137,7 +9120,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:heavy_weighted_pressure_plate",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -9147,6 +9129,7 @@
 			"interactable": false,
 			"itemType": "minecraft:heavy_weighted_pressure_plate",
 			"key": "minecraft:heavy_weighted_pressure_plate",
+			"material": "minecraft:heavy_weighted_pressure_plate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9158,7 +9141,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:honey_block",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -9168,6 +9150,7 @@
 			"interactable": false,
 			"itemType": "minecraft:honey_block",
 			"key": "minecraft:honey_block",
+			"material": "minecraft:honey_block",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9179,7 +9162,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:honeycomb_block",
 			"blastResistance": 0.6,
 			"burnable": false,
 			"collision": true,
@@ -9189,6 +9171,7 @@
 			"interactable": false,
 			"itemType": "minecraft:honeycomb_block",
 			"key": "minecraft:honeycomb_block",
+			"material": "minecraft:honeycomb_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9200,7 +9183,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:hopper",
 			"blastResistance": 4.8,
 			"burnable": false,
 			"collision": true,
@@ -9210,6 +9192,7 @@
 			"interactable": true,
 			"itemType": "minecraft:hopper",
 			"key": "minecraft:hopper",
+			"material": "minecraft:hopper",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9221,7 +9204,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:horn_coral",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -9231,6 +9213,7 @@
 			"interactable": false,
 			"itemType": "minecraft:horn_coral",
 			"key": "minecraft:horn_coral",
+			"material": "minecraft:horn_coral",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9242,7 +9225,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:horn_coral_block",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -9252,6 +9234,7 @@
 			"interactable": false,
 			"itemType": "minecraft:horn_coral_block",
 			"key": "minecraft:horn_coral_block",
+			"material": "minecraft:horn_coral_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9263,7 +9246,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:horn_coral_fan",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -9273,6 +9255,7 @@
 			"interactable": false,
 			"itemType": "minecraft:horn_coral_fan",
 			"key": "minecraft:horn_coral_fan",
+			"material": "minecraft:horn_coral_fan",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9284,7 +9267,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:horn_coral_wall_fan",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -9294,6 +9276,7 @@
 			"interactable": false,
 			"itemType": "minecraft:horn_coral_fan",
 			"key": "minecraft:horn_coral_wall_fan",
+			"material": "minecraft:horn_coral_wall_fan",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9305,7 +9288,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:ice",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -9315,6 +9297,7 @@
 			"interactable": false,
 			"itemType": "minecraft:ice",
 			"key": "minecraft:ice",
+			"material": "minecraft:ice",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9326,7 +9309,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:infested_chiseled_stone_bricks",
 			"blastResistance": 0.75,
 			"burnable": false,
 			"collision": true,
@@ -9336,6 +9318,7 @@
 			"interactable": false,
 			"itemType": "minecraft:infested_chiseled_stone_bricks",
 			"key": "minecraft:infested_chiseled_stone_bricks",
+			"material": "minecraft:infested_chiseled_stone_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9347,7 +9330,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:infested_cobblestone",
 			"blastResistance": 0.75,
 			"burnable": false,
 			"collision": true,
@@ -9357,6 +9339,7 @@
 			"interactable": false,
 			"itemType": "minecraft:infested_cobblestone",
 			"key": "minecraft:infested_cobblestone",
+			"material": "minecraft:infested_cobblestone",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9368,7 +9351,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:infested_cracked_stone_bricks",
 			"blastResistance": 0.75,
 			"burnable": false,
 			"collision": true,
@@ -9378,6 +9360,7 @@
 			"interactable": false,
 			"itemType": "minecraft:infested_cracked_stone_bricks",
 			"key": "minecraft:infested_cracked_stone_bricks",
+			"material": "minecraft:infested_cracked_stone_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9389,7 +9372,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:infested_deepslate",
 			"blastResistance": 0.75,
 			"burnable": false,
 			"collision": true,
@@ -9399,6 +9381,7 @@
 			"interactable": false,
 			"itemType": "minecraft:infested_deepslate",
 			"key": "minecraft:infested_deepslate",
+			"material": "minecraft:infested_deepslate",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9410,7 +9393,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:infested_mossy_stone_bricks",
 			"blastResistance": 0.75,
 			"burnable": false,
 			"collision": true,
@@ -9420,6 +9402,7 @@
 			"interactable": false,
 			"itemType": "minecraft:infested_mossy_stone_bricks",
 			"key": "minecraft:infested_mossy_stone_bricks",
+			"material": "minecraft:infested_mossy_stone_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9431,7 +9414,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:infested_stone",
 			"blastResistance": 0.75,
 			"burnable": false,
 			"collision": true,
@@ -9441,6 +9423,7 @@
 			"interactable": false,
 			"itemType": "minecraft:infested_stone",
 			"key": "minecraft:infested_stone",
+			"material": "minecraft:infested_stone",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9452,7 +9435,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:infested_stone_bricks",
 			"blastResistance": 0.75,
 			"burnable": false,
 			"collision": true,
@@ -9462,6 +9444,7 @@
 			"interactable": false,
 			"itemType": "minecraft:infested_stone_bricks",
 			"key": "minecraft:infested_stone_bricks",
+			"material": "minecraft:infested_stone_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9473,7 +9456,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:iron_bars",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -9483,6 +9465,7 @@
 			"interactable": false,
 			"itemType": "minecraft:iron_bars",
 			"key": "minecraft:iron_bars",
+			"material": "minecraft:iron_bars",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9494,7 +9477,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:iron_block",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -9504,6 +9486,7 @@
 			"interactable": false,
 			"itemType": "minecraft:iron_block",
 			"key": "minecraft:iron_block",
+			"material": "minecraft:iron_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9515,7 +9498,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:iron_door",
 			"blastResistance": 5.0,
 			"burnable": false,
 			"collision": true,
@@ -9525,6 +9507,7 @@
 			"interactable": true,
 			"itemType": "minecraft:iron_door",
 			"key": "minecraft:iron_door",
+			"material": "minecraft:iron_door",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9536,7 +9519,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:iron_ore",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -9546,6 +9528,7 @@
 			"interactable": false,
 			"itemType": "minecraft:iron_ore",
 			"key": "minecraft:iron_ore",
+			"material": "minecraft:iron_ore",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9557,7 +9540,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:iron_trapdoor",
 			"blastResistance": 5.0,
 			"burnable": false,
 			"collision": true,
@@ -9567,6 +9549,7 @@
 			"interactable": true,
 			"itemType": "minecraft:iron_trapdoor",
 			"key": "minecraft:iron_trapdoor",
+			"material": "minecraft:iron_trapdoor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9578,7 +9561,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:jack_o_lantern",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": true,
@@ -9588,6 +9570,7 @@
 			"interactable": false,
 			"itemType": "minecraft:jack_o_lantern",
 			"key": "minecraft:jack_o_lantern",
+			"material": "minecraft:jack_o_lantern",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9599,7 +9582,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:jigsaw",
 			"blastResistance": 3600000.0,
 			"burnable": false,
 			"collision": true,
@@ -9609,6 +9591,7 @@
 			"interactable": true,
 			"itemType": "minecraft:jigsaw",
 			"key": "minecraft:jigsaw",
+			"material": "minecraft:jigsaw",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9620,7 +9603,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:jukebox",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -9630,6 +9612,7 @@
 			"interactable": true,
 			"itemType": "minecraft:jukebox",
 			"key": "minecraft:jukebox",
+			"material": "minecraft:jukebox",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9641,7 +9624,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:jungle_button",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -9651,6 +9633,7 @@
 			"interactable": true,
 			"itemType": "minecraft:jungle_button",
 			"key": "minecraft:jungle_button",
+			"material": "minecraft:jungle_button",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9662,7 +9645,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:jungle_door",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -9672,6 +9654,7 @@
 			"interactable": true,
 			"itemType": "minecraft:jungle_door",
 			"key": "minecraft:jungle_door",
+			"material": "minecraft:jungle_door",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9683,7 +9666,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:jungle_fence",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -9693,6 +9675,7 @@
 			"interactable": true,
 			"itemType": "minecraft:jungle_fence",
 			"key": "minecraft:jungle_fence",
+			"material": "minecraft:jungle_fence",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9704,7 +9687,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:jungle_fence_gate",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -9714,6 +9696,7 @@
 			"interactable": true,
 			"itemType": "minecraft:jungle_fence_gate",
 			"key": "minecraft:jungle_fence_gate",
+			"material": "minecraft:jungle_fence_gate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9725,7 +9708,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:jungle_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -9735,6 +9717,7 @@
 			"interactable": true,
 			"itemType": "minecraft:jungle_hanging_sign",
 			"key": "minecraft:jungle_hanging_sign",
+			"material": "minecraft:jungle_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9746,7 +9729,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:jungle_leaves",
 			"blastResistance": 0.2,
 			"burnable": true,
 			"collision": true,
@@ -9756,6 +9738,7 @@
 			"interactable": false,
 			"itemType": "minecraft:jungle_leaves",
 			"key": "minecraft:jungle_leaves",
+			"material": "minecraft:jungle_leaves",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9767,7 +9750,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:jungle_log",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -9777,6 +9759,7 @@
 			"interactable": false,
 			"itemType": "minecraft:jungle_log",
 			"key": "minecraft:jungle_log",
+			"material": "minecraft:jungle_log",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9788,7 +9771,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:jungle_planks",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -9798,6 +9780,7 @@
 			"interactable": false,
 			"itemType": "minecraft:jungle_planks",
 			"key": "minecraft:jungle_planks",
+			"material": "minecraft:jungle_planks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9809,7 +9792,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:jungle_pressure_plate",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -9819,6 +9801,7 @@
 			"interactable": false,
 			"itemType": "minecraft:jungle_pressure_plate",
 			"key": "minecraft:jungle_pressure_plate",
+			"material": "minecraft:jungle_pressure_plate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9830,7 +9813,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:jungle_sapling",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -9840,6 +9822,7 @@
 			"interactable": false,
 			"itemType": "minecraft:jungle_sapling",
 			"key": "minecraft:jungle_sapling",
+			"material": "minecraft:jungle_sapling",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9851,7 +9834,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:jungle_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -9861,6 +9843,7 @@
 			"interactable": true,
 			"itemType": "minecraft:jungle_sign",
 			"key": "minecraft:jungle_sign",
+			"material": "minecraft:jungle_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9872,7 +9855,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:jungle_slab",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -9882,6 +9864,7 @@
 			"interactable": false,
 			"itemType": "minecraft:jungle_slab",
 			"key": "minecraft:jungle_slab",
+			"material": "minecraft:jungle_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9893,7 +9876,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:jungle_stairs",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -9903,6 +9885,7 @@
 			"interactable": false,
 			"itemType": "minecraft:jungle_stairs",
 			"key": "minecraft:jungle_stairs",
+			"material": "minecraft:jungle_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9914,7 +9897,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:jungle_trapdoor",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -9924,6 +9906,7 @@
 			"interactable": true,
 			"itemType": "minecraft:jungle_trapdoor",
 			"key": "minecraft:jungle_trapdoor",
+			"material": "minecraft:jungle_trapdoor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9935,7 +9918,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:jungle_wall_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -9945,6 +9927,7 @@
 			"interactable": true,
 			"itemType": "minecraft:jungle_hanging_sign",
 			"key": "minecraft:jungle_wall_hanging_sign",
+			"material": "minecraft:jungle_wall_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9956,7 +9939,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:jungle_wall_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -9966,6 +9948,7 @@
 			"interactable": true,
 			"itemType": "minecraft:jungle_sign",
 			"key": "minecraft:jungle_wall_sign",
+			"material": "minecraft:jungle_wall_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9977,7 +9960,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:jungle_wood",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -9987,6 +9969,7 @@
 			"interactable": false,
 			"itemType": "minecraft:jungle_wood",
 			"key": "minecraft:jungle_wood",
+			"material": "minecraft:jungle_wood",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9998,7 +9981,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:kelp",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -10008,6 +9990,7 @@
 			"interactable": false,
 			"itemType": "minecraft:kelp",
 			"key": "minecraft:kelp",
+			"material": "minecraft:kelp",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10019,7 +10002,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:kelp_plant",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -10027,8 +10009,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": false,
-			"itemType": false,
 			"key": "minecraft:kelp_plant",
+			"material": "minecraft:kelp_plant",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10040,7 +10022,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:ladder",
 			"blastResistance": 0.4,
 			"burnable": false,
 			"collision": true,
@@ -10050,6 +10031,7 @@
 			"interactable": false,
 			"itemType": "minecraft:ladder",
 			"key": "minecraft:ladder",
+			"material": "minecraft:ladder",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10061,7 +10043,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lantern",
 			"blastResistance": 3.5,
 			"burnable": false,
 			"collision": true,
@@ -10071,6 +10052,7 @@
 			"interactable": false,
 			"itemType": "minecraft:lantern",
 			"key": "minecraft:lantern",
+			"material": "minecraft:lantern",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10082,7 +10064,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lapis_block",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -10092,6 +10073,7 @@
 			"interactable": false,
 			"itemType": "minecraft:lapis_block",
 			"key": "minecraft:lapis_block",
+			"material": "minecraft:lapis_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10103,7 +10085,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lapis_ore",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -10113,6 +10094,7 @@
 			"interactable": false,
 			"itemType": "minecraft:lapis_ore",
 			"key": "minecraft:lapis_ore",
+			"material": "minecraft:lapis_ore",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10124,7 +10106,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:large_amethyst_bud",
 			"blastResistance": 1.5,
 			"burnable": false,
 			"collision": true,
@@ -10134,6 +10115,7 @@
 			"interactable": false,
 			"itemType": "minecraft:large_amethyst_bud",
 			"key": "minecraft:large_amethyst_bud",
+			"material": "minecraft:large_amethyst_bud",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10145,7 +10127,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:large_fern",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -10155,6 +10136,7 @@
 			"interactable": false,
 			"itemType": "minecraft:large_fern",
 			"key": "minecraft:large_fern",
+			"material": "minecraft:large_fern",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10166,7 +10148,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lava",
 			"blastResistance": 100.0,
 			"burnable": false,
 			"collision": false,
@@ -10174,8 +10155,8 @@
 			"gravity": false,
 			"hardness": 100.0,
 			"interactable": false,
-			"itemType": false,
 			"key": "minecraft:lava",
+			"material": "minecraft:lava",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10187,7 +10168,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lava_cauldron",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -10197,6 +10177,7 @@
 			"interactable": true,
 			"itemType": "minecraft:cauldron",
 			"key": "minecraft:lava_cauldron",
+			"material": "minecraft:lava_cauldron",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10208,7 +10189,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:leaf_litter",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -10218,6 +10198,7 @@
 			"interactable": false,
 			"itemType": "minecraft:leaf_litter",
 			"key": "minecraft:leaf_litter",
+			"material": "minecraft:leaf_litter",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10229,7 +10210,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lectern",
 			"blastResistance": 2.5,
 			"burnable": true,
 			"collision": true,
@@ -10239,6 +10219,7 @@
 			"interactable": true,
 			"itemType": "minecraft:lectern",
 			"key": "minecraft:lectern",
+			"material": "minecraft:lectern",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10250,7 +10231,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lever",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -10260,6 +10240,7 @@
 			"interactable": true,
 			"itemType": "minecraft:lever",
 			"key": "minecraft:lever",
+			"material": "minecraft:lever",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10271,7 +10252,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light",
 			"blastResistance": 3600000.8,
 			"burnable": false,
 			"collision": true,
@@ -10281,6 +10261,7 @@
 			"interactable": true,
 			"itemType": "minecraft:light",
 			"key": "minecraft:light",
+			"material": "minecraft:light",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10292,7 +10273,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_blue_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -10302,6 +10282,7 @@
 			"interactable": false,
 			"itemType": "minecraft:light_blue_banner",
 			"key": "minecraft:light_blue_banner",
+			"material": "minecraft:light_blue_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10313,7 +10294,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_blue_bed",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": true,
@@ -10323,6 +10303,7 @@
 			"interactable": true,
 			"itemType": "minecraft:light_blue_bed",
 			"key": "minecraft:light_blue_bed",
+			"material": "minecraft:light_blue_bed",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10334,7 +10315,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_blue_candle",
 			"blastResistance": 0.1,
 			"burnable": false,
 			"collision": true,
@@ -10344,6 +10324,7 @@
 			"interactable": true,
 			"itemType": "minecraft:light_blue_candle",
 			"key": "minecraft:light_blue_candle",
+			"material": "minecraft:light_blue_candle",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10355,7 +10336,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_blue_candle_cake",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -10363,8 +10343,8 @@
 			"gravity": false,
 			"hardness": 0.5,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:light_blue_candle_cake",
+			"material": "minecraft:light_blue_candle_cake",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10376,7 +10356,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_blue_carpet",
 			"blastResistance": 0.1,
 			"burnable": true,
 			"collision": true,
@@ -10386,6 +10365,7 @@
 			"interactable": false,
 			"itemType": "minecraft:light_blue_carpet",
 			"key": "minecraft:light_blue_carpet",
+			"material": "minecraft:light_blue_carpet",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10397,7 +10377,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_blue_concrete",
 			"blastResistance": 1.8,
 			"burnable": false,
 			"collision": true,
@@ -10407,6 +10386,7 @@
 			"interactable": false,
 			"itemType": "minecraft:light_blue_concrete",
 			"key": "minecraft:light_blue_concrete",
+			"material": "minecraft:light_blue_concrete",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10418,7 +10398,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_blue_concrete_powder",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -10428,6 +10407,7 @@
 			"interactable": false,
 			"itemType": "minecraft:light_blue_concrete_powder",
 			"key": "minecraft:light_blue_concrete_powder",
+			"material": "minecraft:light_blue_concrete_powder",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10439,7 +10419,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_blue_glazed_terracotta",
 			"blastResistance": 1.4,
 			"burnable": false,
 			"collision": true,
@@ -10449,6 +10428,7 @@
 			"interactable": false,
 			"itemType": "minecraft:light_blue_glazed_terracotta",
 			"key": "minecraft:light_blue_glazed_terracotta",
+			"material": "minecraft:light_blue_glazed_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10460,7 +10440,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_blue_shulker_box",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -10470,6 +10449,7 @@
 			"interactable": true,
 			"itemType": "minecraft:light_blue_shulker_box",
 			"key": "minecraft:light_blue_shulker_box",
+			"material": "minecraft:light_blue_shulker_box",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10481,7 +10461,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_blue_stained_glass",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -10491,6 +10470,7 @@
 			"interactable": false,
 			"itemType": "minecraft:light_blue_stained_glass",
 			"key": "minecraft:light_blue_stained_glass",
+			"material": "minecraft:light_blue_stained_glass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10502,7 +10482,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_blue_stained_glass_pane",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -10512,6 +10491,7 @@
 			"interactable": false,
 			"itemType": "minecraft:light_blue_stained_glass_pane",
 			"key": "minecraft:light_blue_stained_glass_pane",
+			"material": "minecraft:light_blue_stained_glass_pane",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10523,7 +10503,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_blue_terracotta",
 			"blastResistance": 4.2,
 			"burnable": false,
 			"collision": true,
@@ -10533,6 +10512,7 @@
 			"interactable": false,
 			"itemType": "minecraft:light_blue_terracotta",
 			"key": "minecraft:light_blue_terracotta",
+			"material": "minecraft:light_blue_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10544,7 +10524,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_blue_wall_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -10554,6 +10533,7 @@
 			"interactable": false,
 			"itemType": "minecraft:light_blue_banner",
 			"key": "minecraft:light_blue_wall_banner",
+			"material": "minecraft:light_blue_wall_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10565,7 +10545,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_blue_wool",
 			"blastResistance": 0.8,
 			"burnable": true,
 			"collision": true,
@@ -10575,6 +10554,7 @@
 			"interactable": false,
 			"itemType": "minecraft:light_blue_wool",
 			"key": "minecraft:light_blue_wool",
+			"material": "minecraft:light_blue_wool",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10586,7 +10566,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_gray_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -10596,6 +10575,7 @@
 			"interactable": false,
 			"itemType": "minecraft:light_gray_banner",
 			"key": "minecraft:light_gray_banner",
+			"material": "minecraft:light_gray_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10607,7 +10587,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_gray_bed",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": true,
@@ -10617,6 +10596,7 @@
 			"interactable": true,
 			"itemType": "minecraft:light_gray_bed",
 			"key": "minecraft:light_gray_bed",
+			"material": "minecraft:light_gray_bed",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10628,7 +10608,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_gray_candle",
 			"blastResistance": 0.1,
 			"burnable": false,
 			"collision": true,
@@ -10638,6 +10617,7 @@
 			"interactable": true,
 			"itemType": "minecraft:light_gray_candle",
 			"key": "minecraft:light_gray_candle",
+			"material": "minecraft:light_gray_candle",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10649,7 +10629,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_gray_candle_cake",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -10657,8 +10636,8 @@
 			"gravity": false,
 			"hardness": 0.5,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:light_gray_candle_cake",
+			"material": "minecraft:light_gray_candle_cake",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10670,7 +10649,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_gray_carpet",
 			"blastResistance": 0.1,
 			"burnable": true,
 			"collision": true,
@@ -10680,6 +10658,7 @@
 			"interactable": false,
 			"itemType": "minecraft:light_gray_carpet",
 			"key": "minecraft:light_gray_carpet",
+			"material": "minecraft:light_gray_carpet",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10691,7 +10670,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_gray_concrete",
 			"blastResistance": 1.8,
 			"burnable": false,
 			"collision": true,
@@ -10701,6 +10679,7 @@
 			"interactable": false,
 			"itemType": "minecraft:light_gray_concrete",
 			"key": "minecraft:light_gray_concrete",
+			"material": "minecraft:light_gray_concrete",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10712,7 +10691,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_gray_concrete_powder",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -10722,6 +10700,7 @@
 			"interactable": false,
 			"itemType": "minecraft:light_gray_concrete_powder",
 			"key": "minecraft:light_gray_concrete_powder",
+			"material": "minecraft:light_gray_concrete_powder",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10733,7 +10712,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_gray_glazed_terracotta",
 			"blastResistance": 1.4,
 			"burnable": false,
 			"collision": true,
@@ -10743,6 +10721,7 @@
 			"interactable": false,
 			"itemType": "minecraft:light_gray_glazed_terracotta",
 			"key": "minecraft:light_gray_glazed_terracotta",
+			"material": "minecraft:light_gray_glazed_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10754,7 +10733,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_gray_shulker_box",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -10764,6 +10742,7 @@
 			"interactable": true,
 			"itemType": "minecraft:light_gray_shulker_box",
 			"key": "minecraft:light_gray_shulker_box",
+			"material": "minecraft:light_gray_shulker_box",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10775,7 +10754,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_gray_stained_glass",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -10785,6 +10763,7 @@
 			"interactable": false,
 			"itemType": "minecraft:light_gray_stained_glass",
 			"key": "minecraft:light_gray_stained_glass",
+			"material": "minecraft:light_gray_stained_glass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10796,7 +10775,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_gray_stained_glass_pane",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -10806,6 +10784,7 @@
 			"interactable": false,
 			"itemType": "minecraft:light_gray_stained_glass_pane",
 			"key": "minecraft:light_gray_stained_glass_pane",
+			"material": "minecraft:light_gray_stained_glass_pane",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10817,7 +10796,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_gray_terracotta",
 			"blastResistance": 4.2,
 			"burnable": false,
 			"collision": true,
@@ -10827,6 +10805,7 @@
 			"interactable": false,
 			"itemType": "minecraft:light_gray_terracotta",
 			"key": "minecraft:light_gray_terracotta",
+			"material": "minecraft:light_gray_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10838,7 +10817,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_gray_wall_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -10848,6 +10826,7 @@
 			"interactable": false,
 			"itemType": "minecraft:light_gray_banner",
 			"key": "minecraft:light_gray_wall_banner",
+			"material": "minecraft:light_gray_wall_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10859,7 +10838,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_gray_wool",
 			"blastResistance": 0.8,
 			"burnable": true,
 			"collision": true,
@@ -10869,6 +10847,7 @@
 			"interactable": false,
 			"itemType": "minecraft:light_gray_wool",
 			"key": "minecraft:light_gray_wool",
+			"material": "minecraft:light_gray_wool",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10880,7 +10859,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:light_weighted_pressure_plate",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -10890,6 +10868,7 @@
 			"interactable": false,
 			"itemType": "minecraft:light_weighted_pressure_plate",
 			"key": "minecraft:light_weighted_pressure_plate",
+			"material": "minecraft:light_weighted_pressure_plate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10901,7 +10880,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lightning_rod",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -10911,6 +10889,7 @@
 			"interactable": false,
 			"itemType": "minecraft:lightning_rod",
 			"key": "minecraft:lightning_rod",
+			"material": "minecraft:lightning_rod",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10922,7 +10901,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lilac",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -10932,6 +10910,7 @@
 			"interactable": false,
 			"itemType": "minecraft:lilac",
 			"key": "minecraft:lilac",
+			"material": "minecraft:lilac",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10943,7 +10922,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lily_of_the_valley",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -10953,6 +10931,7 @@
 			"interactable": false,
 			"itemType": "minecraft:lily_of_the_valley",
 			"key": "minecraft:lily_of_the_valley",
+			"material": "minecraft:lily_of_the_valley",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10964,7 +10943,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lily_pad",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -10974,6 +10952,7 @@
 			"interactable": false,
 			"itemType": "minecraft:lily_pad",
 			"key": "minecraft:lily_pad",
+			"material": "minecraft:lily_pad",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10985,7 +10964,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lime_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -10995,6 +10973,7 @@
 			"interactable": false,
 			"itemType": "minecraft:lime_banner",
 			"key": "minecraft:lime_banner",
+			"material": "minecraft:lime_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11006,7 +10985,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lime_bed",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": true,
@@ -11016,6 +10994,7 @@
 			"interactable": true,
 			"itemType": "minecraft:lime_bed",
 			"key": "minecraft:lime_bed",
+			"material": "minecraft:lime_bed",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11027,7 +11006,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lime_candle",
 			"blastResistance": 0.1,
 			"burnable": false,
 			"collision": true,
@@ -11037,6 +11015,7 @@
 			"interactable": true,
 			"itemType": "minecraft:lime_candle",
 			"key": "minecraft:lime_candle",
+			"material": "minecraft:lime_candle",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11048,7 +11027,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lime_candle_cake",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -11056,8 +11034,8 @@
 			"gravity": false,
 			"hardness": 0.5,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:lime_candle_cake",
+			"material": "minecraft:lime_candle_cake",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11069,7 +11047,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lime_carpet",
 			"blastResistance": 0.1,
 			"burnable": true,
 			"collision": true,
@@ -11079,6 +11056,7 @@
 			"interactable": false,
 			"itemType": "minecraft:lime_carpet",
 			"key": "minecraft:lime_carpet",
+			"material": "minecraft:lime_carpet",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11090,7 +11068,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lime_concrete",
 			"blastResistance": 1.8,
 			"burnable": false,
 			"collision": true,
@@ -11100,6 +11077,7 @@
 			"interactable": false,
 			"itemType": "minecraft:lime_concrete",
 			"key": "minecraft:lime_concrete",
+			"material": "minecraft:lime_concrete",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11111,7 +11089,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lime_concrete_powder",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -11121,6 +11098,7 @@
 			"interactable": false,
 			"itemType": "minecraft:lime_concrete_powder",
 			"key": "minecraft:lime_concrete_powder",
+			"material": "minecraft:lime_concrete_powder",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11132,7 +11110,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lime_glazed_terracotta",
 			"blastResistance": 1.4,
 			"burnable": false,
 			"collision": true,
@@ -11142,6 +11119,7 @@
 			"interactable": false,
 			"itemType": "minecraft:lime_glazed_terracotta",
 			"key": "minecraft:lime_glazed_terracotta",
+			"material": "minecraft:lime_glazed_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11153,7 +11131,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lime_shulker_box",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -11163,6 +11140,7 @@
 			"interactable": true,
 			"itemType": "minecraft:lime_shulker_box",
 			"key": "minecraft:lime_shulker_box",
+			"material": "minecraft:lime_shulker_box",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11174,7 +11152,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lime_stained_glass",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -11184,6 +11161,7 @@
 			"interactable": false,
 			"itemType": "minecraft:lime_stained_glass",
 			"key": "minecraft:lime_stained_glass",
+			"material": "minecraft:lime_stained_glass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11195,7 +11173,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lime_stained_glass_pane",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -11205,6 +11182,7 @@
 			"interactable": false,
 			"itemType": "minecraft:lime_stained_glass_pane",
 			"key": "minecraft:lime_stained_glass_pane",
+			"material": "minecraft:lime_stained_glass_pane",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11216,7 +11194,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lime_terracotta",
 			"blastResistance": 4.2,
 			"burnable": false,
 			"collision": true,
@@ -11226,6 +11203,7 @@
 			"interactable": false,
 			"itemType": "minecraft:lime_terracotta",
 			"key": "minecraft:lime_terracotta",
+			"material": "minecraft:lime_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11237,7 +11215,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lime_wall_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -11247,6 +11224,7 @@
 			"interactable": false,
 			"itemType": "minecraft:lime_banner",
 			"key": "minecraft:lime_wall_banner",
+			"material": "minecraft:lime_wall_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11258,7 +11236,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lime_wool",
 			"blastResistance": 0.8,
 			"burnable": true,
 			"collision": true,
@@ -11268,6 +11245,7 @@
 			"interactable": false,
 			"itemType": "minecraft:lime_wool",
 			"key": "minecraft:lime_wool",
+			"material": "minecraft:lime_wool",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11279,7 +11257,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:lodestone",
 			"blastResistance": 3.5,
 			"burnable": false,
 			"collision": true,
@@ -11289,6 +11266,7 @@
 			"interactable": false,
 			"itemType": "minecraft:lodestone",
 			"key": "minecraft:lodestone",
+			"material": "minecraft:lodestone",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11300,7 +11278,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:loom",
 			"blastResistance": 2.5,
 			"burnable": false,
 			"collision": true,
@@ -11310,6 +11287,7 @@
 			"interactable": true,
 			"itemType": "minecraft:loom",
 			"key": "minecraft:loom",
+			"material": "minecraft:loom",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11321,7 +11299,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:magenta_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -11331,6 +11308,7 @@
 			"interactable": false,
 			"itemType": "minecraft:magenta_banner",
 			"key": "minecraft:magenta_banner",
+			"material": "minecraft:magenta_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11342,7 +11320,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:magenta_bed",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": true,
@@ -11352,6 +11329,7 @@
 			"interactable": true,
 			"itemType": "minecraft:magenta_bed",
 			"key": "minecraft:magenta_bed",
+			"material": "minecraft:magenta_bed",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11363,7 +11341,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:magenta_candle",
 			"blastResistance": 0.1,
 			"burnable": false,
 			"collision": true,
@@ -11373,6 +11350,7 @@
 			"interactable": true,
 			"itemType": "minecraft:magenta_candle",
 			"key": "minecraft:magenta_candle",
+			"material": "minecraft:magenta_candle",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11384,7 +11362,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:magenta_candle_cake",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -11392,8 +11369,8 @@
 			"gravity": false,
 			"hardness": 0.5,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:magenta_candle_cake",
+			"material": "minecraft:magenta_candle_cake",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11405,7 +11382,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:magenta_carpet",
 			"blastResistance": 0.1,
 			"burnable": true,
 			"collision": true,
@@ -11415,6 +11391,7 @@
 			"interactable": false,
 			"itemType": "minecraft:magenta_carpet",
 			"key": "minecraft:magenta_carpet",
+			"material": "minecraft:magenta_carpet",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11426,7 +11403,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:magenta_concrete",
 			"blastResistance": 1.8,
 			"burnable": false,
 			"collision": true,
@@ -11436,6 +11412,7 @@
 			"interactable": false,
 			"itemType": "minecraft:magenta_concrete",
 			"key": "minecraft:magenta_concrete",
+			"material": "minecraft:magenta_concrete",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11447,7 +11424,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:magenta_concrete_powder",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -11457,6 +11433,7 @@
 			"interactable": false,
 			"itemType": "minecraft:magenta_concrete_powder",
 			"key": "minecraft:magenta_concrete_powder",
+			"material": "minecraft:magenta_concrete_powder",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11468,7 +11445,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:magenta_glazed_terracotta",
 			"blastResistance": 1.4,
 			"burnable": false,
 			"collision": true,
@@ -11478,6 +11454,7 @@
 			"interactable": false,
 			"itemType": "minecraft:magenta_glazed_terracotta",
 			"key": "minecraft:magenta_glazed_terracotta",
+			"material": "minecraft:magenta_glazed_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11489,7 +11466,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:magenta_shulker_box",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -11499,6 +11475,7 @@
 			"interactable": true,
 			"itemType": "minecraft:magenta_shulker_box",
 			"key": "minecraft:magenta_shulker_box",
+			"material": "minecraft:magenta_shulker_box",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11510,7 +11487,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:magenta_stained_glass",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -11520,6 +11496,7 @@
 			"interactable": false,
 			"itemType": "minecraft:magenta_stained_glass",
 			"key": "minecraft:magenta_stained_glass",
+			"material": "minecraft:magenta_stained_glass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11531,7 +11508,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:magenta_stained_glass_pane",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -11541,6 +11517,7 @@
 			"interactable": false,
 			"itemType": "minecraft:magenta_stained_glass_pane",
 			"key": "minecraft:magenta_stained_glass_pane",
+			"material": "minecraft:magenta_stained_glass_pane",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11552,7 +11529,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:magenta_terracotta",
 			"blastResistance": 4.2,
 			"burnable": false,
 			"collision": true,
@@ -11562,6 +11538,7 @@
 			"interactable": false,
 			"itemType": "minecraft:magenta_terracotta",
 			"key": "minecraft:magenta_terracotta",
+			"material": "minecraft:magenta_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11573,7 +11550,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:magenta_wall_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -11583,6 +11559,7 @@
 			"interactable": false,
 			"itemType": "minecraft:magenta_banner",
 			"key": "minecraft:magenta_wall_banner",
+			"material": "minecraft:magenta_wall_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11594,7 +11571,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:magenta_wool",
 			"blastResistance": 0.8,
 			"burnable": true,
 			"collision": true,
@@ -11604,6 +11580,7 @@
 			"interactable": false,
 			"itemType": "minecraft:magenta_wool",
 			"key": "minecraft:magenta_wool",
+			"material": "minecraft:magenta_wool",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11615,7 +11592,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:magma_block",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -11625,6 +11601,7 @@
 			"interactable": false,
 			"itemType": "minecraft:magma_block",
 			"key": "minecraft:magma_block",
+			"material": "minecraft:magma_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11636,7 +11613,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mangrove_button",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -11646,6 +11622,7 @@
 			"interactable": true,
 			"itemType": "minecraft:mangrove_button",
 			"key": "minecraft:mangrove_button",
+			"material": "minecraft:mangrove_button",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11657,7 +11634,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mangrove_door",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -11667,6 +11643,7 @@
 			"interactable": true,
 			"itemType": "minecraft:mangrove_door",
 			"key": "minecraft:mangrove_door",
+			"material": "minecraft:mangrove_door",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11678,7 +11655,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mangrove_fence",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -11688,6 +11664,7 @@
 			"interactable": true,
 			"itemType": "minecraft:mangrove_fence",
 			"key": "minecraft:mangrove_fence",
+			"material": "minecraft:mangrove_fence",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11699,7 +11676,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mangrove_fence_gate",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -11709,6 +11685,7 @@
 			"interactable": true,
 			"itemType": "minecraft:mangrove_fence_gate",
 			"key": "minecraft:mangrove_fence_gate",
+			"material": "minecraft:mangrove_fence_gate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11720,7 +11697,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mangrove_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -11730,6 +11706,7 @@
 			"interactable": true,
 			"itemType": "minecraft:mangrove_hanging_sign",
 			"key": "minecraft:mangrove_hanging_sign",
+			"material": "minecraft:mangrove_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11741,7 +11718,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mangrove_leaves",
 			"blastResistance": 0.2,
 			"burnable": true,
 			"collision": true,
@@ -11751,6 +11727,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mangrove_leaves",
 			"key": "minecraft:mangrove_leaves",
+			"material": "minecraft:mangrove_leaves",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11762,7 +11739,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mangrove_log",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -11772,6 +11748,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mangrove_log",
 			"key": "minecraft:mangrove_log",
+			"material": "minecraft:mangrove_log",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11783,7 +11760,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mangrove_planks",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -11793,6 +11769,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mangrove_planks",
 			"key": "minecraft:mangrove_planks",
+			"material": "minecraft:mangrove_planks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11804,7 +11781,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mangrove_pressure_plate",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -11814,6 +11790,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mangrove_pressure_plate",
 			"key": "minecraft:mangrove_pressure_plate",
+			"material": "minecraft:mangrove_pressure_plate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11825,7 +11802,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mangrove_propagule",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -11835,6 +11811,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mangrove_propagule",
 			"key": "minecraft:mangrove_propagule",
+			"material": "minecraft:mangrove_propagule",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11846,7 +11823,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mangrove_roots",
 			"blastResistance": 0.7,
 			"burnable": true,
 			"collision": true,
@@ -11856,6 +11832,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mangrove_roots",
 			"key": "minecraft:mangrove_roots",
+			"material": "minecraft:mangrove_roots",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11867,7 +11844,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mangrove_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -11877,6 +11853,7 @@
 			"interactable": true,
 			"itemType": "minecraft:mangrove_sign",
 			"key": "minecraft:mangrove_sign",
+			"material": "minecraft:mangrove_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11888,7 +11865,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mangrove_slab",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -11898,6 +11874,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mangrove_slab",
 			"key": "minecraft:mangrove_slab",
+			"material": "minecraft:mangrove_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11909,7 +11886,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mangrove_stairs",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -11919,6 +11895,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mangrove_stairs",
 			"key": "minecraft:mangrove_stairs",
+			"material": "minecraft:mangrove_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11930,7 +11907,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mangrove_trapdoor",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -11940,6 +11916,7 @@
 			"interactable": true,
 			"itemType": "minecraft:mangrove_trapdoor",
 			"key": "minecraft:mangrove_trapdoor",
+			"material": "minecraft:mangrove_trapdoor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11951,7 +11928,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mangrove_wall_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -11961,6 +11937,7 @@
 			"interactable": true,
 			"itemType": "minecraft:mangrove_hanging_sign",
 			"key": "minecraft:mangrove_wall_hanging_sign",
+			"material": "minecraft:mangrove_wall_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11972,7 +11949,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mangrove_wall_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -11982,6 +11958,7 @@
 			"interactable": true,
 			"itemType": "minecraft:mangrove_sign",
 			"key": "minecraft:mangrove_wall_sign",
+			"material": "minecraft:mangrove_wall_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11993,7 +11970,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mangrove_wood",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -12003,6 +11979,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mangrove_wood",
 			"key": "minecraft:mangrove_wood",
+			"material": "minecraft:mangrove_wood",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12014,7 +11991,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:medium_amethyst_bud",
 			"blastResistance": 1.5,
 			"burnable": false,
 			"collision": true,
@@ -12024,6 +12000,7 @@
 			"interactable": false,
 			"itemType": "minecraft:medium_amethyst_bud",
 			"key": "minecraft:medium_amethyst_bud",
+			"material": "minecraft:medium_amethyst_bud",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12035,7 +12012,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:melon",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": true,
@@ -12045,6 +12021,7 @@
 			"interactable": false,
 			"itemType": "minecraft:melon",
 			"key": "minecraft:melon",
+			"material": "minecraft:melon",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12056,7 +12033,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:melon_stem",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -12066,6 +12042,7 @@
 			"interactable": false,
 			"itemType": "minecraft:melon_seeds",
 			"key": "minecraft:melon_stem",
+			"material": "minecraft:melon_stem",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12077,7 +12054,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:moss_block",
 			"blastResistance": 0.1,
 			"burnable": false,
 			"collision": true,
@@ -12087,6 +12063,7 @@
 			"interactable": false,
 			"itemType": "minecraft:moss_block",
 			"key": "minecraft:moss_block",
+			"material": "minecraft:moss_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12098,7 +12075,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:moss_carpet",
 			"blastResistance": 0.1,
 			"burnable": false,
 			"collision": true,
@@ -12108,6 +12084,7 @@
 			"interactable": false,
 			"itemType": "minecraft:moss_carpet",
 			"key": "minecraft:moss_carpet",
+			"material": "minecraft:moss_carpet",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12119,7 +12096,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mossy_cobblestone",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -12129,6 +12105,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mossy_cobblestone",
 			"key": "minecraft:mossy_cobblestone",
+			"material": "minecraft:mossy_cobblestone",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12140,7 +12117,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mossy_cobblestone_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -12150,6 +12126,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mossy_cobblestone_slab",
 			"key": "minecraft:mossy_cobblestone_slab",
+			"material": "minecraft:mossy_cobblestone_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12161,7 +12138,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mossy_cobblestone_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -12171,6 +12147,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mossy_cobblestone_stairs",
 			"key": "minecraft:mossy_cobblestone_stairs",
+			"material": "minecraft:mossy_cobblestone_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12182,7 +12159,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mossy_cobblestone_wall",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -12192,6 +12168,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mossy_cobblestone_wall",
 			"key": "minecraft:mossy_cobblestone_wall",
+			"material": "minecraft:mossy_cobblestone_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12203,7 +12180,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mossy_stone_brick_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -12213,6 +12189,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mossy_stone_brick_slab",
 			"key": "minecraft:mossy_stone_brick_slab",
+			"material": "minecraft:mossy_stone_brick_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12224,7 +12201,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mossy_stone_brick_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -12234,6 +12210,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mossy_stone_brick_stairs",
 			"key": "minecraft:mossy_stone_brick_stairs",
+			"material": "minecraft:mossy_stone_brick_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12245,7 +12222,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mossy_stone_brick_wall",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -12255,6 +12231,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mossy_stone_brick_wall",
 			"key": "minecraft:mossy_stone_brick_wall",
+			"material": "minecraft:mossy_stone_brick_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12266,7 +12243,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mossy_stone_bricks",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -12276,6 +12252,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mossy_stone_bricks",
 			"key": "minecraft:mossy_stone_bricks",
+			"material": "minecraft:mossy_stone_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12287,7 +12264,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:moving_piston",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -12295,8 +12271,8 @@
 			"gravity": false,
 			"hardness": -1.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:moving_piston",
+			"material": "minecraft:moving_piston",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12308,7 +12284,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mud",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -12318,6 +12293,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mud",
 			"key": "minecraft:mud",
+			"material": "minecraft:mud",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12329,7 +12305,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mud_brick_slab",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -12339,6 +12314,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mud_brick_slab",
 			"key": "minecraft:mud_brick_slab",
+			"material": "minecraft:mud_brick_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12350,7 +12326,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mud_brick_stairs",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -12360,6 +12335,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mud_brick_stairs",
 			"key": "minecraft:mud_brick_stairs",
+			"material": "minecraft:mud_brick_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12371,7 +12347,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mud_brick_wall",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -12381,6 +12356,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mud_brick_wall",
 			"key": "minecraft:mud_brick_wall",
+			"material": "minecraft:mud_brick_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12392,7 +12368,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mud_bricks",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -12402,6 +12377,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mud_bricks",
 			"key": "minecraft:mud_bricks",
+			"material": "minecraft:mud_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12413,7 +12389,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:muddy_mangrove_roots",
 			"blastResistance": 0.7,
 			"burnable": false,
 			"collision": true,
@@ -12423,6 +12398,7 @@
 			"interactable": false,
 			"itemType": "minecraft:muddy_mangrove_roots",
 			"key": "minecraft:muddy_mangrove_roots",
+			"material": "minecraft:muddy_mangrove_roots",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12434,7 +12410,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mushroom_stem",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": true,
@@ -12444,6 +12419,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mushroom_stem",
 			"key": "minecraft:mushroom_stem",
+			"material": "minecraft:mushroom_stem",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12455,7 +12431,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:mycelium",
 			"blastResistance": 0.6,
 			"burnable": false,
 			"collision": true,
@@ -12465,6 +12440,7 @@
 			"interactable": false,
 			"itemType": "minecraft:mycelium",
 			"key": "minecraft:mycelium",
+			"material": "minecraft:mycelium",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12476,7 +12452,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:nether_brick_fence",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -12486,6 +12461,7 @@
 			"interactable": true,
 			"itemType": "minecraft:nether_brick_fence",
 			"key": "minecraft:nether_brick_fence",
+			"material": "minecraft:nether_brick_fence",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12497,7 +12473,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:nether_brick_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -12507,6 +12482,7 @@
 			"interactable": false,
 			"itemType": "minecraft:nether_brick_slab",
 			"key": "minecraft:nether_brick_slab",
+			"material": "minecraft:nether_brick_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12518,7 +12494,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:nether_brick_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -12528,6 +12503,7 @@
 			"interactable": false,
 			"itemType": "minecraft:nether_brick_stairs",
 			"key": "minecraft:nether_brick_stairs",
+			"material": "minecraft:nether_brick_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12539,7 +12515,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:nether_brick_wall",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -12549,6 +12524,7 @@
 			"interactable": false,
 			"itemType": "minecraft:nether_brick_wall",
 			"key": "minecraft:nether_brick_wall",
+			"material": "minecraft:nether_brick_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12560,7 +12536,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:nether_bricks",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -12570,6 +12545,7 @@
 			"interactable": false,
 			"itemType": "minecraft:nether_bricks",
 			"key": "minecraft:nether_bricks",
+			"material": "minecraft:nether_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12581,7 +12557,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:nether_gold_ore",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -12591,6 +12566,7 @@
 			"interactable": false,
 			"itemType": "minecraft:nether_gold_ore",
 			"key": "minecraft:nether_gold_ore",
+			"material": "minecraft:nether_gold_ore",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12602,7 +12578,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:nether_portal",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -12610,8 +12585,8 @@
 			"gravity": false,
 			"hardness": -1.0,
 			"interactable": false,
-			"itemType": false,
 			"key": "minecraft:nether_portal",
+			"material": "minecraft:nether_portal",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12623,7 +12598,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:nether_quartz_ore",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -12633,6 +12607,7 @@
 			"interactable": false,
 			"itemType": "minecraft:nether_quartz_ore",
 			"key": "minecraft:nether_quartz_ore",
+			"material": "minecraft:nether_quartz_ore",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12644,7 +12619,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:nether_sprouts",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -12654,6 +12628,7 @@
 			"interactable": false,
 			"itemType": "minecraft:nether_sprouts",
 			"key": "minecraft:nether_sprouts",
+			"material": "minecraft:nether_sprouts",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12665,7 +12640,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:nether_wart",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -12675,6 +12649,7 @@
 			"interactable": false,
 			"itemType": "minecraft:nether_wart",
 			"key": "minecraft:nether_wart",
+			"material": "minecraft:nether_wart",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12686,7 +12661,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:nether_wart_block",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": true,
@@ -12696,6 +12670,7 @@
 			"interactable": false,
 			"itemType": "minecraft:nether_wart_block",
 			"key": "minecraft:nether_wart_block",
+			"material": "minecraft:nether_wart_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12707,7 +12682,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:netherite_block",
 			"blastResistance": 1200.0,
 			"burnable": false,
 			"collision": true,
@@ -12717,6 +12691,7 @@
 			"interactable": false,
 			"itemType": "minecraft:netherite_block",
 			"key": "minecraft:netherite_block",
+			"material": "minecraft:netherite_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12728,7 +12703,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:netherrack",
 			"blastResistance": 0.4,
 			"burnable": false,
 			"collision": true,
@@ -12738,6 +12712,7 @@
 			"interactable": false,
 			"itemType": "minecraft:netherrack",
 			"key": "minecraft:netherrack",
+			"material": "minecraft:netherrack",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12749,7 +12724,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:note_block",
 			"blastResistance": 0.8,
 			"burnable": false,
 			"collision": true,
@@ -12759,6 +12733,7 @@
 			"interactable": true,
 			"itemType": "minecraft:note_block",
 			"key": "minecraft:note_block",
+			"material": "minecraft:note_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12770,7 +12745,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oak_button",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -12780,6 +12754,7 @@
 			"interactable": true,
 			"itemType": "minecraft:oak_button",
 			"key": "minecraft:oak_button",
+			"material": "minecraft:oak_button",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12791,7 +12766,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oak_door",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -12801,6 +12775,7 @@
 			"interactable": true,
 			"itemType": "minecraft:oak_door",
 			"key": "minecraft:oak_door",
+			"material": "minecraft:oak_door",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12812,7 +12787,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oak_fence",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -12822,6 +12796,7 @@
 			"interactable": true,
 			"itemType": "minecraft:oak_fence",
 			"key": "minecraft:oak_fence",
+			"material": "minecraft:oak_fence",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12833,7 +12808,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oak_fence_gate",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -12843,6 +12817,7 @@
 			"interactable": true,
 			"itemType": "minecraft:oak_fence_gate",
 			"key": "minecraft:oak_fence_gate",
+			"material": "minecraft:oak_fence_gate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12854,7 +12829,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oak_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -12864,6 +12838,7 @@
 			"interactable": true,
 			"itemType": "minecraft:oak_hanging_sign",
 			"key": "minecraft:oak_hanging_sign",
+			"material": "minecraft:oak_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12875,7 +12850,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oak_leaves",
 			"blastResistance": 0.2,
 			"burnable": true,
 			"collision": true,
@@ -12885,6 +12859,7 @@
 			"interactable": false,
 			"itemType": "minecraft:oak_leaves",
 			"key": "minecraft:oak_leaves",
+			"material": "minecraft:oak_leaves",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12896,7 +12871,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oak_log",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -12906,6 +12880,7 @@
 			"interactable": false,
 			"itemType": "minecraft:oak_log",
 			"key": "minecraft:oak_log",
+			"material": "minecraft:oak_log",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12917,7 +12892,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oak_planks",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -12927,6 +12901,7 @@
 			"interactable": false,
 			"itemType": "minecraft:oak_planks",
 			"key": "minecraft:oak_planks",
+			"material": "minecraft:oak_planks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12938,7 +12913,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oak_pressure_plate",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -12948,6 +12922,7 @@
 			"interactable": false,
 			"itemType": "minecraft:oak_pressure_plate",
 			"key": "minecraft:oak_pressure_plate",
+			"material": "minecraft:oak_pressure_plate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12959,7 +12934,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oak_sapling",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -12969,6 +12943,7 @@
 			"interactable": false,
 			"itemType": "minecraft:oak_sapling",
 			"key": "minecraft:oak_sapling",
+			"material": "minecraft:oak_sapling",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12980,7 +12955,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oak_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -12990,6 +12964,7 @@
 			"interactable": true,
 			"itemType": "minecraft:oak_sign",
 			"key": "minecraft:oak_sign",
+			"material": "minecraft:oak_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13001,7 +12976,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oak_slab",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -13011,6 +12985,7 @@
 			"interactable": false,
 			"itemType": "minecraft:oak_slab",
 			"key": "minecraft:oak_slab",
+			"material": "minecraft:oak_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13022,7 +12997,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oak_stairs",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -13032,6 +13006,7 @@
 			"interactable": false,
 			"itemType": "minecraft:oak_stairs",
 			"key": "minecraft:oak_stairs",
+			"material": "minecraft:oak_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13043,7 +13018,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oak_trapdoor",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -13053,6 +13027,7 @@
 			"interactable": true,
 			"itemType": "minecraft:oak_trapdoor",
 			"key": "minecraft:oak_trapdoor",
+			"material": "minecraft:oak_trapdoor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13064,7 +13039,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oak_wall_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -13074,6 +13048,7 @@
 			"interactable": true,
 			"itemType": "minecraft:oak_hanging_sign",
 			"key": "minecraft:oak_wall_hanging_sign",
+			"material": "minecraft:oak_wall_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13085,7 +13060,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oak_wall_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -13095,6 +13069,7 @@
 			"interactable": true,
 			"itemType": "minecraft:oak_sign",
 			"key": "minecraft:oak_wall_sign",
+			"material": "minecraft:oak_wall_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13106,7 +13081,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oak_wood",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -13116,6 +13090,7 @@
 			"interactable": false,
 			"itemType": "minecraft:oak_wood",
 			"key": "minecraft:oak_wood",
+			"material": "minecraft:oak_wood",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13127,7 +13102,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:observer",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -13137,6 +13111,7 @@
 			"interactable": false,
 			"itemType": "minecraft:observer",
 			"key": "minecraft:observer",
+			"material": "minecraft:observer",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13148,7 +13123,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:obsidian",
 			"blastResistance": 1200.0,
 			"burnable": false,
 			"collision": true,
@@ -13158,6 +13132,7 @@
 			"interactable": false,
 			"itemType": "minecraft:obsidian",
 			"key": "minecraft:obsidian",
+			"material": "minecraft:obsidian",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13169,7 +13144,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:ochre_froglight",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -13179,6 +13153,7 @@
 			"interactable": false,
 			"itemType": "minecraft:ochre_froglight",
 			"key": "minecraft:ochre_froglight",
+			"material": "minecraft:ochre_froglight",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13190,7 +13165,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:open_eyeblossom",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -13200,6 +13174,7 @@
 			"interactable": false,
 			"itemType": "minecraft:open_eyeblossom",
 			"key": "minecraft:open_eyeblossom",
+			"material": "minecraft:open_eyeblossom",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13211,7 +13186,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:orange_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -13221,6 +13195,7 @@
 			"interactable": false,
 			"itemType": "minecraft:orange_banner",
 			"key": "minecraft:orange_banner",
+			"material": "minecraft:orange_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13232,7 +13207,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:orange_bed",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": true,
@@ -13242,6 +13216,7 @@
 			"interactable": true,
 			"itemType": "minecraft:orange_bed",
 			"key": "minecraft:orange_bed",
+			"material": "minecraft:orange_bed",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13253,7 +13228,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:orange_candle",
 			"blastResistance": 0.1,
 			"burnable": false,
 			"collision": true,
@@ -13263,6 +13237,7 @@
 			"interactable": true,
 			"itemType": "minecraft:orange_candle",
 			"key": "minecraft:orange_candle",
+			"material": "minecraft:orange_candle",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13274,7 +13249,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:orange_candle_cake",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -13282,8 +13256,8 @@
 			"gravity": false,
 			"hardness": 0.5,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:orange_candle_cake",
+			"material": "minecraft:orange_candle_cake",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13295,7 +13269,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:orange_carpet",
 			"blastResistance": 0.1,
 			"burnable": true,
 			"collision": true,
@@ -13305,6 +13278,7 @@
 			"interactable": false,
 			"itemType": "minecraft:orange_carpet",
 			"key": "minecraft:orange_carpet",
+			"material": "minecraft:orange_carpet",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13316,7 +13290,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:orange_concrete",
 			"blastResistance": 1.8,
 			"burnable": false,
 			"collision": true,
@@ -13326,6 +13299,7 @@
 			"interactable": false,
 			"itemType": "minecraft:orange_concrete",
 			"key": "minecraft:orange_concrete",
+			"material": "minecraft:orange_concrete",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13337,7 +13311,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:orange_concrete_powder",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -13347,6 +13320,7 @@
 			"interactable": false,
 			"itemType": "minecraft:orange_concrete_powder",
 			"key": "minecraft:orange_concrete_powder",
+			"material": "minecraft:orange_concrete_powder",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13358,7 +13332,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:orange_glazed_terracotta",
 			"blastResistance": 1.4,
 			"burnable": false,
 			"collision": true,
@@ -13368,6 +13341,7 @@
 			"interactable": false,
 			"itemType": "minecraft:orange_glazed_terracotta",
 			"key": "minecraft:orange_glazed_terracotta",
+			"material": "minecraft:orange_glazed_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13379,7 +13353,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:orange_shulker_box",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -13389,6 +13362,7 @@
 			"interactable": true,
 			"itemType": "minecraft:orange_shulker_box",
 			"key": "minecraft:orange_shulker_box",
+			"material": "minecraft:orange_shulker_box",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13400,7 +13374,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:orange_stained_glass",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -13410,6 +13383,7 @@
 			"interactable": false,
 			"itemType": "minecraft:orange_stained_glass",
 			"key": "minecraft:orange_stained_glass",
+			"material": "minecraft:orange_stained_glass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13421,7 +13395,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:orange_stained_glass_pane",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -13431,6 +13404,7 @@
 			"interactable": false,
 			"itemType": "minecraft:orange_stained_glass_pane",
 			"key": "minecraft:orange_stained_glass_pane",
+			"material": "minecraft:orange_stained_glass_pane",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13442,7 +13416,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:orange_terracotta",
 			"blastResistance": 4.2,
 			"burnable": false,
 			"collision": true,
@@ -13452,6 +13425,7 @@
 			"interactable": false,
 			"itemType": "minecraft:orange_terracotta",
 			"key": "minecraft:orange_terracotta",
+			"material": "minecraft:orange_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13463,7 +13437,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:orange_tulip",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -13473,6 +13446,7 @@
 			"interactable": false,
 			"itemType": "minecraft:orange_tulip",
 			"key": "minecraft:orange_tulip",
+			"material": "minecraft:orange_tulip",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13484,7 +13458,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:orange_wall_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -13494,6 +13467,7 @@
 			"interactable": false,
 			"itemType": "minecraft:orange_banner",
 			"key": "minecraft:orange_wall_banner",
+			"material": "minecraft:orange_wall_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13505,7 +13479,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:orange_wool",
 			"blastResistance": 0.8,
 			"burnable": true,
 			"collision": true,
@@ -13515,6 +13488,7 @@
 			"interactable": false,
 			"itemType": "minecraft:orange_wool",
 			"key": "minecraft:orange_wool",
+			"material": "minecraft:orange_wool",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13526,7 +13500,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oxeye_daisy",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -13536,6 +13509,7 @@
 			"interactable": false,
 			"itemType": "minecraft:oxeye_daisy",
 			"key": "minecraft:oxeye_daisy",
+			"material": "minecraft:oxeye_daisy",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13547,7 +13521,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oxidized_chiseled_copper",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -13557,6 +13530,7 @@
 			"interactable": false,
 			"itemType": "minecraft:oxidized_chiseled_copper",
 			"key": "minecraft:oxidized_chiseled_copper",
+			"material": "minecraft:oxidized_chiseled_copper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13568,7 +13542,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oxidized_copper",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -13578,6 +13551,7 @@
 			"interactable": false,
 			"itemType": "minecraft:oxidized_copper",
 			"key": "minecraft:oxidized_copper",
+			"material": "minecraft:oxidized_copper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13589,7 +13563,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oxidized_copper_bulb",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -13599,6 +13572,7 @@
 			"interactable": false,
 			"itemType": "minecraft:oxidized_copper_bulb",
 			"key": "minecraft:oxidized_copper_bulb",
+			"material": "minecraft:oxidized_copper_bulb",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13610,7 +13584,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oxidized_copper_door",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -13620,6 +13593,7 @@
 			"interactable": true,
 			"itemType": "minecraft:oxidized_copper_door",
 			"key": "minecraft:oxidized_copper_door",
+			"material": "minecraft:oxidized_copper_door",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13631,7 +13605,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oxidized_copper_grate",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -13641,6 +13614,7 @@
 			"interactable": false,
 			"itemType": "minecraft:oxidized_copper_grate",
 			"key": "minecraft:oxidized_copper_grate",
+			"material": "minecraft:oxidized_copper_grate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13652,7 +13626,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oxidized_copper_trapdoor",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -13662,6 +13635,7 @@
 			"interactable": true,
 			"itemType": "minecraft:oxidized_copper_trapdoor",
 			"key": "minecraft:oxidized_copper_trapdoor",
+			"material": "minecraft:oxidized_copper_trapdoor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13673,7 +13647,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oxidized_cut_copper",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -13683,6 +13656,7 @@
 			"interactable": false,
 			"itemType": "minecraft:oxidized_cut_copper",
 			"key": "minecraft:oxidized_cut_copper",
+			"material": "minecraft:oxidized_cut_copper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13694,7 +13668,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oxidized_cut_copper_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -13704,6 +13677,7 @@
 			"interactable": false,
 			"itemType": "minecraft:oxidized_cut_copper_slab",
 			"key": "minecraft:oxidized_cut_copper_slab",
+			"material": "minecraft:oxidized_cut_copper_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13715,7 +13689,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:oxidized_cut_copper_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -13725,6 +13698,7 @@
 			"interactable": false,
 			"itemType": "minecraft:oxidized_cut_copper_stairs",
 			"key": "minecraft:oxidized_cut_copper_stairs",
+			"material": "minecraft:oxidized_cut_copper_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13736,7 +13710,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:packed_ice",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -13746,6 +13719,7 @@
 			"interactable": false,
 			"itemType": "minecraft:packed_ice",
 			"key": "minecraft:packed_ice",
+			"material": "minecraft:packed_ice",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13757,7 +13731,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:packed_mud",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -13767,6 +13740,7 @@
 			"interactable": false,
 			"itemType": "minecraft:packed_mud",
 			"key": "minecraft:packed_mud",
+			"material": "minecraft:packed_mud",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13778,7 +13752,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pale_hanging_moss",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -13788,6 +13761,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pale_hanging_moss",
 			"key": "minecraft:pale_hanging_moss",
+			"material": "minecraft:pale_hanging_moss",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13799,7 +13773,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pale_moss_block",
 			"blastResistance": 0.1,
 			"burnable": true,
 			"collision": true,
@@ -13809,6 +13782,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pale_moss_block",
 			"key": "minecraft:pale_moss_block",
+			"material": "minecraft:pale_moss_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13820,7 +13794,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pale_moss_carpet",
 			"blastResistance": 0.1,
 			"burnable": true,
 			"collision": true,
@@ -13830,6 +13803,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pale_moss_carpet",
 			"key": "minecraft:pale_moss_carpet",
+			"material": "minecraft:pale_moss_carpet",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13841,7 +13815,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pale_oak_button",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -13851,6 +13824,7 @@
 			"interactable": true,
 			"itemType": "minecraft:pale_oak_button",
 			"key": "minecraft:pale_oak_button",
+			"material": "minecraft:pale_oak_button",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13862,7 +13836,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pale_oak_door",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -13872,6 +13845,7 @@
 			"interactable": true,
 			"itemType": "minecraft:pale_oak_door",
 			"key": "minecraft:pale_oak_door",
+			"material": "minecraft:pale_oak_door",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13883,7 +13857,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pale_oak_fence",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -13893,6 +13866,7 @@
 			"interactable": true,
 			"itemType": "minecraft:pale_oak_fence",
 			"key": "minecraft:pale_oak_fence",
+			"material": "minecraft:pale_oak_fence",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13904,7 +13878,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pale_oak_fence_gate",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -13914,6 +13887,7 @@
 			"interactable": true,
 			"itemType": "minecraft:pale_oak_fence_gate",
 			"key": "minecraft:pale_oak_fence_gate",
+			"material": "minecraft:pale_oak_fence_gate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13925,7 +13899,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pale_oak_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -13935,6 +13908,7 @@
 			"interactable": true,
 			"itemType": "minecraft:pale_oak_hanging_sign",
 			"key": "minecraft:pale_oak_hanging_sign",
+			"material": "minecraft:pale_oak_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13946,7 +13920,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pale_oak_leaves",
 			"blastResistance": 0.2,
 			"burnable": true,
 			"collision": true,
@@ -13956,6 +13929,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pale_oak_leaves",
 			"key": "minecraft:pale_oak_leaves",
+			"material": "minecraft:pale_oak_leaves",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13967,7 +13941,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pale_oak_log",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -13977,6 +13950,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pale_oak_log",
 			"key": "minecraft:pale_oak_log",
+			"material": "minecraft:pale_oak_log",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13988,7 +13962,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pale_oak_planks",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -13998,6 +13971,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pale_oak_planks",
 			"key": "minecraft:pale_oak_planks",
+			"material": "minecraft:pale_oak_planks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14009,7 +13983,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pale_oak_pressure_plate",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -14019,6 +13992,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pale_oak_pressure_plate",
 			"key": "minecraft:pale_oak_pressure_plate",
+			"material": "minecraft:pale_oak_pressure_plate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14030,7 +14004,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pale_oak_sapling",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -14040,6 +14013,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pale_oak_sapling",
 			"key": "minecraft:pale_oak_sapling",
+			"material": "minecraft:pale_oak_sapling",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14051,7 +14025,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pale_oak_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -14061,6 +14034,7 @@
 			"interactable": true,
 			"itemType": "minecraft:pale_oak_sign",
 			"key": "minecraft:pale_oak_sign",
+			"material": "minecraft:pale_oak_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14072,7 +14046,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pale_oak_slab",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -14082,6 +14055,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pale_oak_slab",
 			"key": "minecraft:pale_oak_slab",
+			"material": "minecraft:pale_oak_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14093,7 +14067,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pale_oak_stairs",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -14103,6 +14076,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pale_oak_stairs",
 			"key": "minecraft:pale_oak_stairs",
+			"material": "minecraft:pale_oak_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14114,7 +14088,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pale_oak_trapdoor",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -14124,6 +14097,7 @@
 			"interactable": true,
 			"itemType": "minecraft:pale_oak_trapdoor",
 			"key": "minecraft:pale_oak_trapdoor",
+			"material": "minecraft:pale_oak_trapdoor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14135,7 +14109,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pale_oak_wall_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -14145,6 +14118,7 @@
 			"interactable": true,
 			"itemType": "minecraft:pale_oak_hanging_sign",
 			"key": "minecraft:pale_oak_wall_hanging_sign",
+			"material": "minecraft:pale_oak_wall_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14156,7 +14130,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pale_oak_wall_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -14166,6 +14139,7 @@
 			"interactable": true,
 			"itemType": "minecraft:pale_oak_sign",
 			"key": "minecraft:pale_oak_wall_sign",
+			"material": "minecraft:pale_oak_wall_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14177,7 +14151,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pale_oak_wood",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -14187,6 +14160,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pale_oak_wood",
 			"key": "minecraft:pale_oak_wood",
+			"material": "minecraft:pale_oak_wood",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14198,7 +14172,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pearlescent_froglight",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -14208,6 +14181,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pearlescent_froglight",
 			"key": "minecraft:pearlescent_froglight",
+			"material": "minecraft:pearlescent_froglight",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14219,7 +14193,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:peony",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -14229,6 +14202,7 @@
 			"interactable": false,
 			"itemType": "minecraft:peony",
 			"key": "minecraft:peony",
+			"material": "minecraft:peony",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14240,7 +14214,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:petrified_oak_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -14250,6 +14223,7 @@
 			"interactable": false,
 			"itemType": "minecraft:petrified_oak_slab",
 			"key": "minecraft:petrified_oak_slab",
+			"material": "minecraft:petrified_oak_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14261,7 +14235,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:piglin_head",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": true,
@@ -14271,6 +14244,7 @@
 			"interactable": false,
 			"itemType": "minecraft:piglin_head",
 			"key": "minecraft:piglin_head",
+			"material": "minecraft:piglin_head",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14282,7 +14256,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:piglin_wall_head",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": true,
@@ -14292,6 +14265,7 @@
 			"interactable": false,
 			"itemType": "minecraft:piglin_head",
 			"key": "minecraft:piglin_wall_head",
+			"material": "minecraft:piglin_wall_head",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14303,7 +14277,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pink_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -14313,6 +14286,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pink_banner",
 			"key": "minecraft:pink_banner",
+			"material": "minecraft:pink_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14324,7 +14298,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pink_bed",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": true,
@@ -14334,6 +14307,7 @@
 			"interactable": true,
 			"itemType": "minecraft:pink_bed",
 			"key": "minecraft:pink_bed",
+			"material": "minecraft:pink_bed",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14345,7 +14319,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pink_candle",
 			"blastResistance": 0.1,
 			"burnable": false,
 			"collision": true,
@@ -14355,6 +14328,7 @@
 			"interactable": true,
 			"itemType": "minecraft:pink_candle",
 			"key": "minecraft:pink_candle",
+			"material": "minecraft:pink_candle",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14366,7 +14340,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pink_candle_cake",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -14374,8 +14347,8 @@
 			"gravity": false,
 			"hardness": 0.5,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:pink_candle_cake",
+			"material": "minecraft:pink_candle_cake",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14387,7 +14360,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pink_carpet",
 			"blastResistance": 0.1,
 			"burnable": true,
 			"collision": true,
@@ -14397,6 +14369,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pink_carpet",
 			"key": "minecraft:pink_carpet",
+			"material": "minecraft:pink_carpet",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14408,7 +14381,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pink_concrete",
 			"blastResistance": 1.8,
 			"burnable": false,
 			"collision": true,
@@ -14418,6 +14390,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pink_concrete",
 			"key": "minecraft:pink_concrete",
+			"material": "minecraft:pink_concrete",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14429,7 +14402,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pink_concrete_powder",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -14439,6 +14411,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pink_concrete_powder",
 			"key": "minecraft:pink_concrete_powder",
+			"material": "minecraft:pink_concrete_powder",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14450,7 +14423,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pink_glazed_terracotta",
 			"blastResistance": 1.4,
 			"burnable": false,
 			"collision": true,
@@ -14460,6 +14432,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pink_glazed_terracotta",
 			"key": "minecraft:pink_glazed_terracotta",
+			"material": "minecraft:pink_glazed_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14471,7 +14444,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pink_petals",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -14481,6 +14453,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pink_petals",
 			"key": "minecraft:pink_petals",
+			"material": "minecraft:pink_petals",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14492,7 +14465,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pink_shulker_box",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -14502,6 +14474,7 @@
 			"interactable": true,
 			"itemType": "minecraft:pink_shulker_box",
 			"key": "minecraft:pink_shulker_box",
+			"material": "minecraft:pink_shulker_box",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14513,7 +14486,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pink_stained_glass",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -14523,6 +14495,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pink_stained_glass",
 			"key": "minecraft:pink_stained_glass",
+			"material": "minecraft:pink_stained_glass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14534,7 +14507,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pink_stained_glass_pane",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -14544,6 +14516,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pink_stained_glass_pane",
 			"key": "minecraft:pink_stained_glass_pane",
+			"material": "minecraft:pink_stained_glass_pane",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14555,7 +14528,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pink_terracotta",
 			"blastResistance": 4.2,
 			"burnable": false,
 			"collision": true,
@@ -14565,6 +14537,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pink_terracotta",
 			"key": "minecraft:pink_terracotta",
+			"material": "minecraft:pink_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14576,7 +14549,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pink_tulip",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -14586,6 +14558,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pink_tulip",
 			"key": "minecraft:pink_tulip",
+			"material": "minecraft:pink_tulip",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14597,7 +14570,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pink_wall_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -14607,6 +14579,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pink_banner",
 			"key": "minecraft:pink_wall_banner",
+			"material": "minecraft:pink_wall_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14618,7 +14591,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pink_wool",
 			"blastResistance": 0.8,
 			"burnable": true,
 			"collision": true,
@@ -14628,6 +14600,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pink_wool",
 			"key": "minecraft:pink_wool",
+			"material": "minecraft:pink_wool",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14639,7 +14612,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:piston",
 			"blastResistance": 1.5,
 			"burnable": false,
 			"collision": true,
@@ -14649,6 +14621,7 @@
 			"interactable": false,
 			"itemType": "minecraft:piston",
 			"key": "minecraft:piston",
+			"material": "minecraft:piston",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14660,7 +14633,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:piston_head",
 			"blastResistance": 1.5,
 			"burnable": false,
 			"collision": true,
@@ -14668,8 +14640,8 @@
 			"gravity": false,
 			"hardness": 1.5,
 			"interactable": false,
-			"itemType": false,
 			"key": "minecraft:piston_head",
+			"material": "minecraft:piston_head",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14681,7 +14653,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pitcher_crop",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -14691,6 +14662,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pitcher_pod",
 			"key": "minecraft:pitcher_crop",
+			"material": "minecraft:pitcher_crop",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14702,7 +14674,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pitcher_plant",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -14712,6 +14683,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pitcher_plant",
 			"key": "minecraft:pitcher_plant",
+			"material": "minecraft:pitcher_plant",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14723,7 +14695,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:player_head",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": true,
@@ -14733,6 +14704,7 @@
 			"interactable": false,
 			"itemType": "minecraft:player_head",
 			"key": "minecraft:player_head",
+			"material": "minecraft:player_head",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14744,7 +14716,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:player_wall_head",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": true,
@@ -14754,6 +14725,7 @@
 			"interactable": false,
 			"itemType": "minecraft:player_head",
 			"key": "minecraft:player_wall_head",
+			"material": "minecraft:player_wall_head",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14765,7 +14737,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:podzol",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -14775,6 +14746,7 @@
 			"interactable": false,
 			"itemType": "minecraft:podzol",
 			"key": "minecraft:podzol",
+			"material": "minecraft:podzol",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14786,7 +14758,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pointed_dripstone",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -14796,6 +14767,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pointed_dripstone",
 			"key": "minecraft:pointed_dripstone",
+			"material": "minecraft:pointed_dripstone",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14807,7 +14779,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_andesite",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -14817,6 +14788,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_andesite",
 			"key": "minecraft:polished_andesite",
+			"material": "minecraft:polished_andesite",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14828,7 +14800,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_andesite_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -14838,6 +14809,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_andesite_slab",
 			"key": "minecraft:polished_andesite_slab",
+			"material": "minecraft:polished_andesite_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14849,7 +14821,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_andesite_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -14859,6 +14830,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_andesite_stairs",
 			"key": "minecraft:polished_andesite_stairs",
+			"material": "minecraft:polished_andesite_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14870,7 +14842,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_basalt",
 			"blastResistance": 4.2,
 			"burnable": false,
 			"collision": true,
@@ -14880,6 +14851,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_basalt",
 			"key": "minecraft:polished_basalt",
+			"material": "minecraft:polished_basalt",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14891,7 +14863,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_blackstone",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -14901,6 +14872,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_blackstone",
 			"key": "minecraft:polished_blackstone",
+			"material": "minecraft:polished_blackstone",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14912,7 +14884,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_blackstone_brick_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -14922,6 +14893,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_blackstone_brick_slab",
 			"key": "minecraft:polished_blackstone_brick_slab",
+			"material": "minecraft:polished_blackstone_brick_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14933,7 +14905,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_blackstone_brick_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -14943,6 +14914,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_blackstone_brick_stairs",
 			"key": "minecraft:polished_blackstone_brick_stairs",
+			"material": "minecraft:polished_blackstone_brick_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14954,7 +14926,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_blackstone_brick_wall",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -14964,6 +14935,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_blackstone_brick_wall",
 			"key": "minecraft:polished_blackstone_brick_wall",
+			"material": "minecraft:polished_blackstone_brick_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14975,7 +14947,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_blackstone_bricks",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -14985,6 +14956,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_blackstone_bricks",
 			"key": "minecraft:polished_blackstone_bricks",
+			"material": "minecraft:polished_blackstone_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14996,7 +14968,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_blackstone_button",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -15006,6 +14977,7 @@
 			"interactable": true,
 			"itemType": "minecraft:polished_blackstone_button",
 			"key": "minecraft:polished_blackstone_button",
+			"material": "minecraft:polished_blackstone_button",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15017,7 +14989,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_blackstone_pressure_plate",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -15027,6 +14998,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_blackstone_pressure_plate",
 			"key": "minecraft:polished_blackstone_pressure_plate",
+			"material": "minecraft:polished_blackstone_pressure_plate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15038,7 +15010,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_blackstone_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -15048,6 +15019,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_blackstone_slab",
 			"key": "minecraft:polished_blackstone_slab",
+			"material": "minecraft:polished_blackstone_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15059,7 +15031,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_blackstone_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -15069,6 +15040,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_blackstone_stairs",
 			"key": "minecraft:polished_blackstone_stairs",
+			"material": "minecraft:polished_blackstone_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15080,7 +15052,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_blackstone_wall",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -15090,6 +15061,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_blackstone_wall",
 			"key": "minecraft:polished_blackstone_wall",
+			"material": "minecraft:polished_blackstone_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15101,7 +15073,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_deepslate",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -15111,6 +15082,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_deepslate",
 			"key": "minecraft:polished_deepslate",
+			"material": "minecraft:polished_deepslate",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15122,7 +15094,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_deepslate_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -15132,6 +15103,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_deepslate_slab",
 			"key": "minecraft:polished_deepslate_slab",
+			"material": "minecraft:polished_deepslate_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15143,7 +15115,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_deepslate_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -15153,6 +15124,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_deepslate_stairs",
 			"key": "minecraft:polished_deepslate_stairs",
+			"material": "minecraft:polished_deepslate_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15164,7 +15136,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_deepslate_wall",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -15174,6 +15145,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_deepslate_wall",
 			"key": "minecraft:polished_deepslate_wall",
+			"material": "minecraft:polished_deepslate_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15185,7 +15157,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_diorite",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -15195,6 +15166,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_diorite",
 			"key": "minecraft:polished_diorite",
+			"material": "minecraft:polished_diorite",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15206,7 +15178,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_diorite_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -15216,6 +15187,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_diorite_slab",
 			"key": "minecraft:polished_diorite_slab",
+			"material": "minecraft:polished_diorite_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15227,7 +15199,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_diorite_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -15237,6 +15208,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_diorite_stairs",
 			"key": "minecraft:polished_diorite_stairs",
+			"material": "minecraft:polished_diorite_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15248,7 +15220,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_granite",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -15258,6 +15229,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_granite",
 			"key": "minecraft:polished_granite",
+			"material": "minecraft:polished_granite",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15269,7 +15241,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_granite_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -15279,6 +15250,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_granite_slab",
 			"key": "minecraft:polished_granite_slab",
+			"material": "minecraft:polished_granite_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15290,7 +15262,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_granite_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -15300,6 +15271,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_granite_stairs",
 			"key": "minecraft:polished_granite_stairs",
+			"material": "minecraft:polished_granite_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15311,7 +15283,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_tuff",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -15321,6 +15292,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_tuff",
 			"key": "minecraft:polished_tuff",
+			"material": "minecraft:polished_tuff",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15332,7 +15304,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_tuff_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -15342,6 +15313,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_tuff_slab",
 			"key": "minecraft:polished_tuff_slab",
+			"material": "minecraft:polished_tuff_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15353,7 +15325,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_tuff_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -15363,6 +15334,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_tuff_stairs",
 			"key": "minecraft:polished_tuff_stairs",
+			"material": "minecraft:polished_tuff_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15374,7 +15346,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:polished_tuff_wall",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -15384,6 +15355,7 @@
 			"interactable": false,
 			"itemType": "minecraft:polished_tuff_wall",
 			"key": "minecraft:polished_tuff_wall",
+			"material": "minecraft:polished_tuff_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15395,7 +15367,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:poppy",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -15405,6 +15376,7 @@
 			"interactable": false,
 			"itemType": "minecraft:poppy",
 			"key": "minecraft:poppy",
+			"material": "minecraft:poppy",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15416,7 +15388,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potatoes",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -15426,6 +15397,7 @@
 			"interactable": false,
 			"itemType": "minecraft:potato",
 			"key": "minecraft:potatoes",
+			"material": "minecraft:potatoes",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15437,7 +15409,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_acacia_sapling",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15445,8 +15416,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_acacia_sapling",
+			"material": "minecraft:potted_acacia_sapling",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15458,7 +15429,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_allium",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15466,8 +15436,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_allium",
+			"material": "minecraft:potted_allium",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15479,7 +15449,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_azalea_bush",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15487,8 +15456,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_azalea_bush",
+			"material": "minecraft:potted_azalea_bush",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15500,7 +15469,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_azure_bluet",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15508,8 +15476,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_azure_bluet",
+			"material": "minecraft:potted_azure_bluet",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15521,7 +15489,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_bamboo",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15529,8 +15496,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_bamboo",
+			"material": "minecraft:potted_bamboo",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15542,7 +15509,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_birch_sapling",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15550,8 +15516,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_birch_sapling",
+			"material": "minecraft:potted_birch_sapling",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15563,7 +15529,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_blue_orchid",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15571,8 +15536,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_blue_orchid",
+			"material": "minecraft:potted_blue_orchid",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15584,7 +15549,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_brown_mushroom",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15592,8 +15556,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_brown_mushroom",
+			"material": "minecraft:potted_brown_mushroom",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15605,7 +15569,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_cactus",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15613,8 +15576,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_cactus",
+			"material": "minecraft:potted_cactus",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15626,7 +15589,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_cherry_sapling",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15634,8 +15596,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_cherry_sapling",
+			"material": "minecraft:potted_cherry_sapling",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15647,7 +15609,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_closed_eyeblossom",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15655,8 +15616,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_closed_eyeblossom",
+			"material": "minecraft:potted_closed_eyeblossom",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15668,7 +15629,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_cornflower",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15676,8 +15636,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_cornflower",
+			"material": "minecraft:potted_cornflower",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15689,7 +15649,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_crimson_fungus",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15697,8 +15656,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_crimson_fungus",
+			"material": "minecraft:potted_crimson_fungus",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15710,7 +15669,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_crimson_roots",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15718,8 +15676,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_crimson_roots",
+			"material": "minecraft:potted_crimson_roots",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15731,7 +15689,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_dandelion",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15739,8 +15696,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_dandelion",
+			"material": "minecraft:potted_dandelion",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15752,7 +15709,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_dark_oak_sapling",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15760,8 +15716,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_dark_oak_sapling",
+			"material": "minecraft:potted_dark_oak_sapling",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15773,7 +15729,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_dead_bush",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15781,8 +15736,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_dead_bush",
+			"material": "minecraft:potted_dead_bush",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15794,7 +15749,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_fern",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15802,8 +15756,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_fern",
+			"material": "minecraft:potted_fern",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15815,7 +15769,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_flowering_azalea_bush",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15823,8 +15776,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_flowering_azalea_bush",
+			"material": "minecraft:potted_flowering_azalea_bush",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15836,7 +15789,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_jungle_sapling",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15844,8 +15796,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_jungle_sapling",
+			"material": "minecraft:potted_jungle_sapling",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15857,7 +15809,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_lily_of_the_valley",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15865,8 +15816,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_lily_of_the_valley",
+			"material": "minecraft:potted_lily_of_the_valley",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15878,7 +15829,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_mangrove_propagule",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15886,8 +15836,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_mangrove_propagule",
+			"material": "minecraft:potted_mangrove_propagule",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15899,7 +15849,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_oak_sapling",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15907,8 +15856,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_oak_sapling",
+			"material": "minecraft:potted_oak_sapling",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15920,7 +15869,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_open_eyeblossom",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15928,8 +15876,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_open_eyeblossom",
+			"material": "minecraft:potted_open_eyeblossom",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15941,7 +15889,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_orange_tulip",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15949,8 +15896,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_orange_tulip",
+			"material": "minecraft:potted_orange_tulip",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15962,7 +15909,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_oxeye_daisy",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15970,8 +15916,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_oxeye_daisy",
+			"material": "minecraft:potted_oxeye_daisy",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15983,7 +15929,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_pale_oak_sapling",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -15991,8 +15936,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_pale_oak_sapling",
+			"material": "minecraft:potted_pale_oak_sapling",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16004,7 +15949,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_pink_tulip",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -16012,8 +15956,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_pink_tulip",
+			"material": "minecraft:potted_pink_tulip",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16025,7 +15969,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_poppy",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -16033,8 +15976,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_poppy",
+			"material": "minecraft:potted_poppy",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16046,7 +15989,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_red_mushroom",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -16054,8 +15996,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_red_mushroom",
+			"material": "minecraft:potted_red_mushroom",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16067,7 +16009,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_red_tulip",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -16075,8 +16016,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_red_tulip",
+			"material": "minecraft:potted_red_tulip",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16088,7 +16029,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_spruce_sapling",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -16096,8 +16036,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_spruce_sapling",
+			"material": "minecraft:potted_spruce_sapling",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16109,7 +16049,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_torchflower",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -16117,8 +16056,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_torchflower",
+			"material": "minecraft:potted_torchflower",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16130,7 +16069,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_warped_fungus",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -16138,8 +16076,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_warped_fungus",
+			"material": "minecraft:potted_warped_fungus",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16151,7 +16089,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_warped_roots",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -16159,8 +16096,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_warped_roots",
+			"material": "minecraft:potted_warped_roots",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16172,7 +16109,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_white_tulip",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -16180,8 +16116,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_white_tulip",
+			"material": "minecraft:potted_white_tulip",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16193,7 +16129,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:potted_wither_rose",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -16201,8 +16136,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:potted_wither_rose",
+			"material": "minecraft:potted_wither_rose",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16214,7 +16149,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:powder_snow",
 			"blastResistance": 0.25,
 			"burnable": false,
 			"collision": true,
@@ -16224,6 +16158,7 @@
 			"interactable": false,
 			"itemType": "minecraft:powder_snow_bucket",
 			"key": "minecraft:powder_snow",
+			"material": "minecraft:powder_snow",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16235,7 +16170,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:powder_snow_cauldron",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -16245,6 +16179,7 @@
 			"interactable": true,
 			"itemType": "minecraft:cauldron",
 			"key": "minecraft:powder_snow_cauldron",
+			"material": "minecraft:powder_snow_cauldron",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16256,7 +16191,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:powered_rail",
 			"blastResistance": 0.7,
 			"burnable": false,
 			"collision": false,
@@ -16266,6 +16200,7 @@
 			"interactable": false,
 			"itemType": "minecraft:powered_rail",
 			"key": "minecraft:powered_rail",
+			"material": "minecraft:powered_rail",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16277,7 +16212,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:prismarine",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -16287,6 +16221,7 @@
 			"interactable": false,
 			"itemType": "minecraft:prismarine",
 			"key": "minecraft:prismarine",
+			"material": "minecraft:prismarine",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16298,7 +16233,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:prismarine_brick_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -16308,6 +16242,7 @@
 			"interactable": false,
 			"itemType": "minecraft:prismarine_brick_slab",
 			"key": "minecraft:prismarine_brick_slab",
+			"material": "minecraft:prismarine_brick_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16319,7 +16254,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:prismarine_brick_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -16329,6 +16263,7 @@
 			"interactable": false,
 			"itemType": "minecraft:prismarine_brick_stairs",
 			"key": "minecraft:prismarine_brick_stairs",
+			"material": "minecraft:prismarine_brick_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16340,7 +16275,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:prismarine_bricks",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -16350,6 +16284,7 @@
 			"interactable": false,
 			"itemType": "minecraft:prismarine_bricks",
 			"key": "minecraft:prismarine_bricks",
+			"material": "minecraft:prismarine_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16361,7 +16296,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:prismarine_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -16371,6 +16305,7 @@
 			"interactable": false,
 			"itemType": "minecraft:prismarine_slab",
 			"key": "minecraft:prismarine_slab",
+			"material": "minecraft:prismarine_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16382,7 +16317,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:prismarine_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -16392,6 +16326,7 @@
 			"interactable": false,
 			"itemType": "minecraft:prismarine_stairs",
 			"key": "minecraft:prismarine_stairs",
+			"material": "minecraft:prismarine_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16403,7 +16338,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:prismarine_wall",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -16413,6 +16347,7 @@
 			"interactable": false,
 			"itemType": "minecraft:prismarine_wall",
 			"key": "minecraft:prismarine_wall",
+			"material": "minecraft:prismarine_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16424,7 +16359,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pumpkin",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": true,
@@ -16434,6 +16368,7 @@
 			"interactable": true,
 			"itemType": "minecraft:pumpkin",
 			"key": "minecraft:pumpkin",
+			"material": "minecraft:pumpkin",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16445,7 +16380,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:pumpkin_stem",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -16455,6 +16389,7 @@
 			"interactable": false,
 			"itemType": "minecraft:pumpkin_seeds",
 			"key": "minecraft:pumpkin_stem",
+			"material": "minecraft:pumpkin_stem",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16466,7 +16401,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:purple_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -16476,6 +16410,7 @@
 			"interactable": false,
 			"itemType": "minecraft:purple_banner",
 			"key": "minecraft:purple_banner",
+			"material": "minecraft:purple_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16487,7 +16422,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:purple_bed",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": true,
@@ -16497,6 +16431,7 @@
 			"interactable": true,
 			"itemType": "minecraft:purple_bed",
 			"key": "minecraft:purple_bed",
+			"material": "minecraft:purple_bed",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16508,7 +16443,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:purple_candle",
 			"blastResistance": 0.1,
 			"burnable": false,
 			"collision": true,
@@ -16518,6 +16452,7 @@
 			"interactable": true,
 			"itemType": "minecraft:purple_candle",
 			"key": "minecraft:purple_candle",
+			"material": "minecraft:purple_candle",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16529,7 +16464,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:purple_candle_cake",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -16537,8 +16471,8 @@
 			"gravity": false,
 			"hardness": 0.5,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:purple_candle_cake",
+			"material": "minecraft:purple_candle_cake",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16550,7 +16484,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:purple_carpet",
 			"blastResistance": 0.1,
 			"burnable": true,
 			"collision": true,
@@ -16560,6 +16493,7 @@
 			"interactable": false,
 			"itemType": "minecraft:purple_carpet",
 			"key": "minecraft:purple_carpet",
+			"material": "minecraft:purple_carpet",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16571,7 +16505,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:purple_concrete",
 			"blastResistance": 1.8,
 			"burnable": false,
 			"collision": true,
@@ -16581,6 +16514,7 @@
 			"interactable": false,
 			"itemType": "minecraft:purple_concrete",
 			"key": "minecraft:purple_concrete",
+			"material": "minecraft:purple_concrete",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16592,7 +16526,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:purple_concrete_powder",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -16602,6 +16535,7 @@
 			"interactable": false,
 			"itemType": "minecraft:purple_concrete_powder",
 			"key": "minecraft:purple_concrete_powder",
+			"material": "minecraft:purple_concrete_powder",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16613,7 +16547,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:purple_glazed_terracotta",
 			"blastResistance": 1.4,
 			"burnable": false,
 			"collision": true,
@@ -16623,6 +16556,7 @@
 			"interactable": false,
 			"itemType": "minecraft:purple_glazed_terracotta",
 			"key": "minecraft:purple_glazed_terracotta",
+			"material": "minecraft:purple_glazed_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16634,7 +16568,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:purple_shulker_box",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -16644,6 +16577,7 @@
 			"interactable": true,
 			"itemType": "minecraft:purple_shulker_box",
 			"key": "minecraft:purple_shulker_box",
+			"material": "minecraft:purple_shulker_box",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16655,7 +16589,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:purple_stained_glass",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -16665,6 +16598,7 @@
 			"interactable": false,
 			"itemType": "minecraft:purple_stained_glass",
 			"key": "minecraft:purple_stained_glass",
+			"material": "minecraft:purple_stained_glass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16676,7 +16610,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:purple_stained_glass_pane",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -16686,6 +16619,7 @@
 			"interactable": false,
 			"itemType": "minecraft:purple_stained_glass_pane",
 			"key": "minecraft:purple_stained_glass_pane",
+			"material": "minecraft:purple_stained_glass_pane",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16697,7 +16631,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:purple_terracotta",
 			"blastResistance": 4.2,
 			"burnable": false,
 			"collision": true,
@@ -16707,6 +16640,7 @@
 			"interactable": false,
 			"itemType": "minecraft:purple_terracotta",
 			"key": "minecraft:purple_terracotta",
+			"material": "minecraft:purple_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16718,7 +16652,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:purple_wall_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -16728,6 +16661,7 @@
 			"interactable": false,
 			"itemType": "minecraft:purple_banner",
 			"key": "minecraft:purple_wall_banner",
+			"material": "minecraft:purple_wall_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16739,7 +16673,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:purple_wool",
 			"blastResistance": 0.8,
 			"burnable": true,
 			"collision": true,
@@ -16749,6 +16682,7 @@
 			"interactable": false,
 			"itemType": "minecraft:purple_wool",
 			"key": "minecraft:purple_wool",
+			"material": "minecraft:purple_wool",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16760,7 +16694,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:purpur_block",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -16770,6 +16703,7 @@
 			"interactable": false,
 			"itemType": "minecraft:purpur_block",
 			"key": "minecraft:purpur_block",
+			"material": "minecraft:purpur_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16781,7 +16715,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:purpur_pillar",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -16791,6 +16724,7 @@
 			"interactable": false,
 			"itemType": "minecraft:purpur_pillar",
 			"key": "minecraft:purpur_pillar",
+			"material": "minecraft:purpur_pillar",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16802,7 +16736,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:purpur_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -16812,6 +16745,7 @@
 			"interactable": false,
 			"itemType": "minecraft:purpur_slab",
 			"key": "minecraft:purpur_slab",
+			"material": "minecraft:purpur_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16823,7 +16757,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:purpur_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -16833,6 +16766,7 @@
 			"interactable": false,
 			"itemType": "minecraft:purpur_stairs",
 			"key": "minecraft:purpur_stairs",
+			"material": "minecraft:purpur_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16844,7 +16778,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:quartz_block",
 			"blastResistance": 0.8,
 			"burnable": false,
 			"collision": true,
@@ -16854,6 +16787,7 @@
 			"interactable": false,
 			"itemType": "minecraft:quartz_block",
 			"key": "minecraft:quartz_block",
+			"material": "minecraft:quartz_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16865,7 +16799,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:quartz_bricks",
 			"blastResistance": 0.8,
 			"burnable": false,
 			"collision": true,
@@ -16875,6 +16808,7 @@
 			"interactable": false,
 			"itemType": "minecraft:quartz_bricks",
 			"key": "minecraft:quartz_bricks",
+			"material": "minecraft:quartz_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16886,7 +16820,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:quartz_pillar",
 			"blastResistance": 0.8,
 			"burnable": false,
 			"collision": true,
@@ -16896,6 +16829,7 @@
 			"interactable": false,
 			"itemType": "minecraft:quartz_pillar",
 			"key": "minecraft:quartz_pillar",
+			"material": "minecraft:quartz_pillar",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16907,7 +16841,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:quartz_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -16917,6 +16850,7 @@
 			"interactable": false,
 			"itemType": "minecraft:quartz_slab",
 			"key": "minecraft:quartz_slab",
+			"material": "minecraft:quartz_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16928,7 +16862,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:quartz_stairs",
 			"blastResistance": 0.8,
 			"burnable": false,
 			"collision": true,
@@ -16938,6 +16871,7 @@
 			"interactable": false,
 			"itemType": "minecraft:quartz_stairs",
 			"key": "minecraft:quartz_stairs",
+			"material": "minecraft:quartz_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16949,7 +16883,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:rail",
 			"blastResistance": 0.7,
 			"burnable": false,
 			"collision": false,
@@ -16959,6 +16892,7 @@
 			"interactable": false,
 			"itemType": "minecraft:rail",
 			"key": "minecraft:rail",
+			"material": "minecraft:rail",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16970,7 +16904,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:raw_copper_block",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -16980,6 +16913,7 @@
 			"interactable": false,
 			"itemType": "minecraft:raw_copper_block",
 			"key": "minecraft:raw_copper_block",
+			"material": "minecraft:raw_copper_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16991,7 +16925,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:raw_gold_block",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -17001,6 +16934,7 @@
 			"interactable": false,
 			"itemType": "minecraft:raw_gold_block",
 			"key": "minecraft:raw_gold_block",
+			"material": "minecraft:raw_gold_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17012,7 +16946,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:raw_iron_block",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -17022,6 +16955,7 @@
 			"interactable": false,
 			"itemType": "minecraft:raw_iron_block",
 			"key": "minecraft:raw_iron_block",
+			"material": "minecraft:raw_iron_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17033,7 +16967,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -17043,6 +16976,7 @@
 			"interactable": false,
 			"itemType": "minecraft:red_banner",
 			"key": "minecraft:red_banner",
+			"material": "minecraft:red_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17054,7 +16988,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_bed",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": true,
@@ -17064,6 +16997,7 @@
 			"interactable": true,
 			"itemType": "minecraft:red_bed",
 			"key": "minecraft:red_bed",
+			"material": "minecraft:red_bed",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17075,7 +17009,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_candle",
 			"blastResistance": 0.1,
 			"burnable": false,
 			"collision": true,
@@ -17085,6 +17018,7 @@
 			"interactable": true,
 			"itemType": "minecraft:red_candle",
 			"key": "minecraft:red_candle",
+			"material": "minecraft:red_candle",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17096,7 +17030,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_candle_cake",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -17104,8 +17037,8 @@
 			"gravity": false,
 			"hardness": 0.5,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:red_candle_cake",
+			"material": "minecraft:red_candle_cake",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17117,7 +17050,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_carpet",
 			"blastResistance": 0.1,
 			"burnable": true,
 			"collision": true,
@@ -17127,6 +17059,7 @@
 			"interactable": false,
 			"itemType": "minecraft:red_carpet",
 			"key": "minecraft:red_carpet",
+			"material": "minecraft:red_carpet",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17138,7 +17071,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_concrete",
 			"blastResistance": 1.8,
 			"burnable": false,
 			"collision": true,
@@ -17148,6 +17080,7 @@
 			"interactable": false,
 			"itemType": "minecraft:red_concrete",
 			"key": "minecraft:red_concrete",
+			"material": "minecraft:red_concrete",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17159,7 +17092,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_concrete_powder",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -17169,6 +17101,7 @@
 			"interactable": false,
 			"itemType": "minecraft:red_concrete_powder",
 			"key": "minecraft:red_concrete_powder",
+			"material": "minecraft:red_concrete_powder",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17180,7 +17113,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_glazed_terracotta",
 			"blastResistance": 1.4,
 			"burnable": false,
 			"collision": true,
@@ -17190,6 +17122,7 @@
 			"interactable": false,
 			"itemType": "minecraft:red_glazed_terracotta",
 			"key": "minecraft:red_glazed_terracotta",
+			"material": "minecraft:red_glazed_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17201,7 +17134,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_mushroom",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -17211,6 +17143,7 @@
 			"interactable": false,
 			"itemType": "minecraft:red_mushroom",
 			"key": "minecraft:red_mushroom",
+			"material": "minecraft:red_mushroom",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17222,7 +17155,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_mushroom_block",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": true,
@@ -17232,6 +17164,7 @@
 			"interactable": false,
 			"itemType": "minecraft:red_mushroom_block",
 			"key": "minecraft:red_mushroom_block",
+			"material": "minecraft:red_mushroom_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17243,7 +17176,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_nether_brick_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -17253,6 +17185,7 @@
 			"interactable": false,
 			"itemType": "minecraft:red_nether_brick_slab",
 			"key": "minecraft:red_nether_brick_slab",
+			"material": "minecraft:red_nether_brick_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17264,7 +17197,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_nether_brick_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -17274,6 +17206,7 @@
 			"interactable": false,
 			"itemType": "minecraft:red_nether_brick_stairs",
 			"key": "minecraft:red_nether_brick_stairs",
+			"material": "minecraft:red_nether_brick_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17285,7 +17218,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_nether_brick_wall",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -17295,6 +17227,7 @@
 			"interactable": false,
 			"itemType": "minecraft:red_nether_brick_wall",
 			"key": "minecraft:red_nether_brick_wall",
+			"material": "minecraft:red_nether_brick_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17306,7 +17239,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_nether_bricks",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -17316,6 +17248,7 @@
 			"interactable": false,
 			"itemType": "minecraft:red_nether_bricks",
 			"key": "minecraft:red_nether_bricks",
+			"material": "minecraft:red_nether_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17327,7 +17260,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_sand",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -17337,6 +17269,7 @@
 			"interactable": false,
 			"itemType": "minecraft:red_sand",
 			"key": "minecraft:red_sand",
+			"material": "minecraft:red_sand",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17348,7 +17281,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_sandstone",
 			"blastResistance": 0.8,
 			"burnable": false,
 			"collision": true,
@@ -17358,6 +17290,7 @@
 			"interactable": false,
 			"itemType": "minecraft:red_sandstone",
 			"key": "minecraft:red_sandstone",
+			"material": "minecraft:red_sandstone",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17369,7 +17302,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_sandstone_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -17379,6 +17311,7 @@
 			"interactable": false,
 			"itemType": "minecraft:red_sandstone_slab",
 			"key": "minecraft:red_sandstone_slab",
+			"material": "minecraft:red_sandstone_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17390,7 +17323,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_sandstone_stairs",
 			"blastResistance": 0.8,
 			"burnable": false,
 			"collision": true,
@@ -17400,6 +17332,7 @@
 			"interactable": false,
 			"itemType": "minecraft:red_sandstone_stairs",
 			"key": "minecraft:red_sandstone_stairs",
+			"material": "minecraft:red_sandstone_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17411,7 +17344,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_sandstone_wall",
 			"blastResistance": 0.8,
 			"burnable": false,
 			"collision": true,
@@ -17421,6 +17353,7 @@
 			"interactable": false,
 			"itemType": "minecraft:red_sandstone_wall",
 			"key": "minecraft:red_sandstone_wall",
+			"material": "minecraft:red_sandstone_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17432,7 +17365,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_shulker_box",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -17442,6 +17374,7 @@
 			"interactable": true,
 			"itemType": "minecraft:red_shulker_box",
 			"key": "minecraft:red_shulker_box",
+			"material": "minecraft:red_shulker_box",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17453,7 +17386,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_stained_glass",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -17463,6 +17395,7 @@
 			"interactable": false,
 			"itemType": "minecraft:red_stained_glass",
 			"key": "minecraft:red_stained_glass",
+			"material": "minecraft:red_stained_glass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17474,7 +17407,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_stained_glass_pane",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -17484,6 +17416,7 @@
 			"interactable": false,
 			"itemType": "minecraft:red_stained_glass_pane",
 			"key": "minecraft:red_stained_glass_pane",
+			"material": "minecraft:red_stained_glass_pane",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17495,7 +17428,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_terracotta",
 			"blastResistance": 4.2,
 			"burnable": false,
 			"collision": true,
@@ -17505,6 +17437,7 @@
 			"interactable": false,
 			"itemType": "minecraft:red_terracotta",
 			"key": "minecraft:red_terracotta",
+			"material": "minecraft:red_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17516,7 +17449,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_tulip",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -17526,6 +17458,7 @@
 			"interactable": false,
 			"itemType": "minecraft:red_tulip",
 			"key": "minecraft:red_tulip",
+			"material": "minecraft:red_tulip",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17537,7 +17470,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_wall_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -17547,6 +17479,7 @@
 			"interactable": false,
 			"itemType": "minecraft:red_banner",
 			"key": "minecraft:red_wall_banner",
+			"material": "minecraft:red_wall_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17558,7 +17491,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:red_wool",
 			"blastResistance": 0.8,
 			"burnable": true,
 			"collision": true,
@@ -17568,6 +17500,7 @@
 			"interactable": false,
 			"itemType": "minecraft:red_wool",
 			"key": "minecraft:red_wool",
+			"material": "minecraft:red_wool",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17579,7 +17512,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:redstone_block",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -17589,6 +17521,7 @@
 			"interactable": false,
 			"itemType": "minecraft:redstone_block",
 			"key": "minecraft:redstone_block",
+			"material": "minecraft:redstone_block",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17600,7 +17533,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:redstone_lamp",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -17610,6 +17542,7 @@
 			"interactable": false,
 			"itemType": "minecraft:redstone_lamp",
 			"key": "minecraft:redstone_lamp",
+			"material": "minecraft:redstone_lamp",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17621,7 +17554,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:redstone_ore",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -17631,6 +17563,7 @@
 			"interactable": true,
 			"itemType": "minecraft:redstone_ore",
 			"key": "minecraft:redstone_ore",
+			"material": "minecraft:redstone_ore",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17642,7 +17575,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:redstone_torch",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -17652,6 +17584,7 @@
 			"interactable": false,
 			"itemType": "minecraft:redstone_torch",
 			"key": "minecraft:redstone_torch",
+			"material": "minecraft:redstone_torch",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17663,7 +17596,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:redstone_wall_torch",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -17673,6 +17605,7 @@
 			"interactable": false,
 			"itemType": "minecraft:redstone_torch",
 			"key": "minecraft:redstone_wall_torch",
+			"material": "minecraft:redstone_wall_torch",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17684,7 +17617,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:redstone_wire",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -17694,6 +17626,7 @@
 			"interactable": true,
 			"itemType": "minecraft:redstone",
 			"key": "minecraft:redstone_wire",
+			"material": "minecraft:redstone_wire",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17705,7 +17638,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:reinforced_deepslate",
 			"blastResistance": 1200.0,
 			"burnable": false,
 			"collision": true,
@@ -17715,6 +17647,7 @@
 			"interactable": false,
 			"itemType": "minecraft:reinforced_deepslate",
 			"key": "minecraft:reinforced_deepslate",
+			"material": "minecraft:reinforced_deepslate",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17726,7 +17659,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:repeater",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -17736,6 +17668,7 @@
 			"interactable": true,
 			"itemType": "minecraft:repeater",
 			"key": "minecraft:repeater",
+			"material": "minecraft:repeater",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17747,7 +17680,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:repeating_command_block",
 			"blastResistance": 3600000.0,
 			"burnable": false,
 			"collision": true,
@@ -17757,6 +17689,7 @@
 			"interactable": true,
 			"itemType": "minecraft:repeating_command_block",
 			"key": "minecraft:repeating_command_block",
+			"material": "minecraft:repeating_command_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17768,7 +17701,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:resin_block",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -17778,6 +17710,7 @@
 			"interactable": false,
 			"itemType": "minecraft:resin_block",
 			"key": "minecraft:resin_block",
+			"material": "minecraft:resin_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17789,7 +17722,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:resin_brick_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -17799,6 +17731,7 @@
 			"interactable": false,
 			"itemType": "minecraft:resin_brick_slab",
 			"key": "minecraft:resin_brick_slab",
+			"material": "minecraft:resin_brick_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17810,7 +17743,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:resin_brick_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -17820,6 +17752,7 @@
 			"interactable": false,
 			"itemType": "minecraft:resin_brick_stairs",
 			"key": "minecraft:resin_brick_stairs",
+			"material": "minecraft:resin_brick_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17831,7 +17764,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:resin_brick_wall",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -17841,6 +17773,7 @@
 			"interactable": false,
 			"itemType": "minecraft:resin_brick_wall",
 			"key": "minecraft:resin_brick_wall",
+			"material": "minecraft:resin_brick_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17852,7 +17785,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:resin_bricks",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -17862,6 +17794,7 @@
 			"interactable": false,
 			"itemType": "minecraft:resin_bricks",
 			"key": "minecraft:resin_bricks",
+			"material": "minecraft:resin_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17873,7 +17806,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:resin_clump",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -17883,6 +17815,7 @@
 			"interactable": false,
 			"itemType": "minecraft:resin_clump",
 			"key": "minecraft:resin_clump",
+			"material": "minecraft:resin_clump",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17894,7 +17827,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:respawn_anchor",
 			"blastResistance": 1200.0,
 			"burnable": false,
 			"collision": true,
@@ -17904,6 +17836,7 @@
 			"interactable": true,
 			"itemType": "minecraft:respawn_anchor",
 			"key": "minecraft:respawn_anchor",
+			"material": "minecraft:respawn_anchor",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17915,7 +17848,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:rooted_dirt",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -17925,6 +17857,7 @@
 			"interactable": false,
 			"itemType": "minecraft:rooted_dirt",
 			"key": "minecraft:rooted_dirt",
+			"material": "minecraft:rooted_dirt",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17936,7 +17869,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:rose_bush",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -17946,6 +17878,7 @@
 			"interactable": false,
 			"itemType": "minecraft:rose_bush",
 			"key": "minecraft:rose_bush",
+			"material": "minecraft:rose_bush",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17957,7 +17890,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:sand",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -17967,6 +17899,7 @@
 			"interactable": false,
 			"itemType": "minecraft:sand",
 			"key": "minecraft:sand",
+			"material": "minecraft:sand",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17978,7 +17911,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:sandstone",
 			"blastResistance": 0.8,
 			"burnable": false,
 			"collision": true,
@@ -17988,6 +17920,7 @@
 			"interactable": false,
 			"itemType": "minecraft:sandstone",
 			"key": "minecraft:sandstone",
+			"material": "minecraft:sandstone",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17999,7 +17932,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:sandstone_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -18009,6 +17941,7 @@
 			"interactable": false,
 			"itemType": "minecraft:sandstone_slab",
 			"key": "minecraft:sandstone_slab",
+			"material": "minecraft:sandstone_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18020,7 +17953,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:sandstone_stairs",
 			"blastResistance": 0.8,
 			"burnable": false,
 			"collision": true,
@@ -18030,6 +17962,7 @@
 			"interactable": false,
 			"itemType": "minecraft:sandstone_stairs",
 			"key": "minecraft:sandstone_stairs",
+			"material": "minecraft:sandstone_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18041,7 +17974,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:sandstone_wall",
 			"blastResistance": 0.8,
 			"burnable": false,
 			"collision": true,
@@ -18051,6 +17983,7 @@
 			"interactable": false,
 			"itemType": "minecraft:sandstone_wall",
 			"key": "minecraft:sandstone_wall",
+			"material": "minecraft:sandstone_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18062,7 +17995,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:scaffolding",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -18072,6 +18004,7 @@
 			"interactable": false,
 			"itemType": "minecraft:scaffolding",
 			"key": "minecraft:scaffolding",
+			"material": "minecraft:scaffolding",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18083,7 +18016,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:sculk",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": true,
@@ -18093,6 +18025,7 @@
 			"interactable": false,
 			"itemType": "minecraft:sculk",
 			"key": "minecraft:sculk",
+			"material": "minecraft:sculk",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18104,7 +18037,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:sculk_catalyst",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -18114,6 +18046,7 @@
 			"interactable": false,
 			"itemType": "minecraft:sculk_catalyst",
 			"key": "minecraft:sculk_catalyst",
+			"material": "minecraft:sculk_catalyst",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18125,7 +18058,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:sculk_sensor",
 			"blastResistance": 1.5,
 			"burnable": false,
 			"collision": true,
@@ -18135,6 +18067,7 @@
 			"interactable": false,
 			"itemType": "minecraft:sculk_sensor",
 			"key": "minecraft:sculk_sensor",
+			"material": "minecraft:sculk_sensor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18146,7 +18079,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:sculk_shrieker",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -18156,6 +18088,7 @@
 			"interactable": false,
 			"itemType": "minecraft:sculk_shrieker",
 			"key": "minecraft:sculk_shrieker",
+			"material": "minecraft:sculk_shrieker",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18167,7 +18100,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:sculk_vein",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": false,
@@ -18177,6 +18109,7 @@
 			"interactable": false,
 			"itemType": "minecraft:sculk_vein",
 			"key": "minecraft:sculk_vein",
+			"material": "minecraft:sculk_vein",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18188,7 +18121,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:sea_lantern",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -18198,6 +18130,7 @@
 			"interactable": false,
 			"itemType": "minecraft:sea_lantern",
 			"key": "minecraft:sea_lantern",
+			"material": "minecraft:sea_lantern",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18209,7 +18142,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:sea_pickle",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -18219,6 +18151,7 @@
 			"interactable": false,
 			"itemType": "minecraft:sea_pickle",
 			"key": "minecraft:sea_pickle",
+			"material": "minecraft:sea_pickle",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18230,7 +18163,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:seagrass",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -18240,6 +18172,7 @@
 			"interactable": false,
 			"itemType": "minecraft:seagrass",
 			"key": "minecraft:seagrass",
+			"material": "minecraft:seagrass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18251,7 +18184,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:short_dry_grass",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -18261,6 +18193,7 @@
 			"interactable": false,
 			"itemType": "minecraft:short_dry_grass",
 			"key": "minecraft:short_dry_grass",
+			"material": "minecraft:short_dry_grass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18272,7 +18205,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:short_grass",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -18282,6 +18214,7 @@
 			"interactable": false,
 			"itemType": "minecraft:short_grass",
 			"key": "minecraft:short_grass",
+			"material": "minecraft:short_grass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18293,7 +18226,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:shroomlight",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": true,
@@ -18303,6 +18235,7 @@
 			"interactable": false,
 			"itemType": "minecraft:shroomlight",
 			"key": "minecraft:shroomlight",
+			"material": "minecraft:shroomlight",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18314,7 +18247,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:shulker_box",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -18324,6 +18256,7 @@
 			"interactable": true,
 			"itemType": "minecraft:shulker_box",
 			"key": "minecraft:shulker_box",
+			"material": "minecraft:shulker_box",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18335,7 +18268,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:skeleton_skull",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": true,
@@ -18345,6 +18277,7 @@
 			"interactable": false,
 			"itemType": "minecraft:skeleton_skull",
 			"key": "minecraft:skeleton_skull",
+			"material": "minecraft:skeleton_skull",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18356,7 +18289,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:skeleton_wall_skull",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": true,
@@ -18366,6 +18298,7 @@
 			"interactable": false,
 			"itemType": "minecraft:skeleton_skull",
 			"key": "minecraft:skeleton_wall_skull",
+			"material": "minecraft:skeleton_wall_skull",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18377,7 +18310,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:slime_block",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": true,
@@ -18387,6 +18319,7 @@
 			"interactable": false,
 			"itemType": "minecraft:slime_block",
 			"key": "minecraft:slime_block",
+			"material": "minecraft:slime_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18398,7 +18331,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:small_amethyst_bud",
 			"blastResistance": 1.5,
 			"burnable": false,
 			"collision": true,
@@ -18408,6 +18340,7 @@
 			"interactable": false,
 			"itemType": "minecraft:small_amethyst_bud",
 			"key": "minecraft:small_amethyst_bud",
+			"material": "minecraft:small_amethyst_bud",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18419,7 +18352,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:small_dripleaf",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -18429,6 +18361,7 @@
 			"interactable": false,
 			"itemType": "minecraft:small_dripleaf",
 			"key": "minecraft:small_dripleaf",
+			"material": "minecraft:small_dripleaf",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18440,7 +18373,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:smithing_table",
 			"blastResistance": 2.5,
 			"burnable": false,
 			"collision": true,
@@ -18450,6 +18382,7 @@
 			"interactable": true,
 			"itemType": "minecraft:smithing_table",
 			"key": "minecraft:smithing_table",
+			"material": "minecraft:smithing_table",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18461,7 +18394,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:smoker",
 			"blastResistance": 3.5,
 			"burnable": false,
 			"collision": true,
@@ -18471,6 +18403,7 @@
 			"interactable": true,
 			"itemType": "minecraft:smoker",
 			"key": "minecraft:smoker",
+			"material": "minecraft:smoker",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18482,7 +18415,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:smooth_basalt",
 			"blastResistance": 4.2,
 			"burnable": false,
 			"collision": true,
@@ -18492,6 +18424,7 @@
 			"interactable": false,
 			"itemType": "minecraft:smooth_basalt",
 			"key": "minecraft:smooth_basalt",
+			"material": "minecraft:smooth_basalt",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18503,7 +18436,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:smooth_quartz",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -18513,6 +18445,7 @@
 			"interactable": false,
 			"itemType": "minecraft:smooth_quartz",
 			"key": "minecraft:smooth_quartz",
+			"material": "minecraft:smooth_quartz",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18524,7 +18457,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:smooth_quartz_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -18534,6 +18466,7 @@
 			"interactable": false,
 			"itemType": "minecraft:smooth_quartz_slab",
 			"key": "minecraft:smooth_quartz_slab",
+			"material": "minecraft:smooth_quartz_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18545,7 +18478,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:smooth_quartz_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -18555,6 +18487,7 @@
 			"interactable": false,
 			"itemType": "minecraft:smooth_quartz_stairs",
 			"key": "minecraft:smooth_quartz_stairs",
+			"material": "minecraft:smooth_quartz_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18566,7 +18499,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:smooth_red_sandstone",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -18576,6 +18508,7 @@
 			"interactable": false,
 			"itemType": "minecraft:smooth_red_sandstone",
 			"key": "minecraft:smooth_red_sandstone",
+			"material": "minecraft:smooth_red_sandstone",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18587,7 +18520,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:smooth_red_sandstone_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -18597,6 +18529,7 @@
 			"interactable": false,
 			"itemType": "minecraft:smooth_red_sandstone_slab",
 			"key": "minecraft:smooth_red_sandstone_slab",
+			"material": "minecraft:smooth_red_sandstone_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18608,7 +18541,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:smooth_red_sandstone_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -18618,6 +18550,7 @@
 			"interactable": false,
 			"itemType": "minecraft:smooth_red_sandstone_stairs",
 			"key": "minecraft:smooth_red_sandstone_stairs",
+			"material": "minecraft:smooth_red_sandstone_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18629,7 +18562,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:smooth_sandstone",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -18639,6 +18571,7 @@
 			"interactable": false,
 			"itemType": "minecraft:smooth_sandstone",
 			"key": "minecraft:smooth_sandstone",
+			"material": "minecraft:smooth_sandstone",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18650,7 +18583,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:smooth_sandstone_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -18660,6 +18592,7 @@
 			"interactable": false,
 			"itemType": "minecraft:smooth_sandstone_slab",
 			"key": "minecraft:smooth_sandstone_slab",
+			"material": "minecraft:smooth_sandstone_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18671,7 +18604,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:smooth_sandstone_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -18681,6 +18613,7 @@
 			"interactable": false,
 			"itemType": "minecraft:smooth_sandstone_stairs",
 			"key": "minecraft:smooth_sandstone_stairs",
+			"material": "minecraft:smooth_sandstone_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18692,7 +18625,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:smooth_stone",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -18702,6 +18634,7 @@
 			"interactable": false,
 			"itemType": "minecraft:smooth_stone",
 			"key": "minecraft:smooth_stone",
+			"material": "minecraft:smooth_stone",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18713,7 +18646,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:smooth_stone_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -18723,6 +18655,7 @@
 			"interactable": false,
 			"itemType": "minecraft:smooth_stone_slab",
 			"key": "minecraft:smooth_stone_slab",
+			"material": "minecraft:smooth_stone_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18734,7 +18667,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:sniffer_egg",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -18744,6 +18676,7 @@
 			"interactable": false,
 			"itemType": "minecraft:sniffer_egg",
 			"key": "minecraft:sniffer_egg",
+			"material": "minecraft:sniffer_egg",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18755,7 +18688,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:snow",
 			"blastResistance": 0.1,
 			"burnable": false,
 			"collision": true,
@@ -18765,6 +18697,7 @@
 			"interactable": false,
 			"itemType": "minecraft:snow",
 			"key": "minecraft:snow",
+			"material": "minecraft:snow",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18776,7 +18709,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:snow_block",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": true,
@@ -18786,6 +18718,7 @@
 			"interactable": false,
 			"itemType": "minecraft:snow_block",
 			"key": "minecraft:snow_block",
+			"material": "minecraft:snow_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18797,7 +18730,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:soul_campfire",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -18807,6 +18739,7 @@
 			"interactable": true,
 			"itemType": "minecraft:soul_campfire",
 			"key": "minecraft:soul_campfire",
+			"material": "minecraft:soul_campfire",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18818,7 +18751,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:soul_fire",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -18826,8 +18758,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": false,
-			"itemType": false,
 			"key": "minecraft:soul_fire",
+			"material": "minecraft:soul_fire",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18839,7 +18771,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:soul_lantern",
 			"blastResistance": 3.5,
 			"burnable": false,
 			"collision": true,
@@ -18849,6 +18780,7 @@
 			"interactable": false,
 			"itemType": "minecraft:soul_lantern",
 			"key": "minecraft:soul_lantern",
+			"material": "minecraft:soul_lantern",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18860,7 +18792,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:soul_sand",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -18870,6 +18801,7 @@
 			"interactable": false,
 			"itemType": "minecraft:soul_sand",
 			"key": "minecraft:soul_sand",
+			"material": "minecraft:soul_sand",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18881,7 +18813,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:soul_soil",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -18891,6 +18822,7 @@
 			"interactable": false,
 			"itemType": "minecraft:soul_soil",
 			"key": "minecraft:soul_soil",
+			"material": "minecraft:soul_soil",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18902,7 +18834,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:soul_torch",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -18912,6 +18843,7 @@
 			"interactable": false,
 			"itemType": "minecraft:soul_torch",
 			"key": "minecraft:soul_torch",
+			"material": "minecraft:soul_torch",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18923,7 +18855,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:soul_wall_torch",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -18933,6 +18864,7 @@
 			"interactable": false,
 			"itemType": "minecraft:soul_torch",
 			"key": "minecraft:soul_wall_torch",
+			"material": "minecraft:soul_wall_torch",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18944,7 +18876,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:spawner",
 			"blastResistance": 5.0,
 			"burnable": false,
 			"collision": true,
@@ -18954,6 +18885,7 @@
 			"interactable": false,
 			"itemType": "minecraft:spawner",
 			"key": "minecraft:spawner",
+			"material": "minecraft:spawner",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18965,7 +18897,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:sponge",
 			"blastResistance": 0.6,
 			"burnable": false,
 			"collision": true,
@@ -18975,6 +18906,7 @@
 			"interactable": false,
 			"itemType": "minecraft:sponge",
 			"key": "minecraft:sponge",
+			"material": "minecraft:sponge",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18986,7 +18918,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:spore_blossom",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -18996,6 +18927,7 @@
 			"interactable": false,
 			"itemType": "minecraft:spore_blossom",
 			"key": "minecraft:spore_blossom",
+			"material": "minecraft:spore_blossom",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19007,7 +18939,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:spruce_button",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -19017,6 +18948,7 @@
 			"interactable": true,
 			"itemType": "minecraft:spruce_button",
 			"key": "minecraft:spruce_button",
+			"material": "minecraft:spruce_button",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19028,7 +18960,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:spruce_door",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -19038,6 +18969,7 @@
 			"interactable": true,
 			"itemType": "minecraft:spruce_door",
 			"key": "minecraft:spruce_door",
+			"material": "minecraft:spruce_door",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19049,7 +18981,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:spruce_fence",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -19059,6 +18990,7 @@
 			"interactable": true,
 			"itemType": "minecraft:spruce_fence",
 			"key": "minecraft:spruce_fence",
+			"material": "minecraft:spruce_fence",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19070,7 +19002,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:spruce_fence_gate",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -19080,6 +19011,7 @@
 			"interactable": true,
 			"itemType": "minecraft:spruce_fence_gate",
 			"key": "minecraft:spruce_fence_gate",
+			"material": "minecraft:spruce_fence_gate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19091,7 +19023,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:spruce_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -19101,6 +19032,7 @@
 			"interactable": true,
 			"itemType": "minecraft:spruce_hanging_sign",
 			"key": "minecraft:spruce_hanging_sign",
+			"material": "minecraft:spruce_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19112,7 +19044,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:spruce_leaves",
 			"blastResistance": 0.2,
 			"burnable": true,
 			"collision": true,
@@ -19122,6 +19053,7 @@
 			"interactable": false,
 			"itemType": "minecraft:spruce_leaves",
 			"key": "minecraft:spruce_leaves",
+			"material": "minecraft:spruce_leaves",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19133,7 +19065,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:spruce_log",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -19143,6 +19074,7 @@
 			"interactable": false,
 			"itemType": "minecraft:spruce_log",
 			"key": "minecraft:spruce_log",
+			"material": "minecraft:spruce_log",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19154,7 +19086,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:spruce_planks",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -19164,6 +19095,7 @@
 			"interactable": false,
 			"itemType": "minecraft:spruce_planks",
 			"key": "minecraft:spruce_planks",
+			"material": "minecraft:spruce_planks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19175,7 +19107,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:spruce_pressure_plate",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -19185,6 +19116,7 @@
 			"interactable": false,
 			"itemType": "minecraft:spruce_pressure_plate",
 			"key": "minecraft:spruce_pressure_plate",
+			"material": "minecraft:spruce_pressure_plate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19196,7 +19128,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:spruce_sapling",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -19206,6 +19137,7 @@
 			"interactable": false,
 			"itemType": "minecraft:spruce_sapling",
 			"key": "minecraft:spruce_sapling",
+			"material": "minecraft:spruce_sapling",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19217,7 +19149,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:spruce_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -19227,6 +19158,7 @@
 			"interactable": true,
 			"itemType": "minecraft:spruce_sign",
 			"key": "minecraft:spruce_sign",
+			"material": "minecraft:spruce_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19238,7 +19170,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:spruce_slab",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -19248,6 +19179,7 @@
 			"interactable": false,
 			"itemType": "minecraft:spruce_slab",
 			"key": "minecraft:spruce_slab",
+			"material": "minecraft:spruce_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19259,7 +19191,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:spruce_stairs",
 			"blastResistance": 3.0,
 			"burnable": true,
 			"collision": true,
@@ -19269,6 +19200,7 @@
 			"interactable": false,
 			"itemType": "minecraft:spruce_stairs",
 			"key": "minecraft:spruce_stairs",
+			"material": "minecraft:spruce_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19280,7 +19212,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:spruce_trapdoor",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -19290,6 +19221,7 @@
 			"interactable": true,
 			"itemType": "minecraft:spruce_trapdoor",
 			"key": "minecraft:spruce_trapdoor",
+			"material": "minecraft:spruce_trapdoor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19301,7 +19233,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:spruce_wall_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -19311,6 +19242,7 @@
 			"interactable": true,
 			"itemType": "minecraft:spruce_hanging_sign",
 			"key": "minecraft:spruce_wall_hanging_sign",
+			"material": "minecraft:spruce_wall_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19322,7 +19254,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:spruce_wall_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -19332,6 +19263,7 @@
 			"interactable": true,
 			"itemType": "minecraft:spruce_sign",
 			"key": "minecraft:spruce_wall_sign",
+			"material": "minecraft:spruce_wall_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19343,7 +19275,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:spruce_wood",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -19353,6 +19284,7 @@
 			"interactable": false,
 			"itemType": "minecraft:spruce_wood",
 			"key": "minecraft:spruce_wood",
+			"material": "minecraft:spruce_wood",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19364,7 +19296,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:sticky_piston",
 			"blastResistance": 1.5,
 			"burnable": false,
 			"collision": true,
@@ -19374,6 +19305,7 @@
 			"interactable": false,
 			"itemType": "minecraft:sticky_piston",
 			"key": "minecraft:sticky_piston",
+			"material": "minecraft:sticky_piston",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19385,7 +19317,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stone",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -19395,6 +19326,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stone",
 			"key": "minecraft:stone",
+			"material": "minecraft:stone",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19406,7 +19338,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stone_brick_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -19416,6 +19347,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stone_brick_slab",
 			"key": "minecraft:stone_brick_slab",
+			"material": "minecraft:stone_brick_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19427,7 +19359,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stone_brick_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -19437,6 +19368,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stone_brick_stairs",
 			"key": "minecraft:stone_brick_stairs",
+			"material": "minecraft:stone_brick_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19448,7 +19380,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stone_brick_wall",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -19458,6 +19389,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stone_brick_wall",
 			"key": "minecraft:stone_brick_wall",
+			"material": "minecraft:stone_brick_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19469,7 +19401,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stone_bricks",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -19479,6 +19410,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stone_bricks",
 			"key": "minecraft:stone_bricks",
+			"material": "minecraft:stone_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19490,7 +19422,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stone_button",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -19500,6 +19431,7 @@
 			"interactable": true,
 			"itemType": "minecraft:stone_button",
 			"key": "minecraft:stone_button",
+			"material": "minecraft:stone_button",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19511,7 +19443,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stone_pressure_plate",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -19521,6 +19452,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stone_pressure_plate",
 			"key": "minecraft:stone_pressure_plate",
+			"material": "minecraft:stone_pressure_plate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19532,7 +19464,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stone_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -19542,6 +19473,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stone_slab",
 			"key": "minecraft:stone_slab",
+			"material": "minecraft:stone_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19553,7 +19485,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stone_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -19563,6 +19494,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stone_stairs",
 			"key": "minecraft:stone_stairs",
+			"material": "minecraft:stone_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19574,7 +19506,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stonecutter",
 			"blastResistance": 3.5,
 			"burnable": false,
 			"collision": true,
@@ -19584,6 +19515,7 @@
 			"interactable": true,
 			"itemType": "minecraft:stonecutter",
 			"key": "minecraft:stonecutter",
+			"material": "minecraft:stonecutter",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19595,7 +19527,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_acacia_log",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -19605,6 +19536,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_acacia_log",
 			"key": "minecraft:stripped_acacia_log",
+			"material": "minecraft:stripped_acacia_log",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19616,7 +19548,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_acacia_wood",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -19626,6 +19557,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_acacia_wood",
 			"key": "minecraft:stripped_acacia_wood",
+			"material": "minecraft:stripped_acacia_wood",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19637,7 +19569,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_bamboo_block",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -19647,6 +19578,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_bamboo_block",
 			"key": "minecraft:stripped_bamboo_block",
+			"material": "minecraft:stripped_bamboo_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19658,7 +19590,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_birch_log",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -19668,6 +19599,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_birch_log",
 			"key": "minecraft:stripped_birch_log",
+			"material": "minecraft:stripped_birch_log",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19679,7 +19611,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_birch_wood",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -19689,6 +19620,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_birch_wood",
 			"key": "minecraft:stripped_birch_wood",
+			"material": "minecraft:stripped_birch_wood",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19700,7 +19632,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_cherry_log",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -19710,6 +19641,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_cherry_log",
 			"key": "minecraft:stripped_cherry_log",
+			"material": "minecraft:stripped_cherry_log",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19721,7 +19653,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_cherry_wood",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -19731,6 +19662,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_cherry_wood",
 			"key": "minecraft:stripped_cherry_wood",
+			"material": "minecraft:stripped_cherry_wood",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19742,7 +19674,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_crimson_hyphae",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -19752,6 +19683,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_crimson_hyphae",
 			"key": "minecraft:stripped_crimson_hyphae",
+			"material": "minecraft:stripped_crimson_hyphae",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19763,7 +19695,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_crimson_stem",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -19773,6 +19704,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_crimson_stem",
 			"key": "minecraft:stripped_crimson_stem",
+			"material": "minecraft:stripped_crimson_stem",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19784,7 +19716,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_dark_oak_log",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -19794,6 +19725,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_dark_oak_log",
 			"key": "minecraft:stripped_dark_oak_log",
+			"material": "minecraft:stripped_dark_oak_log",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19805,7 +19737,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_dark_oak_wood",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -19815,6 +19746,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_dark_oak_wood",
 			"key": "minecraft:stripped_dark_oak_wood",
+			"material": "minecraft:stripped_dark_oak_wood",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19826,7 +19758,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_jungle_log",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -19836,6 +19767,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_jungle_log",
 			"key": "minecraft:stripped_jungle_log",
+			"material": "minecraft:stripped_jungle_log",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19847,7 +19779,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_jungle_wood",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -19857,6 +19788,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_jungle_wood",
 			"key": "minecraft:stripped_jungle_wood",
+			"material": "minecraft:stripped_jungle_wood",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19868,7 +19800,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_mangrove_log",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -19878,6 +19809,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_mangrove_log",
 			"key": "minecraft:stripped_mangrove_log",
+			"material": "minecraft:stripped_mangrove_log",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19889,7 +19821,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_mangrove_wood",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -19899,6 +19830,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_mangrove_wood",
 			"key": "minecraft:stripped_mangrove_wood",
+			"material": "minecraft:stripped_mangrove_wood",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19910,7 +19842,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_oak_log",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -19920,6 +19851,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_oak_log",
 			"key": "minecraft:stripped_oak_log",
+			"material": "minecraft:stripped_oak_log",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19931,7 +19863,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_oak_wood",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -19941,6 +19872,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_oak_wood",
 			"key": "minecraft:stripped_oak_wood",
+			"material": "minecraft:stripped_oak_wood",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19952,7 +19884,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_pale_oak_log",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -19962,6 +19893,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_pale_oak_log",
 			"key": "minecraft:stripped_pale_oak_log",
+			"material": "minecraft:stripped_pale_oak_log",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19973,7 +19905,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_pale_oak_wood",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -19983,6 +19914,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_pale_oak_wood",
 			"key": "minecraft:stripped_pale_oak_wood",
+			"material": "minecraft:stripped_pale_oak_wood",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19994,7 +19926,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_spruce_log",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -20004,6 +19935,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_spruce_log",
 			"key": "minecraft:stripped_spruce_log",
+			"material": "minecraft:stripped_spruce_log",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20015,7 +19947,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_spruce_wood",
 			"blastResistance": 2.0,
 			"burnable": true,
 			"collision": true,
@@ -20025,6 +19956,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_spruce_wood",
 			"key": "minecraft:stripped_spruce_wood",
+			"material": "minecraft:stripped_spruce_wood",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20036,7 +19968,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_warped_hyphae",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -20046,6 +19977,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_warped_hyphae",
 			"key": "minecraft:stripped_warped_hyphae",
+			"material": "minecraft:stripped_warped_hyphae",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20057,7 +19989,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:stripped_warped_stem",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -20067,6 +19998,7 @@
 			"interactable": false,
 			"itemType": "minecraft:stripped_warped_stem",
 			"key": "minecraft:stripped_warped_stem",
+			"material": "minecraft:stripped_warped_stem",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20078,7 +20010,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:structure_block",
 			"blastResistance": 3600000.0,
 			"burnable": false,
 			"collision": true,
@@ -20088,6 +20019,7 @@
 			"interactable": true,
 			"itemType": "minecraft:structure_block",
 			"key": "minecraft:structure_block",
+			"material": "minecraft:structure_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20099,7 +20031,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:structure_void",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -20109,6 +20040,7 @@
 			"interactable": false,
 			"itemType": "minecraft:structure_void",
 			"key": "minecraft:structure_void",
+			"material": "minecraft:structure_void",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20120,7 +20052,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:sugar_cane",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -20130,6 +20061,7 @@
 			"interactable": false,
 			"itemType": "minecraft:sugar_cane",
 			"key": "minecraft:sugar_cane",
+			"material": "minecraft:sugar_cane",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20141,7 +20073,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:sunflower",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -20151,6 +20082,7 @@
 			"interactable": false,
 			"itemType": "minecraft:sunflower",
 			"key": "minecraft:sunflower",
+			"material": "minecraft:sunflower",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20162,7 +20094,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:suspicious_gravel",
 			"blastResistance": 0.25,
 			"burnable": false,
 			"collision": true,
@@ -20172,6 +20103,7 @@
 			"interactable": false,
 			"itemType": "minecraft:suspicious_gravel",
 			"key": "minecraft:suspicious_gravel",
+			"material": "minecraft:suspicious_gravel",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20183,7 +20115,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:suspicious_sand",
 			"blastResistance": 0.25,
 			"burnable": false,
 			"collision": true,
@@ -20193,6 +20124,7 @@
 			"interactable": false,
 			"itemType": "minecraft:suspicious_sand",
 			"key": "minecraft:suspicious_sand",
+			"material": "minecraft:suspicious_sand",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20204,7 +20136,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:sweet_berry_bush",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -20214,6 +20145,7 @@
 			"interactable": true,
 			"itemType": "minecraft:sweet_berries",
 			"key": "minecraft:sweet_berry_bush",
+			"material": "minecraft:sweet_berry_bush",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20225,7 +20157,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:tall_dry_grass",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -20235,6 +20166,7 @@
 			"interactable": false,
 			"itemType": "minecraft:tall_dry_grass",
 			"key": "minecraft:tall_dry_grass",
+			"material": "minecraft:tall_dry_grass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20246,7 +20178,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:tall_grass",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -20256,6 +20187,7 @@
 			"interactable": false,
 			"itemType": "minecraft:tall_grass",
 			"key": "minecraft:tall_grass",
+			"material": "minecraft:tall_grass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20267,7 +20199,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:tall_seagrass",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -20275,8 +20206,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": false,
-			"itemType": false,
 			"key": "minecraft:tall_seagrass",
+			"material": "minecraft:tall_seagrass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20288,7 +20219,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:target",
 			"blastResistance": 0.5,
 			"burnable": true,
 			"collision": true,
@@ -20298,6 +20228,7 @@
 			"interactable": false,
 			"itemType": "minecraft:target",
 			"key": "minecraft:target",
+			"material": "minecraft:target",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20309,7 +20240,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:terracotta",
 			"blastResistance": 4.2,
 			"burnable": false,
 			"collision": true,
@@ -20319,6 +20249,7 @@
 			"interactable": false,
 			"itemType": "minecraft:terracotta",
 			"key": "minecraft:terracotta",
+			"material": "minecraft:terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20330,7 +20261,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:test_block",
 			"blastResistance": 3600000.0,
 			"burnable": false,
 			"collision": true,
@@ -20340,6 +20270,7 @@
 			"interactable": true,
 			"itemType": "minecraft:test_block",
 			"key": "minecraft:test_block",
+			"material": "minecraft:test_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20351,7 +20282,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:test_instance_block",
 			"blastResistance": 3600000.0,
 			"burnable": false,
 			"collision": true,
@@ -20361,6 +20291,7 @@
 			"interactable": true,
 			"itemType": "minecraft:test_instance_block",
 			"key": "minecraft:test_instance_block",
+			"material": "minecraft:test_instance_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20372,7 +20303,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:tinted_glass",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -20382,6 +20312,7 @@
 			"interactable": false,
 			"itemType": "minecraft:tinted_glass",
 			"key": "minecraft:tinted_glass",
+			"material": "minecraft:tinted_glass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20393,7 +20324,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:tnt",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": true,
@@ -20403,6 +20333,7 @@
 			"interactable": true,
 			"itemType": "minecraft:tnt",
 			"key": "minecraft:tnt",
+			"material": "minecraft:tnt",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20414,7 +20345,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:torch",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -20424,6 +20354,7 @@
 			"interactable": false,
 			"itemType": "minecraft:torch",
 			"key": "minecraft:torch",
+			"material": "minecraft:torch",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20435,7 +20366,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:torchflower",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -20445,6 +20375,7 @@
 			"interactable": false,
 			"itemType": "minecraft:torchflower",
 			"key": "minecraft:torchflower",
+			"material": "minecraft:torchflower",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20456,7 +20387,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:torchflower_crop",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -20466,6 +20396,7 @@
 			"interactable": false,
 			"itemType": "minecraft:torchflower_seeds",
 			"key": "minecraft:torchflower_crop",
+			"material": "minecraft:torchflower_crop",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20477,7 +20408,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:trapped_chest",
 			"blastResistance": 2.5,
 			"burnable": false,
 			"collision": true,
@@ -20487,6 +20417,7 @@
 			"interactable": true,
 			"itemType": "minecraft:trapped_chest",
 			"key": "minecraft:trapped_chest",
+			"material": "minecraft:trapped_chest",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20498,7 +20429,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:trial_spawner",
 			"blastResistance": 50.0,
 			"burnable": false,
 			"collision": true,
@@ -20508,6 +20438,7 @@
 			"interactable": false,
 			"itemType": "minecraft:trial_spawner",
 			"key": "minecraft:trial_spawner",
+			"material": "minecraft:trial_spawner",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20519,7 +20450,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:tripwire",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -20529,6 +20459,7 @@
 			"interactable": false,
 			"itemType": "minecraft:string",
 			"key": "minecraft:tripwire",
+			"material": "minecraft:tripwire",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20540,7 +20471,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:tripwire_hook",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -20550,6 +20480,7 @@
 			"interactable": false,
 			"itemType": "minecraft:tripwire_hook",
 			"key": "minecraft:tripwire_hook",
+			"material": "minecraft:tripwire_hook",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20561,7 +20492,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:tube_coral",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -20571,6 +20501,7 @@
 			"interactable": false,
 			"itemType": "minecraft:tube_coral",
 			"key": "minecraft:tube_coral",
+			"material": "minecraft:tube_coral",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20582,7 +20513,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:tube_coral_block",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -20592,6 +20522,7 @@
 			"interactable": false,
 			"itemType": "minecraft:tube_coral_block",
 			"key": "minecraft:tube_coral_block",
+			"material": "minecraft:tube_coral_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20603,7 +20534,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:tube_coral_fan",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -20613,6 +20543,7 @@
 			"interactable": false,
 			"itemType": "minecraft:tube_coral_fan",
 			"key": "minecraft:tube_coral_fan",
+			"material": "minecraft:tube_coral_fan",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20624,7 +20555,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:tube_coral_wall_fan",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -20634,6 +20564,7 @@
 			"interactable": false,
 			"itemType": "minecraft:tube_coral_fan",
 			"key": "minecraft:tube_coral_wall_fan",
+			"material": "minecraft:tube_coral_wall_fan",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20645,7 +20576,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:tuff",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -20655,6 +20585,7 @@
 			"interactable": false,
 			"itemType": "minecraft:tuff",
 			"key": "minecraft:tuff",
+			"material": "minecraft:tuff",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20666,7 +20597,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:tuff_brick_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -20676,6 +20606,7 @@
 			"interactable": false,
 			"itemType": "minecraft:tuff_brick_slab",
 			"key": "minecraft:tuff_brick_slab",
+			"material": "minecraft:tuff_brick_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20687,7 +20618,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:tuff_brick_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -20697,6 +20627,7 @@
 			"interactable": false,
 			"itemType": "minecraft:tuff_brick_stairs",
 			"key": "minecraft:tuff_brick_stairs",
+			"material": "minecraft:tuff_brick_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20708,7 +20639,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:tuff_brick_wall",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -20718,6 +20648,7 @@
 			"interactable": false,
 			"itemType": "minecraft:tuff_brick_wall",
 			"key": "minecraft:tuff_brick_wall",
+			"material": "minecraft:tuff_brick_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20729,7 +20660,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:tuff_bricks",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -20739,6 +20669,7 @@
 			"interactable": false,
 			"itemType": "minecraft:tuff_bricks",
 			"key": "minecraft:tuff_bricks",
+			"material": "minecraft:tuff_bricks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20750,7 +20681,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:tuff_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -20760,6 +20690,7 @@
 			"interactable": false,
 			"itemType": "minecraft:tuff_slab",
 			"key": "minecraft:tuff_slab",
+			"material": "minecraft:tuff_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20771,7 +20702,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:tuff_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -20781,6 +20711,7 @@
 			"interactable": false,
 			"itemType": "minecraft:tuff_stairs",
 			"key": "minecraft:tuff_stairs",
+			"material": "minecraft:tuff_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20792,7 +20723,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:tuff_wall",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -20802,6 +20732,7 @@
 			"interactable": false,
 			"itemType": "minecraft:tuff_wall",
 			"key": "minecraft:tuff_wall",
+			"material": "minecraft:tuff_wall",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20813,7 +20744,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:turtle_egg",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -20823,6 +20753,7 @@
 			"interactable": false,
 			"itemType": "minecraft:turtle_egg",
 			"key": "minecraft:turtle_egg",
+			"material": "minecraft:turtle_egg",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20834,7 +20765,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:twisting_vines",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -20844,6 +20774,7 @@
 			"interactable": false,
 			"itemType": "minecraft:twisting_vines",
 			"key": "minecraft:twisting_vines",
+			"material": "minecraft:twisting_vines",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20855,7 +20786,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:twisting_vines_plant",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -20863,8 +20793,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": false,
-			"itemType": false,
 			"key": "minecraft:twisting_vines_plant",
+			"material": "minecraft:twisting_vines_plant",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20876,7 +20806,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:vault",
 			"blastResistance": 50.0,
 			"burnable": false,
 			"collision": true,
@@ -20886,6 +20815,7 @@
 			"interactable": true,
 			"itemType": "minecraft:vault",
 			"key": "minecraft:vault",
+			"material": "minecraft:vault",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20897,7 +20827,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:verdant_froglight",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -20907,6 +20836,7 @@
 			"interactable": false,
 			"itemType": "minecraft:verdant_froglight",
 			"key": "minecraft:verdant_froglight",
+			"material": "minecraft:verdant_froglight",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20918,7 +20848,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:vine",
 			"blastResistance": 0.2,
 			"burnable": true,
 			"collision": false,
@@ -20928,6 +20857,7 @@
 			"interactable": false,
 			"itemType": "minecraft:vine",
 			"key": "minecraft:vine",
+			"material": "minecraft:vine",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20939,7 +20869,6 @@
 		},
 		{
 			"air": true,
-			"asMaterial": "minecraft:void_air",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -20947,8 +20876,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": false,
-			"itemType": false,
 			"key": "minecraft:void_air",
+			"material": "minecraft:void_air",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20960,7 +20889,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:wall_torch",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -20970,6 +20898,7 @@
 			"interactable": false,
 			"itemType": "minecraft:torch",
 			"key": "minecraft:wall_torch",
+			"material": "minecraft:wall_torch",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20981,7 +20910,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:warped_button",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -20991,6 +20919,7 @@
 			"interactable": true,
 			"itemType": "minecraft:warped_button",
 			"key": "minecraft:warped_button",
+			"material": "minecraft:warped_button",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21002,7 +20931,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:warped_door",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -21012,6 +20940,7 @@
 			"interactable": true,
 			"itemType": "minecraft:warped_door",
 			"key": "minecraft:warped_door",
+			"material": "minecraft:warped_door",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21023,7 +20952,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:warped_fence",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -21033,6 +20961,7 @@
 			"interactable": true,
 			"itemType": "minecraft:warped_fence",
 			"key": "minecraft:warped_fence",
+			"material": "minecraft:warped_fence",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21044,7 +20973,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:warped_fence_gate",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -21054,6 +20982,7 @@
 			"interactable": true,
 			"itemType": "minecraft:warped_fence_gate",
 			"key": "minecraft:warped_fence_gate",
+			"material": "minecraft:warped_fence_gate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21065,7 +20994,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:warped_fungus",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -21075,6 +21003,7 @@
 			"interactable": false,
 			"itemType": "minecraft:warped_fungus",
 			"key": "minecraft:warped_fungus",
+			"material": "minecraft:warped_fungus",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21086,7 +21015,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:warped_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -21096,6 +21024,7 @@
 			"interactable": true,
 			"itemType": "minecraft:warped_hanging_sign",
 			"key": "minecraft:warped_hanging_sign",
+			"material": "minecraft:warped_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21107,7 +21036,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:warped_hyphae",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -21117,6 +21045,7 @@
 			"interactable": false,
 			"itemType": "minecraft:warped_hyphae",
 			"key": "minecraft:warped_hyphae",
+			"material": "minecraft:warped_hyphae",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21128,7 +21057,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:warped_nylium",
 			"blastResistance": 0.4,
 			"burnable": false,
 			"collision": true,
@@ -21138,6 +21066,7 @@
 			"interactable": false,
 			"itemType": "minecraft:warped_nylium",
 			"key": "minecraft:warped_nylium",
+			"material": "minecraft:warped_nylium",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21149,7 +21078,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:warped_planks",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -21159,6 +21087,7 @@
 			"interactable": false,
 			"itemType": "minecraft:warped_planks",
 			"key": "minecraft:warped_planks",
+			"material": "minecraft:warped_planks",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21170,7 +21099,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:warped_pressure_plate",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": false,
@@ -21180,6 +21108,7 @@
 			"interactable": false,
 			"itemType": "minecraft:warped_pressure_plate",
 			"key": "minecraft:warped_pressure_plate",
+			"material": "minecraft:warped_pressure_plate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21191,7 +21120,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:warped_roots",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -21201,6 +21129,7 @@
 			"interactable": false,
 			"itemType": "minecraft:warped_roots",
 			"key": "minecraft:warped_roots",
+			"material": "minecraft:warped_roots",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21212,7 +21141,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:warped_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -21222,6 +21150,7 @@
 			"interactable": true,
 			"itemType": "minecraft:warped_sign",
 			"key": "minecraft:warped_sign",
+			"material": "minecraft:warped_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21233,7 +21162,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:warped_slab",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -21243,6 +21171,7 @@
 			"interactable": false,
 			"itemType": "minecraft:warped_slab",
 			"key": "minecraft:warped_slab",
+			"material": "minecraft:warped_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21254,7 +21183,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:warped_stairs",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -21264,6 +21192,7 @@
 			"interactable": false,
 			"itemType": "minecraft:warped_stairs",
 			"key": "minecraft:warped_stairs",
+			"material": "minecraft:warped_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21275,7 +21204,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:warped_stem",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -21285,6 +21213,7 @@
 			"interactable": false,
 			"itemType": "minecraft:warped_stem",
 			"key": "minecraft:warped_stem",
+			"material": "minecraft:warped_stem",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21296,7 +21225,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:warped_trapdoor",
 			"blastResistance": 3.0,
 			"burnable": false,
 			"collision": true,
@@ -21306,6 +21234,7 @@
 			"interactable": true,
 			"itemType": "minecraft:warped_trapdoor",
 			"key": "minecraft:warped_trapdoor",
+			"material": "minecraft:warped_trapdoor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21317,7 +21246,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:warped_wall_hanging_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -21327,6 +21255,7 @@
 			"interactable": true,
 			"itemType": "minecraft:warped_hanging_sign",
 			"key": "minecraft:warped_wall_hanging_sign",
+			"material": "minecraft:warped_wall_hanging_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21338,7 +21267,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:warped_wall_sign",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -21348,6 +21276,7 @@
 			"interactable": true,
 			"itemType": "minecraft:warped_sign",
 			"key": "minecraft:warped_wall_sign",
+			"material": "minecraft:warped_wall_sign",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21359,7 +21288,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:warped_wart_block",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": true,
@@ -21369,6 +21297,7 @@
 			"interactable": false,
 			"itemType": "minecraft:warped_wart_block",
 			"key": "minecraft:warped_wart_block",
+			"material": "minecraft:warped_wart_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21380,7 +21309,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:water",
 			"blastResistance": 100.0,
 			"burnable": false,
 			"collision": false,
@@ -21388,8 +21316,8 @@
 			"gravity": false,
 			"hardness": 100.0,
 			"interactable": false,
-			"itemType": false,
 			"key": "minecraft:water",
+			"material": "minecraft:water",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21401,7 +21329,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:water_cauldron",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -21411,6 +21338,7 @@
 			"interactable": true,
 			"itemType": "minecraft:cauldron",
 			"key": "minecraft:water_cauldron",
+			"material": "minecraft:water_cauldron",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21422,7 +21350,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_chiseled_copper",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21432,6 +21359,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_chiseled_copper",
 			"key": "minecraft:waxed_chiseled_copper",
+			"material": "minecraft:waxed_chiseled_copper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21443,7 +21371,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_copper_block",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21453,6 +21380,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_copper_block",
 			"key": "minecraft:waxed_copper_block",
+			"material": "minecraft:waxed_copper_block",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21464,7 +21392,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_copper_bulb",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21474,6 +21401,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_copper_bulb",
 			"key": "minecraft:waxed_copper_bulb",
+			"material": "minecraft:waxed_copper_bulb",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21485,7 +21413,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_copper_door",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21495,6 +21422,7 @@
 			"interactable": true,
 			"itemType": "minecraft:waxed_copper_door",
 			"key": "minecraft:waxed_copper_door",
+			"material": "minecraft:waxed_copper_door",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21506,7 +21434,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_copper_grate",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21516,6 +21443,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_copper_grate",
 			"key": "minecraft:waxed_copper_grate",
+			"material": "minecraft:waxed_copper_grate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21527,7 +21455,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_copper_trapdoor",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21537,6 +21464,7 @@
 			"interactable": true,
 			"itemType": "minecraft:waxed_copper_trapdoor",
 			"key": "minecraft:waxed_copper_trapdoor",
+			"material": "minecraft:waxed_copper_trapdoor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21548,7 +21476,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_cut_copper",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21558,6 +21485,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_cut_copper",
 			"key": "minecraft:waxed_cut_copper",
+			"material": "minecraft:waxed_cut_copper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21569,7 +21497,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_cut_copper_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21579,6 +21506,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_cut_copper_slab",
 			"key": "minecraft:waxed_cut_copper_slab",
+			"material": "minecraft:waxed_cut_copper_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21590,7 +21518,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_cut_copper_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21600,6 +21527,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_cut_copper_stairs",
 			"key": "minecraft:waxed_cut_copper_stairs",
+			"material": "minecraft:waxed_cut_copper_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21611,7 +21539,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_exposed_chiseled_copper",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21621,6 +21548,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_exposed_chiseled_copper",
 			"key": "minecraft:waxed_exposed_chiseled_copper",
+			"material": "minecraft:waxed_exposed_chiseled_copper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21632,7 +21560,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_exposed_copper",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21642,6 +21569,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_exposed_copper",
 			"key": "minecraft:waxed_exposed_copper",
+			"material": "minecraft:waxed_exposed_copper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21653,7 +21581,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_exposed_copper_bulb",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21663,6 +21590,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_exposed_copper_bulb",
 			"key": "minecraft:waxed_exposed_copper_bulb",
+			"material": "minecraft:waxed_exposed_copper_bulb",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21674,7 +21602,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_exposed_copper_door",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21684,6 +21611,7 @@
 			"interactable": true,
 			"itemType": "minecraft:waxed_exposed_copper_door",
 			"key": "minecraft:waxed_exposed_copper_door",
+			"material": "minecraft:waxed_exposed_copper_door",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21695,7 +21623,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_exposed_copper_grate",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21705,6 +21632,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_exposed_copper_grate",
 			"key": "minecraft:waxed_exposed_copper_grate",
+			"material": "minecraft:waxed_exposed_copper_grate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21716,7 +21644,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_exposed_copper_trapdoor",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21726,6 +21653,7 @@
 			"interactable": true,
 			"itemType": "minecraft:waxed_exposed_copper_trapdoor",
 			"key": "minecraft:waxed_exposed_copper_trapdoor",
+			"material": "minecraft:waxed_exposed_copper_trapdoor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21737,7 +21665,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_exposed_cut_copper",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21747,6 +21674,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_exposed_cut_copper",
 			"key": "minecraft:waxed_exposed_cut_copper",
+			"material": "minecraft:waxed_exposed_cut_copper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21758,7 +21686,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_exposed_cut_copper_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21768,6 +21695,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_exposed_cut_copper_slab",
 			"key": "minecraft:waxed_exposed_cut_copper_slab",
+			"material": "minecraft:waxed_exposed_cut_copper_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21779,7 +21707,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_exposed_cut_copper_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21789,6 +21716,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_exposed_cut_copper_stairs",
 			"key": "minecraft:waxed_exposed_cut_copper_stairs",
+			"material": "minecraft:waxed_exposed_cut_copper_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21800,7 +21728,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_oxidized_chiseled_copper",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21810,6 +21737,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_oxidized_chiseled_copper",
 			"key": "minecraft:waxed_oxidized_chiseled_copper",
+			"material": "minecraft:waxed_oxidized_chiseled_copper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21821,7 +21749,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_oxidized_copper",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21831,6 +21758,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_oxidized_copper",
 			"key": "minecraft:waxed_oxidized_copper",
+			"material": "minecraft:waxed_oxidized_copper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21842,7 +21770,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_oxidized_copper_bulb",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21852,6 +21779,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_oxidized_copper_bulb",
 			"key": "minecraft:waxed_oxidized_copper_bulb",
+			"material": "minecraft:waxed_oxidized_copper_bulb",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21863,7 +21791,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_oxidized_copper_door",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21873,6 +21800,7 @@
 			"interactable": true,
 			"itemType": "minecraft:waxed_oxidized_copper_door",
 			"key": "minecraft:waxed_oxidized_copper_door",
+			"material": "minecraft:waxed_oxidized_copper_door",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21884,7 +21812,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_oxidized_copper_grate",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21894,6 +21821,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_oxidized_copper_grate",
 			"key": "minecraft:waxed_oxidized_copper_grate",
+			"material": "minecraft:waxed_oxidized_copper_grate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21905,7 +21833,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_oxidized_copper_trapdoor",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21915,6 +21842,7 @@
 			"interactable": true,
 			"itemType": "minecraft:waxed_oxidized_copper_trapdoor",
 			"key": "minecraft:waxed_oxidized_copper_trapdoor",
+			"material": "minecraft:waxed_oxidized_copper_trapdoor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21926,7 +21854,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_oxidized_cut_copper",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21936,6 +21863,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_oxidized_cut_copper",
 			"key": "minecraft:waxed_oxidized_cut_copper",
+			"material": "minecraft:waxed_oxidized_cut_copper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21947,7 +21875,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_oxidized_cut_copper_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21957,6 +21884,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_oxidized_cut_copper_slab",
 			"key": "minecraft:waxed_oxidized_cut_copper_slab",
+			"material": "minecraft:waxed_oxidized_cut_copper_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21968,7 +21896,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_oxidized_cut_copper_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21978,6 +21905,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_oxidized_cut_copper_stairs",
 			"key": "minecraft:waxed_oxidized_cut_copper_stairs",
+			"material": "minecraft:waxed_oxidized_cut_copper_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21989,7 +21917,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_weathered_chiseled_copper",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -21999,6 +21926,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_weathered_chiseled_copper",
 			"key": "minecraft:waxed_weathered_chiseled_copper",
+			"material": "minecraft:waxed_weathered_chiseled_copper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22010,7 +21938,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_weathered_copper",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -22020,6 +21947,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_weathered_copper",
 			"key": "minecraft:waxed_weathered_copper",
+			"material": "minecraft:waxed_weathered_copper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22031,7 +21959,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_weathered_copper_bulb",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -22041,6 +21968,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_weathered_copper_bulb",
 			"key": "minecraft:waxed_weathered_copper_bulb",
+			"material": "minecraft:waxed_weathered_copper_bulb",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22052,7 +21980,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_weathered_copper_door",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -22062,6 +21989,7 @@
 			"interactable": true,
 			"itemType": "minecraft:waxed_weathered_copper_door",
 			"key": "minecraft:waxed_weathered_copper_door",
+			"material": "minecraft:waxed_weathered_copper_door",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22073,7 +22001,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_weathered_copper_grate",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -22083,6 +22010,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_weathered_copper_grate",
 			"key": "minecraft:waxed_weathered_copper_grate",
+			"material": "minecraft:waxed_weathered_copper_grate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22094,7 +22022,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_weathered_copper_trapdoor",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -22104,6 +22031,7 @@
 			"interactable": true,
 			"itemType": "minecraft:waxed_weathered_copper_trapdoor",
 			"key": "minecraft:waxed_weathered_copper_trapdoor",
+			"material": "minecraft:waxed_weathered_copper_trapdoor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22115,7 +22043,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_weathered_cut_copper",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -22125,6 +22052,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_weathered_cut_copper",
 			"key": "minecraft:waxed_weathered_cut_copper",
+			"material": "minecraft:waxed_weathered_cut_copper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22136,7 +22064,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_weathered_cut_copper_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -22146,6 +22073,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_weathered_cut_copper_slab",
 			"key": "minecraft:waxed_weathered_cut_copper_slab",
+			"material": "minecraft:waxed_weathered_cut_copper_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22157,7 +22085,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:waxed_weathered_cut_copper_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -22167,6 +22094,7 @@
 			"interactable": false,
 			"itemType": "minecraft:waxed_weathered_cut_copper_stairs",
 			"key": "minecraft:waxed_weathered_cut_copper_stairs",
+			"material": "minecraft:waxed_weathered_cut_copper_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22178,7 +22106,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:weathered_chiseled_copper",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -22188,6 +22115,7 @@
 			"interactable": false,
 			"itemType": "minecraft:weathered_chiseled_copper",
 			"key": "minecraft:weathered_chiseled_copper",
+			"material": "minecraft:weathered_chiseled_copper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22199,7 +22127,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:weathered_copper",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -22209,6 +22136,7 @@
 			"interactable": false,
 			"itemType": "minecraft:weathered_copper",
 			"key": "minecraft:weathered_copper",
+			"material": "minecraft:weathered_copper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22220,7 +22148,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:weathered_copper_bulb",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -22230,6 +22157,7 @@
 			"interactable": false,
 			"itemType": "minecraft:weathered_copper_bulb",
 			"key": "minecraft:weathered_copper_bulb",
+			"material": "minecraft:weathered_copper_bulb",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22241,7 +22169,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:weathered_copper_door",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -22251,6 +22178,7 @@
 			"interactable": true,
 			"itemType": "minecraft:weathered_copper_door",
 			"key": "minecraft:weathered_copper_door",
+			"material": "minecraft:weathered_copper_door",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22262,7 +22190,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:weathered_copper_grate",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -22272,6 +22199,7 @@
 			"interactable": false,
 			"itemType": "minecraft:weathered_copper_grate",
 			"key": "minecraft:weathered_copper_grate",
+			"material": "minecraft:weathered_copper_grate",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22283,7 +22211,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:weathered_copper_trapdoor",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -22293,6 +22220,7 @@
 			"interactable": true,
 			"itemType": "minecraft:weathered_copper_trapdoor",
 			"key": "minecraft:weathered_copper_trapdoor",
+			"material": "minecraft:weathered_copper_trapdoor",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22304,7 +22232,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:weathered_cut_copper",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -22314,6 +22241,7 @@
 			"interactable": false,
 			"itemType": "minecraft:weathered_cut_copper",
 			"key": "minecraft:weathered_cut_copper",
+			"material": "minecraft:weathered_cut_copper",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22325,7 +22253,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:weathered_cut_copper_slab",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -22335,6 +22262,7 @@
 			"interactable": false,
 			"itemType": "minecraft:weathered_cut_copper_slab",
 			"key": "minecraft:weathered_cut_copper_slab",
+			"material": "minecraft:weathered_cut_copper_slab",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22346,7 +22274,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:weathered_cut_copper_stairs",
 			"blastResistance": 6.0,
 			"burnable": false,
 			"collision": true,
@@ -22356,6 +22283,7 @@
 			"interactable": false,
 			"itemType": "minecraft:weathered_cut_copper_stairs",
 			"key": "minecraft:weathered_cut_copper_stairs",
+			"material": "minecraft:weathered_cut_copper_stairs",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22367,7 +22295,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:weeping_vines",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -22377,6 +22304,7 @@
 			"interactable": false,
 			"itemType": "minecraft:weeping_vines",
 			"key": "minecraft:weeping_vines",
+			"material": "minecraft:weeping_vines",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22388,7 +22316,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:weeping_vines_plant",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -22396,8 +22323,8 @@
 			"gravity": false,
 			"hardness": 0.0,
 			"interactable": false,
-			"itemType": false,
 			"key": "minecraft:weeping_vines_plant",
+			"material": "minecraft:weeping_vines_plant",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22409,7 +22336,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:wet_sponge",
 			"blastResistance": 0.6,
 			"burnable": false,
 			"collision": true,
@@ -22419,6 +22345,7 @@
 			"interactable": false,
 			"itemType": "minecraft:wet_sponge",
 			"key": "minecraft:wet_sponge",
+			"material": "minecraft:wet_sponge",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22430,7 +22357,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:wheat",
 			"blastResistance": 0.0,
 			"burnable": false,
 			"collision": false,
@@ -22440,6 +22366,7 @@
 			"interactable": false,
 			"itemType": "minecraft:wheat_seeds",
 			"key": "minecraft:wheat",
+			"material": "minecraft:wheat",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22451,7 +22378,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:white_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -22461,6 +22387,7 @@
 			"interactable": false,
 			"itemType": "minecraft:white_banner",
 			"key": "minecraft:white_banner",
+			"material": "minecraft:white_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22472,7 +22399,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:white_bed",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": true,
@@ -22482,6 +22408,7 @@
 			"interactable": true,
 			"itemType": "minecraft:white_bed",
 			"key": "minecraft:white_bed",
+			"material": "minecraft:white_bed",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22493,7 +22420,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:white_candle",
 			"blastResistance": 0.1,
 			"burnable": false,
 			"collision": true,
@@ -22503,6 +22429,7 @@
 			"interactable": true,
 			"itemType": "minecraft:white_candle",
 			"key": "minecraft:white_candle",
+			"material": "minecraft:white_candle",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22514,7 +22441,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:white_candle_cake",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -22522,8 +22448,8 @@
 			"gravity": false,
 			"hardness": 0.5,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:white_candle_cake",
+			"material": "minecraft:white_candle_cake",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22535,7 +22461,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:white_carpet",
 			"blastResistance": 0.1,
 			"burnable": true,
 			"collision": true,
@@ -22545,6 +22470,7 @@
 			"interactable": false,
 			"itemType": "minecraft:white_carpet",
 			"key": "minecraft:white_carpet",
+			"material": "minecraft:white_carpet",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22556,7 +22482,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:white_concrete",
 			"blastResistance": 1.8,
 			"burnable": false,
 			"collision": true,
@@ -22566,6 +22491,7 @@
 			"interactable": false,
 			"itemType": "minecraft:white_concrete",
 			"key": "minecraft:white_concrete",
+			"material": "minecraft:white_concrete",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22577,7 +22503,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:white_concrete_powder",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -22587,6 +22512,7 @@
 			"interactable": false,
 			"itemType": "minecraft:white_concrete_powder",
 			"key": "minecraft:white_concrete_powder",
+			"material": "minecraft:white_concrete_powder",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22598,7 +22524,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:white_glazed_terracotta",
 			"blastResistance": 1.4,
 			"burnable": false,
 			"collision": true,
@@ -22608,6 +22533,7 @@
 			"interactable": false,
 			"itemType": "minecraft:white_glazed_terracotta",
 			"key": "minecraft:white_glazed_terracotta",
+			"material": "minecraft:white_glazed_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22619,7 +22545,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:white_shulker_box",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -22629,6 +22554,7 @@
 			"interactable": true,
 			"itemType": "minecraft:white_shulker_box",
 			"key": "minecraft:white_shulker_box",
+			"material": "minecraft:white_shulker_box",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22640,7 +22566,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:white_stained_glass",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -22650,6 +22575,7 @@
 			"interactable": false,
 			"itemType": "minecraft:white_stained_glass",
 			"key": "minecraft:white_stained_glass",
+			"material": "minecraft:white_stained_glass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22661,7 +22587,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:white_stained_glass_pane",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -22671,6 +22596,7 @@
 			"interactable": false,
 			"itemType": "minecraft:white_stained_glass_pane",
 			"key": "minecraft:white_stained_glass_pane",
+			"material": "minecraft:white_stained_glass_pane",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22682,7 +22608,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:white_terracotta",
 			"blastResistance": 4.2,
 			"burnable": false,
 			"collision": true,
@@ -22692,6 +22617,7 @@
 			"interactable": false,
 			"itemType": "minecraft:white_terracotta",
 			"key": "minecraft:white_terracotta",
+			"material": "minecraft:white_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22703,7 +22629,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:white_tulip",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -22713,6 +22638,7 @@
 			"interactable": false,
 			"itemType": "minecraft:white_tulip",
 			"key": "minecraft:white_tulip",
+			"material": "minecraft:white_tulip",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22724,7 +22650,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:white_wall_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -22734,6 +22659,7 @@
 			"interactable": false,
 			"itemType": "minecraft:white_banner",
 			"key": "minecraft:white_wall_banner",
+			"material": "minecraft:white_wall_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22745,7 +22671,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:white_wool",
 			"blastResistance": 0.8,
 			"burnable": true,
 			"collision": true,
@@ -22755,6 +22680,7 @@
 			"interactable": false,
 			"itemType": "minecraft:white_wool",
 			"key": "minecraft:white_wool",
+			"material": "minecraft:white_wool",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22766,7 +22692,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:wildflowers",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -22776,6 +22701,7 @@
 			"interactable": false,
 			"itemType": "minecraft:wildflowers",
 			"key": "minecraft:wildflowers",
+			"material": "minecraft:wildflowers",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22787,7 +22713,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:wither_rose",
 			"blastResistance": 0.0,
 			"burnable": true,
 			"collision": false,
@@ -22797,6 +22722,7 @@
 			"interactable": false,
 			"itemType": "minecraft:wither_rose",
 			"key": "minecraft:wither_rose",
+			"material": "minecraft:wither_rose",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22808,7 +22734,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:wither_skeleton_skull",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": true,
@@ -22818,6 +22743,7 @@
 			"interactable": false,
 			"itemType": "minecraft:wither_skeleton_skull",
 			"key": "minecraft:wither_skeleton_skull",
+			"material": "minecraft:wither_skeleton_skull",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22829,7 +22755,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:wither_skeleton_wall_skull",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": true,
@@ -22839,6 +22764,7 @@
 			"interactable": false,
 			"itemType": "minecraft:wither_skeleton_skull",
 			"key": "minecraft:wither_skeleton_wall_skull",
+			"material": "minecraft:wither_skeleton_wall_skull",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22850,7 +22776,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:yellow_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -22860,6 +22785,7 @@
 			"interactable": false,
 			"itemType": "minecraft:yellow_banner",
 			"key": "minecraft:yellow_banner",
+			"material": "minecraft:yellow_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22871,7 +22797,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:yellow_bed",
 			"blastResistance": 0.2,
 			"burnable": false,
 			"collision": true,
@@ -22881,6 +22806,7 @@
 			"interactable": true,
 			"itemType": "minecraft:yellow_bed",
 			"key": "minecraft:yellow_bed",
+			"material": "minecraft:yellow_bed",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22892,7 +22818,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:yellow_candle",
 			"blastResistance": 0.1,
 			"burnable": false,
 			"collision": true,
@@ -22902,6 +22827,7 @@
 			"interactable": true,
 			"itemType": "minecraft:yellow_candle",
 			"key": "minecraft:yellow_candle",
+			"material": "minecraft:yellow_candle",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22913,7 +22839,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:yellow_candle_cake",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -22921,8 +22846,8 @@
 			"gravity": false,
 			"hardness": 0.5,
 			"interactable": true,
-			"itemType": false,
 			"key": "minecraft:yellow_candle_cake",
+			"material": "minecraft:yellow_candle_cake",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22934,7 +22859,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:yellow_carpet",
 			"blastResistance": 0.1,
 			"burnable": true,
 			"collision": true,
@@ -22944,6 +22868,7 @@
 			"interactable": false,
 			"itemType": "minecraft:yellow_carpet",
 			"key": "minecraft:yellow_carpet",
+			"material": "minecraft:yellow_carpet",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22955,7 +22880,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:yellow_concrete",
 			"blastResistance": 1.8,
 			"burnable": false,
 			"collision": true,
@@ -22965,6 +22889,7 @@
 			"interactable": false,
 			"itemType": "minecraft:yellow_concrete",
 			"key": "minecraft:yellow_concrete",
+			"material": "minecraft:yellow_concrete",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22976,7 +22901,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:yellow_concrete_powder",
 			"blastResistance": 0.5,
 			"burnable": false,
 			"collision": true,
@@ -22986,6 +22910,7 @@
 			"interactable": false,
 			"itemType": "minecraft:yellow_concrete_powder",
 			"key": "minecraft:yellow_concrete_powder",
+			"material": "minecraft:yellow_concrete_powder",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22997,7 +22922,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:yellow_glazed_terracotta",
 			"blastResistance": 1.4,
 			"burnable": false,
 			"collision": true,
@@ -23007,6 +22931,7 @@
 			"interactable": false,
 			"itemType": "minecraft:yellow_glazed_terracotta",
 			"key": "minecraft:yellow_glazed_terracotta",
+			"material": "minecraft:yellow_glazed_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23018,7 +22943,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:yellow_shulker_box",
 			"blastResistance": 2.0,
 			"burnable": false,
 			"collision": true,
@@ -23028,6 +22952,7 @@
 			"interactable": true,
 			"itemType": "minecraft:yellow_shulker_box",
 			"key": "minecraft:yellow_shulker_box",
+			"material": "minecraft:yellow_shulker_box",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23039,7 +22964,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:yellow_stained_glass",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -23049,6 +22973,7 @@
 			"interactable": false,
 			"itemType": "minecraft:yellow_stained_glass",
 			"key": "minecraft:yellow_stained_glass",
+			"material": "minecraft:yellow_stained_glass",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23060,7 +22985,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:yellow_stained_glass_pane",
 			"blastResistance": 0.3,
 			"burnable": false,
 			"collision": true,
@@ -23070,6 +22994,7 @@
 			"interactable": false,
 			"itemType": "minecraft:yellow_stained_glass_pane",
 			"key": "minecraft:yellow_stained_glass_pane",
+			"material": "minecraft:yellow_stained_glass_pane",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23081,7 +23006,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:yellow_terracotta",
 			"blastResistance": 4.2,
 			"burnable": false,
 			"collision": true,
@@ -23091,6 +23015,7 @@
 			"interactable": false,
 			"itemType": "minecraft:yellow_terracotta",
 			"key": "minecraft:yellow_terracotta",
+			"material": "minecraft:yellow_terracotta",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23102,7 +23027,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:yellow_wall_banner",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": false,
@@ -23112,6 +23036,7 @@
 			"interactable": false,
 			"itemType": "minecraft:yellow_banner",
 			"key": "minecraft:yellow_wall_banner",
+			"material": "minecraft:yellow_wall_banner",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23123,7 +23048,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:yellow_wool",
 			"blastResistance": 0.8,
 			"burnable": true,
 			"collision": true,
@@ -23133,6 +23057,7 @@
 			"interactable": false,
 			"itemType": "minecraft:yellow_wool",
 			"key": "minecraft:yellow_wool",
+			"material": "minecraft:yellow_wool",
 			"occluding": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23144,7 +23069,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:zombie_head",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": true,
@@ -23154,6 +23078,7 @@
 			"interactable": false,
 			"itemType": "minecraft:zombie_head",
 			"key": "minecraft:zombie_head",
+			"material": "minecraft:zombie_head",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23165,7 +23090,6 @@
 		},
 		{
 			"air": false,
-			"asMaterial": "minecraft:zombie_wall_head",
 			"blastResistance": 1.0,
 			"burnable": false,
 			"collision": true,
@@ -23175,6 +23099,7 @@
 			"interactable": false,
 			"itemType": "minecraft:zombie_head",
 			"key": "minecraft:zombie_wall_head",
+			"material": "minecraft:zombie_wall_head",
 			"occluding": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"

--- a/src/main/resources/keyed/entity_type.json
+++ b/src/main/resources/keyed/entity_type.json
@@ -2,7 +2,6 @@
 	"values": [
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:acacia_boat",
 			"name": "ACACIA_BOAT",
 			"ordinal": 0,
@@ -15,7 +14,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:acacia_chest_boat",
 			"name": "ACACIA_CHEST_BOAT",
 			"ordinal": 1,
@@ -28,7 +26,92 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 2.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:flying_speed": {
+					"baseValue": 0.10000000149011612,
+					"defaultValue": 0.4
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 20.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.10000000149011612,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:allay",
 			"name": "ALLAY",
 			"ordinal": 2,
@@ -41,7 +124,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:area_effect_cloud",
 			"name": "AREA_EFFECT_CLOUD",
 			"ordinal": 3,
@@ -54,7 +136,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 12.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.14,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:armadillo",
 			"name": "ARMADILLO",
 			"ordinal": 4,
@@ -67,7 +230,80 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 20.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.7,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.0,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:armor_stand",
 			"name": "ARMOR_STAND",
 			"ordinal": 5,
@@ -80,7 +316,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:arrow",
 			"name": "ARROW",
 			"ordinal": 6,
@@ -93,7 +328,92 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 2.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 14.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 1.0,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 1.0,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:axolotl",
 			"name": "AXOLOTL",
 			"ordinal": 7,
@@ -106,7 +426,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:bamboo_chest_raft",
 			"name": "BAMBOO_CHEST_RAFT",
 			"ordinal": 8,
@@ -119,7 +438,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:bamboo_raft",
 			"name": "BAMBOO_RAFT",
 			"ordinal": 9,
@@ -132,7 +450,84 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 6.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.7,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:bat",
 			"name": "BAT",
 			"ordinal": 10,
@@ -145,7 +540,96 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 2.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:flying_speed": {
+					"baseValue": 0.6000000238418579,
+					"defaultValue": 0.4
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 10.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.30000001192092896,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:bee",
 			"name": "BEE",
 			"ordinal": 11,
@@ -158,7 +642,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:birch_boat",
 			"name": "BIRCH_BOAT",
 			"ordinal": 12,
@@ -171,7 +654,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:birch_chest_boat",
 			"name": "BIRCH_CHEST_BOAT",
 			"ordinal": 13,
@@ -184,7 +666,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 6.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 48.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 20.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.23000000417232513,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:blaze",
 			"name": "BLAZE",
 			"ordinal": 14,
@@ -197,7 +760,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:block_display",
 			"name": "BLOCK_DISPLAY",
 			"ordinal": 15,
@@ -210,7 +772,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 2.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 16.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.25,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:bogged",
 			"name": "BOGGED",
 			"ordinal": 16,
@@ -223,7 +866,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 3.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 24.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 30.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.6299999952316284,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:breeze",
 			"name": "BREEZE",
 			"ordinal": 17,
@@ -236,7 +960,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:breeze_wind_charge",
 			"name": "BREEZE_WIND_CHARGE",
 			"ordinal": 18,
@@ -249,7 +972,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 0.5,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 32.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.09000000357627869,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 6.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 1.5,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:camel",
 			"name": "CAMEL",
 			"ordinal": 19,
@@ -262,7 +1066,92 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 3.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 10.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.30000001192092896,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:cat",
 			"name": "CAT",
 			"ordinal": 20,
@@ -275,7 +1164,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 2.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 12.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.30000001192092896,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:cave_spider",
 			"name": "CAVE_SPIDER",
 			"ordinal": 21,
@@ -288,7 +1258,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:cherry_boat",
 			"name": "CHERRY_BOAT",
 			"ordinal": 22,
@@ -301,7 +1270,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:cherry_chest_boat",
 			"name": "CHERRY_CHEST_BOAT",
 			"ordinal": 23,
@@ -314,7 +1282,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:chest_minecart",
 			"name": "CHEST_MINECART",
 			"ordinal": 24,
@@ -327,7 +1294,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 4.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.25,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:chicken",
 			"name": "CHICKEN",
 			"ordinal": 25,
@@ -340,7 +1388,84 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 3.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.7,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:cod",
 			"name": "COD",
 			"ordinal": 26,
@@ -353,7 +1478,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:command_block_minecart",
 			"name": "COMMAND_BLOCK_MINECART",
 			"ordinal": 27,
@@ -366,7 +1490,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 10.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.20000000298023224,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:cow",
 			"name": "COW",
 			"ordinal": 28,
@@ -379,7 +1584,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 3.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 32.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 1.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.4000000059604645,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 1.0625,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:creaking",
 			"name": "CREAKING",
 			"ordinal": 29,
@@ -392,7 +1678,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 2.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 20.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.25,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:creeper",
 			"name": "CREEPER",
 			"ordinal": 30,
@@ -405,7 +1772,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:dark_oak_boat",
 			"name": "DARK_OAK_BOAT",
 			"ordinal": 31,
@@ -418,7 +1784,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:dark_oak_chest_boat",
 			"name": "DARK_OAK_CHEST_BOAT",
 			"ordinal": 32,
@@ -431,7 +1796,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 3.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 10.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 1.2000000476837158,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:dolphin",
 			"name": "DOLPHIN",
 			"ordinal": 33,
@@ -444,7 +1890,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 0.5,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.5,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 53.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.17499999701976776,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 6.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 1.0,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:donkey",
 			"name": "DONKEY",
 			"ordinal": 34,
@@ -457,7 +1984,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:dragon_fireball",
 			"name": "DRAGON_FIREBALL",
 			"ordinal": 35,
@@ -470,7 +1996,92 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 2.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 3.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 35.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 20.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.23000000417232513,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:spawn_reinforcements": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 1.0,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:drowned",
 			"name": "DROWNED",
 			"ordinal": 36,
@@ -483,7 +2094,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:egg",
 			"name": "EGG",
 			"ordinal": 37,
@@ -496,7 +2106,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 8.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 80.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.30000001192092896,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:elder_guardian",
 			"name": "ELDER_GUARDIAN",
 			"ordinal": 38,
@@ -509,7 +2200,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:end_crystal",
 			"name": "END_CRYSTAL",
 			"ordinal": 39,
@@ -522,7 +2212,84 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 200.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.7,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:ender_dragon",
 			"name": "ENDER_DRAGON",
 			"ordinal": 40,
@@ -535,7 +2302,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:ender_pearl",
 			"name": "ENDER_PEARL",
 			"ordinal": 41,
@@ -548,7 +2314,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 7.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 64.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 40.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.30000001192092896,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 1.0,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:enderman",
 			"name": "ENDERMAN",
 			"ordinal": 42,
@@ -561,7 +2408,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 2.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 8.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.25,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:endermite",
 			"name": "ENDERMITE",
 			"ordinal": 43,
@@ -574,7 +2502,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 2.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 12.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 24.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.5,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:evoker",
 			"name": "EVOKER",
 			"ordinal": 44,
@@ -587,7 +2596,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:evoker_fangs",
 			"name": "EVOKER_FANGS",
 			"ordinal": 45,
@@ -600,7 +2608,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:experience_bottle",
 			"name": "EXPERIENCE_BOTTLE",
 			"ordinal": 46,
@@ -613,7 +2620,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:experience_orb",
 			"name": "EXPERIENCE_ORB",
 			"ordinal": 47,
@@ -626,7 +2632,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:eye_of_ender",
 			"name": "EYE_OF_ENDER",
 			"ordinal": 48,
@@ -639,7 +2644,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:falling_block",
 			"name": "FALLING_BLOCK",
 			"ordinal": 49,
@@ -652,7 +2656,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:fireball",
 			"name": "FIREBALL",
 			"ordinal": 50,
@@ -665,7 +2668,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:firework_rocket",
 			"name": "FIREWORK_ROCKET",
 			"ordinal": 51,
@@ -678,7 +2680,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:fishing_bobber",
 			"name": "FISHING_BOBBER",
 			"ordinal": 52,
@@ -691,7 +2692,92 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 2.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 32.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 10.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.30000001192092896,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 5.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:fox",
 			"name": "FOX",
 			"ordinal": 53,
@@ -704,7 +2790,92 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 10.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 10.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 1.0,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 1.0,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:frog",
 			"name": "FROG",
 			"ordinal": 54,
@@ -717,7 +2888,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:furnace_minecart",
 			"name": "FURNACE_MINECART",
 			"ordinal": 55,
@@ -730,7 +2900,84 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 100.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 10.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.7,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:ghast",
 			"name": "GHAST",
 			"ordinal": 56,
@@ -743,7 +2990,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 50.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 100.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.5,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:giant",
 			"name": "GIANT",
 			"ordinal": 57,
@@ -756,7 +3084,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:glow_item_frame",
 			"name": "GLOW_ITEM_FRAME",
 			"ordinal": 58,
@@ -769,7 +3096,84 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 10.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.7,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:glow_squid",
 			"name": "GLOW_SQUID",
 			"ordinal": 59,
@@ -782,7 +3186,92 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 2.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 10.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.20000000298023224,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:goat",
 			"name": "GOAT",
 			"ordinal": 60,
@@ -795,7 +3284,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 6.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 30.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.5,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:guardian",
 			"name": "GUARDIAN",
 			"ordinal": 61,
@@ -808,7 +3378,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 6.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 1.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.6000000238418579,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 40.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.30000001192092896,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:hoglin",
 			"name": "HOGLIN",
 			"ordinal": 62,
@@ -821,7 +3472,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:hopper_minecart",
 			"name": "HOPPER_MINECART",
 			"ordinal": 63,
@@ -834,7 +3484,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 0.5,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.7,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 53.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.22499999403953552,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 6.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 1.0,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:horse",
 			"name": "HORSE",
 			"ordinal": 64,
@@ -847,7 +3578,92 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 2.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 3.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 35.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 20.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.23000000417232513,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:spawn_reinforcements": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:husk",
 			"name": "HUSK",
 			"ordinal": 65,
@@ -860,7 +3676,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 2.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 18.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 32.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.5,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:illusioner",
 			"name": "ILLUSIONER",
 			"ordinal": 66,
@@ -873,7 +3770,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:interaction",
 			"name": "INTERACTION",
 			"ordinal": 67,
@@ -886,7 +3782,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 15.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 1.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 100.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.25,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 1.0,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:iron_golem",
 			"name": "IRON_GOLEM",
 			"ordinal": 68,
@@ -899,7 +3876,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:item",
 			"name": "ITEM",
 			"ordinal": 69,
@@ -912,7 +3888,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:item_display",
 			"name": "ITEM_DISPLAY",
 			"ordinal": 70,
@@ -925,7 +3900,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:item_frame",
 			"name": "ITEM_FRAME",
 			"ordinal": 71,
@@ -938,7 +3912,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:jungle_boat",
 			"name": "JUNGLE_BOAT",
 			"ordinal": 72,
@@ -951,7 +3924,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:jungle_chest_boat",
 			"name": "JUNGLE_CHEST_BOAT",
 			"ordinal": 73,
@@ -964,7 +3936,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:leash_knot",
 			"name": "LEASH_KNOT",
 			"ordinal": 74,
@@ -977,7 +3948,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:lightning_bolt",
 			"name": "LIGHTNING_BOLT",
 			"ordinal": 75,
@@ -990,7 +3960,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:lingering_potion",
 			"name": "LINGERING_POTION",
 			"ordinal": 76,
@@ -1003,7 +3972,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 0.5,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.5,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 53.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.17499999701976776,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 6.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 1.0,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:llama",
 			"name": "LLAMA",
 			"ordinal": 77,
@@ -1016,7 +4066,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:llama_spit",
 			"name": "LLAMA_SPIT",
 			"ordinal": 78,
@@ -1029,7 +4078,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 2.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 20.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.20000000298023224,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:magma_cube",
 			"name": "MAGMA_CUBE",
 			"ordinal": 79,
@@ -1042,7 +4172,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:mangrove_boat",
 			"name": "MANGROVE_BOAT",
 			"ordinal": 80,
@@ -1055,7 +4184,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:mangrove_chest_boat",
 			"name": "MANGROVE_CHEST_BOAT",
 			"ordinal": 81,
@@ -1068,7 +4196,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:marker",
 			"name": "MARKER",
 			"ordinal": 82,
@@ -1081,7 +4208,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:minecart",
 			"name": "MINECART",
 			"ordinal": 83,
@@ -1094,7 +4220,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 10.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.20000000298023224,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:mooshroom",
 			"name": "MOOSHROOM",
 			"ordinal": 84,
@@ -1107,7 +4314,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 0.5,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.5,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 53.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.17499999701976776,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 6.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 1.0,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:mule",
 			"name": "MULE",
 			"ordinal": 85,
@@ -1120,7 +4408,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:oak_boat",
 			"name": "OAK_BOAT",
 			"ordinal": 86,
@@ -1133,7 +4420,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:oak_chest_boat",
 			"name": "OAK_CHEST_BOAT",
 			"ordinal": 87,
@@ -1146,7 +4432,92 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 3.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 10.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.30000001192092896,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:ocelot",
 			"name": "OCELOT",
 			"ordinal": 88,
@@ -1159,7 +4530,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:ominous_item_spawner",
 			"name": "OMINOUS_ITEM_SPAWNER",
 			"ordinal": 89,
@@ -1172,7 +4542,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:painting",
 			"name": "PAINTING",
 			"ordinal": 90,
@@ -1185,7 +4554,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:pale_oak_boat",
 			"name": "PALE_OAK_BOAT",
 			"ordinal": 91,
@@ -1198,7 +4566,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:pale_oak_chest_boat",
 			"name": "PALE_OAK_CHEST_BOAT",
 			"ordinal": 92,
@@ -1211,7 +4578,92 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 6.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 20.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.15000000596046448,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:panda",
 			"name": "PANDA",
 			"ordinal": 93,
@@ -1224,7 +4676,96 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 3.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:flying_speed": {
+					"baseValue": 0.4000000059604645,
+					"defaultValue": 0.4
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 6.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.20000000298023224,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:parrot",
 			"name": "PARROT",
 			"ordinal": 94,
@@ -1237,7 +4778,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 2.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 20.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.7,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:phantom",
 			"name": "PHANTOM",
 			"ordinal": 95,
@@ -1250,7 +4872,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 10.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.25,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:pig",
 			"name": "PIG",
 			"ordinal": 96,
@@ -1263,7 +4966,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 5.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 16.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.3499999940395355,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:piglin",
 			"name": "PIGLIN",
 			"ordinal": 97,
@@ -1276,7 +5060,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 7.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 12.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 50.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.3499999940395355,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:piglin_brute",
 			"name": "PIGLIN_BRUTE",
 			"ordinal": 98,
@@ -1289,7 +5154,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 5.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 32.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 24.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.3499999940395355,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:pillager",
 			"name": "PILLAGER",
 			"ordinal": 99,
@@ -1302,7 +5248,120 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 1.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_speed": {
+					"baseValue": 4.0,
+					"defaultValue": 4.0
+				},
+				"minecraft:block_break_speed": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:block_interaction_range": {
+					"baseValue": 4.5,
+					"defaultValue": 4.5
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:entity_interaction_range": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:luck": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 20.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:mining_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.10000000149011612,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:sneaking_speed": {
+					"baseValue": 0.3,
+					"defaultValue": 0.3
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:submerged_mining_speed": {
+					"baseValue": 0.2,
+					"defaultValue": 0.2
+				},
+				"minecraft:sweeping_damage_ratio": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:player",
 			"name": "PLAYER",
 			"ordinal": 100,
@@ -1315,7 +5374,92 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 6.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 20.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 30.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.25,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:polar_bear",
 			"name": "POLAR_BEAR",
 			"ordinal": 101,
@@ -1328,7 +5472,84 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 3.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.7,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:pufferfish",
 			"name": "PUFFERFISH",
 			"ordinal": 102,
@@ -1341,7 +5562,92 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 3.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 3.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.30000001192092896,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:rabbit",
 			"name": "RABBIT",
 			"ordinal": 103,
@@ -1354,7 +5660,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 12.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 1.5,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 32.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.75,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 100.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.3,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 1.0,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:ravager",
 			"name": "RAVAGER",
 			"ordinal": 104,
@@ -1367,7 +5754,84 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 3.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.7,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:salmon",
 			"name": "SALMON",
 			"ordinal": 105,
@@ -1380,7 +5844,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 8.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.23000000417232513,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:sheep",
 			"name": "SHEEP",
 			"ordinal": 106,
@@ -1393,7 +5938,84 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 30.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.7,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:shulker",
 			"name": "SHULKER",
 			"ordinal": 107,
@@ -1406,7 +6028,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:shulker_bullet",
 			"name": "SHULKER_BULLET",
 			"ordinal": 108,
@@ -1419,7 +6040,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 1.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 8.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.25,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:silverfish",
 			"name": "SILVERFISH",
 			"ordinal": 109,
@@ -1432,7 +6134,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 2.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 20.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.25,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:skeleton",
 			"name": "SKELETON",
 			"ordinal": 110,
@@ -1445,7 +6228,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 0.5,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.7,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 15.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.20000000298023224,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 6.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 1.0,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:skeleton_horse",
 			"name": "SKELETON_HORSE",
 			"ordinal": 111,
@@ -1458,7 +6322,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 2.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 20.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.7,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:slime",
 			"name": "SLIME",
 			"ordinal": 112,
@@ -1471,7 +6416,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:small_fireball",
 			"name": "SMALL_FIREBALL",
 			"ordinal": 113,
@@ -1484,7 +6428,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 14.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.10000000149011612,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:sniffer",
 			"name": "SNIFFER",
 			"ordinal": 114,
@@ -1497,7 +6522,84 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 4.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.20000000298023224,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:snow_golem",
 			"name": "SNOW_GOLEM",
 			"ordinal": 115,
@@ -1510,7 +6612,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:snowball",
 			"name": "SNOWBALL",
 			"ordinal": 116,
@@ -1523,7 +6624,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:spawner_minecart",
 			"name": "SPAWNER_MINECART",
 			"ordinal": 117,
@@ -1536,7 +6636,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:spectral_arrow",
 			"name": "SPECTRAL_ARROW",
 			"ordinal": 118,
@@ -1549,7 +6648,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 2.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 16.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.30000001192092896,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:spider",
 			"name": "SPIDER",
 			"ordinal": 119,
@@ -1562,7 +6742,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:splash_potion",
 			"name": "SPLASH_POTION",
 			"ordinal": 120,
@@ -1575,7 +6754,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:spruce_boat",
 			"name": "SPRUCE_BOAT",
 			"ordinal": 121,
@@ -1588,7 +6766,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:spruce_chest_boat",
 			"name": "SPRUCE_CHEST_BOAT",
 			"ordinal": 122,
@@ -1601,7 +6778,84 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 10.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.7,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:squid",
 			"name": "SQUID",
 			"ordinal": 123,
@@ -1614,7 +6868,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 2.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 20.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.25,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:stray",
 			"name": "STRAY",
 			"ordinal": 124,
@@ -1627,7 +6962,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 20.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.17499999701976776,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:strider",
 			"name": "STRIDER",
 			"ordinal": 125,
@@ -1640,7 +7056,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 6.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 1.0,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:tadpole",
 			"name": "TADPOLE",
 			"ordinal": 126,
@@ -1653,7 +7150,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:text_display",
 			"name": "TEXT_DISPLAY",
 			"ordinal": 127,
@@ -1666,7 +7162,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:tnt",
 			"name": "TNT",
 			"ordinal": 128,
@@ -1679,7 +7174,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:tnt_minecart",
 			"name": "TNT_MINECART",
 			"ordinal": 129,
@@ -1692,7 +7186,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 0.5,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.5,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 53.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.17499999701976776,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 6.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 1.0,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:trader_llama",
 			"name": "TRADER_LLAMA",
 			"ordinal": 130,
@@ -1705,7 +7280,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:trident",
 			"name": "TRIDENT",
 			"ordinal": 131,
@@ -1718,7 +7292,84 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 3.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.7,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:tropical_fish",
 			"name": "TROPICAL_FISH",
 			"ordinal": 132,
@@ -1731,7 +7382,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 30.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.25,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 1.0,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:turtle",
 			"name": "TURTLE",
 			"ordinal": 133,
@@ -1744,7 +7476,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 4.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 14.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.7,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:vex",
 			"name": "VEX",
 			"ordinal": 134,
@@ -1757,7 +7570,84 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 20.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.5,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:villager",
 			"name": "VILLAGER",
 			"ordinal": 135,
@@ -1770,7 +7660,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 5.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 12.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 24.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.3499999940395355,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:vindicator",
 			"name": "VINDICATOR",
 			"ordinal": 136,
@@ -1783,7 +7754,84 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 20.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.7,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:wandering_trader",
 			"name": "WANDERING_TRADER",
 			"ordinal": 137,
@@ -1796,7 +7844,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 30.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 1.5,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 24.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 1.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 500.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.30000001192092896,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:warden",
 			"name": "WARDEN",
 			"ordinal": 138,
@@ -1809,7 +7938,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:wind_charge",
 			"name": "WIND_CHARGE",
 			"ordinal": 139,
@@ -1822,7 +7950,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 2.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 26.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.25,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:witch",
 			"name": "WITCH",
 			"ordinal": 140,
@@ -1835,7 +8044,92 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 4.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 2.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:flying_speed": {
+					"baseValue": 0.6000000238418579,
+					"defaultValue": 0.4
+				},
+				"minecraft:follow_range": {
+					"baseValue": 40.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 300.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.6000000238418579,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:wither",
 			"name": "WITHER",
 			"ordinal": 141,
@@ -1848,7 +8142,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 2.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 20.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.25,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:wither_skeleton",
 			"name": "WITHER_SKELETON",
 			"ordinal": 142,
@@ -1861,7 +8236,6 @@
 		},
 		{
 			"alive": false,
-			"defaultAttributes": false,
 			"key": "minecraft:wither_skull",
 			"name": "WITHER_SKULL",
 			"ordinal": 143,
@@ -1874,7 +8248,92 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 4.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 8.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.30000001192092896,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:wolf",
 			"name": "WOLF",
 			"ordinal": 144,
@@ -1887,7 +8346,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 6.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 1.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.6000000238418579,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 40.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.30000001192092896,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:zoglin",
 			"name": "ZOGLIN",
 			"ordinal": 145,
@@ -1900,7 +8440,92 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 2.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 3.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 35.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 20.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.23000000417232513,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:spawn_reinforcements": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:zombie",
 			"name": "ZOMBIE",
 			"ordinal": 146,
@@ -1913,7 +8538,88 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 0.5,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 16.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.7,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 15.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.20000000298023224,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 6.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 1.0,
+					"defaultValue": 0.6
+				},
+				"minecraft:tempt_range": {
+					"baseValue": 10.0,
+					"defaultValue": 10.0
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:zombie_horse",
 			"name": "ZOMBIE_HORSE",
 			"ordinal": 147,
@@ -1926,7 +8632,92 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 2.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 3.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 35.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 20.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.23000000417232513,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:spawn_reinforcements": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:zombie_villager",
 			"name": "ZOMBIE_VILLAGER",
 			"ordinal": 148,
@@ -1939,7 +8730,92 @@
 		},
 		{
 			"alive": true,
-			"defaultAttributes": true,
+			"defaultAttributes": {
+				"minecraft:armor": {
+					"baseValue": 2.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:armor_toughness": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:attack_damage": {
+					"baseValue": 5.0,
+					"defaultValue": 2.0
+				},
+				"minecraft:attack_knockback": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:burning_time": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:explosion_knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:fall_damage_multiplier": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:follow_range": {
+					"baseValue": 35.0,
+					"defaultValue": 32.0
+				},
+				"minecraft:gravity": {
+					"baseValue": 0.08,
+					"defaultValue": 0.08
+				},
+				"minecraft:jump_strength": {
+					"baseValue": 0.41999998688697815,
+					"defaultValue": 0.41999998688697815
+				},
+				"minecraft:knockback_resistance": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_absorption": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:max_health": {
+					"baseValue": 20.0,
+					"defaultValue": 20.0
+				},
+				"minecraft:movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:movement_speed": {
+					"baseValue": 0.23000000417232513,
+					"defaultValue": 0.7
+				},
+				"minecraft:oxygen_bonus": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:safe_fall_distance": {
+					"baseValue": 3.0,
+					"defaultValue": 3.0
+				},
+				"minecraft:scale": {
+					"baseValue": 1.0,
+					"defaultValue": 1.0
+				},
+				"minecraft:spawn_reinforcements": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				},
+				"minecraft:step_height": {
+					"baseValue": 0.6,
+					"defaultValue": 0.6
+				},
+				"minecraft:water_movement_efficiency": {
+					"baseValue": 0.0,
+					"defaultValue": 0.0
+				}
+			},
 			"key": "minecraft:zombified_piglin",
 			"name": "ZOMBIFIED_PIGLIN",
 			"ordinal": 149,

--- a/src/main/resources/keyed/item.json
+++ b/src/main/resources/keyed/item.json
@@ -1,8 +1,6 @@
 {
 	"values": [
 		{
-			"asMaterial": "minecraft:acacia_boat",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25,11 +23,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:acacia_boat",
-			"material": "ACACIA_BOAT",
+			"material": "minecraft:acacia_boat",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38,8 +35,7 @@
 			"typed": "minecraft:acacia_boat"
 		},
 		{
-			"asMaterial": "minecraft:acacia_button",
-			"blockType": true,
+			"blockType": "minecraft:acacia_button",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -62,11 +58,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:acacia_button",
-			"material": "ACACIA_BUTTON",
+			"material": "minecraft:acacia_button",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -75,8 +70,6 @@
 			"typed": "minecraft:acacia_button"
 		},
 		{
-			"asMaterial": "minecraft:acacia_chest_boat",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -99,11 +92,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:acacia_chest_boat",
-			"material": "ACACIA_CHEST_BOAT",
+			"material": "minecraft:acacia_chest_boat",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -112,8 +104,7 @@
 			"typed": "minecraft:acacia_chest_boat"
 		},
 		{
-			"asMaterial": "minecraft:acacia_door",
-			"blockType": true,
+			"blockType": "minecraft:acacia_door",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -136,11 +127,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:acacia_door",
-			"material": "ACACIA_DOOR",
+			"material": "minecraft:acacia_door",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -149,8 +139,7 @@
 			"typed": "minecraft:acacia_door"
 		},
 		{
-			"asMaterial": "minecraft:acacia_fence",
-			"blockType": true,
+			"blockType": "minecraft:acacia_fence",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -173,11 +162,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:acacia_fence",
-			"material": "ACACIA_FENCE",
+			"material": "minecraft:acacia_fence",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -186,8 +174,7 @@
 			"typed": "minecraft:acacia_fence"
 		},
 		{
-			"asMaterial": "minecraft:acacia_fence_gate",
-			"blockType": true,
+			"blockType": "minecraft:acacia_fence_gate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -210,11 +197,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:acacia_fence_gate",
-			"material": "ACACIA_FENCE_GATE",
+			"material": "minecraft:acacia_fence_gate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -223,8 +209,7 @@
 			"typed": "minecraft:acacia_fence_gate"
 		},
 		{
-			"asMaterial": "minecraft:acacia_hanging_sign",
-			"blockType": true,
+			"blockType": "minecraft:acacia_hanging_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -247,11 +232,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:acacia_hanging_sign",
-			"material": "ACACIA_HANGING_SIGN",
+			"material": "minecraft:acacia_hanging_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -260,8 +244,7 @@
 			"typed": "minecraft:acacia_hanging_sign"
 		},
 		{
-			"asMaterial": "minecraft:acacia_leaves",
-			"blockType": true,
+			"blockType": "minecraft:acacia_leaves",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -285,11 +268,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:acacia_leaves",
-			"material": "ACACIA_LEAVES",
+			"material": "minecraft:acacia_leaves",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -298,8 +280,7 @@
 			"typed": "minecraft:acacia_leaves"
 		},
 		{
-			"asMaterial": "minecraft:acacia_log",
-			"blockType": true,
+			"blockType": "minecraft:acacia_log",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -322,11 +303,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:acacia_log",
-			"material": "ACACIA_LOG",
+			"material": "minecraft:acacia_log",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -335,8 +315,7 @@
 			"typed": "minecraft:acacia_log"
 		},
 		{
-			"asMaterial": "minecraft:acacia_planks",
-			"blockType": true,
+			"blockType": "minecraft:acacia_planks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -359,11 +338,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:acacia_planks",
-			"material": "ACACIA_PLANKS",
+			"material": "minecraft:acacia_planks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -372,8 +350,7 @@
 			"typed": "minecraft:acacia_planks"
 		},
 		{
-			"asMaterial": "minecraft:acacia_pressure_plate",
-			"blockType": true,
+			"blockType": "minecraft:acacia_pressure_plate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -396,11 +373,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:acacia_pressure_plate",
-			"material": "ACACIA_PRESSURE_PLATE",
+			"material": "minecraft:acacia_pressure_plate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -409,8 +385,7 @@
 			"typed": "minecraft:acacia_pressure_plate"
 		},
 		{
-			"asMaterial": "minecraft:acacia_sapling",
-			"blockType": true,
+			"blockType": "minecraft:acacia_sapling",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -434,11 +409,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:acacia_sapling",
-			"material": "ACACIA_SAPLING",
+			"material": "minecraft:acacia_sapling",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -447,8 +421,7 @@
 			"typed": "minecraft:acacia_sapling"
 		},
 		{
-			"asMaterial": "minecraft:acacia_sign",
-			"blockType": true,
+			"blockType": "minecraft:acacia_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -471,11 +444,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:acacia_sign",
-			"material": "ACACIA_SIGN",
+			"material": "minecraft:acacia_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -484,8 +456,7 @@
 			"typed": "minecraft:acacia_sign"
 		},
 		{
-			"asMaterial": "minecraft:acacia_slab",
-			"blockType": true,
+			"blockType": "minecraft:acacia_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -508,11 +479,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:acacia_slab",
-			"material": "ACACIA_SLAB",
+			"material": "minecraft:acacia_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -521,8 +491,7 @@
 			"typed": "minecraft:acacia_slab"
 		},
 		{
-			"asMaterial": "minecraft:acacia_stairs",
-			"blockType": true,
+			"blockType": "minecraft:acacia_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -545,11 +514,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:acacia_stairs",
-			"material": "ACACIA_STAIRS",
+			"material": "minecraft:acacia_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -558,8 +526,7 @@
 			"typed": "minecraft:acacia_stairs"
 		},
 		{
-			"asMaterial": "minecraft:acacia_trapdoor",
-			"blockType": true,
+			"blockType": "minecraft:acacia_trapdoor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -582,11 +549,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:acacia_trapdoor",
-			"material": "ACACIA_TRAPDOOR",
+			"material": "minecraft:acacia_trapdoor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -595,8 +561,7 @@
 			"typed": "minecraft:acacia_trapdoor"
 		},
 		{
-			"asMaterial": "minecraft:acacia_wood",
-			"blockType": true,
+			"blockType": "minecraft:acacia_wood",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -619,11 +584,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:acacia_wood",
-			"material": "ACACIA_WOOD",
+			"material": "minecraft:acacia_wood",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -632,8 +596,7 @@
 			"typed": "minecraft:acacia_wood"
 		},
 		{
-			"asMaterial": "minecraft:activator_rail",
-			"blockType": true,
+			"blockType": "minecraft:activator_rail",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -656,11 +619,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:activator_rail",
-			"material": "ACTIVATOR_RAIL",
+			"material": "minecraft:activator_rail",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -669,8 +631,6 @@
 			"typed": "minecraft:activator_rail"
 		},
 		{
-			"asMaterial": "minecraft:air",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 0,
@@ -693,10 +653,9 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:air",
-			"material": "AIR",
+			"material": "minecraft:air",
 			"maxDurability": 0,
 			"maxStackSize": 64,
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -705,8 +664,6 @@
 			"typed": "minecraft:air"
 		},
 		{
-			"asMaterial": "minecraft:allay_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -729,11 +686,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:allay_spawn_egg",
-			"material": "ALLAY_SPAWN_EGG",
+			"material": "minecraft:allay_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -742,8 +698,7 @@
 			"typed": "minecraft:allay_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:allium",
-			"blockType": true,
+			"blockType": "minecraft:allium",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -767,11 +722,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:allium",
-			"material": "ALLIUM",
+			"material": "minecraft:allium",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -780,8 +734,7 @@
 			"typed": "minecraft:allium"
 		},
 		{
-			"asMaterial": "minecraft:amethyst_block",
-			"blockType": true,
+			"blockType": "minecraft:amethyst_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -804,11 +757,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:amethyst_block",
-			"material": "AMETHYST_BLOCK",
+			"material": "minecraft:amethyst_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -817,8 +769,7 @@
 			"typed": "minecraft:amethyst_block"
 		},
 		{
-			"asMaterial": "minecraft:amethyst_cluster",
-			"blockType": true,
+			"blockType": "minecraft:amethyst_cluster",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -841,11 +792,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:amethyst_cluster",
-			"material": "AMETHYST_CLUSTER",
+			"material": "minecraft:amethyst_cluster",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -854,8 +804,6 @@
 			"typed": "minecraft:amethyst_cluster"
 		},
 		{
-			"asMaterial": "minecraft:amethyst_shard",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -879,11 +827,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:amethyst_shard",
-			"material": "AMETHYST_SHARD",
+			"material": "minecraft:amethyst_shard",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -892,8 +839,7 @@
 			"typed": "minecraft:amethyst_shard"
 		},
 		{
-			"asMaterial": "minecraft:ancient_debris",
-			"blockType": true,
+			"blockType": "minecraft:ancient_debris",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -917,11 +863,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:ancient_debris",
-			"material": "ANCIENT_DEBRIS",
+			"material": "minecraft:ancient_debris",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -930,8 +875,7 @@
 			"typed": "minecraft:ancient_debris"
 		},
 		{
-			"asMaterial": "minecraft:andesite",
-			"blockType": true,
+			"blockType": "minecraft:andesite",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -954,11 +898,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:andesite",
-			"material": "ANDESITE",
+			"material": "minecraft:andesite",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -967,8 +910,7 @@
 			"typed": "minecraft:andesite"
 		},
 		{
-			"asMaterial": "minecraft:andesite_slab",
-			"blockType": true,
+			"blockType": "minecraft:andesite_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -991,11 +933,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:andesite_slab",
-			"material": "ANDESITE_SLAB",
+			"material": "minecraft:andesite_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1004,8 +945,7 @@
 			"typed": "minecraft:andesite_slab"
 		},
 		{
-			"asMaterial": "minecraft:andesite_stairs",
-			"blockType": true,
+			"blockType": "minecraft:andesite_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -1028,11 +968,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:andesite_stairs",
-			"material": "ANDESITE_STAIRS",
+			"material": "minecraft:andesite_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1041,8 +980,7 @@
 			"typed": "minecraft:andesite_stairs"
 		},
 		{
-			"asMaterial": "minecraft:andesite_wall",
-			"blockType": true,
+			"blockType": "minecraft:andesite_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -1065,11 +1003,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:andesite_wall",
-			"material": "ANDESITE_WALL",
+			"material": "minecraft:andesite_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1078,8 +1015,6 @@
 			"typed": "minecraft:andesite_wall"
 		},
 		{
-			"asMaterial": "minecraft:angler_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -1102,11 +1037,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:angler_pottery_sherd",
-			"material": "ANGLER_POTTERY_SHERD",
+			"material": "minecraft:angler_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1115,8 +1049,7 @@
 			"typed": "minecraft:angler_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:anvil",
-			"blockType": true,
+			"blockType": "minecraft:anvil",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -1139,11 +1072,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:anvil",
-			"material": "ANVIL",
+			"material": "minecraft:anvil",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1152,8 +1084,6 @@
 			"typed": "minecraft:anvil"
 		},
 		{
-			"asMaterial": "minecraft:apple",
-			"blockType": false,
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -1179,11 +1109,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:apple",
-			"material": "APPLE",
+			"material": "minecraft:apple",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1192,8 +1121,6 @@
 			"typed": "minecraft:apple"
 		},
 		{
-			"asMaterial": "minecraft:archer_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -1216,11 +1143,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:archer_pottery_sherd",
-			"material": "ARCHER_POTTERY_SHERD",
+			"material": "minecraft:archer_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1229,8 +1155,6 @@
 			"typed": "minecraft:archer_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:armadillo_scute",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -1253,11 +1177,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:armadillo_scute",
-			"material": "ARMADILLO_SCUTE",
+			"material": "minecraft:armadillo_scute",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1266,8 +1189,6 @@
 			"typed": "minecraft:armadillo_scute"
 		},
 		{
-			"asMaterial": "minecraft:armadillo_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -1290,11 +1211,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:armadillo_spawn_egg",
-			"material": "ARMADILLO_SPAWN_EGG",
+			"material": "minecraft:armadillo_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1303,8 +1223,6 @@
 			"typed": "minecraft:armadillo_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:armor_stand",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -1327,11 +1245,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:armor_stand",
-			"material": "ARMOR_STAND",
+			"material": "minecraft:armor_stand",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "ArmorStandMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1340,8 +1257,6 @@
 			"typed": "minecraft:armor_stand"
 		},
 		{
-			"asMaterial": "minecraft:arms_up_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -1364,11 +1279,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:arms_up_pottery_sherd",
-			"material": "ARMS_UP_POTTERY_SHERD",
+			"material": "minecraft:arms_up_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1377,8 +1291,6 @@
 			"typed": "minecraft:arms_up_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:arrow",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -1401,11 +1313,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:arrow",
-			"material": "ARROW",
+			"material": "minecraft:arrow",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1414,8 +1325,6 @@
 			"typed": "minecraft:arrow"
 		},
 		{
-			"asMaterial": "minecraft:axolotl_bucket",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -1439,11 +1348,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:axolotl_bucket",
-			"material": "AXOLOTL_BUCKET",
+			"material": "minecraft:axolotl_bucket",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "AxolotlBucketMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1452,8 +1360,6 @@
 			"typed": "minecraft:axolotl_bucket"
 		},
 		{
-			"asMaterial": "minecraft:axolotl_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -1476,11 +1382,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:axolotl_spawn_egg",
-			"material": "AXOLOTL_SPAWN_EGG",
+			"material": "minecraft:axolotl_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1489,8 +1394,7 @@
 			"typed": "minecraft:axolotl_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:azalea",
-			"blockType": true,
+			"blockType": "minecraft:azalea",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -1514,11 +1418,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:azalea",
-			"material": "AZALEA",
+			"material": "minecraft:azalea",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1527,8 +1430,7 @@
 			"typed": "minecraft:azalea"
 		},
 		{
-			"asMaterial": "minecraft:azalea_leaves",
-			"blockType": true,
+			"blockType": "minecraft:azalea_leaves",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -1552,11 +1454,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:azalea_leaves",
-			"material": "AZALEA_LEAVES",
+			"material": "minecraft:azalea_leaves",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1565,8 +1466,7 @@
 			"typed": "minecraft:azalea_leaves"
 		},
 		{
-			"asMaterial": "minecraft:azure_bluet",
-			"blockType": true,
+			"blockType": "minecraft:azure_bluet",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -1590,11 +1490,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:azure_bluet",
-			"material": "AZURE_BLUET",
+			"material": "minecraft:azure_bluet",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1603,8 +1502,6 @@
 			"typed": "minecraft:azure_bluet"
 		},
 		{
-			"asMaterial": "minecraft:baked_potato",
-			"blockType": false,
 			"compostChance": "0.85F",
 			"compostable": true,
 			"createItemStack": {
@@ -1630,11 +1527,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:baked_potato",
-			"material": "BAKED_POTATO",
+			"material": "minecraft:baked_potato",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1643,8 +1539,7 @@
 			"typed": "minecraft:baked_potato"
 		},
 		{
-			"asMaterial": "minecraft:bamboo",
-			"blockType": true,
+			"blockType": "minecraft:bamboo",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -1667,11 +1562,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bamboo",
-			"material": "BAMBOO",
+			"material": "minecraft:bamboo",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1680,8 +1574,7 @@
 			"typed": "minecraft:bamboo"
 		},
 		{
-			"asMaterial": "minecraft:bamboo_block",
-			"blockType": true,
+			"blockType": "minecraft:bamboo_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -1704,11 +1597,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bamboo_block",
-			"material": "BAMBOO_BLOCK",
+			"material": "minecraft:bamboo_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1717,8 +1609,7 @@
 			"typed": "minecraft:bamboo_block"
 		},
 		{
-			"asMaterial": "minecraft:bamboo_button",
-			"blockType": true,
+			"blockType": "minecraft:bamboo_button",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -1741,11 +1632,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bamboo_button",
-			"material": "BAMBOO_BUTTON",
+			"material": "minecraft:bamboo_button",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1754,8 +1644,6 @@
 			"typed": "minecraft:bamboo_button"
 		},
 		{
-			"asMaterial": "minecraft:bamboo_chest_raft",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -1778,11 +1666,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bamboo_chest_raft",
-			"material": "BAMBOO_CHEST_RAFT",
+			"material": "minecraft:bamboo_chest_raft",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1791,8 +1678,7 @@
 			"typed": "minecraft:bamboo_chest_raft"
 		},
 		{
-			"asMaterial": "minecraft:bamboo_door",
-			"blockType": true,
+			"blockType": "minecraft:bamboo_door",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -1815,11 +1701,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bamboo_door",
-			"material": "BAMBOO_DOOR",
+			"material": "minecraft:bamboo_door",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1828,8 +1713,7 @@
 			"typed": "minecraft:bamboo_door"
 		},
 		{
-			"asMaterial": "minecraft:bamboo_fence",
-			"blockType": true,
+			"blockType": "minecraft:bamboo_fence",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -1852,11 +1736,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bamboo_fence",
-			"material": "BAMBOO_FENCE",
+			"material": "minecraft:bamboo_fence",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1865,8 +1748,7 @@
 			"typed": "minecraft:bamboo_fence"
 		},
 		{
-			"asMaterial": "minecraft:bamboo_fence_gate",
-			"blockType": true,
+			"blockType": "minecraft:bamboo_fence_gate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -1889,11 +1771,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bamboo_fence_gate",
-			"material": "BAMBOO_FENCE_GATE",
+			"material": "minecraft:bamboo_fence_gate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1902,8 +1783,7 @@
 			"typed": "minecraft:bamboo_fence_gate"
 		},
 		{
-			"asMaterial": "minecraft:bamboo_hanging_sign",
-			"blockType": true,
+			"blockType": "minecraft:bamboo_hanging_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -1926,11 +1806,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bamboo_hanging_sign",
-			"material": "BAMBOO_HANGING_SIGN",
+			"material": "minecraft:bamboo_hanging_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1939,8 +1818,7 @@
 			"typed": "minecraft:bamboo_hanging_sign"
 		},
 		{
-			"asMaterial": "minecraft:bamboo_mosaic",
-			"blockType": true,
+			"blockType": "minecraft:bamboo_mosaic",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -1963,11 +1841,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bamboo_mosaic",
-			"material": "BAMBOO_MOSAIC",
+			"material": "minecraft:bamboo_mosaic",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -1976,8 +1853,7 @@
 			"typed": "minecraft:bamboo_mosaic"
 		},
 		{
-			"asMaterial": "minecraft:bamboo_mosaic_slab",
-			"blockType": true,
+			"blockType": "minecraft:bamboo_mosaic_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2000,11 +1876,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bamboo_mosaic_slab",
-			"material": "BAMBOO_MOSAIC_SLAB",
+			"material": "minecraft:bamboo_mosaic_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2013,8 +1888,7 @@
 			"typed": "minecraft:bamboo_mosaic_slab"
 		},
 		{
-			"asMaterial": "minecraft:bamboo_mosaic_stairs",
-			"blockType": true,
+			"blockType": "minecraft:bamboo_mosaic_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2037,11 +1911,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bamboo_mosaic_stairs",
-			"material": "BAMBOO_MOSAIC_STAIRS",
+			"material": "minecraft:bamboo_mosaic_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2050,8 +1923,7 @@
 			"typed": "minecraft:bamboo_mosaic_stairs"
 		},
 		{
-			"asMaterial": "minecraft:bamboo_planks",
-			"blockType": true,
+			"blockType": "minecraft:bamboo_planks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2074,11 +1946,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bamboo_planks",
-			"material": "BAMBOO_PLANKS",
+			"material": "minecraft:bamboo_planks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2087,8 +1958,7 @@
 			"typed": "minecraft:bamboo_planks"
 		},
 		{
-			"asMaterial": "minecraft:bamboo_pressure_plate",
-			"blockType": true,
+			"blockType": "minecraft:bamboo_pressure_plate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2111,11 +1981,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bamboo_pressure_plate",
-			"material": "BAMBOO_PRESSURE_PLATE",
+			"material": "minecraft:bamboo_pressure_plate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2124,8 +1993,6 @@
 			"typed": "minecraft:bamboo_pressure_plate"
 		},
 		{
-			"asMaterial": "minecraft:bamboo_raft",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2148,11 +2015,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bamboo_raft",
-			"material": "BAMBOO_RAFT",
+			"material": "minecraft:bamboo_raft",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2161,8 +2027,7 @@
 			"typed": "minecraft:bamboo_raft"
 		},
 		{
-			"asMaterial": "minecraft:bamboo_sign",
-			"blockType": true,
+			"blockType": "minecraft:bamboo_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2185,11 +2050,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bamboo_sign",
-			"material": "BAMBOO_SIGN",
+			"material": "minecraft:bamboo_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2198,8 +2062,7 @@
 			"typed": "minecraft:bamboo_sign"
 		},
 		{
-			"asMaterial": "minecraft:bamboo_slab",
-			"blockType": true,
+			"blockType": "minecraft:bamboo_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2222,11 +2085,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bamboo_slab",
-			"material": "BAMBOO_SLAB",
+			"material": "minecraft:bamboo_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2235,8 +2097,7 @@
 			"typed": "minecraft:bamboo_slab"
 		},
 		{
-			"asMaterial": "minecraft:bamboo_stairs",
-			"blockType": true,
+			"blockType": "minecraft:bamboo_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2259,11 +2120,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bamboo_stairs",
-			"material": "BAMBOO_STAIRS",
+			"material": "minecraft:bamboo_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2272,8 +2132,7 @@
 			"typed": "minecraft:bamboo_stairs"
 		},
 		{
-			"asMaterial": "minecraft:bamboo_trapdoor",
-			"blockType": true,
+			"blockType": "minecraft:bamboo_trapdoor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2296,11 +2155,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bamboo_trapdoor",
-			"material": "BAMBOO_TRAPDOOR",
+			"material": "minecraft:bamboo_trapdoor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2309,8 +2167,7 @@
 			"typed": "minecraft:bamboo_trapdoor"
 		},
 		{
-			"asMaterial": "minecraft:barrel",
-			"blockType": true,
+			"blockType": "minecraft:barrel",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2334,11 +2191,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:barrel",
-			"material": "BARREL",
+			"material": "minecraft:barrel",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2347,8 +2203,7 @@
 			"typed": "minecraft:barrel"
 		},
 		{
-			"asMaterial": "minecraft:barrier",
-			"blockType": true,
+			"blockType": "minecraft:barrier",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2371,11 +2226,10 @@
 			"fuel": false,
 			"itemRarity": "EPIC",
 			"key": "minecraft:barrier",
-			"material": "BARRIER",
+			"material": "minecraft:barrier",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "EPIC",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2384,8 +2238,7 @@
 			"typed": "minecraft:barrier"
 		},
 		{
-			"asMaterial": "minecraft:basalt",
-			"blockType": true,
+			"blockType": "minecraft:basalt",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2408,11 +2261,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:basalt",
-			"material": "BASALT",
+			"material": "minecraft:basalt",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2421,8 +2273,6 @@
 			"typed": "minecraft:basalt"
 		},
 		{
-			"asMaterial": "minecraft:bat_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2445,11 +2295,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bat_spawn_egg",
-			"material": "BAT_SPAWN_EGG",
+			"material": "minecraft:bat_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2458,8 +2307,7 @@
 			"typed": "minecraft:bat_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:beacon",
-			"blockType": true,
+			"blockType": "minecraft:beacon",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2482,11 +2330,10 @@
 			"fuel": false,
 			"itemRarity": "RARE",
 			"key": "minecraft:beacon",
-			"material": "BEACON",
+			"material": "minecraft:beacon",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "RARE",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2495,8 +2342,7 @@
 			"typed": "minecraft:beacon"
 		},
 		{
-			"asMaterial": "minecraft:bedrock",
-			"blockType": true,
+			"blockType": "minecraft:bedrock",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2519,11 +2365,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bedrock",
-			"material": "BEDROCK",
+			"material": "minecraft:bedrock",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2532,8 +2377,7 @@
 			"typed": "minecraft:bedrock"
 		},
 		{
-			"asMaterial": "minecraft:bee_nest",
-			"blockType": true,
+			"blockType": "minecraft:bee_nest",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2558,11 +2402,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bee_nest",
-			"material": "BEE_NEST",
+			"material": "minecraft:bee_nest",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2571,8 +2414,6 @@
 			"typed": "minecraft:bee_nest"
 		},
 		{
-			"asMaterial": "minecraft:bee_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2595,11 +2436,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bee_spawn_egg",
-			"material": "BEE_SPAWN_EGG",
+			"material": "minecraft:bee_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2608,8 +2448,6 @@
 			"typed": "minecraft:bee_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:beef",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2634,11 +2472,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:beef",
-			"material": "BEEF",
+			"material": "minecraft:beef",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2647,8 +2484,7 @@
 			"typed": "minecraft:beef"
 		},
 		{
-			"asMaterial": "minecraft:beehive",
-			"blockType": true,
+			"blockType": "minecraft:beehive",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2673,11 +2509,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:beehive",
-			"material": "BEEHIVE",
+			"material": "minecraft:beehive",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2686,8 +2521,6 @@
 			"typed": "minecraft:beehive"
 		},
 		{
-			"asMaterial": "minecraft:beetroot",
-			"blockType": false,
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -2713,11 +2546,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:beetroot",
-			"material": "BEETROOT",
+			"material": "minecraft:beetroot",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2726,8 +2558,7 @@
 			"typed": "minecraft:beetroot"
 		},
 		{
-			"asMaterial": "minecraft:beetroot_seeds",
-			"blockType": true,
+			"blockType": "minecraft:beetroots",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -2751,11 +2582,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:beetroot_seeds",
-			"material": "BEETROOT_SEEDS",
+			"material": "minecraft:beetroot_seeds",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2764,8 +2594,6 @@
 			"typed": "minecraft:beetroot_seeds"
 		},
 		{
-			"asMaterial": "minecraft:beetroot_soup",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2791,11 +2619,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:beetroot_soup",
-			"material": "BEETROOT_SOUP",
+			"material": "minecraft:beetroot_soup",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2804,8 +2631,7 @@
 			"typed": "minecraft:beetroot_soup"
 		},
 		{
-			"asMaterial": "minecraft:bell",
-			"blockType": true,
+			"blockType": "minecraft:bell",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2828,11 +2654,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bell",
-			"material": "BELL",
+			"material": "minecraft:bell",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2841,8 +2666,7 @@
 			"typed": "minecraft:bell"
 		},
 		{
-			"asMaterial": "minecraft:big_dripleaf",
-			"blockType": true,
+			"blockType": "minecraft:big_dripleaf",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -2866,11 +2690,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:big_dripleaf",
-			"material": "BIG_DRIPLEAF",
+			"material": "minecraft:big_dripleaf",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2879,8 +2702,6 @@
 			"typed": "minecraft:big_dripleaf"
 		},
 		{
-			"asMaterial": "minecraft:birch_boat",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2903,11 +2724,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:birch_boat",
-			"material": "BIRCH_BOAT",
+			"material": "minecraft:birch_boat",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2916,8 +2736,7 @@
 			"typed": "minecraft:birch_boat"
 		},
 		{
-			"asMaterial": "minecraft:birch_button",
-			"blockType": true,
+			"blockType": "minecraft:birch_button",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2940,11 +2759,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:birch_button",
-			"material": "BIRCH_BUTTON",
+			"material": "minecraft:birch_button",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2953,8 +2771,6 @@
 			"typed": "minecraft:birch_button"
 		},
 		{
-			"asMaterial": "minecraft:birch_chest_boat",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -2977,11 +2793,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:birch_chest_boat",
-			"material": "BIRCH_CHEST_BOAT",
+			"material": "minecraft:birch_chest_boat",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -2990,8 +2805,7 @@
 			"typed": "minecraft:birch_chest_boat"
 		},
 		{
-			"asMaterial": "minecraft:birch_door",
-			"blockType": true,
+			"blockType": "minecraft:birch_door",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3014,11 +2828,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:birch_door",
-			"material": "BIRCH_DOOR",
+			"material": "minecraft:birch_door",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3027,8 +2840,7 @@
 			"typed": "minecraft:birch_door"
 		},
 		{
-			"asMaterial": "minecraft:birch_fence",
-			"blockType": true,
+			"blockType": "minecraft:birch_fence",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3051,11 +2863,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:birch_fence",
-			"material": "BIRCH_FENCE",
+			"material": "minecraft:birch_fence",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3064,8 +2875,7 @@
 			"typed": "minecraft:birch_fence"
 		},
 		{
-			"asMaterial": "minecraft:birch_fence_gate",
-			"blockType": true,
+			"blockType": "minecraft:birch_fence_gate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3088,11 +2898,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:birch_fence_gate",
-			"material": "BIRCH_FENCE_GATE",
+			"material": "minecraft:birch_fence_gate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3101,8 +2910,7 @@
 			"typed": "minecraft:birch_fence_gate"
 		},
 		{
-			"asMaterial": "minecraft:birch_hanging_sign",
-			"blockType": true,
+			"blockType": "minecraft:birch_hanging_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3125,11 +2933,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:birch_hanging_sign",
-			"material": "BIRCH_HANGING_SIGN",
+			"material": "minecraft:birch_hanging_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3138,8 +2945,7 @@
 			"typed": "minecraft:birch_hanging_sign"
 		},
 		{
-			"asMaterial": "minecraft:birch_leaves",
-			"blockType": true,
+			"blockType": "minecraft:birch_leaves",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -3163,11 +2969,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:birch_leaves",
-			"material": "BIRCH_LEAVES",
+			"material": "minecraft:birch_leaves",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3176,8 +2981,7 @@
 			"typed": "minecraft:birch_leaves"
 		},
 		{
-			"asMaterial": "minecraft:birch_log",
-			"blockType": true,
+			"blockType": "minecraft:birch_log",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3200,11 +3004,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:birch_log",
-			"material": "BIRCH_LOG",
+			"material": "minecraft:birch_log",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3213,8 +3016,7 @@
 			"typed": "minecraft:birch_log"
 		},
 		{
-			"asMaterial": "minecraft:birch_planks",
-			"blockType": true,
+			"blockType": "minecraft:birch_planks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3237,11 +3039,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:birch_planks",
-			"material": "BIRCH_PLANKS",
+			"material": "minecraft:birch_planks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3250,8 +3051,7 @@
 			"typed": "minecraft:birch_planks"
 		},
 		{
-			"asMaterial": "minecraft:birch_pressure_plate",
-			"blockType": true,
+			"blockType": "minecraft:birch_pressure_plate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3274,11 +3074,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:birch_pressure_plate",
-			"material": "BIRCH_PRESSURE_PLATE",
+			"material": "minecraft:birch_pressure_plate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3287,8 +3086,7 @@
 			"typed": "minecraft:birch_pressure_plate"
 		},
 		{
-			"asMaterial": "minecraft:birch_sapling",
-			"blockType": true,
+			"blockType": "minecraft:birch_sapling",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -3312,11 +3110,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:birch_sapling",
-			"material": "BIRCH_SAPLING",
+			"material": "minecraft:birch_sapling",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3325,8 +3122,7 @@
 			"typed": "minecraft:birch_sapling"
 		},
 		{
-			"asMaterial": "minecraft:birch_sign",
-			"blockType": true,
+			"blockType": "minecraft:birch_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3349,11 +3145,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:birch_sign",
-			"material": "BIRCH_SIGN",
+			"material": "minecraft:birch_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3362,8 +3157,7 @@
 			"typed": "minecraft:birch_sign"
 		},
 		{
-			"asMaterial": "minecraft:birch_slab",
-			"blockType": true,
+			"blockType": "minecraft:birch_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3386,11 +3180,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:birch_slab",
-			"material": "BIRCH_SLAB",
+			"material": "minecraft:birch_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3399,8 +3192,7 @@
 			"typed": "minecraft:birch_slab"
 		},
 		{
-			"asMaterial": "minecraft:birch_stairs",
-			"blockType": true,
+			"blockType": "minecraft:birch_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3423,11 +3215,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:birch_stairs",
-			"material": "BIRCH_STAIRS",
+			"material": "minecraft:birch_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3436,8 +3227,7 @@
 			"typed": "minecraft:birch_stairs"
 		},
 		{
-			"asMaterial": "minecraft:birch_trapdoor",
-			"blockType": true,
+			"blockType": "minecraft:birch_trapdoor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3460,11 +3250,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:birch_trapdoor",
-			"material": "BIRCH_TRAPDOOR",
+			"material": "minecraft:birch_trapdoor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3473,8 +3262,7 @@
 			"typed": "minecraft:birch_trapdoor"
 		},
 		{
-			"asMaterial": "minecraft:birch_wood",
-			"blockType": true,
+			"blockType": "minecraft:birch_wood",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3497,11 +3285,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:birch_wood",
-			"material": "BIRCH_WOOD",
+			"material": "minecraft:birch_wood",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3510,8 +3297,7 @@
 			"typed": "minecraft:birch_wood"
 		},
 		{
-			"asMaterial": "minecraft:black_banner",
-			"blockType": true,
+			"blockType": "minecraft:black_banner",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3535,11 +3321,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:black_banner",
-			"material": "BLACK_BANNER",
+			"material": "minecraft:black_banner",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BannerMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3548,8 +3333,7 @@
 			"typed": "minecraft:black_banner"
 		},
 		{
-			"asMaterial": "minecraft:black_bed",
-			"blockType": true,
+			"blockType": "minecraft:black_bed",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3572,11 +3356,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:black_bed",
-			"material": "BLACK_BED",
+			"material": "minecraft:black_bed",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3585,8 +3368,6 @@
 			"typed": "minecraft:black_bed"
 		},
 		{
-			"asMaterial": "minecraft:black_bundle",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3610,11 +3391,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:black_bundle",
-			"material": "BLACK_BUNDLE",
+			"material": "minecraft:black_bundle",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BundleMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3623,8 +3403,7 @@
 			"typed": "minecraft:black_bundle"
 		},
 		{
-			"asMaterial": "minecraft:black_candle",
-			"blockType": true,
+			"blockType": "minecraft:black_candle",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3647,11 +3426,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:black_candle",
-			"material": "BLACK_CANDLE",
+			"material": "minecraft:black_candle",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3660,8 +3438,7 @@
 			"typed": "minecraft:black_candle"
 		},
 		{
-			"asMaterial": "minecraft:black_carpet",
-			"blockType": true,
+			"blockType": "minecraft:black_carpet",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3685,11 +3462,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:black_carpet",
-			"material": "BLACK_CARPET",
+			"material": "minecraft:black_carpet",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3698,8 +3474,7 @@
 			"typed": "minecraft:black_carpet"
 		},
 		{
-			"asMaterial": "minecraft:black_concrete",
-			"blockType": true,
+			"blockType": "minecraft:black_concrete",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3722,11 +3497,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:black_concrete",
-			"material": "BLACK_CONCRETE",
+			"material": "minecraft:black_concrete",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3735,8 +3509,7 @@
 			"typed": "minecraft:black_concrete"
 		},
 		{
-			"asMaterial": "minecraft:black_concrete_powder",
-			"blockType": true,
+			"blockType": "minecraft:black_concrete_powder",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3759,11 +3532,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:black_concrete_powder",
-			"material": "BLACK_CONCRETE_POWDER",
+			"material": "minecraft:black_concrete_powder",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3772,8 +3544,6 @@
 			"typed": "minecraft:black_concrete_powder"
 		},
 		{
-			"asMaterial": "minecraft:black_dye",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3796,11 +3566,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:black_dye",
-			"material": "BLACK_DYE",
+			"material": "minecraft:black_dye",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3809,8 +3578,7 @@
 			"typed": "minecraft:black_dye"
 		},
 		{
-			"asMaterial": "minecraft:black_glazed_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:black_glazed_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3833,11 +3601,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:black_glazed_terracotta",
-			"material": "BLACK_GLAZED_TERRACOTTA",
+			"material": "minecraft:black_glazed_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3846,8 +3613,7 @@
 			"typed": "minecraft:black_glazed_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:black_shulker_box",
-			"blockType": true,
+			"blockType": "minecraft:black_shulker_box",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3871,11 +3637,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:black_shulker_box",
-			"material": "BLACK_SHULKER_BOX",
+			"material": "minecraft:black_shulker_box",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3884,8 +3649,7 @@
 			"typed": "minecraft:black_shulker_box"
 		},
 		{
-			"asMaterial": "minecraft:black_stained_glass",
-			"blockType": true,
+			"blockType": "minecraft:black_stained_glass",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3908,11 +3672,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:black_stained_glass",
-			"material": "BLACK_STAINED_GLASS",
+			"material": "minecraft:black_stained_glass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3921,8 +3684,7 @@
 			"typed": "minecraft:black_stained_glass"
 		},
 		{
-			"asMaterial": "minecraft:black_stained_glass_pane",
-			"blockType": true,
+			"blockType": "minecraft:black_stained_glass_pane",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3945,11 +3707,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:black_stained_glass_pane",
-			"material": "BLACK_STAINED_GLASS_PANE",
+			"material": "minecraft:black_stained_glass_pane",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3958,8 +3719,7 @@
 			"typed": "minecraft:black_stained_glass_pane"
 		},
 		{
-			"asMaterial": "minecraft:black_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:black_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -3982,11 +3742,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:black_terracotta",
-			"material": "BLACK_TERRACOTTA",
+			"material": "minecraft:black_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -3995,8 +3754,7 @@
 			"typed": "minecraft:black_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:black_wool",
-			"blockType": true,
+			"blockType": "minecraft:black_wool",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4019,11 +3777,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:black_wool",
-			"material": "BLACK_WOOL",
+			"material": "minecraft:black_wool",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4032,8 +3789,7 @@
 			"typed": "minecraft:black_wool"
 		},
 		{
-			"asMaterial": "minecraft:blackstone",
-			"blockType": true,
+			"blockType": "minecraft:blackstone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4056,11 +3812,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blackstone",
-			"material": "BLACKSTONE",
+			"material": "minecraft:blackstone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4069,8 +3824,7 @@
 			"typed": "minecraft:blackstone"
 		},
 		{
-			"asMaterial": "minecraft:blackstone_slab",
-			"blockType": true,
+			"blockType": "minecraft:blackstone_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4093,11 +3847,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blackstone_slab",
-			"material": "BLACKSTONE_SLAB",
+			"material": "minecraft:blackstone_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4106,8 +3859,7 @@
 			"typed": "minecraft:blackstone_slab"
 		},
 		{
-			"asMaterial": "minecraft:blackstone_stairs",
-			"blockType": true,
+			"blockType": "minecraft:blackstone_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4130,11 +3882,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blackstone_stairs",
-			"material": "BLACKSTONE_STAIRS",
+			"material": "minecraft:blackstone_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4143,8 +3894,7 @@
 			"typed": "minecraft:blackstone_stairs"
 		},
 		{
-			"asMaterial": "minecraft:blackstone_wall",
-			"blockType": true,
+			"blockType": "minecraft:blackstone_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4167,11 +3917,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blackstone_wall",
-			"material": "BLACKSTONE_WALL",
+			"material": "minecraft:blackstone_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4180,8 +3929,6 @@
 			"typed": "minecraft:blackstone_wall"
 		},
 		{
-			"asMaterial": "minecraft:blade_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4204,11 +3951,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:blade_pottery_sherd",
-			"material": "BLADE_POTTERY_SHERD",
+			"material": "minecraft:blade_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4217,8 +3963,7 @@
 			"typed": "minecraft:blade_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:blast_furnace",
-			"blockType": true,
+			"blockType": "minecraft:blast_furnace",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4242,11 +3987,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blast_furnace",
-			"material": "BLAST_FURNACE",
+			"material": "minecraft:blast_furnace",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4255,8 +3999,6 @@
 			"typed": "minecraft:blast_furnace"
 		},
 		{
-			"asMaterial": "minecraft:blaze_powder",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4279,11 +4021,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blaze_powder",
-			"material": "BLAZE_POWDER",
+			"material": "minecraft:blaze_powder",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4292,8 +4033,6 @@
 			"typed": "minecraft:blaze_powder"
 		},
 		{
-			"asMaterial": "minecraft:blaze_rod",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4316,11 +4055,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blaze_rod",
-			"material": "BLAZE_ROD",
+			"material": "minecraft:blaze_rod",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4329,8 +4067,6 @@
 			"typed": "minecraft:blaze_rod"
 		},
 		{
-			"asMaterial": "minecraft:blaze_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4353,11 +4089,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blaze_spawn_egg",
-			"material": "BLAZE_SPAWN_EGG",
+			"material": "minecraft:blaze_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4366,8 +4101,7 @@
 			"typed": "minecraft:blaze_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:blue_banner",
-			"blockType": true,
+			"blockType": "minecraft:blue_banner",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4391,11 +4125,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blue_banner",
-			"material": "BLUE_BANNER",
+			"material": "minecraft:blue_banner",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BannerMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4404,8 +4137,7 @@
 			"typed": "minecraft:blue_banner"
 		},
 		{
-			"asMaterial": "minecraft:blue_bed",
-			"blockType": true,
+			"blockType": "minecraft:blue_bed",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4428,11 +4160,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blue_bed",
-			"material": "BLUE_BED",
+			"material": "minecraft:blue_bed",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4441,8 +4172,6 @@
 			"typed": "minecraft:blue_bed"
 		},
 		{
-			"asMaterial": "minecraft:blue_bundle",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4466,11 +4195,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blue_bundle",
-			"material": "BLUE_BUNDLE",
+			"material": "minecraft:blue_bundle",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BundleMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4479,8 +4207,7 @@
 			"typed": "minecraft:blue_bundle"
 		},
 		{
-			"asMaterial": "minecraft:blue_candle",
-			"blockType": true,
+			"blockType": "minecraft:blue_candle",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4503,11 +4230,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blue_candle",
-			"material": "BLUE_CANDLE",
+			"material": "minecraft:blue_candle",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4516,8 +4242,7 @@
 			"typed": "minecraft:blue_candle"
 		},
 		{
-			"asMaterial": "minecraft:blue_carpet",
-			"blockType": true,
+			"blockType": "minecraft:blue_carpet",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4541,11 +4266,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blue_carpet",
-			"material": "BLUE_CARPET",
+			"material": "minecraft:blue_carpet",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4554,8 +4278,7 @@
 			"typed": "minecraft:blue_carpet"
 		},
 		{
-			"asMaterial": "minecraft:blue_concrete",
-			"blockType": true,
+			"blockType": "minecraft:blue_concrete",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4578,11 +4301,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blue_concrete",
-			"material": "BLUE_CONCRETE",
+			"material": "minecraft:blue_concrete",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4591,8 +4313,7 @@
 			"typed": "minecraft:blue_concrete"
 		},
 		{
-			"asMaterial": "minecraft:blue_concrete_powder",
-			"blockType": true,
+			"blockType": "minecraft:blue_concrete_powder",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4615,11 +4336,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blue_concrete_powder",
-			"material": "BLUE_CONCRETE_POWDER",
+			"material": "minecraft:blue_concrete_powder",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4628,8 +4348,6 @@
 			"typed": "minecraft:blue_concrete_powder"
 		},
 		{
-			"asMaterial": "minecraft:blue_dye",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4652,11 +4370,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blue_dye",
-			"material": "BLUE_DYE",
+			"material": "minecraft:blue_dye",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4665,8 +4382,6 @@
 			"typed": "minecraft:blue_dye"
 		},
 		{
-			"asMaterial": "minecraft:blue_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4690,11 +4405,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blue_egg",
-			"material": "BLUE_EGG",
+			"material": "minecraft:blue_egg",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4703,8 +4417,7 @@
 			"typed": "minecraft:blue_egg"
 		},
 		{
-			"asMaterial": "minecraft:blue_glazed_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:blue_glazed_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4727,11 +4440,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blue_glazed_terracotta",
-			"material": "BLUE_GLAZED_TERRACOTTA",
+			"material": "minecraft:blue_glazed_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4740,8 +4452,7 @@
 			"typed": "minecraft:blue_glazed_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:blue_ice",
-			"blockType": true,
+			"blockType": "minecraft:blue_ice",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4764,11 +4475,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blue_ice",
-			"material": "BLUE_ICE",
+			"material": "minecraft:blue_ice",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4777,8 +4487,7 @@
 			"typed": "minecraft:blue_ice"
 		},
 		{
-			"asMaterial": "minecraft:blue_orchid",
-			"blockType": true,
+			"blockType": "minecraft:blue_orchid",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -4802,11 +4511,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blue_orchid",
-			"material": "BLUE_ORCHID",
+			"material": "minecraft:blue_orchid",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4815,8 +4523,7 @@
 			"typed": "minecraft:blue_orchid"
 		},
 		{
-			"asMaterial": "minecraft:blue_shulker_box",
-			"blockType": true,
+			"blockType": "minecraft:blue_shulker_box",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4840,11 +4547,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blue_shulker_box",
-			"material": "BLUE_SHULKER_BOX",
+			"material": "minecraft:blue_shulker_box",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4853,8 +4559,7 @@
 			"typed": "minecraft:blue_shulker_box"
 		},
 		{
-			"asMaterial": "minecraft:blue_stained_glass",
-			"blockType": true,
+			"blockType": "minecraft:blue_stained_glass",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4877,11 +4582,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blue_stained_glass",
-			"material": "BLUE_STAINED_GLASS",
+			"material": "minecraft:blue_stained_glass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4890,8 +4594,7 @@
 			"typed": "minecraft:blue_stained_glass"
 		},
 		{
-			"asMaterial": "minecraft:blue_stained_glass_pane",
-			"blockType": true,
+			"blockType": "minecraft:blue_stained_glass_pane",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4914,11 +4617,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blue_stained_glass_pane",
-			"material": "BLUE_STAINED_GLASS_PANE",
+			"material": "minecraft:blue_stained_glass_pane",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4927,8 +4629,7 @@
 			"typed": "minecraft:blue_stained_glass_pane"
 		},
 		{
-			"asMaterial": "minecraft:blue_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:blue_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4951,11 +4652,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blue_terracotta",
-			"material": "BLUE_TERRACOTTA",
+			"material": "minecraft:blue_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -4964,8 +4664,7 @@
 			"typed": "minecraft:blue_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:blue_wool",
-			"blockType": true,
+			"blockType": "minecraft:blue_wool",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -4988,11 +4687,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:blue_wool",
-			"material": "BLUE_WOOL",
+			"material": "minecraft:blue_wool",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5001,8 +4699,6 @@
 			"typed": "minecraft:blue_wool"
 		},
 		{
-			"asMaterial": "minecraft:bogged_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5025,11 +4721,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bogged_spawn_egg",
-			"material": "BOGGED_SPAWN_EGG",
+			"material": "minecraft:bogged_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5038,8 +4733,6 @@
 			"typed": "minecraft:bogged_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:bolt_armor_trim_smithing_template",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5062,11 +4755,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:bolt_armor_trim_smithing_template",
-			"material": "BOLT_ARMOR_TRIM_SMITHING_TEMPLATE",
+			"material": "minecraft:bolt_armor_trim_smithing_template",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5075,8 +4767,6 @@
 			"typed": "minecraft:bolt_armor_trim_smithing_template"
 		},
 		{
-			"asMaterial": "minecraft:bone",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5099,11 +4789,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bone",
-			"material": "BONE",
+			"material": "minecraft:bone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5112,8 +4801,7 @@
 			"typed": "minecraft:bone"
 		},
 		{
-			"asMaterial": "minecraft:bone_block",
-			"blockType": true,
+			"blockType": "minecraft:bone_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5136,11 +4824,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bone_block",
-			"material": "BONE_BLOCK",
+			"material": "minecraft:bone_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5149,8 +4836,6 @@
 			"typed": "minecraft:bone_block"
 		},
 		{
-			"asMaterial": "minecraft:bone_meal",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5173,11 +4858,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bone_meal",
-			"material": "BONE_MEAL",
+			"material": "minecraft:bone_meal",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5186,8 +4870,6 @@
 			"typed": "minecraft:bone_meal"
 		},
 		{
-			"asMaterial": "minecraft:book",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5211,11 +4893,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:book",
-			"material": "BOOK",
+			"material": "minecraft:book",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5224,8 +4905,7 @@
 			"typed": "minecraft:book"
 		},
 		{
-			"asMaterial": "minecraft:bookshelf",
-			"blockType": true,
+			"blockType": "minecraft:bookshelf",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5248,11 +4928,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bookshelf",
-			"material": "BOOKSHELF",
+			"material": "minecraft:bookshelf",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5261,8 +4940,6 @@
 			"typed": "minecraft:bookshelf"
 		},
 		{
-			"asMaterial": "minecraft:bordure_indented_banner_pattern",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5286,11 +4963,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bordure_indented_banner_pattern",
-			"material": "BORDURE_INDENTED_BANNER_PATTERN",
+			"material": "minecraft:bordure_indented_banner_pattern",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5299,8 +4975,6 @@
 			"typed": "minecraft:bordure_indented_banner_pattern"
 		},
 		{
-			"asMaterial": "minecraft:bow",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5326,11 +5000,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bow",
-			"material": "BOW",
+			"material": "minecraft:bow",
 			"maxDurability": 384,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5339,8 +5012,6 @@
 			"typed": "minecraft:bow"
 		},
 		{
-			"asMaterial": "minecraft:bowl",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5363,11 +5034,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bowl",
-			"material": "BOWL",
+			"material": "minecraft:bowl",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5376,8 +5046,7 @@
 			"typed": "minecraft:bowl"
 		},
 		{
-			"asMaterial": "minecraft:brain_coral",
-			"blockType": true,
+			"blockType": "minecraft:brain_coral",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5400,11 +5069,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brain_coral",
-			"material": "BRAIN_CORAL",
+			"material": "minecraft:brain_coral",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5413,8 +5081,7 @@
 			"typed": "minecraft:brain_coral"
 		},
 		{
-			"asMaterial": "minecraft:brain_coral_block",
-			"blockType": true,
+			"blockType": "minecraft:brain_coral_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5437,11 +5104,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brain_coral_block",
-			"material": "BRAIN_CORAL_BLOCK",
+			"material": "minecraft:brain_coral_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5450,8 +5116,7 @@
 			"typed": "minecraft:brain_coral_block"
 		},
 		{
-			"asMaterial": "minecraft:brain_coral_fan",
-			"blockType": true,
+			"blockType": "minecraft:brain_coral_fan",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5474,11 +5139,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brain_coral_fan",
-			"material": "BRAIN_CORAL_FAN",
+			"material": "minecraft:brain_coral_fan",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5487,8 +5151,6 @@
 			"typed": "minecraft:brain_coral_fan"
 		},
 		{
-			"asMaterial": "minecraft:bread",
-			"blockType": false,
 			"compostChance": "0.85F",
 			"compostable": true,
 			"createItemStack": {
@@ -5514,11 +5176,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bread",
-			"material": "BREAD",
+			"material": "minecraft:bread",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5527,8 +5188,6 @@
 			"typed": "minecraft:bread"
 		},
 		{
-			"asMaterial": "minecraft:breeze_rod",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5551,11 +5210,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:breeze_rod",
-			"material": "BREEZE_ROD",
+			"material": "minecraft:breeze_rod",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5564,8 +5222,6 @@
 			"typed": "minecraft:breeze_rod"
 		},
 		{
-			"asMaterial": "minecraft:breeze_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5588,11 +5244,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:breeze_spawn_egg",
-			"material": "BREEZE_SPAWN_EGG",
+			"material": "minecraft:breeze_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5601,8 +5256,6 @@
 			"typed": "minecraft:breeze_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:brewer_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5625,11 +5278,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:brewer_pottery_sherd",
-			"material": "BREWER_POTTERY_SHERD",
+			"material": "minecraft:brewer_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5638,8 +5290,7 @@
 			"typed": "minecraft:brewer_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:brewing_stand",
-			"blockType": true,
+			"blockType": "minecraft:brewing_stand",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5663,11 +5314,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brewing_stand",
-			"material": "BREWING_STAND",
+			"material": "minecraft:brewing_stand",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5676,8 +5326,6 @@
 			"typed": "minecraft:brewing_stand"
 		},
 		{
-			"asMaterial": "minecraft:brick",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5700,11 +5348,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brick",
-			"material": "BRICK",
+			"material": "minecraft:brick",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5713,8 +5360,7 @@
 			"typed": "minecraft:brick"
 		},
 		{
-			"asMaterial": "minecraft:brick_slab",
-			"blockType": true,
+			"blockType": "minecraft:brick_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5737,11 +5383,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brick_slab",
-			"material": "BRICK_SLAB",
+			"material": "minecraft:brick_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5750,8 +5395,7 @@
 			"typed": "minecraft:brick_slab"
 		},
 		{
-			"asMaterial": "minecraft:brick_stairs",
-			"blockType": true,
+			"blockType": "minecraft:brick_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5774,11 +5418,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brick_stairs",
-			"material": "BRICK_STAIRS",
+			"material": "minecraft:brick_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5787,8 +5430,7 @@
 			"typed": "minecraft:brick_stairs"
 		},
 		{
-			"asMaterial": "minecraft:brick_wall",
-			"blockType": true,
+			"blockType": "minecraft:brick_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5811,11 +5453,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brick_wall",
-			"material": "BRICK_WALL",
+			"material": "minecraft:brick_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5824,8 +5465,7 @@
 			"typed": "minecraft:brick_wall"
 		},
 		{
-			"asMaterial": "minecraft:bricks",
-			"blockType": true,
+			"blockType": "minecraft:bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5848,11 +5488,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bricks",
-			"material": "BRICKS",
+			"material": "minecraft:bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5861,8 +5500,7 @@
 			"typed": "minecraft:bricks"
 		},
 		{
-			"asMaterial": "minecraft:brown_banner",
-			"blockType": true,
+			"blockType": "minecraft:brown_banner",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5886,11 +5524,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brown_banner",
-			"material": "BROWN_BANNER",
+			"material": "minecraft:brown_banner",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BannerMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5899,8 +5536,7 @@
 			"typed": "minecraft:brown_banner"
 		},
 		{
-			"asMaterial": "minecraft:brown_bed",
-			"blockType": true,
+			"blockType": "minecraft:brown_bed",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5923,11 +5559,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brown_bed",
-			"material": "BROWN_BED",
+			"material": "minecraft:brown_bed",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5936,8 +5571,6 @@
 			"typed": "minecraft:brown_bed"
 		},
 		{
-			"asMaterial": "minecraft:brown_bundle",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5961,11 +5594,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brown_bundle",
-			"material": "BROWN_BUNDLE",
+			"material": "minecraft:brown_bundle",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BundleMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -5974,8 +5606,7 @@
 			"typed": "minecraft:brown_bundle"
 		},
 		{
-			"asMaterial": "minecraft:brown_candle",
-			"blockType": true,
+			"blockType": "minecraft:brown_candle",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -5998,11 +5629,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brown_candle",
-			"material": "BROWN_CANDLE",
+			"material": "minecraft:brown_candle",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6011,8 +5641,7 @@
 			"typed": "minecraft:brown_candle"
 		},
 		{
-			"asMaterial": "minecraft:brown_carpet",
-			"blockType": true,
+			"blockType": "minecraft:brown_carpet",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -6036,11 +5665,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brown_carpet",
-			"material": "BROWN_CARPET",
+			"material": "minecraft:brown_carpet",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6049,8 +5677,7 @@
 			"typed": "minecraft:brown_carpet"
 		},
 		{
-			"asMaterial": "minecraft:brown_concrete",
-			"blockType": true,
+			"blockType": "minecraft:brown_concrete",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -6073,11 +5700,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brown_concrete",
-			"material": "BROWN_CONCRETE",
+			"material": "minecraft:brown_concrete",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6086,8 +5712,7 @@
 			"typed": "minecraft:brown_concrete"
 		},
 		{
-			"asMaterial": "minecraft:brown_concrete_powder",
-			"blockType": true,
+			"blockType": "minecraft:brown_concrete_powder",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -6110,11 +5735,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brown_concrete_powder",
-			"material": "BROWN_CONCRETE_POWDER",
+			"material": "minecraft:brown_concrete_powder",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6123,8 +5747,6 @@
 			"typed": "minecraft:brown_concrete_powder"
 		},
 		{
-			"asMaterial": "minecraft:brown_dye",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -6147,11 +5769,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brown_dye",
-			"material": "BROWN_DYE",
+			"material": "minecraft:brown_dye",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6160,8 +5781,6 @@
 			"typed": "minecraft:brown_dye"
 		},
 		{
-			"asMaterial": "minecraft:brown_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -6185,11 +5804,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brown_egg",
-			"material": "BROWN_EGG",
+			"material": "minecraft:brown_egg",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6198,8 +5816,7 @@
 			"typed": "minecraft:brown_egg"
 		},
 		{
-			"asMaterial": "minecraft:brown_glazed_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:brown_glazed_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -6222,11 +5839,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brown_glazed_terracotta",
-			"material": "BROWN_GLAZED_TERRACOTTA",
+			"material": "minecraft:brown_glazed_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6235,8 +5851,7 @@
 			"typed": "minecraft:brown_glazed_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:brown_mushroom",
-			"blockType": true,
+			"blockType": "minecraft:brown_mushroom",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -6260,11 +5875,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brown_mushroom",
-			"material": "BROWN_MUSHROOM",
+			"material": "minecraft:brown_mushroom",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6273,8 +5887,7 @@
 			"typed": "minecraft:brown_mushroom"
 		},
 		{
-			"asMaterial": "minecraft:brown_mushroom_block",
-			"blockType": true,
+			"blockType": "minecraft:brown_mushroom_block",
 			"compostChance": "0.85F",
 			"compostable": true,
 			"createItemStack": {
@@ -6298,11 +5911,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brown_mushroom_block",
-			"material": "BROWN_MUSHROOM_BLOCK",
+			"material": "minecraft:brown_mushroom_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6311,8 +5923,7 @@
 			"typed": "minecraft:brown_mushroom_block"
 		},
 		{
-			"asMaterial": "minecraft:brown_shulker_box",
-			"blockType": true,
+			"blockType": "minecraft:brown_shulker_box",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -6336,11 +5947,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brown_shulker_box",
-			"material": "BROWN_SHULKER_BOX",
+			"material": "minecraft:brown_shulker_box",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6349,8 +5959,7 @@
 			"typed": "minecraft:brown_shulker_box"
 		},
 		{
-			"asMaterial": "minecraft:brown_stained_glass",
-			"blockType": true,
+			"blockType": "minecraft:brown_stained_glass",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -6373,11 +5982,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brown_stained_glass",
-			"material": "BROWN_STAINED_GLASS",
+			"material": "minecraft:brown_stained_glass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6386,8 +5994,7 @@
 			"typed": "minecraft:brown_stained_glass"
 		},
 		{
-			"asMaterial": "minecraft:brown_stained_glass_pane",
-			"blockType": true,
+			"blockType": "minecraft:brown_stained_glass_pane",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -6410,11 +6017,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brown_stained_glass_pane",
-			"material": "BROWN_STAINED_GLASS_PANE",
+			"material": "minecraft:brown_stained_glass_pane",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6423,8 +6029,7 @@
 			"typed": "minecraft:brown_stained_glass_pane"
 		},
 		{
-			"asMaterial": "minecraft:brown_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:brown_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -6447,11 +6052,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brown_terracotta",
-			"material": "BROWN_TERRACOTTA",
+			"material": "minecraft:brown_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6460,8 +6064,7 @@
 			"typed": "minecraft:brown_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:brown_wool",
-			"blockType": true,
+			"blockType": "minecraft:brown_wool",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -6484,11 +6087,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brown_wool",
-			"material": "BROWN_WOOL",
+			"material": "minecraft:brown_wool",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6497,8 +6099,6 @@
 			"typed": "minecraft:brown_wool"
 		},
 		{
-			"asMaterial": "minecraft:brush",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -6523,11 +6123,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:brush",
-			"material": "BRUSH",
+			"material": "minecraft:brush",
 			"maxDurability": 64,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6536,8 +6135,7 @@
 			"typed": "minecraft:brush"
 		},
 		{
-			"asMaterial": "minecraft:bubble_coral",
-			"blockType": true,
+			"blockType": "minecraft:bubble_coral",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -6560,11 +6158,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bubble_coral",
-			"material": "BUBBLE_CORAL",
+			"material": "minecraft:bubble_coral",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6573,8 +6170,7 @@
 			"typed": "minecraft:bubble_coral"
 		},
 		{
-			"asMaterial": "minecraft:bubble_coral_block",
-			"blockType": true,
+			"blockType": "minecraft:bubble_coral_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -6597,11 +6193,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bubble_coral_block",
-			"material": "BUBBLE_CORAL_BLOCK",
+			"material": "minecraft:bubble_coral_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6610,8 +6205,7 @@
 			"typed": "minecraft:bubble_coral_block"
 		},
 		{
-			"asMaterial": "minecraft:bubble_coral_fan",
-			"blockType": true,
+			"blockType": "minecraft:bubble_coral_fan",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -6634,11 +6228,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bubble_coral_fan",
-			"material": "BUBBLE_CORAL_FAN",
+			"material": "minecraft:bubble_coral_fan",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6647,8 +6240,6 @@
 			"typed": "minecraft:bubble_coral_fan"
 		},
 		{
-			"asMaterial": "minecraft:bucket",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -6671,11 +6262,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bucket",
-			"material": "BUCKET",
+			"material": "minecraft:bucket",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6684,8 +6274,7 @@
 			"typed": "minecraft:bucket"
 		},
 		{
-			"asMaterial": "minecraft:budding_amethyst",
-			"blockType": true,
+			"blockType": "minecraft:budding_amethyst",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -6708,11 +6297,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:budding_amethyst",
-			"material": "BUDDING_AMETHYST",
+			"material": "minecraft:budding_amethyst",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6721,8 +6309,6 @@
 			"typed": "minecraft:budding_amethyst"
 		},
 		{
-			"asMaterial": "minecraft:bundle",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -6746,11 +6332,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bundle",
-			"material": "BUNDLE",
+			"material": "minecraft:bundle",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BundleMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6759,8 +6344,6 @@
 			"typed": "minecraft:bundle"
 		},
 		{
-			"asMaterial": "minecraft:burn_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -6783,11 +6366,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:burn_pottery_sherd",
-			"material": "BURN_POTTERY_SHERD",
+			"material": "minecraft:burn_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6796,8 +6378,7 @@
 			"typed": "minecraft:burn_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:bush",
-			"blockType": true,
+			"blockType": "minecraft:bush",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -6821,11 +6402,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:bush",
-			"material": "BUSH",
+			"material": "minecraft:bush",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6834,8 +6414,7 @@
 			"typed": "minecraft:bush"
 		},
 		{
-			"asMaterial": "minecraft:cactus",
-			"blockType": true,
+			"blockType": "minecraft:cactus",
 			"compostChance": "0.5F",
 			"compostable": true,
 			"createItemStack": {
@@ -6859,11 +6438,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cactus",
-			"material": "CACTUS",
+			"material": "minecraft:cactus",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6872,8 +6450,7 @@
 			"typed": "minecraft:cactus"
 		},
 		{
-			"asMaterial": "minecraft:cactus_flower",
-			"blockType": true,
+			"blockType": "minecraft:cactus_flower",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -6897,11 +6474,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cactus_flower",
-			"material": "CACTUS_FLOWER",
+			"material": "minecraft:cactus_flower",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6910,8 +6486,7 @@
 			"typed": "minecraft:cactus_flower"
 		},
 		{
-			"asMaterial": "minecraft:cake",
-			"blockType": true,
+			"blockType": "minecraft:cake",
 			"compostChance": "1.0F",
 			"compostable": true,
 			"createItemStack": {
@@ -6935,11 +6510,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cake",
-			"material": "CAKE",
+			"material": "minecraft:cake",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6948,8 +6522,7 @@
 			"typed": "minecraft:cake"
 		},
 		{
-			"asMaterial": "minecraft:calcite",
-			"blockType": true,
+			"blockType": "minecraft:calcite",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -6972,11 +6545,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:calcite",
-			"material": "CALCITE",
+			"material": "minecraft:calcite",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -6985,8 +6557,7 @@
 			"typed": "minecraft:calcite"
 		},
 		{
-			"asMaterial": "minecraft:calibrated_sculk_sensor",
-			"blockType": true,
+			"blockType": "minecraft:calibrated_sculk_sensor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7009,11 +6580,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:calibrated_sculk_sensor",
-			"material": "CALIBRATED_SCULK_SENSOR",
+			"material": "minecraft:calibrated_sculk_sensor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7022,8 +6592,6 @@
 			"typed": "minecraft:calibrated_sculk_sensor"
 		},
 		{
-			"asMaterial": "minecraft:camel_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7046,11 +6614,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:camel_spawn_egg",
-			"material": "CAMEL_SPAWN_EGG",
+			"material": "minecraft:camel_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7059,8 +6626,7 @@
 			"typed": "minecraft:camel_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:campfire",
-			"blockType": true,
+			"blockType": "minecraft:campfire",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7084,11 +6650,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:campfire",
-			"material": "CAMPFIRE",
+			"material": "minecraft:campfire",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7097,8 +6662,7 @@
 			"typed": "minecraft:campfire"
 		},
 		{
-			"asMaterial": "minecraft:candle",
-			"blockType": true,
+			"blockType": "minecraft:candle",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7121,11 +6685,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:candle",
-			"material": "CANDLE",
+			"material": "minecraft:candle",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7134,8 +6697,7 @@
 			"typed": "minecraft:candle"
 		},
 		{
-			"asMaterial": "minecraft:carrot",
-			"blockType": true,
+			"blockType": "minecraft:carrots",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -7161,11 +6723,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:carrot",
-			"material": "CARROT",
+			"material": "minecraft:carrot",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7174,8 +6735,6 @@
 			"typed": "minecraft:carrot"
 		},
 		{
-			"asMaterial": "minecraft:carrot_on_a_stick",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7200,11 +6759,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:carrot_on_a_stick",
-			"material": "CARROT_ON_A_STICK",
+			"material": "minecraft:carrot_on_a_stick",
 			"maxDurability": 25,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7213,8 +6771,7 @@
 			"typed": "minecraft:carrot_on_a_stick"
 		},
 		{
-			"asMaterial": "minecraft:cartography_table",
-			"blockType": true,
+			"blockType": "minecraft:cartography_table",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7237,11 +6794,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cartography_table",
-			"material": "CARTOGRAPHY_TABLE",
+			"material": "minecraft:cartography_table",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7250,8 +6806,7 @@
 			"typed": "minecraft:cartography_table"
 		},
 		{
-			"asMaterial": "minecraft:carved_pumpkin",
-			"blockType": true,
+			"blockType": "minecraft:carved_pumpkin",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -7276,11 +6831,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:carved_pumpkin",
-			"material": "CARVED_PUMPKIN",
+			"material": "minecraft:carved_pumpkin",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7289,8 +6843,6 @@
 			"typed": "minecraft:carved_pumpkin"
 		},
 		{
-			"asMaterial": "minecraft:cat_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7313,11 +6865,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cat_spawn_egg",
-			"material": "CAT_SPAWN_EGG",
+			"material": "minecraft:cat_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7326,8 +6877,7 @@
 			"typed": "minecraft:cat_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:cauldron",
-			"blockType": true,
+			"blockType": "minecraft:cauldron",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7350,11 +6900,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cauldron",
-			"material": "CAULDRON",
+			"material": "minecraft:cauldron",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7363,8 +6912,6 @@
 			"typed": "minecraft:cauldron"
 		},
 		{
-			"asMaterial": "minecraft:cave_spider_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7387,11 +6934,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cave_spider_spawn_egg",
-			"material": "CAVE_SPIDER_SPAWN_EGG",
+			"material": "minecraft:cave_spider_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7400,8 +6946,7 @@
 			"typed": "minecraft:cave_spider_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:chain",
-			"blockType": true,
+			"blockType": "minecraft:chain",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7424,11 +6969,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:chain",
-			"material": "CHAIN",
+			"material": "minecraft:chain",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7437,8 +6981,7 @@
 			"typed": "minecraft:chain"
 		},
 		{
-			"asMaterial": "minecraft:chain_command_block",
-			"blockType": true,
+			"blockType": "minecraft:chain_command_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7461,11 +7004,10 @@
 			"fuel": false,
 			"itemRarity": "EPIC",
 			"key": "minecraft:chain_command_block",
-			"material": "CHAIN_COMMAND_BLOCK",
+			"material": "minecraft:chain_command_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "EPIC",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7474,8 +7016,6 @@
 			"typed": "minecraft:chain_command_block"
 		},
 		{
-			"asMaterial": "minecraft:chainmail_boots",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7503,11 +7043,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:chainmail_boots",
-			"material": "CHAINMAIL_BOOTS",
+			"material": "minecraft:chainmail_boots",
 			"maxDurability": 195,
 			"maxStackSize": 1,
 			"metaClass": "ArmorMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7516,8 +7055,6 @@
 			"typed": "minecraft:chainmail_boots"
 		},
 		{
-			"asMaterial": "minecraft:chainmail_chestplate",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7545,11 +7082,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:chainmail_chestplate",
-			"material": "CHAINMAIL_CHESTPLATE",
+			"material": "minecraft:chainmail_chestplate",
 			"maxDurability": 240,
 			"maxStackSize": 1,
 			"metaClass": "ArmorMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7558,8 +7094,6 @@
 			"typed": "minecraft:chainmail_chestplate"
 		},
 		{
-			"asMaterial": "minecraft:chainmail_helmet",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7587,11 +7121,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:chainmail_helmet",
-			"material": "CHAINMAIL_HELMET",
+			"material": "minecraft:chainmail_helmet",
 			"maxDurability": 165,
 			"maxStackSize": 1,
 			"metaClass": "ArmorMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7600,8 +7133,6 @@
 			"typed": "minecraft:chainmail_helmet"
 		},
 		{
-			"asMaterial": "minecraft:chainmail_leggings",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7629,11 +7160,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:chainmail_leggings",
-			"material": "CHAINMAIL_LEGGINGS",
+			"material": "minecraft:chainmail_leggings",
 			"maxDurability": 225,
 			"maxStackSize": 1,
 			"metaClass": "ArmorMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7642,8 +7172,6 @@
 			"typed": "minecraft:chainmail_leggings"
 		},
 		{
-			"asMaterial": "minecraft:charcoal",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7666,11 +7194,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:charcoal",
-			"material": "CHARCOAL",
+			"material": "minecraft:charcoal",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7679,8 +7206,6 @@
 			"typed": "minecraft:charcoal"
 		},
 		{
-			"asMaterial": "minecraft:cherry_boat",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7703,11 +7228,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cherry_boat",
-			"material": "CHERRY_BOAT",
+			"material": "minecraft:cherry_boat",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7716,8 +7240,7 @@
 			"typed": "minecraft:cherry_boat"
 		},
 		{
-			"asMaterial": "minecraft:cherry_button",
-			"blockType": true,
+			"blockType": "minecraft:cherry_button",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7740,11 +7263,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cherry_button",
-			"material": "CHERRY_BUTTON",
+			"material": "minecraft:cherry_button",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7753,8 +7275,6 @@
 			"typed": "minecraft:cherry_button"
 		},
 		{
-			"asMaterial": "minecraft:cherry_chest_boat",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7777,11 +7297,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cherry_chest_boat",
-			"material": "CHERRY_CHEST_BOAT",
+			"material": "minecraft:cherry_chest_boat",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7790,8 +7309,7 @@
 			"typed": "minecraft:cherry_chest_boat"
 		},
 		{
-			"asMaterial": "minecraft:cherry_door",
-			"blockType": true,
+			"blockType": "minecraft:cherry_door",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7814,11 +7332,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cherry_door",
-			"material": "CHERRY_DOOR",
+			"material": "minecraft:cherry_door",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7827,8 +7344,7 @@
 			"typed": "minecraft:cherry_door"
 		},
 		{
-			"asMaterial": "minecraft:cherry_fence",
-			"blockType": true,
+			"blockType": "minecraft:cherry_fence",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7851,11 +7367,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cherry_fence",
-			"material": "CHERRY_FENCE",
+			"material": "minecraft:cherry_fence",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7864,8 +7379,7 @@
 			"typed": "minecraft:cherry_fence"
 		},
 		{
-			"asMaterial": "minecraft:cherry_fence_gate",
-			"blockType": true,
+			"blockType": "minecraft:cherry_fence_gate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7888,11 +7402,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cherry_fence_gate",
-			"material": "CHERRY_FENCE_GATE",
+			"material": "minecraft:cherry_fence_gate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7901,8 +7414,7 @@
 			"typed": "minecraft:cherry_fence_gate"
 		},
 		{
-			"asMaterial": "minecraft:cherry_hanging_sign",
-			"blockType": true,
+			"blockType": "minecraft:cherry_hanging_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -7925,11 +7437,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cherry_hanging_sign",
-			"material": "CHERRY_HANGING_SIGN",
+			"material": "minecraft:cherry_hanging_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7938,8 +7449,7 @@
 			"typed": "minecraft:cherry_hanging_sign"
 		},
 		{
-			"asMaterial": "minecraft:cherry_leaves",
-			"blockType": true,
+			"blockType": "minecraft:cherry_leaves",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -7963,11 +7473,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cherry_leaves",
-			"material": "CHERRY_LEAVES",
+			"material": "minecraft:cherry_leaves",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -7976,8 +7485,7 @@
 			"typed": "minecraft:cherry_leaves"
 		},
 		{
-			"asMaterial": "minecraft:cherry_log",
-			"blockType": true,
+			"blockType": "minecraft:cherry_log",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8000,11 +7508,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cherry_log",
-			"material": "CHERRY_LOG",
+			"material": "minecraft:cherry_log",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8013,8 +7520,7 @@
 			"typed": "minecraft:cherry_log"
 		},
 		{
-			"asMaterial": "minecraft:cherry_planks",
-			"blockType": true,
+			"blockType": "minecraft:cherry_planks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8037,11 +7543,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cherry_planks",
-			"material": "CHERRY_PLANKS",
+			"material": "minecraft:cherry_planks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8050,8 +7555,7 @@
 			"typed": "minecraft:cherry_planks"
 		},
 		{
-			"asMaterial": "minecraft:cherry_pressure_plate",
-			"blockType": true,
+			"blockType": "minecraft:cherry_pressure_plate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8074,11 +7578,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cherry_pressure_plate",
-			"material": "CHERRY_PRESSURE_PLATE",
+			"material": "minecraft:cherry_pressure_plate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8087,8 +7590,7 @@
 			"typed": "minecraft:cherry_pressure_plate"
 		},
 		{
-			"asMaterial": "minecraft:cherry_sapling",
-			"blockType": true,
+			"blockType": "minecraft:cherry_sapling",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -8112,11 +7614,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cherry_sapling",
-			"material": "CHERRY_SAPLING",
+			"material": "minecraft:cherry_sapling",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8125,8 +7626,7 @@
 			"typed": "minecraft:cherry_sapling"
 		},
 		{
-			"asMaterial": "minecraft:cherry_sign",
-			"blockType": true,
+			"blockType": "minecraft:cherry_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8149,11 +7649,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cherry_sign",
-			"material": "CHERRY_SIGN",
+			"material": "minecraft:cherry_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8162,8 +7661,7 @@
 			"typed": "minecraft:cherry_sign"
 		},
 		{
-			"asMaterial": "minecraft:cherry_slab",
-			"blockType": true,
+			"blockType": "minecraft:cherry_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8186,11 +7684,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cherry_slab",
-			"material": "CHERRY_SLAB",
+			"material": "minecraft:cherry_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8199,8 +7696,7 @@
 			"typed": "minecraft:cherry_slab"
 		},
 		{
-			"asMaterial": "minecraft:cherry_stairs",
-			"blockType": true,
+			"blockType": "minecraft:cherry_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8223,11 +7719,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cherry_stairs",
-			"material": "CHERRY_STAIRS",
+			"material": "minecraft:cherry_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8236,8 +7731,7 @@
 			"typed": "minecraft:cherry_stairs"
 		},
 		{
-			"asMaterial": "minecraft:cherry_trapdoor",
-			"blockType": true,
+			"blockType": "minecraft:cherry_trapdoor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8260,11 +7754,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cherry_trapdoor",
-			"material": "CHERRY_TRAPDOOR",
+			"material": "minecraft:cherry_trapdoor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8273,8 +7766,7 @@
 			"typed": "minecraft:cherry_trapdoor"
 		},
 		{
-			"asMaterial": "minecraft:cherry_wood",
-			"blockType": true,
+			"blockType": "minecraft:cherry_wood",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8297,11 +7789,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cherry_wood",
-			"material": "CHERRY_WOOD",
+			"material": "minecraft:cherry_wood",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8310,8 +7801,7 @@
 			"typed": "minecraft:cherry_wood"
 		},
 		{
-			"asMaterial": "minecraft:chest",
-			"blockType": true,
+			"blockType": "minecraft:chest",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8335,11 +7825,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:chest",
-			"material": "CHEST",
+			"material": "minecraft:chest",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8348,8 +7837,6 @@
 			"typed": "minecraft:chest"
 		},
 		{
-			"asMaterial": "minecraft:chest_minecart",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8372,11 +7859,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:chest_minecart",
-			"material": "CHEST_MINECART",
+			"material": "minecraft:chest_minecart",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8385,8 +7871,6 @@
 			"typed": "minecraft:chest_minecart"
 		},
 		{
-			"asMaterial": "minecraft:chicken",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8411,11 +7895,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:chicken",
-			"material": "CHICKEN",
+			"material": "minecraft:chicken",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8424,8 +7907,6 @@
 			"typed": "minecraft:chicken"
 		},
 		{
-			"asMaterial": "minecraft:chicken_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8448,11 +7929,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:chicken_spawn_egg",
-			"material": "CHICKEN_SPAWN_EGG",
+			"material": "minecraft:chicken_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8461,8 +7941,7 @@
 			"typed": "minecraft:chicken_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:chipped_anvil",
-			"blockType": true,
+			"blockType": "minecraft:chipped_anvil",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8485,11 +7964,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:chipped_anvil",
-			"material": "CHIPPED_ANVIL",
+			"material": "minecraft:chipped_anvil",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8498,8 +7976,7 @@
 			"typed": "minecraft:chipped_anvil"
 		},
 		{
-			"asMaterial": "minecraft:chiseled_bookshelf",
-			"blockType": true,
+			"blockType": "minecraft:chiseled_bookshelf",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8523,11 +8000,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:chiseled_bookshelf",
-			"material": "CHISELED_BOOKSHELF",
+			"material": "minecraft:chiseled_bookshelf",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8536,8 +8012,7 @@
 			"typed": "minecraft:chiseled_bookshelf"
 		},
 		{
-			"asMaterial": "minecraft:chiseled_copper",
-			"blockType": true,
+			"blockType": "minecraft:chiseled_copper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8560,11 +8035,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:chiseled_copper",
-			"material": "CHISELED_COPPER",
+			"material": "minecraft:chiseled_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8573,8 +8047,7 @@
 			"typed": "minecraft:chiseled_copper"
 		},
 		{
-			"asMaterial": "minecraft:chiseled_deepslate",
-			"blockType": true,
+			"blockType": "minecraft:chiseled_deepslate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8597,11 +8070,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:chiseled_deepslate",
-			"material": "CHISELED_DEEPSLATE",
+			"material": "minecraft:chiseled_deepslate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8610,8 +8082,7 @@
 			"typed": "minecraft:chiseled_deepslate"
 		},
 		{
-			"asMaterial": "minecraft:chiseled_nether_bricks",
-			"blockType": true,
+			"blockType": "minecraft:chiseled_nether_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8634,11 +8105,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:chiseled_nether_bricks",
-			"material": "CHISELED_NETHER_BRICKS",
+			"material": "minecraft:chiseled_nether_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8647,8 +8117,7 @@
 			"typed": "minecraft:chiseled_nether_bricks"
 		},
 		{
-			"asMaterial": "minecraft:chiseled_polished_blackstone",
-			"blockType": true,
+			"blockType": "minecraft:chiseled_polished_blackstone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8671,11 +8140,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:chiseled_polished_blackstone",
-			"material": "CHISELED_POLISHED_BLACKSTONE",
+			"material": "minecraft:chiseled_polished_blackstone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8684,8 +8152,7 @@
 			"typed": "minecraft:chiseled_polished_blackstone"
 		},
 		{
-			"asMaterial": "minecraft:chiseled_quartz_block",
-			"blockType": true,
+			"blockType": "minecraft:chiseled_quartz_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8708,11 +8175,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:chiseled_quartz_block",
-			"material": "CHISELED_QUARTZ_BLOCK",
+			"material": "minecraft:chiseled_quartz_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8721,8 +8187,7 @@
 			"typed": "minecraft:chiseled_quartz_block"
 		},
 		{
-			"asMaterial": "minecraft:chiseled_red_sandstone",
-			"blockType": true,
+			"blockType": "minecraft:chiseled_red_sandstone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8745,11 +8210,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:chiseled_red_sandstone",
-			"material": "CHISELED_RED_SANDSTONE",
+			"material": "minecraft:chiseled_red_sandstone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8758,8 +8222,7 @@
 			"typed": "minecraft:chiseled_red_sandstone"
 		},
 		{
-			"asMaterial": "minecraft:chiseled_resin_bricks",
-			"blockType": true,
+			"blockType": "minecraft:chiseled_resin_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8782,11 +8245,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:chiseled_resin_bricks",
-			"material": "CHISELED_RESIN_BRICKS",
+			"material": "minecraft:chiseled_resin_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8795,8 +8257,7 @@
 			"typed": "minecraft:chiseled_resin_bricks"
 		},
 		{
-			"asMaterial": "minecraft:chiseled_sandstone",
-			"blockType": true,
+			"blockType": "minecraft:chiseled_sandstone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8819,11 +8280,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:chiseled_sandstone",
-			"material": "CHISELED_SANDSTONE",
+			"material": "minecraft:chiseled_sandstone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8832,8 +8292,7 @@
 			"typed": "minecraft:chiseled_sandstone"
 		},
 		{
-			"asMaterial": "minecraft:chiseled_stone_bricks",
-			"blockType": true,
+			"blockType": "minecraft:chiseled_stone_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8856,11 +8315,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:chiseled_stone_bricks",
-			"material": "CHISELED_STONE_BRICKS",
+			"material": "minecraft:chiseled_stone_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8869,8 +8327,7 @@
 			"typed": "minecraft:chiseled_stone_bricks"
 		},
 		{
-			"asMaterial": "minecraft:chiseled_tuff",
-			"blockType": true,
+			"blockType": "minecraft:chiseled_tuff",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8893,11 +8350,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:chiseled_tuff",
-			"material": "CHISELED_TUFF",
+			"material": "minecraft:chiseled_tuff",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8906,8 +8362,7 @@
 			"typed": "minecraft:chiseled_tuff"
 		},
 		{
-			"asMaterial": "minecraft:chiseled_tuff_bricks",
-			"blockType": true,
+			"blockType": "minecraft:chiseled_tuff_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8930,11 +8385,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:chiseled_tuff_bricks",
-			"material": "CHISELED_TUFF_BRICKS",
+			"material": "minecraft:chiseled_tuff_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8943,8 +8397,7 @@
 			"typed": "minecraft:chiseled_tuff_bricks"
 		},
 		{
-			"asMaterial": "minecraft:chorus_flower",
-			"blockType": true,
+			"blockType": "minecraft:chorus_flower",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -8967,11 +8420,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:chorus_flower",
-			"material": "CHORUS_FLOWER",
+			"material": "minecraft:chorus_flower",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -8980,8 +8432,6 @@
 			"typed": "minecraft:chorus_flower"
 		},
 		{
-			"asMaterial": "minecraft:chorus_fruit",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9007,11 +8457,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:chorus_fruit",
-			"material": "CHORUS_FRUIT",
+			"material": "minecraft:chorus_fruit",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9020,8 +8469,7 @@
 			"typed": "minecraft:chorus_fruit"
 		},
 		{
-			"asMaterial": "minecraft:chorus_plant",
-			"blockType": true,
+			"blockType": "minecraft:chorus_plant",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9044,11 +8492,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:chorus_plant",
-			"material": "CHORUS_PLANT",
+			"material": "minecraft:chorus_plant",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9057,8 +8504,7 @@
 			"typed": "minecraft:chorus_plant"
 		},
 		{
-			"asMaterial": "minecraft:clay",
-			"blockType": true,
+			"blockType": "minecraft:clay",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9081,11 +8527,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:clay",
-			"material": "CLAY",
+			"material": "minecraft:clay",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9094,8 +8539,6 @@
 			"typed": "minecraft:clay"
 		},
 		{
-			"asMaterial": "minecraft:clay_ball",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9118,11 +8561,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:clay_ball",
-			"material": "CLAY_BALL",
+			"material": "minecraft:clay_ball",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9131,8 +8573,6 @@
 			"typed": "minecraft:clay_ball"
 		},
 		{
-			"asMaterial": "minecraft:clock",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9155,11 +8595,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:clock",
-			"material": "CLOCK",
+			"material": "minecraft:clock",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9168,8 +8607,7 @@
 			"typed": "minecraft:clock"
 		},
 		{
-			"asMaterial": "minecraft:closed_eyeblossom",
-			"blockType": true,
+			"blockType": "minecraft:closed_eyeblossom",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -9193,11 +8631,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:closed_eyeblossom",
-			"material": "CLOSED_EYEBLOSSOM",
+			"material": "minecraft:closed_eyeblossom",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9206,8 +8643,6 @@
 			"typed": "minecraft:closed_eyeblossom"
 		},
 		{
-			"asMaterial": "minecraft:coal",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9230,11 +8665,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:coal",
-			"material": "COAL",
+			"material": "minecraft:coal",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9243,8 +8677,7 @@
 			"typed": "minecraft:coal"
 		},
 		{
-			"asMaterial": "minecraft:coal_block",
-			"blockType": true,
+			"blockType": "minecraft:coal_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9267,11 +8700,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:coal_block",
-			"material": "COAL_BLOCK",
+			"material": "minecraft:coal_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9280,8 +8712,7 @@
 			"typed": "minecraft:coal_block"
 		},
 		{
-			"asMaterial": "minecraft:coal_ore",
-			"blockType": true,
+			"blockType": "minecraft:coal_ore",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9304,11 +8735,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:coal_ore",
-			"material": "COAL_ORE",
+			"material": "minecraft:coal_ore",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9317,8 +8747,7 @@
 			"typed": "minecraft:coal_ore"
 		},
 		{
-			"asMaterial": "minecraft:coarse_dirt",
-			"blockType": true,
+			"blockType": "minecraft:coarse_dirt",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9341,11 +8770,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:coarse_dirt",
-			"material": "COARSE_DIRT",
+			"material": "minecraft:coarse_dirt",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9354,8 +8782,6 @@
 			"typed": "minecraft:coarse_dirt"
 		},
 		{
-			"asMaterial": "minecraft:coast_armor_trim_smithing_template",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9378,11 +8804,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:coast_armor_trim_smithing_template",
-			"material": "COAST_ARMOR_TRIM_SMITHING_TEMPLATE",
+			"material": "minecraft:coast_armor_trim_smithing_template",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9391,8 +8816,7 @@
 			"typed": "minecraft:coast_armor_trim_smithing_template"
 		},
 		{
-			"asMaterial": "minecraft:cobbled_deepslate",
-			"blockType": true,
+			"blockType": "minecraft:cobbled_deepslate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9415,11 +8839,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cobbled_deepslate",
-			"material": "COBBLED_DEEPSLATE",
+			"material": "minecraft:cobbled_deepslate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9428,8 +8851,7 @@
 			"typed": "minecraft:cobbled_deepslate"
 		},
 		{
-			"asMaterial": "minecraft:cobbled_deepslate_slab",
-			"blockType": true,
+			"blockType": "minecraft:cobbled_deepslate_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9452,11 +8874,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cobbled_deepslate_slab",
-			"material": "COBBLED_DEEPSLATE_SLAB",
+			"material": "minecraft:cobbled_deepslate_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9465,8 +8886,7 @@
 			"typed": "minecraft:cobbled_deepslate_slab"
 		},
 		{
-			"asMaterial": "minecraft:cobbled_deepslate_stairs",
-			"blockType": true,
+			"blockType": "minecraft:cobbled_deepslate_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9489,11 +8909,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cobbled_deepslate_stairs",
-			"material": "COBBLED_DEEPSLATE_STAIRS",
+			"material": "minecraft:cobbled_deepslate_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9502,8 +8921,7 @@
 			"typed": "minecraft:cobbled_deepslate_stairs"
 		},
 		{
-			"asMaterial": "minecraft:cobbled_deepslate_wall",
-			"blockType": true,
+			"blockType": "minecraft:cobbled_deepslate_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9526,11 +8944,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cobbled_deepslate_wall",
-			"material": "COBBLED_DEEPSLATE_WALL",
+			"material": "minecraft:cobbled_deepslate_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9539,8 +8956,7 @@
 			"typed": "minecraft:cobbled_deepslate_wall"
 		},
 		{
-			"asMaterial": "minecraft:cobblestone",
-			"blockType": true,
+			"blockType": "minecraft:cobblestone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9563,11 +8979,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cobblestone",
-			"material": "COBBLESTONE",
+			"material": "minecraft:cobblestone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9576,8 +8991,7 @@
 			"typed": "minecraft:cobblestone"
 		},
 		{
-			"asMaterial": "minecraft:cobblestone_slab",
-			"blockType": true,
+			"blockType": "minecraft:cobblestone_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9600,11 +9014,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cobblestone_slab",
-			"material": "COBBLESTONE_SLAB",
+			"material": "minecraft:cobblestone_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9613,8 +9026,7 @@
 			"typed": "minecraft:cobblestone_slab"
 		},
 		{
-			"asMaterial": "minecraft:cobblestone_stairs",
-			"blockType": true,
+			"blockType": "minecraft:cobblestone_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9637,11 +9049,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cobblestone_stairs",
-			"material": "COBBLESTONE_STAIRS",
+			"material": "minecraft:cobblestone_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9650,8 +9061,7 @@
 			"typed": "minecraft:cobblestone_stairs"
 		},
 		{
-			"asMaterial": "minecraft:cobblestone_wall",
-			"blockType": true,
+			"blockType": "minecraft:cobblestone_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9674,11 +9084,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cobblestone_wall",
-			"material": "COBBLESTONE_WALL",
+			"material": "minecraft:cobblestone_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9687,8 +9096,7 @@
 			"typed": "minecraft:cobblestone_wall"
 		},
 		{
-			"asMaterial": "minecraft:cobweb",
-			"blockType": true,
+			"blockType": "minecraft:cobweb",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9711,11 +9119,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cobweb",
-			"material": "COBWEB",
+			"material": "minecraft:cobweb",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9724,8 +9131,7 @@
 			"typed": "minecraft:cobweb"
 		},
 		{
-			"asMaterial": "minecraft:cocoa_beans",
-			"blockType": true,
+			"blockType": "minecraft:cocoa",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -9749,11 +9155,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cocoa_beans",
-			"material": "COCOA_BEANS",
+			"material": "minecraft:cocoa_beans",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9762,8 +9167,6 @@
 			"typed": "minecraft:cocoa_beans"
 		},
 		{
-			"asMaterial": "minecraft:cod",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9788,11 +9191,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cod",
-			"material": "COD",
+			"material": "minecraft:cod",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9801,8 +9203,6 @@
 			"typed": "minecraft:cod"
 		},
 		{
-			"asMaterial": "minecraft:cod_bucket",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9826,11 +9226,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cod_bucket",
-			"material": "COD_BUCKET",
+			"material": "minecraft:cod_bucket",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9839,8 +9238,6 @@
 			"typed": "minecraft:cod_bucket"
 		},
 		{
-			"asMaterial": "minecraft:cod_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9863,11 +9260,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cod_spawn_egg",
-			"material": "COD_SPAWN_EGG",
+			"material": "minecraft:cod_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9876,8 +9272,7 @@
 			"typed": "minecraft:cod_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:command_block",
-			"blockType": true,
+			"blockType": "minecraft:command_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9900,11 +9295,10 @@
 			"fuel": false,
 			"itemRarity": "EPIC",
 			"key": "minecraft:command_block",
-			"material": "COMMAND_BLOCK",
+			"material": "minecraft:command_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "EPIC",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9913,8 +9307,6 @@
 			"typed": "minecraft:command_block"
 		},
 		{
-			"asMaterial": "minecraft:command_block_minecart",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9937,11 +9329,10 @@
 			"fuel": false,
 			"itemRarity": "EPIC",
 			"key": "minecraft:command_block_minecart",
-			"material": "COMMAND_BLOCK_MINECART",
+			"material": "minecraft:command_block_minecart",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "EPIC",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9950,8 +9341,7 @@
 			"typed": "minecraft:command_block_minecart"
 		},
 		{
-			"asMaterial": "minecraft:comparator",
-			"blockType": true,
+			"blockType": "minecraft:comparator",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -9974,11 +9364,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:comparator",
-			"material": "COMPARATOR",
+			"material": "minecraft:comparator",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -9987,8 +9376,6 @@
 			"typed": "minecraft:comparator"
 		},
 		{
-			"asMaterial": "minecraft:compass",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10011,11 +9398,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:compass",
-			"material": "COMPASS",
+			"material": "minecraft:compass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "CompassMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10024,8 +9410,7 @@
 			"typed": "minecraft:compass"
 		},
 		{
-			"asMaterial": "minecraft:composter",
-			"blockType": true,
+			"blockType": "minecraft:composter",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10048,11 +9433,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:composter",
-			"material": "COMPOSTER",
+			"material": "minecraft:composter",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10061,8 +9445,7 @@
 			"typed": "minecraft:composter"
 		},
 		{
-			"asMaterial": "minecraft:conduit",
-			"blockType": true,
+			"blockType": "minecraft:conduit",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10085,11 +9468,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:conduit",
-			"material": "CONDUIT",
+			"material": "minecraft:conduit",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10098,8 +9480,6 @@
 			"typed": "minecraft:conduit"
 		},
 		{
-			"asMaterial": "minecraft:cooked_beef",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10124,11 +9504,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cooked_beef",
-			"material": "COOKED_BEEF",
+			"material": "minecraft:cooked_beef",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10137,8 +9516,6 @@
 			"typed": "minecraft:cooked_beef"
 		},
 		{
-			"asMaterial": "minecraft:cooked_chicken",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10163,11 +9540,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cooked_chicken",
-			"material": "COOKED_CHICKEN",
+			"material": "minecraft:cooked_chicken",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10176,8 +9552,6 @@
 			"typed": "minecraft:cooked_chicken"
 		},
 		{
-			"asMaterial": "minecraft:cooked_cod",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10202,11 +9576,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cooked_cod",
-			"material": "COOKED_COD",
+			"material": "minecraft:cooked_cod",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10215,8 +9588,6 @@
 			"typed": "minecraft:cooked_cod"
 		},
 		{
-			"asMaterial": "minecraft:cooked_mutton",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10241,11 +9612,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cooked_mutton",
-			"material": "COOKED_MUTTON",
+			"material": "minecraft:cooked_mutton",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10254,8 +9624,6 @@
 			"typed": "minecraft:cooked_mutton"
 		},
 		{
-			"asMaterial": "minecraft:cooked_porkchop",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10280,11 +9648,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cooked_porkchop",
-			"material": "COOKED_PORKCHOP",
+			"material": "minecraft:cooked_porkchop",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10293,8 +9660,6 @@
 			"typed": "minecraft:cooked_porkchop"
 		},
 		{
-			"asMaterial": "minecraft:cooked_rabbit",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10319,11 +9684,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cooked_rabbit",
-			"material": "COOKED_RABBIT",
+			"material": "minecraft:cooked_rabbit",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10332,8 +9696,6 @@
 			"typed": "minecraft:cooked_rabbit"
 		},
 		{
-			"asMaterial": "minecraft:cooked_salmon",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10358,11 +9720,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cooked_salmon",
-			"material": "COOKED_SALMON",
+			"material": "minecraft:cooked_salmon",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10371,8 +9732,6 @@
 			"typed": "minecraft:cooked_salmon"
 		},
 		{
-			"asMaterial": "minecraft:cookie",
-			"blockType": false,
 			"compostChance": "0.85F",
 			"compostable": true,
 			"createItemStack": {
@@ -10398,11 +9757,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cookie",
-			"material": "COOKIE",
+			"material": "minecraft:cookie",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10411,8 +9769,7 @@
 			"typed": "minecraft:cookie"
 		},
 		{
-			"asMaterial": "minecraft:copper_block",
-			"blockType": true,
+			"blockType": "minecraft:copper_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10435,11 +9792,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:copper_block",
-			"material": "COPPER_BLOCK",
+			"material": "minecraft:copper_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10448,8 +9804,7 @@
 			"typed": "minecraft:copper_block"
 		},
 		{
-			"asMaterial": "minecraft:copper_bulb",
-			"blockType": true,
+			"blockType": "minecraft:copper_bulb",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10472,11 +9827,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:copper_bulb",
-			"material": "COPPER_BULB",
+			"material": "minecraft:copper_bulb",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10485,8 +9839,7 @@
 			"typed": "minecraft:copper_bulb"
 		},
 		{
-			"asMaterial": "minecraft:copper_door",
-			"blockType": true,
+			"blockType": "minecraft:copper_door",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10509,11 +9862,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:copper_door",
-			"material": "COPPER_DOOR",
+			"material": "minecraft:copper_door",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10522,8 +9874,7 @@
 			"typed": "minecraft:copper_door"
 		},
 		{
-			"asMaterial": "minecraft:copper_grate",
-			"blockType": true,
+			"blockType": "minecraft:copper_grate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10546,11 +9897,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:copper_grate",
-			"material": "COPPER_GRATE",
+			"material": "minecraft:copper_grate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10559,8 +9909,6 @@
 			"typed": "minecraft:copper_grate"
 		},
 		{
-			"asMaterial": "minecraft:copper_ingot",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10584,11 +9932,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:copper_ingot",
-			"material": "COPPER_INGOT",
+			"material": "minecraft:copper_ingot",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10597,8 +9944,7 @@
 			"typed": "minecraft:copper_ingot"
 		},
 		{
-			"asMaterial": "minecraft:copper_ore",
-			"blockType": true,
+			"blockType": "minecraft:copper_ore",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10621,11 +9967,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:copper_ore",
-			"material": "COPPER_ORE",
+			"material": "minecraft:copper_ore",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10634,8 +9979,7 @@
 			"typed": "minecraft:copper_ore"
 		},
 		{
-			"asMaterial": "minecraft:copper_trapdoor",
-			"blockType": true,
+			"blockType": "minecraft:copper_trapdoor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10658,11 +10002,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:copper_trapdoor",
-			"material": "COPPER_TRAPDOOR",
+			"material": "minecraft:copper_trapdoor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10671,8 +10014,7 @@
 			"typed": "minecraft:copper_trapdoor"
 		},
 		{
-			"asMaterial": "minecraft:cornflower",
-			"blockType": true,
+			"blockType": "minecraft:cornflower",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -10696,11 +10038,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cornflower",
-			"material": "CORNFLOWER",
+			"material": "minecraft:cornflower",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10709,8 +10050,6 @@
 			"typed": "minecraft:cornflower"
 		},
 		{
-			"asMaterial": "minecraft:cow_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10733,11 +10072,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cow_spawn_egg",
-			"material": "COW_SPAWN_EGG",
+			"material": "minecraft:cow_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10746,8 +10084,7 @@
 			"typed": "minecraft:cow_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:cracked_deepslate_bricks",
-			"blockType": true,
+			"blockType": "minecraft:cracked_deepslate_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10770,11 +10107,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cracked_deepslate_bricks",
-			"material": "CRACKED_DEEPSLATE_BRICKS",
+			"material": "minecraft:cracked_deepslate_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10783,8 +10119,7 @@
 			"typed": "minecraft:cracked_deepslate_bricks"
 		},
 		{
-			"asMaterial": "minecraft:cracked_deepslate_tiles",
-			"blockType": true,
+			"blockType": "minecraft:cracked_deepslate_tiles",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10807,11 +10142,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cracked_deepslate_tiles",
-			"material": "CRACKED_DEEPSLATE_TILES",
+			"material": "minecraft:cracked_deepslate_tiles",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10820,8 +10154,7 @@
 			"typed": "minecraft:cracked_deepslate_tiles"
 		},
 		{
-			"asMaterial": "minecraft:cracked_nether_bricks",
-			"blockType": true,
+			"blockType": "minecraft:cracked_nether_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10844,11 +10177,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cracked_nether_bricks",
-			"material": "CRACKED_NETHER_BRICKS",
+			"material": "minecraft:cracked_nether_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10857,8 +10189,7 @@
 			"typed": "minecraft:cracked_nether_bricks"
 		},
 		{
-			"asMaterial": "minecraft:cracked_polished_blackstone_bricks",
-			"blockType": true,
+			"blockType": "minecraft:cracked_polished_blackstone_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10881,11 +10212,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cracked_polished_blackstone_bricks",
-			"material": "CRACKED_POLISHED_BLACKSTONE_BRICKS",
+			"material": "minecraft:cracked_polished_blackstone_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10894,8 +10224,7 @@
 			"typed": "minecraft:cracked_polished_blackstone_bricks"
 		},
 		{
-			"asMaterial": "minecraft:cracked_stone_bricks",
-			"blockType": true,
+			"blockType": "minecraft:cracked_stone_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10918,11 +10247,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cracked_stone_bricks",
-			"material": "CRACKED_STONE_BRICKS",
+			"material": "minecraft:cracked_stone_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10931,8 +10259,7 @@
 			"typed": "minecraft:cracked_stone_bricks"
 		},
 		{
-			"asMaterial": "minecraft:crafter",
-			"blockType": true,
+			"blockType": "minecraft:crafter",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10956,11 +10283,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:crafter",
-			"material": "CRAFTER",
+			"material": "minecraft:crafter",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -10969,8 +10295,7 @@
 			"typed": "minecraft:crafter"
 		},
 		{
-			"asMaterial": "minecraft:crafting_table",
-			"blockType": true,
+			"blockType": "minecraft:crafting_table",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -10993,11 +10318,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:crafting_table",
-			"material": "CRAFTING_TABLE",
+			"material": "minecraft:crafting_table",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11006,8 +10330,7 @@
 			"typed": "minecraft:crafting_table"
 		},
 		{
-			"asMaterial": "minecraft:creaking_heart",
-			"blockType": true,
+			"blockType": "minecraft:creaking_heart",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11030,11 +10353,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:creaking_heart",
-			"material": "CREAKING_HEART",
+			"material": "minecraft:creaking_heart",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11043,8 +10365,6 @@
 			"typed": "minecraft:creaking_heart"
 		},
 		{
-			"asMaterial": "minecraft:creaking_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11067,11 +10387,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:creaking_spawn_egg",
-			"material": "CREAKING_SPAWN_EGG",
+			"material": "minecraft:creaking_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11080,8 +10399,6 @@
 			"typed": "minecraft:creaking_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:creeper_banner_pattern",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11105,11 +10422,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:creeper_banner_pattern",
-			"material": "CREEPER_BANNER_PATTERN",
+			"material": "minecraft:creeper_banner_pattern",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11118,8 +10434,7 @@
 			"typed": "minecraft:creeper_banner_pattern"
 		},
 		{
-			"asMaterial": "minecraft:creeper_head",
-			"blockType": true,
+			"blockType": "minecraft:creeper_head",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11143,11 +10458,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:creeper_head",
-			"material": "CREEPER_HEAD",
+			"material": "minecraft:creeper_head",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SkullMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11156,8 +10470,6 @@
 			"typed": "minecraft:creeper_head"
 		},
 		{
-			"asMaterial": "minecraft:creeper_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11180,11 +10492,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:creeper_spawn_egg",
-			"material": "CREEPER_SPAWN_EGG",
+			"material": "minecraft:creeper_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11193,8 +10504,7 @@
 			"typed": "minecraft:creeper_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:crimson_button",
-			"blockType": true,
+			"blockType": "minecraft:crimson_button",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11217,11 +10527,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:crimson_button",
-			"material": "CRIMSON_BUTTON",
+			"material": "minecraft:crimson_button",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11230,8 +10539,7 @@
 			"typed": "minecraft:crimson_button"
 		},
 		{
-			"asMaterial": "minecraft:crimson_door",
-			"blockType": true,
+			"blockType": "minecraft:crimson_door",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11254,11 +10562,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:crimson_door",
-			"material": "CRIMSON_DOOR",
+			"material": "minecraft:crimson_door",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11267,8 +10574,7 @@
 			"typed": "minecraft:crimson_door"
 		},
 		{
-			"asMaterial": "minecraft:crimson_fence",
-			"blockType": true,
+			"blockType": "minecraft:crimson_fence",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11291,11 +10597,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:crimson_fence",
-			"material": "CRIMSON_FENCE",
+			"material": "minecraft:crimson_fence",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11304,8 +10609,7 @@
 			"typed": "minecraft:crimson_fence"
 		},
 		{
-			"asMaterial": "minecraft:crimson_fence_gate",
-			"blockType": true,
+			"blockType": "minecraft:crimson_fence_gate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11328,11 +10632,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:crimson_fence_gate",
-			"material": "CRIMSON_FENCE_GATE",
+			"material": "minecraft:crimson_fence_gate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11341,8 +10644,7 @@
 			"typed": "minecraft:crimson_fence_gate"
 		},
 		{
-			"asMaterial": "minecraft:crimson_fungus",
-			"blockType": true,
+			"blockType": "minecraft:crimson_fungus",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -11366,11 +10668,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:crimson_fungus",
-			"material": "CRIMSON_FUNGUS",
+			"material": "minecraft:crimson_fungus",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11379,8 +10680,7 @@
 			"typed": "minecraft:crimson_fungus"
 		},
 		{
-			"asMaterial": "minecraft:crimson_hanging_sign",
-			"blockType": true,
+			"blockType": "minecraft:crimson_hanging_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11403,11 +10703,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:crimson_hanging_sign",
-			"material": "CRIMSON_HANGING_SIGN",
+			"material": "minecraft:crimson_hanging_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11416,8 +10715,7 @@
 			"typed": "minecraft:crimson_hanging_sign"
 		},
 		{
-			"asMaterial": "minecraft:crimson_hyphae",
-			"blockType": true,
+			"blockType": "minecraft:crimson_hyphae",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11440,11 +10738,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:crimson_hyphae",
-			"material": "CRIMSON_HYPHAE",
+			"material": "minecraft:crimson_hyphae",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11453,8 +10750,7 @@
 			"typed": "minecraft:crimson_hyphae"
 		},
 		{
-			"asMaterial": "minecraft:crimson_nylium",
-			"blockType": true,
+			"blockType": "minecraft:crimson_nylium",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11477,11 +10773,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:crimson_nylium",
-			"material": "CRIMSON_NYLIUM",
+			"material": "minecraft:crimson_nylium",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11490,8 +10785,7 @@
 			"typed": "minecraft:crimson_nylium"
 		},
 		{
-			"asMaterial": "minecraft:crimson_planks",
-			"blockType": true,
+			"blockType": "minecraft:crimson_planks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11514,11 +10808,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:crimson_planks",
-			"material": "CRIMSON_PLANKS",
+			"material": "minecraft:crimson_planks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11527,8 +10820,7 @@
 			"typed": "minecraft:crimson_planks"
 		},
 		{
-			"asMaterial": "minecraft:crimson_pressure_plate",
-			"blockType": true,
+			"blockType": "minecraft:crimson_pressure_plate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11551,11 +10843,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:crimson_pressure_plate",
-			"material": "CRIMSON_PRESSURE_PLATE",
+			"material": "minecraft:crimson_pressure_plate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11564,8 +10855,7 @@
 			"typed": "minecraft:crimson_pressure_plate"
 		},
 		{
-			"asMaterial": "minecraft:crimson_roots",
-			"blockType": true,
+			"blockType": "minecraft:crimson_roots",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -11589,11 +10879,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:crimson_roots",
-			"material": "CRIMSON_ROOTS",
+			"material": "minecraft:crimson_roots",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11602,8 +10891,7 @@
 			"typed": "minecraft:crimson_roots"
 		},
 		{
-			"asMaterial": "minecraft:crimson_sign",
-			"blockType": true,
+			"blockType": "minecraft:crimson_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11626,11 +10914,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:crimson_sign",
-			"material": "CRIMSON_SIGN",
+			"material": "minecraft:crimson_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11639,8 +10926,7 @@
 			"typed": "minecraft:crimson_sign"
 		},
 		{
-			"asMaterial": "minecraft:crimson_slab",
-			"blockType": true,
+			"blockType": "minecraft:crimson_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11663,11 +10949,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:crimson_slab",
-			"material": "CRIMSON_SLAB",
+			"material": "minecraft:crimson_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11676,8 +10961,7 @@
 			"typed": "minecraft:crimson_slab"
 		},
 		{
-			"asMaterial": "minecraft:crimson_stairs",
-			"blockType": true,
+			"blockType": "minecraft:crimson_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11700,11 +10984,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:crimson_stairs",
-			"material": "CRIMSON_STAIRS",
+			"material": "minecraft:crimson_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11713,8 +10996,7 @@
 			"typed": "minecraft:crimson_stairs"
 		},
 		{
-			"asMaterial": "minecraft:crimson_stem",
-			"blockType": true,
+			"blockType": "minecraft:crimson_stem",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11737,11 +11019,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:crimson_stem",
-			"material": "CRIMSON_STEM",
+			"material": "minecraft:crimson_stem",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11750,8 +11031,7 @@
 			"typed": "minecraft:crimson_stem"
 		},
 		{
-			"asMaterial": "minecraft:crimson_trapdoor",
-			"blockType": true,
+			"blockType": "minecraft:crimson_trapdoor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11774,11 +11054,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:crimson_trapdoor",
-			"material": "CRIMSON_TRAPDOOR",
+			"material": "minecraft:crimson_trapdoor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11787,8 +11066,6 @@
 			"typed": "minecraft:crimson_trapdoor"
 		},
 		{
-			"asMaterial": "minecraft:crossbow",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11815,11 +11092,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:crossbow",
-			"material": "CROSSBOW",
+			"material": "minecraft:crossbow",
 			"maxDurability": 465,
 			"maxStackSize": 1,
 			"metaClass": "CrossbowMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11828,8 +11104,7 @@
 			"typed": "minecraft:crossbow"
 		},
 		{
-			"asMaterial": "minecraft:crying_obsidian",
-			"blockType": true,
+			"blockType": "minecraft:crying_obsidian",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11852,11 +11127,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:crying_obsidian",
-			"material": "CRYING_OBSIDIAN",
+			"material": "minecraft:crying_obsidian",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11865,8 +11139,7 @@
 			"typed": "minecraft:crying_obsidian"
 		},
 		{
-			"asMaterial": "minecraft:cut_copper",
-			"blockType": true,
+			"blockType": "minecraft:cut_copper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11889,11 +11162,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cut_copper",
-			"material": "CUT_COPPER",
+			"material": "minecraft:cut_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11902,8 +11174,7 @@
 			"typed": "minecraft:cut_copper"
 		},
 		{
-			"asMaterial": "minecraft:cut_copper_slab",
-			"blockType": true,
+			"blockType": "minecraft:cut_copper_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11926,11 +11197,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cut_copper_slab",
-			"material": "CUT_COPPER_SLAB",
+			"material": "minecraft:cut_copper_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11939,8 +11209,7 @@
 			"typed": "minecraft:cut_copper_slab"
 		},
 		{
-			"asMaterial": "minecraft:cut_copper_stairs",
-			"blockType": true,
+			"blockType": "minecraft:cut_copper_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -11963,11 +11232,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cut_copper_stairs",
-			"material": "CUT_COPPER_STAIRS",
+			"material": "minecraft:cut_copper_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -11976,8 +11244,7 @@
 			"typed": "minecraft:cut_copper_stairs"
 		},
 		{
-			"asMaterial": "minecraft:cut_red_sandstone",
-			"blockType": true,
+			"blockType": "minecraft:cut_red_sandstone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12000,11 +11267,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cut_red_sandstone",
-			"material": "CUT_RED_SANDSTONE",
+			"material": "minecraft:cut_red_sandstone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12013,8 +11279,7 @@
 			"typed": "minecraft:cut_red_sandstone"
 		},
 		{
-			"asMaterial": "minecraft:cut_red_sandstone_slab",
-			"blockType": true,
+			"blockType": "minecraft:cut_red_sandstone_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12037,11 +11302,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cut_red_sandstone_slab",
-			"material": "CUT_RED_SANDSTONE_SLAB",
+			"material": "minecraft:cut_red_sandstone_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12050,8 +11314,7 @@
 			"typed": "minecraft:cut_red_sandstone_slab"
 		},
 		{
-			"asMaterial": "minecraft:cut_sandstone",
-			"blockType": true,
+			"blockType": "minecraft:cut_sandstone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12074,11 +11337,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cut_sandstone",
-			"material": "CUT_SANDSTONE",
+			"material": "minecraft:cut_sandstone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12087,8 +11349,7 @@
 			"typed": "minecraft:cut_sandstone"
 		},
 		{
-			"asMaterial": "minecraft:cut_sandstone_slab",
-			"blockType": true,
+			"blockType": "minecraft:cut_sandstone_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12111,11 +11372,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cut_sandstone_slab",
-			"material": "CUT_SANDSTONE_SLAB",
+			"material": "minecraft:cut_sandstone_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12124,8 +11384,7 @@
 			"typed": "minecraft:cut_sandstone_slab"
 		},
 		{
-			"asMaterial": "minecraft:cyan_banner",
-			"blockType": true,
+			"blockType": "minecraft:cyan_banner",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12149,11 +11408,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cyan_banner",
-			"material": "CYAN_BANNER",
+			"material": "minecraft:cyan_banner",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BannerMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12162,8 +11420,7 @@
 			"typed": "minecraft:cyan_banner"
 		},
 		{
-			"asMaterial": "minecraft:cyan_bed",
-			"blockType": true,
+			"blockType": "minecraft:cyan_bed",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12186,11 +11443,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cyan_bed",
-			"material": "CYAN_BED",
+			"material": "minecraft:cyan_bed",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12199,8 +11455,6 @@
 			"typed": "minecraft:cyan_bed"
 		},
 		{
-			"asMaterial": "minecraft:cyan_bundle",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12224,11 +11478,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cyan_bundle",
-			"material": "CYAN_BUNDLE",
+			"material": "minecraft:cyan_bundle",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BundleMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12237,8 +11490,7 @@
 			"typed": "minecraft:cyan_bundle"
 		},
 		{
-			"asMaterial": "minecraft:cyan_candle",
-			"blockType": true,
+			"blockType": "minecraft:cyan_candle",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12261,11 +11513,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cyan_candle",
-			"material": "CYAN_CANDLE",
+			"material": "minecraft:cyan_candle",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12274,8 +11525,7 @@
 			"typed": "minecraft:cyan_candle"
 		},
 		{
-			"asMaterial": "minecraft:cyan_carpet",
-			"blockType": true,
+			"blockType": "minecraft:cyan_carpet",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12299,11 +11549,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cyan_carpet",
-			"material": "CYAN_CARPET",
+			"material": "minecraft:cyan_carpet",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12312,8 +11561,7 @@
 			"typed": "minecraft:cyan_carpet"
 		},
 		{
-			"asMaterial": "minecraft:cyan_concrete",
-			"blockType": true,
+			"blockType": "minecraft:cyan_concrete",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12336,11 +11584,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cyan_concrete",
-			"material": "CYAN_CONCRETE",
+			"material": "minecraft:cyan_concrete",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12349,8 +11596,7 @@
 			"typed": "minecraft:cyan_concrete"
 		},
 		{
-			"asMaterial": "minecraft:cyan_concrete_powder",
-			"blockType": true,
+			"blockType": "minecraft:cyan_concrete_powder",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12373,11 +11619,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cyan_concrete_powder",
-			"material": "CYAN_CONCRETE_POWDER",
+			"material": "minecraft:cyan_concrete_powder",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12386,8 +11631,6 @@
 			"typed": "minecraft:cyan_concrete_powder"
 		},
 		{
-			"asMaterial": "minecraft:cyan_dye",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12410,11 +11653,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cyan_dye",
-			"material": "CYAN_DYE",
+			"material": "minecraft:cyan_dye",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12423,8 +11665,7 @@
 			"typed": "minecraft:cyan_dye"
 		},
 		{
-			"asMaterial": "minecraft:cyan_glazed_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:cyan_glazed_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12447,11 +11688,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cyan_glazed_terracotta",
-			"material": "CYAN_GLAZED_TERRACOTTA",
+			"material": "minecraft:cyan_glazed_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12460,8 +11700,7 @@
 			"typed": "minecraft:cyan_glazed_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:cyan_shulker_box",
-			"blockType": true,
+			"blockType": "minecraft:cyan_shulker_box",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12485,11 +11724,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cyan_shulker_box",
-			"material": "CYAN_SHULKER_BOX",
+			"material": "minecraft:cyan_shulker_box",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12498,8 +11736,7 @@
 			"typed": "minecraft:cyan_shulker_box"
 		},
 		{
-			"asMaterial": "minecraft:cyan_stained_glass",
-			"blockType": true,
+			"blockType": "minecraft:cyan_stained_glass",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12522,11 +11759,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cyan_stained_glass",
-			"material": "CYAN_STAINED_GLASS",
+			"material": "minecraft:cyan_stained_glass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12535,8 +11771,7 @@
 			"typed": "minecraft:cyan_stained_glass"
 		},
 		{
-			"asMaterial": "minecraft:cyan_stained_glass_pane",
-			"blockType": true,
+			"blockType": "minecraft:cyan_stained_glass_pane",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12559,11 +11794,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cyan_stained_glass_pane",
-			"material": "CYAN_STAINED_GLASS_PANE",
+			"material": "minecraft:cyan_stained_glass_pane",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12572,8 +11806,7 @@
 			"typed": "minecraft:cyan_stained_glass_pane"
 		},
 		{
-			"asMaterial": "minecraft:cyan_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:cyan_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12596,11 +11829,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cyan_terracotta",
-			"material": "CYAN_TERRACOTTA",
+			"material": "minecraft:cyan_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12609,8 +11841,7 @@
 			"typed": "minecraft:cyan_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:cyan_wool",
-			"blockType": true,
+			"blockType": "minecraft:cyan_wool",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12633,11 +11864,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:cyan_wool",
-			"material": "CYAN_WOOL",
+			"material": "minecraft:cyan_wool",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12646,8 +11876,7 @@
 			"typed": "minecraft:cyan_wool"
 		},
 		{
-			"asMaterial": "minecraft:damaged_anvil",
-			"blockType": true,
+			"blockType": "minecraft:damaged_anvil",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12670,11 +11899,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:damaged_anvil",
-			"material": "DAMAGED_ANVIL",
+			"material": "minecraft:damaged_anvil",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12683,8 +11911,7 @@
 			"typed": "minecraft:damaged_anvil"
 		},
 		{
-			"asMaterial": "minecraft:dandelion",
-			"blockType": true,
+			"blockType": "minecraft:dandelion",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -12708,11 +11935,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dandelion",
-			"material": "DANDELION",
+			"material": "minecraft:dandelion",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12721,8 +11947,6 @@
 			"typed": "minecraft:dandelion"
 		},
 		{
-			"asMaterial": "minecraft:danger_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12745,11 +11969,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:danger_pottery_sherd",
-			"material": "DANGER_POTTERY_SHERD",
+			"material": "minecraft:danger_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12758,8 +11981,6 @@
 			"typed": "minecraft:danger_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:dark_oak_boat",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12782,11 +12003,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dark_oak_boat",
-			"material": "DARK_OAK_BOAT",
+			"material": "minecraft:dark_oak_boat",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12795,8 +12015,7 @@
 			"typed": "minecraft:dark_oak_boat"
 		},
 		{
-			"asMaterial": "minecraft:dark_oak_button",
-			"blockType": true,
+			"blockType": "minecraft:dark_oak_button",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12819,11 +12038,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dark_oak_button",
-			"material": "DARK_OAK_BUTTON",
+			"material": "minecraft:dark_oak_button",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12832,8 +12050,6 @@
 			"typed": "minecraft:dark_oak_button"
 		},
 		{
-			"asMaterial": "minecraft:dark_oak_chest_boat",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12856,11 +12072,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dark_oak_chest_boat",
-			"material": "DARK_OAK_CHEST_BOAT",
+			"material": "minecraft:dark_oak_chest_boat",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12869,8 +12084,7 @@
 			"typed": "minecraft:dark_oak_chest_boat"
 		},
 		{
-			"asMaterial": "minecraft:dark_oak_door",
-			"blockType": true,
+			"blockType": "minecraft:dark_oak_door",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12893,11 +12107,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dark_oak_door",
-			"material": "DARK_OAK_DOOR",
+			"material": "minecraft:dark_oak_door",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12906,8 +12119,7 @@
 			"typed": "minecraft:dark_oak_door"
 		},
 		{
-			"asMaterial": "minecraft:dark_oak_fence",
-			"blockType": true,
+			"blockType": "minecraft:dark_oak_fence",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12930,11 +12142,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dark_oak_fence",
-			"material": "DARK_OAK_FENCE",
+			"material": "minecraft:dark_oak_fence",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12943,8 +12154,7 @@
 			"typed": "minecraft:dark_oak_fence"
 		},
 		{
-			"asMaterial": "minecraft:dark_oak_fence_gate",
-			"blockType": true,
+			"blockType": "minecraft:dark_oak_fence_gate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -12967,11 +12177,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dark_oak_fence_gate",
-			"material": "DARK_OAK_FENCE_GATE",
+			"material": "minecraft:dark_oak_fence_gate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -12980,8 +12189,7 @@
 			"typed": "minecraft:dark_oak_fence_gate"
 		},
 		{
-			"asMaterial": "minecraft:dark_oak_hanging_sign",
-			"blockType": true,
+			"blockType": "minecraft:dark_oak_hanging_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13004,11 +12212,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dark_oak_hanging_sign",
-			"material": "DARK_OAK_HANGING_SIGN",
+			"material": "minecraft:dark_oak_hanging_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13017,8 +12224,7 @@
 			"typed": "minecraft:dark_oak_hanging_sign"
 		},
 		{
-			"asMaterial": "minecraft:dark_oak_leaves",
-			"blockType": true,
+			"blockType": "minecraft:dark_oak_leaves",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -13042,11 +12248,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dark_oak_leaves",
-			"material": "DARK_OAK_LEAVES",
+			"material": "minecraft:dark_oak_leaves",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13055,8 +12260,7 @@
 			"typed": "minecraft:dark_oak_leaves"
 		},
 		{
-			"asMaterial": "minecraft:dark_oak_log",
-			"blockType": true,
+			"blockType": "minecraft:dark_oak_log",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13079,11 +12283,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dark_oak_log",
-			"material": "DARK_OAK_LOG",
+			"material": "minecraft:dark_oak_log",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13092,8 +12295,7 @@
 			"typed": "minecraft:dark_oak_log"
 		},
 		{
-			"asMaterial": "minecraft:dark_oak_planks",
-			"blockType": true,
+			"blockType": "minecraft:dark_oak_planks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13116,11 +12318,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dark_oak_planks",
-			"material": "DARK_OAK_PLANKS",
+			"material": "minecraft:dark_oak_planks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13129,8 +12330,7 @@
 			"typed": "minecraft:dark_oak_planks"
 		},
 		{
-			"asMaterial": "minecraft:dark_oak_pressure_plate",
-			"blockType": true,
+			"blockType": "minecraft:dark_oak_pressure_plate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13153,11 +12353,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dark_oak_pressure_plate",
-			"material": "DARK_OAK_PRESSURE_PLATE",
+			"material": "minecraft:dark_oak_pressure_plate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13166,8 +12365,7 @@
 			"typed": "minecraft:dark_oak_pressure_plate"
 		},
 		{
-			"asMaterial": "minecraft:dark_oak_sapling",
-			"blockType": true,
+			"blockType": "minecraft:dark_oak_sapling",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -13191,11 +12389,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dark_oak_sapling",
-			"material": "DARK_OAK_SAPLING",
+			"material": "minecraft:dark_oak_sapling",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13204,8 +12401,7 @@
 			"typed": "minecraft:dark_oak_sapling"
 		},
 		{
-			"asMaterial": "minecraft:dark_oak_sign",
-			"blockType": true,
+			"blockType": "minecraft:dark_oak_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13228,11 +12424,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dark_oak_sign",
-			"material": "DARK_OAK_SIGN",
+			"material": "minecraft:dark_oak_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13241,8 +12436,7 @@
 			"typed": "minecraft:dark_oak_sign"
 		},
 		{
-			"asMaterial": "minecraft:dark_oak_slab",
-			"blockType": true,
+			"blockType": "minecraft:dark_oak_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13265,11 +12459,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dark_oak_slab",
-			"material": "DARK_OAK_SLAB",
+			"material": "minecraft:dark_oak_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13278,8 +12471,7 @@
 			"typed": "minecraft:dark_oak_slab"
 		},
 		{
-			"asMaterial": "minecraft:dark_oak_stairs",
-			"blockType": true,
+			"blockType": "minecraft:dark_oak_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13302,11 +12494,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dark_oak_stairs",
-			"material": "DARK_OAK_STAIRS",
+			"material": "minecraft:dark_oak_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13315,8 +12506,7 @@
 			"typed": "minecraft:dark_oak_stairs"
 		},
 		{
-			"asMaterial": "minecraft:dark_oak_trapdoor",
-			"blockType": true,
+			"blockType": "minecraft:dark_oak_trapdoor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13339,11 +12529,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dark_oak_trapdoor",
-			"material": "DARK_OAK_TRAPDOOR",
+			"material": "minecraft:dark_oak_trapdoor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13352,8 +12541,7 @@
 			"typed": "minecraft:dark_oak_trapdoor"
 		},
 		{
-			"asMaterial": "minecraft:dark_oak_wood",
-			"blockType": true,
+			"blockType": "minecraft:dark_oak_wood",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13376,11 +12564,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dark_oak_wood",
-			"material": "DARK_OAK_WOOD",
+			"material": "minecraft:dark_oak_wood",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13389,8 +12576,7 @@
 			"typed": "minecraft:dark_oak_wood"
 		},
 		{
-			"asMaterial": "minecraft:dark_prismarine",
-			"blockType": true,
+			"blockType": "minecraft:dark_prismarine",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13413,11 +12599,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dark_prismarine",
-			"material": "DARK_PRISMARINE",
+			"material": "minecraft:dark_prismarine",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13426,8 +12611,7 @@
 			"typed": "minecraft:dark_prismarine"
 		},
 		{
-			"asMaterial": "minecraft:dark_prismarine_slab",
-			"blockType": true,
+			"blockType": "minecraft:dark_prismarine_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13450,11 +12634,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dark_prismarine_slab",
-			"material": "DARK_PRISMARINE_SLAB",
+			"material": "minecraft:dark_prismarine_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13463,8 +12646,7 @@
 			"typed": "minecraft:dark_prismarine_slab"
 		},
 		{
-			"asMaterial": "minecraft:dark_prismarine_stairs",
-			"blockType": true,
+			"blockType": "minecraft:dark_prismarine_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13487,11 +12669,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dark_prismarine_stairs",
-			"material": "DARK_PRISMARINE_STAIRS",
+			"material": "minecraft:dark_prismarine_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13500,8 +12681,7 @@
 			"typed": "minecraft:dark_prismarine_stairs"
 		},
 		{
-			"asMaterial": "minecraft:daylight_detector",
-			"blockType": true,
+			"blockType": "minecraft:daylight_detector",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13524,11 +12704,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:daylight_detector",
-			"material": "DAYLIGHT_DETECTOR",
+			"material": "minecraft:daylight_detector",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13537,8 +12716,7 @@
 			"typed": "minecraft:daylight_detector"
 		},
 		{
-			"asMaterial": "minecraft:dead_brain_coral",
-			"blockType": true,
+			"blockType": "minecraft:dead_brain_coral",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13561,11 +12739,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dead_brain_coral",
-			"material": "DEAD_BRAIN_CORAL",
+			"material": "minecraft:dead_brain_coral",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13574,8 +12751,7 @@
 			"typed": "minecraft:dead_brain_coral"
 		},
 		{
-			"asMaterial": "minecraft:dead_brain_coral_block",
-			"blockType": true,
+			"blockType": "minecraft:dead_brain_coral_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13598,11 +12774,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dead_brain_coral_block",
-			"material": "DEAD_BRAIN_CORAL_BLOCK",
+			"material": "minecraft:dead_brain_coral_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13611,8 +12786,7 @@
 			"typed": "minecraft:dead_brain_coral_block"
 		},
 		{
-			"asMaterial": "minecraft:dead_brain_coral_fan",
-			"blockType": true,
+			"blockType": "minecraft:dead_brain_coral_fan",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13635,11 +12809,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dead_brain_coral_fan",
-			"material": "DEAD_BRAIN_CORAL_FAN",
+			"material": "minecraft:dead_brain_coral_fan",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13648,8 +12821,7 @@
 			"typed": "minecraft:dead_brain_coral_fan"
 		},
 		{
-			"asMaterial": "minecraft:dead_bubble_coral",
-			"blockType": true,
+			"blockType": "minecraft:dead_bubble_coral",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13672,11 +12844,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dead_bubble_coral",
-			"material": "DEAD_BUBBLE_CORAL",
+			"material": "minecraft:dead_bubble_coral",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13685,8 +12856,7 @@
 			"typed": "minecraft:dead_bubble_coral"
 		},
 		{
-			"asMaterial": "minecraft:dead_bubble_coral_block",
-			"blockType": true,
+			"blockType": "minecraft:dead_bubble_coral_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13709,11 +12879,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dead_bubble_coral_block",
-			"material": "DEAD_BUBBLE_CORAL_BLOCK",
+			"material": "minecraft:dead_bubble_coral_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13722,8 +12891,7 @@
 			"typed": "minecraft:dead_bubble_coral_block"
 		},
 		{
-			"asMaterial": "minecraft:dead_bubble_coral_fan",
-			"blockType": true,
+			"blockType": "minecraft:dead_bubble_coral_fan",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13746,11 +12914,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dead_bubble_coral_fan",
-			"material": "DEAD_BUBBLE_CORAL_FAN",
+			"material": "minecraft:dead_bubble_coral_fan",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13759,8 +12926,7 @@
 			"typed": "minecraft:dead_bubble_coral_fan"
 		},
 		{
-			"asMaterial": "minecraft:dead_bush",
-			"blockType": true,
+			"blockType": "minecraft:dead_bush",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13783,11 +12949,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dead_bush",
-			"material": "DEAD_BUSH",
+			"material": "minecraft:dead_bush",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13796,8 +12961,7 @@
 			"typed": "minecraft:dead_bush"
 		},
 		{
-			"asMaterial": "minecraft:dead_fire_coral",
-			"blockType": true,
+			"blockType": "minecraft:dead_fire_coral",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13820,11 +12984,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dead_fire_coral",
-			"material": "DEAD_FIRE_CORAL",
+			"material": "minecraft:dead_fire_coral",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13833,8 +12996,7 @@
 			"typed": "minecraft:dead_fire_coral"
 		},
 		{
-			"asMaterial": "minecraft:dead_fire_coral_block",
-			"blockType": true,
+			"blockType": "minecraft:dead_fire_coral_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13857,11 +13019,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dead_fire_coral_block",
-			"material": "DEAD_FIRE_CORAL_BLOCK",
+			"material": "minecraft:dead_fire_coral_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13870,8 +13031,7 @@
 			"typed": "minecraft:dead_fire_coral_block"
 		},
 		{
-			"asMaterial": "minecraft:dead_fire_coral_fan",
-			"blockType": true,
+			"blockType": "minecraft:dead_fire_coral_fan",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13894,11 +13054,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dead_fire_coral_fan",
-			"material": "DEAD_FIRE_CORAL_FAN",
+			"material": "minecraft:dead_fire_coral_fan",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13907,8 +13066,7 @@
 			"typed": "minecraft:dead_fire_coral_fan"
 		},
 		{
-			"asMaterial": "minecraft:dead_horn_coral",
-			"blockType": true,
+			"blockType": "minecraft:dead_horn_coral",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13931,11 +13089,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dead_horn_coral",
-			"material": "DEAD_HORN_CORAL",
+			"material": "minecraft:dead_horn_coral",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13944,8 +13101,7 @@
 			"typed": "minecraft:dead_horn_coral"
 		},
 		{
-			"asMaterial": "minecraft:dead_horn_coral_block",
-			"blockType": true,
+			"blockType": "minecraft:dead_horn_coral_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -13968,11 +13124,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dead_horn_coral_block",
-			"material": "DEAD_HORN_CORAL_BLOCK",
+			"material": "minecraft:dead_horn_coral_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -13981,8 +13136,7 @@
 			"typed": "minecraft:dead_horn_coral_block"
 		},
 		{
-			"asMaterial": "minecraft:dead_horn_coral_fan",
-			"blockType": true,
+			"blockType": "minecraft:dead_horn_coral_fan",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14005,11 +13159,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dead_horn_coral_fan",
-			"material": "DEAD_HORN_CORAL_FAN",
+			"material": "minecraft:dead_horn_coral_fan",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14018,8 +13171,7 @@
 			"typed": "minecraft:dead_horn_coral_fan"
 		},
 		{
-			"asMaterial": "minecraft:dead_tube_coral",
-			"blockType": true,
+			"blockType": "minecraft:dead_tube_coral",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14042,11 +13194,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dead_tube_coral",
-			"material": "DEAD_TUBE_CORAL",
+			"material": "minecraft:dead_tube_coral",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14055,8 +13206,7 @@
 			"typed": "minecraft:dead_tube_coral"
 		},
 		{
-			"asMaterial": "minecraft:dead_tube_coral_block",
-			"blockType": true,
+			"blockType": "minecraft:dead_tube_coral_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14079,11 +13229,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dead_tube_coral_block",
-			"material": "DEAD_TUBE_CORAL_BLOCK",
+			"material": "minecraft:dead_tube_coral_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14092,8 +13241,7 @@
 			"typed": "minecraft:dead_tube_coral_block"
 		},
 		{
-			"asMaterial": "minecraft:dead_tube_coral_fan",
-			"blockType": true,
+			"blockType": "minecraft:dead_tube_coral_fan",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14116,11 +13264,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dead_tube_coral_fan",
-			"material": "DEAD_TUBE_CORAL_FAN",
+			"material": "minecraft:dead_tube_coral_fan",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14129,8 +13276,6 @@
 			"typed": "minecraft:dead_tube_coral_fan"
 		},
 		{
-			"asMaterial": "minecraft:debug_stick",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14155,11 +13300,10 @@
 			"fuel": false,
 			"itemRarity": "EPIC",
 			"key": "minecraft:debug_stick",
-			"material": "DEBUG_STICK",
+			"material": "minecraft:debug_stick",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "EPIC",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14168,8 +13312,7 @@
 			"typed": "minecraft:debug_stick"
 		},
 		{
-			"asMaterial": "minecraft:decorated_pot",
-			"blockType": true,
+			"blockType": "minecraft:decorated_pot",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14194,11 +13337,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:decorated_pot",
-			"material": "DECORATED_POT",
+			"material": "minecraft:decorated_pot",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14207,8 +13349,7 @@
 			"typed": "minecraft:decorated_pot"
 		},
 		{
-			"asMaterial": "minecraft:deepslate",
-			"blockType": true,
+			"blockType": "minecraft:deepslate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14231,11 +13372,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:deepslate",
-			"material": "DEEPSLATE",
+			"material": "minecraft:deepslate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14244,8 +13384,7 @@
 			"typed": "minecraft:deepslate"
 		},
 		{
-			"asMaterial": "minecraft:deepslate_brick_slab",
-			"blockType": true,
+			"blockType": "minecraft:deepslate_brick_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14268,11 +13407,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:deepslate_brick_slab",
-			"material": "DEEPSLATE_BRICK_SLAB",
+			"material": "minecraft:deepslate_brick_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14281,8 +13419,7 @@
 			"typed": "minecraft:deepslate_brick_slab"
 		},
 		{
-			"asMaterial": "minecraft:deepslate_brick_stairs",
-			"blockType": true,
+			"blockType": "minecraft:deepslate_brick_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14305,11 +13442,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:deepslate_brick_stairs",
-			"material": "DEEPSLATE_BRICK_STAIRS",
+			"material": "minecraft:deepslate_brick_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14318,8 +13454,7 @@
 			"typed": "minecraft:deepslate_brick_stairs"
 		},
 		{
-			"asMaterial": "minecraft:deepslate_brick_wall",
-			"blockType": true,
+			"blockType": "minecraft:deepslate_brick_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14342,11 +13477,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:deepslate_brick_wall",
-			"material": "DEEPSLATE_BRICK_WALL",
+			"material": "minecraft:deepslate_brick_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14355,8 +13489,7 @@
 			"typed": "minecraft:deepslate_brick_wall"
 		},
 		{
-			"asMaterial": "minecraft:deepslate_bricks",
-			"blockType": true,
+			"blockType": "minecraft:deepslate_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14379,11 +13512,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:deepslate_bricks",
-			"material": "DEEPSLATE_BRICKS",
+			"material": "minecraft:deepslate_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14392,8 +13524,7 @@
 			"typed": "minecraft:deepslate_bricks"
 		},
 		{
-			"asMaterial": "minecraft:deepslate_coal_ore",
-			"blockType": true,
+			"blockType": "minecraft:deepslate_coal_ore",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14416,11 +13547,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:deepslate_coal_ore",
-			"material": "DEEPSLATE_COAL_ORE",
+			"material": "minecraft:deepslate_coal_ore",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14429,8 +13559,7 @@
 			"typed": "minecraft:deepslate_coal_ore"
 		},
 		{
-			"asMaterial": "minecraft:deepslate_copper_ore",
-			"blockType": true,
+			"blockType": "minecraft:deepslate_copper_ore",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14453,11 +13582,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:deepslate_copper_ore",
-			"material": "DEEPSLATE_COPPER_ORE",
+			"material": "minecraft:deepslate_copper_ore",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14466,8 +13594,7 @@
 			"typed": "minecraft:deepslate_copper_ore"
 		},
 		{
-			"asMaterial": "minecraft:deepslate_diamond_ore",
-			"blockType": true,
+			"blockType": "minecraft:deepslate_diamond_ore",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14490,11 +13617,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:deepslate_diamond_ore",
-			"material": "DEEPSLATE_DIAMOND_ORE",
+			"material": "minecraft:deepslate_diamond_ore",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14503,8 +13629,7 @@
 			"typed": "minecraft:deepslate_diamond_ore"
 		},
 		{
-			"asMaterial": "minecraft:deepslate_emerald_ore",
-			"blockType": true,
+			"blockType": "minecraft:deepslate_emerald_ore",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14527,11 +13652,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:deepslate_emerald_ore",
-			"material": "DEEPSLATE_EMERALD_ORE",
+			"material": "minecraft:deepslate_emerald_ore",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14540,8 +13664,7 @@
 			"typed": "minecraft:deepslate_emerald_ore"
 		},
 		{
-			"asMaterial": "minecraft:deepslate_gold_ore",
-			"blockType": true,
+			"blockType": "minecraft:deepslate_gold_ore",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14564,11 +13687,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:deepslate_gold_ore",
-			"material": "DEEPSLATE_GOLD_ORE",
+			"material": "minecraft:deepslate_gold_ore",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14577,8 +13699,7 @@
 			"typed": "minecraft:deepslate_gold_ore"
 		},
 		{
-			"asMaterial": "minecraft:deepslate_iron_ore",
-			"blockType": true,
+			"blockType": "minecraft:deepslate_iron_ore",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14601,11 +13722,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:deepslate_iron_ore",
-			"material": "DEEPSLATE_IRON_ORE",
+			"material": "minecraft:deepslate_iron_ore",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14614,8 +13734,7 @@
 			"typed": "minecraft:deepslate_iron_ore"
 		},
 		{
-			"asMaterial": "minecraft:deepslate_lapis_ore",
-			"blockType": true,
+			"blockType": "minecraft:deepslate_lapis_ore",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14638,11 +13757,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:deepslate_lapis_ore",
-			"material": "DEEPSLATE_LAPIS_ORE",
+			"material": "minecraft:deepslate_lapis_ore",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14651,8 +13769,7 @@
 			"typed": "minecraft:deepslate_lapis_ore"
 		},
 		{
-			"asMaterial": "minecraft:deepslate_redstone_ore",
-			"blockType": true,
+			"blockType": "minecraft:deepslate_redstone_ore",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14675,11 +13792,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:deepslate_redstone_ore",
-			"material": "DEEPSLATE_REDSTONE_ORE",
+			"material": "minecraft:deepslate_redstone_ore",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14688,8 +13804,7 @@
 			"typed": "minecraft:deepslate_redstone_ore"
 		},
 		{
-			"asMaterial": "minecraft:deepslate_tile_slab",
-			"blockType": true,
+			"blockType": "minecraft:deepslate_tile_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14712,11 +13827,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:deepslate_tile_slab",
-			"material": "DEEPSLATE_TILE_SLAB",
+			"material": "minecraft:deepslate_tile_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14725,8 +13839,7 @@
 			"typed": "minecraft:deepslate_tile_slab"
 		},
 		{
-			"asMaterial": "minecraft:deepslate_tile_stairs",
-			"blockType": true,
+			"blockType": "minecraft:deepslate_tile_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14749,11 +13862,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:deepslate_tile_stairs",
-			"material": "DEEPSLATE_TILE_STAIRS",
+			"material": "minecraft:deepslate_tile_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14762,8 +13874,7 @@
 			"typed": "minecraft:deepslate_tile_stairs"
 		},
 		{
-			"asMaterial": "minecraft:deepslate_tile_wall",
-			"blockType": true,
+			"blockType": "minecraft:deepslate_tile_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14786,11 +13897,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:deepslate_tile_wall",
-			"material": "DEEPSLATE_TILE_WALL",
+			"material": "minecraft:deepslate_tile_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14799,8 +13909,7 @@
 			"typed": "minecraft:deepslate_tile_wall"
 		},
 		{
-			"asMaterial": "minecraft:deepslate_tiles",
-			"blockType": true,
+			"blockType": "minecraft:deepslate_tiles",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14823,11 +13932,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:deepslate_tiles",
-			"material": "DEEPSLATE_TILES",
+			"material": "minecraft:deepslate_tiles",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14836,8 +13944,7 @@
 			"typed": "minecraft:deepslate_tiles"
 		},
 		{
-			"asMaterial": "minecraft:detector_rail",
-			"blockType": true,
+			"blockType": "minecraft:detector_rail",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14860,11 +13967,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:detector_rail",
-			"material": "DETECTOR_RAIL",
+			"material": "minecraft:detector_rail",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14873,8 +13979,6 @@
 			"typed": "minecraft:detector_rail"
 		},
 		{
-			"asMaterial": "minecraft:diamond",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14898,11 +14002,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:diamond",
-			"material": "DIAMOND",
+			"material": "minecraft:diamond",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14911,8 +14014,6 @@
 			"typed": "minecraft:diamond"
 		},
 		{
-			"asMaterial": "minecraft:diamond_axe",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14941,11 +14042,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:diamond_axe",
-			"material": "DIAMOND_AXE",
+			"material": "minecraft:diamond_axe",
 			"maxDurability": 1561,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14954,8 +14054,7 @@
 			"typed": "minecraft:diamond_axe"
 		},
 		{
-			"asMaterial": "minecraft:diamond_block",
-			"blockType": true,
+			"blockType": "minecraft:diamond_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -14978,11 +14077,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:diamond_block",
-			"material": "DIAMOND_BLOCK",
+			"material": "minecraft:diamond_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -14991,8 +14089,6 @@
 			"typed": "minecraft:diamond_block"
 		},
 		{
-			"asMaterial": "minecraft:diamond_boots",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15020,11 +14116,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:diamond_boots",
-			"material": "DIAMOND_BOOTS",
+			"material": "minecraft:diamond_boots",
 			"maxDurability": 429,
 			"maxStackSize": 1,
 			"metaClass": "ArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15033,8 +14128,6 @@
 			"typed": "minecraft:diamond_boots"
 		},
 		{
-			"asMaterial": "minecraft:diamond_chestplate",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15062,11 +14155,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:diamond_chestplate",
-			"material": "DIAMOND_CHESTPLATE",
+			"material": "minecraft:diamond_chestplate",
 			"maxDurability": 528,
 			"maxStackSize": 1,
 			"metaClass": "ArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15075,8 +14167,6 @@
 			"typed": "minecraft:diamond_chestplate"
 		},
 		{
-			"asMaterial": "minecraft:diamond_helmet",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15104,11 +14194,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:diamond_helmet",
-			"material": "DIAMOND_HELMET",
+			"material": "minecraft:diamond_helmet",
 			"maxDurability": 363,
 			"maxStackSize": 1,
 			"metaClass": "ArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15117,8 +14206,6 @@
 			"typed": "minecraft:diamond_helmet"
 		},
 		{
-			"asMaterial": "minecraft:diamond_hoe",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15147,11 +14234,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:diamond_hoe",
-			"material": "DIAMOND_HOE",
+			"material": "minecraft:diamond_hoe",
 			"maxDurability": 1561,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15160,8 +14246,6 @@
 			"typed": "minecraft:diamond_hoe"
 		},
 		{
-			"asMaterial": "minecraft:diamond_horse_armor",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15185,11 +14269,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:diamond_horse_armor",
-			"material": "DIAMOND_HORSE_ARMOR",
+			"material": "minecraft:diamond_horse_armor",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15198,8 +14281,6 @@
 			"typed": "minecraft:diamond_horse_armor"
 		},
 		{
-			"asMaterial": "minecraft:diamond_leggings",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15227,11 +14308,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:diamond_leggings",
-			"material": "DIAMOND_LEGGINGS",
+			"material": "minecraft:diamond_leggings",
 			"maxDurability": 495,
 			"maxStackSize": 1,
 			"metaClass": "ArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15240,8 +14320,7 @@
 			"typed": "minecraft:diamond_leggings"
 		},
 		{
-			"asMaterial": "minecraft:diamond_ore",
-			"blockType": true,
+			"blockType": "minecraft:diamond_ore",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15264,11 +14343,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:diamond_ore",
-			"material": "DIAMOND_ORE",
+			"material": "minecraft:diamond_ore",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15277,8 +14355,6 @@
 			"typed": "minecraft:diamond_ore"
 		},
 		{
-			"asMaterial": "minecraft:diamond_pickaxe",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15307,11 +14383,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:diamond_pickaxe",
-			"material": "DIAMOND_PICKAXE",
+			"material": "minecraft:diamond_pickaxe",
 			"maxDurability": 1561,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15320,8 +14395,6 @@
 			"typed": "minecraft:diamond_pickaxe"
 		},
 		{
-			"asMaterial": "minecraft:diamond_shovel",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15350,11 +14423,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:diamond_shovel",
-			"material": "DIAMOND_SHOVEL",
+			"material": "minecraft:diamond_shovel",
 			"maxDurability": 1561,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15363,8 +14435,6 @@
 			"typed": "minecraft:diamond_shovel"
 		},
 		{
-			"asMaterial": "minecraft:diamond_sword",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15393,11 +14463,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:diamond_sword",
-			"material": "DIAMOND_SWORD",
+			"material": "minecraft:diamond_sword",
 			"maxDurability": 1561,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15406,8 +14475,7 @@
 			"typed": "minecraft:diamond_sword"
 		},
 		{
-			"asMaterial": "minecraft:diorite",
-			"blockType": true,
+			"blockType": "minecraft:diorite",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15430,11 +14498,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:diorite",
-			"material": "DIORITE",
+			"material": "minecraft:diorite",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15443,8 +14510,7 @@
 			"typed": "minecraft:diorite"
 		},
 		{
-			"asMaterial": "minecraft:diorite_slab",
-			"blockType": true,
+			"blockType": "minecraft:diorite_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15467,11 +14533,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:diorite_slab",
-			"material": "DIORITE_SLAB",
+			"material": "minecraft:diorite_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15480,8 +14545,7 @@
 			"typed": "minecraft:diorite_slab"
 		},
 		{
-			"asMaterial": "minecraft:diorite_stairs",
-			"blockType": true,
+			"blockType": "minecraft:diorite_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15504,11 +14568,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:diorite_stairs",
-			"material": "DIORITE_STAIRS",
+			"material": "minecraft:diorite_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15517,8 +14580,7 @@
 			"typed": "minecraft:diorite_stairs"
 		},
 		{
-			"asMaterial": "minecraft:diorite_wall",
-			"blockType": true,
+			"blockType": "minecraft:diorite_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15541,11 +14603,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:diorite_wall",
-			"material": "DIORITE_WALL",
+			"material": "minecraft:diorite_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15554,8 +14615,7 @@
 			"typed": "minecraft:diorite_wall"
 		},
 		{
-			"asMaterial": "minecraft:dirt",
-			"blockType": true,
+			"blockType": "minecraft:dirt",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15578,11 +14638,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dirt",
-			"material": "DIRT",
+			"material": "minecraft:dirt",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15591,8 +14650,7 @@
 			"typed": "minecraft:dirt"
 		},
 		{
-			"asMaterial": "minecraft:dirt_path",
-			"blockType": true,
+			"blockType": "minecraft:dirt_path",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15615,11 +14673,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dirt_path",
-			"material": "DIRT_PATH",
+			"material": "minecraft:dirt_path",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15628,8 +14685,6 @@
 			"typed": "minecraft:dirt_path"
 		},
 		{
-			"asMaterial": "minecraft:disc_fragment_5",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15652,11 +14707,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:disc_fragment_5",
-			"material": "DISC_FRAGMENT_5",
+			"material": "minecraft:disc_fragment_5",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15665,8 +14719,7 @@
 			"typed": "minecraft:disc_fragment_5"
 		},
 		{
-			"asMaterial": "minecraft:dispenser",
-			"blockType": true,
+			"blockType": "minecraft:dispenser",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15690,11 +14743,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dispenser",
-			"material": "DISPENSER",
+			"material": "minecraft:dispenser",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15703,8 +14755,6 @@
 			"typed": "minecraft:dispenser"
 		},
 		{
-			"asMaterial": "minecraft:dolphin_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15727,11 +14777,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dolphin_spawn_egg",
-			"material": "DOLPHIN_SPAWN_EGG",
+			"material": "minecraft:dolphin_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15740,8 +14789,6 @@
 			"typed": "minecraft:dolphin_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:donkey_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15764,11 +14811,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:donkey_spawn_egg",
-			"material": "DONKEY_SPAWN_EGG",
+			"material": "minecraft:donkey_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15777,8 +14823,6 @@
 			"typed": "minecraft:donkey_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:dragon_breath",
-			"blockType": false,
 			"compostable": false,
 			"craftingRemainingItem": "minecraft:glass_bottle",
 			"createItemStack": {
@@ -15802,11 +14846,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:dragon_breath",
-			"material": "DRAGON_BREATH",
+			"material": "minecraft:dragon_breath",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15815,8 +14858,7 @@
 			"typed": "minecraft:dragon_breath"
 		},
 		{
-			"asMaterial": "minecraft:dragon_egg",
-			"blockType": true,
+			"blockType": "minecraft:dragon_egg",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15839,11 +14881,10 @@
 			"fuel": false,
 			"itemRarity": "EPIC",
 			"key": "minecraft:dragon_egg",
-			"material": "DRAGON_EGG",
+			"material": "minecraft:dragon_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "EPIC",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15852,8 +14893,7 @@
 			"typed": "minecraft:dragon_egg"
 		},
 		{
-			"asMaterial": "minecraft:dragon_head",
-			"blockType": true,
+			"blockType": "minecraft:dragon_head",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15877,11 +14917,10 @@
 			"fuel": false,
 			"itemRarity": "EPIC",
 			"key": "minecraft:dragon_head",
-			"material": "DRAGON_HEAD",
+			"material": "minecraft:dragon_head",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SkullMeta",
-			"rarity": "EPIC",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15890,8 +14929,6 @@
 			"typed": "minecraft:dragon_head"
 		},
 		{
-			"asMaterial": "minecraft:dried_kelp",
-			"blockType": false,
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -15917,11 +14954,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dried_kelp",
-			"material": "DRIED_KELP",
+			"material": "minecraft:dried_kelp",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15930,8 +14966,7 @@
 			"typed": "minecraft:dried_kelp"
 		},
 		{
-			"asMaterial": "minecraft:dried_kelp_block",
-			"blockType": true,
+			"blockType": "minecraft:dried_kelp_block",
 			"compostChance": "0.5F",
 			"compostable": true,
 			"createItemStack": {
@@ -15955,11 +14990,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dried_kelp_block",
-			"material": "DRIED_KELP_BLOCK",
+			"material": "minecraft:dried_kelp_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -15968,8 +15002,7 @@
 			"typed": "minecraft:dried_kelp_block"
 		},
 		{
-			"asMaterial": "minecraft:dripstone_block",
-			"blockType": true,
+			"blockType": "minecraft:dripstone_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -15992,11 +15025,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dripstone_block",
-			"material": "DRIPSTONE_BLOCK",
+			"material": "minecraft:dripstone_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16005,8 +15037,7 @@
 			"typed": "minecraft:dripstone_block"
 		},
 		{
-			"asMaterial": "minecraft:dropper",
-			"blockType": true,
+			"blockType": "minecraft:dropper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16030,11 +15061,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:dropper",
-			"material": "DROPPER",
+			"material": "minecraft:dropper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16043,8 +15073,6 @@
 			"typed": "minecraft:dropper"
 		},
 		{
-			"asMaterial": "minecraft:drowned_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16067,11 +15095,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:drowned_spawn_egg",
-			"material": "DROWNED_SPAWN_EGG",
+			"material": "minecraft:drowned_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16080,8 +15107,6 @@
 			"typed": "minecraft:drowned_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:dune_armor_trim_smithing_template",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16104,11 +15129,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:dune_armor_trim_smithing_template",
-			"material": "DUNE_ARMOR_TRIM_SMITHING_TEMPLATE",
+			"material": "minecraft:dune_armor_trim_smithing_template",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16117,8 +15141,6 @@
 			"typed": "minecraft:dune_armor_trim_smithing_template"
 		},
 		{
-			"asMaterial": "minecraft:echo_shard",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16141,11 +15163,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:echo_shard",
-			"material": "ECHO_SHARD",
+			"material": "minecraft:echo_shard",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16154,8 +15175,6 @@
 			"typed": "minecraft:echo_shard"
 		},
 		{
-			"asMaterial": "minecraft:egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16179,11 +15198,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:egg",
-			"material": "EGG",
+			"material": "minecraft:egg",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16192,8 +15210,6 @@
 			"typed": "minecraft:egg"
 		},
 		{
-			"asMaterial": "minecraft:elder_guardian_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16216,11 +15232,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:elder_guardian_spawn_egg",
-			"material": "ELDER_GUARDIAN_SPAWN_EGG",
+			"material": "minecraft:elder_guardian_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16229,8 +15244,6 @@
 			"typed": "minecraft:elder_guardian_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:elytra",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16258,11 +15271,10 @@
 			"fuel": false,
 			"itemRarity": "EPIC",
 			"key": "minecraft:elytra",
-			"material": "ELYTRA",
+			"material": "minecraft:elytra",
 			"maxDurability": 432,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "EPIC",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16271,8 +15283,6 @@
 			"typed": "minecraft:elytra"
 		},
 		{
-			"asMaterial": "minecraft:emerald",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16296,11 +15306,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:emerald",
-			"material": "EMERALD",
+			"material": "minecraft:emerald",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16309,8 +15318,7 @@
 			"typed": "minecraft:emerald"
 		},
 		{
-			"asMaterial": "minecraft:emerald_block",
-			"blockType": true,
+			"blockType": "minecraft:emerald_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16333,11 +15341,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:emerald_block",
-			"material": "EMERALD_BLOCK",
+			"material": "minecraft:emerald_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16346,8 +15353,7 @@
 			"typed": "minecraft:emerald_block"
 		},
 		{
-			"asMaterial": "minecraft:emerald_ore",
-			"blockType": true,
+			"blockType": "minecraft:emerald_ore",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16370,11 +15376,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:emerald_ore",
-			"material": "EMERALD_ORE",
+			"material": "minecraft:emerald_ore",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16383,8 +15388,6 @@
 			"typed": "minecraft:emerald_ore"
 		},
 		{
-			"asMaterial": "minecraft:enchanted_book",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16409,11 +15412,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:enchanted_book",
-			"material": "ENCHANTED_BOOK",
+			"material": "minecraft:enchanted_book",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "EnchantmentStorageMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16422,8 +15424,6 @@
 			"typed": "minecraft:enchanted_book"
 		},
 		{
-			"asMaterial": "minecraft:enchanted_golden_apple",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16449,11 +15449,10 @@
 			"fuel": false,
 			"itemRarity": "RARE",
 			"key": "minecraft:enchanted_golden_apple",
-			"material": "ENCHANTED_GOLDEN_APPLE",
+			"material": "minecraft:enchanted_golden_apple",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "RARE",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16462,8 +15461,7 @@
 			"typed": "minecraft:enchanted_golden_apple"
 		},
 		{
-			"asMaterial": "minecraft:enchanting_table",
-			"blockType": true,
+			"blockType": "minecraft:enchanting_table",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16486,11 +15484,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:enchanting_table",
-			"material": "ENCHANTING_TABLE",
+			"material": "minecraft:enchanting_table",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16499,8 +15496,6 @@
 			"typed": "minecraft:enchanting_table"
 		},
 		{
-			"asMaterial": "minecraft:end_crystal",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16524,11 +15519,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:end_crystal",
-			"material": "END_CRYSTAL",
+			"material": "minecraft:end_crystal",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16537,8 +15531,7 @@
 			"typed": "minecraft:end_crystal"
 		},
 		{
-			"asMaterial": "minecraft:end_portal_frame",
-			"blockType": true,
+			"blockType": "minecraft:end_portal_frame",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16561,11 +15554,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:end_portal_frame",
-			"material": "END_PORTAL_FRAME",
+			"material": "minecraft:end_portal_frame",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16574,8 +15566,7 @@
 			"typed": "minecraft:end_portal_frame"
 		},
 		{
-			"asMaterial": "minecraft:end_rod",
-			"blockType": true,
+			"blockType": "minecraft:end_rod",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16598,11 +15589,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:end_rod",
-			"material": "END_ROD",
+			"material": "minecraft:end_rod",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16611,8 +15601,7 @@
 			"typed": "minecraft:end_rod"
 		},
 		{
-			"asMaterial": "minecraft:end_stone",
-			"blockType": true,
+			"blockType": "minecraft:end_stone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16635,11 +15624,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:end_stone",
-			"material": "END_STONE",
+			"material": "minecraft:end_stone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16648,8 +15636,7 @@
 			"typed": "minecraft:end_stone"
 		},
 		{
-			"asMaterial": "minecraft:end_stone_brick_slab",
-			"blockType": true,
+			"blockType": "minecraft:end_stone_brick_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16672,11 +15659,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:end_stone_brick_slab",
-			"material": "END_STONE_BRICK_SLAB",
+			"material": "minecraft:end_stone_brick_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16685,8 +15671,7 @@
 			"typed": "minecraft:end_stone_brick_slab"
 		},
 		{
-			"asMaterial": "minecraft:end_stone_brick_stairs",
-			"blockType": true,
+			"blockType": "minecraft:end_stone_brick_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16709,11 +15694,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:end_stone_brick_stairs",
-			"material": "END_STONE_BRICK_STAIRS",
+			"material": "minecraft:end_stone_brick_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16722,8 +15706,7 @@
 			"typed": "minecraft:end_stone_brick_stairs"
 		},
 		{
-			"asMaterial": "minecraft:end_stone_brick_wall",
-			"blockType": true,
+			"blockType": "minecraft:end_stone_brick_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16746,11 +15729,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:end_stone_brick_wall",
-			"material": "END_STONE_BRICK_WALL",
+			"material": "minecraft:end_stone_brick_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16759,8 +15741,7 @@
 			"typed": "minecraft:end_stone_brick_wall"
 		},
 		{
-			"asMaterial": "minecraft:end_stone_bricks",
-			"blockType": true,
+			"blockType": "minecraft:end_stone_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16783,11 +15764,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:end_stone_bricks",
-			"material": "END_STONE_BRICKS",
+			"material": "minecraft:end_stone_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16796,8 +15776,7 @@
 			"typed": "minecraft:end_stone_bricks"
 		},
 		{
-			"asMaterial": "minecraft:ender_chest",
-			"blockType": true,
+			"blockType": "minecraft:ender_chest",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16820,11 +15799,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:ender_chest",
-			"material": "ENDER_CHEST",
+			"material": "minecraft:ender_chest",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16833,8 +15811,6 @@
 			"typed": "minecraft:ender_chest"
 		},
 		{
-			"asMaterial": "minecraft:ender_dragon_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16857,11 +15833,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:ender_dragon_spawn_egg",
-			"material": "ENDER_DRAGON_SPAWN_EGG",
+			"material": "minecraft:ender_dragon_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16870,8 +15845,6 @@
 			"typed": "minecraft:ender_dragon_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:ender_eye",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16894,11 +15867,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:ender_eye",
-			"material": "ENDER_EYE",
+			"material": "minecraft:ender_eye",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16907,8 +15879,6 @@
 			"typed": "minecraft:ender_eye"
 		},
 		{
-			"asMaterial": "minecraft:ender_pearl",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16932,11 +15902,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:ender_pearl",
-			"material": "ENDER_PEARL",
+			"material": "minecraft:ender_pearl",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16945,8 +15914,6 @@
 			"typed": "minecraft:ender_pearl"
 		},
 		{
-			"asMaterial": "minecraft:enderman_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -16969,11 +15936,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:enderman_spawn_egg",
-			"material": "ENDERMAN_SPAWN_EGG",
+			"material": "minecraft:enderman_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -16982,8 +15948,6 @@
 			"typed": "minecraft:enderman_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:endermite_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17006,11 +15970,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:endermite_spawn_egg",
-			"material": "ENDERMITE_SPAWN_EGG",
+			"material": "minecraft:endermite_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17019,8 +15982,6 @@
 			"typed": "minecraft:endermite_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:evoker_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17043,11 +16004,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:evoker_spawn_egg",
-			"material": "EVOKER_SPAWN_EGG",
+			"material": "minecraft:evoker_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17056,8 +16016,6 @@
 			"typed": "minecraft:evoker_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:experience_bottle",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17081,11 +16039,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:experience_bottle",
-			"material": "EXPERIENCE_BOTTLE",
+			"material": "minecraft:experience_bottle",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17094,8 +16051,6 @@
 			"typed": "minecraft:experience_bottle"
 		},
 		{
-			"asMaterial": "minecraft:explorer_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17118,11 +16073,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:explorer_pottery_sherd",
-			"material": "EXPLORER_POTTERY_SHERD",
+			"material": "minecraft:explorer_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17131,8 +16085,7 @@
 			"typed": "minecraft:explorer_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:exposed_chiseled_copper",
-			"blockType": true,
+			"blockType": "minecraft:exposed_chiseled_copper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17155,11 +16108,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:exposed_chiseled_copper",
-			"material": "EXPOSED_CHISELED_COPPER",
+			"material": "minecraft:exposed_chiseled_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17168,8 +16120,7 @@
 			"typed": "minecraft:exposed_chiseled_copper"
 		},
 		{
-			"asMaterial": "minecraft:exposed_copper",
-			"blockType": true,
+			"blockType": "minecraft:exposed_copper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17192,11 +16143,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:exposed_copper",
-			"material": "EXPOSED_COPPER",
+			"material": "minecraft:exposed_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17205,8 +16155,7 @@
 			"typed": "minecraft:exposed_copper"
 		},
 		{
-			"asMaterial": "minecraft:exposed_copper_bulb",
-			"blockType": true,
+			"blockType": "minecraft:exposed_copper_bulb",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17229,11 +16178,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:exposed_copper_bulb",
-			"material": "EXPOSED_COPPER_BULB",
+			"material": "minecraft:exposed_copper_bulb",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17242,8 +16190,7 @@
 			"typed": "minecraft:exposed_copper_bulb"
 		},
 		{
-			"asMaterial": "minecraft:exposed_copper_door",
-			"blockType": true,
+			"blockType": "minecraft:exposed_copper_door",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17266,11 +16213,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:exposed_copper_door",
-			"material": "EXPOSED_COPPER_DOOR",
+			"material": "minecraft:exposed_copper_door",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17279,8 +16225,7 @@
 			"typed": "minecraft:exposed_copper_door"
 		},
 		{
-			"asMaterial": "minecraft:exposed_copper_grate",
-			"blockType": true,
+			"blockType": "minecraft:exposed_copper_grate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17303,11 +16248,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:exposed_copper_grate",
-			"material": "EXPOSED_COPPER_GRATE",
+			"material": "minecraft:exposed_copper_grate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17316,8 +16260,7 @@
 			"typed": "minecraft:exposed_copper_grate"
 		},
 		{
-			"asMaterial": "minecraft:exposed_copper_trapdoor",
-			"blockType": true,
+			"blockType": "minecraft:exposed_copper_trapdoor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17340,11 +16283,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:exposed_copper_trapdoor",
-			"material": "EXPOSED_COPPER_TRAPDOOR",
+			"material": "minecraft:exposed_copper_trapdoor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17353,8 +16295,7 @@
 			"typed": "minecraft:exposed_copper_trapdoor"
 		},
 		{
-			"asMaterial": "minecraft:exposed_cut_copper",
-			"blockType": true,
+			"blockType": "minecraft:exposed_cut_copper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17377,11 +16318,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:exposed_cut_copper",
-			"material": "EXPOSED_CUT_COPPER",
+			"material": "minecraft:exposed_cut_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17390,8 +16330,7 @@
 			"typed": "minecraft:exposed_cut_copper"
 		},
 		{
-			"asMaterial": "minecraft:exposed_cut_copper_slab",
-			"blockType": true,
+			"blockType": "minecraft:exposed_cut_copper_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17414,11 +16353,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:exposed_cut_copper_slab",
-			"material": "EXPOSED_CUT_COPPER_SLAB",
+			"material": "minecraft:exposed_cut_copper_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17427,8 +16365,7 @@
 			"typed": "minecraft:exposed_cut_copper_slab"
 		},
 		{
-			"asMaterial": "minecraft:exposed_cut_copper_stairs",
-			"blockType": true,
+			"blockType": "minecraft:exposed_cut_copper_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17451,11 +16388,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:exposed_cut_copper_stairs",
-			"material": "EXPOSED_CUT_COPPER_STAIRS",
+			"material": "minecraft:exposed_cut_copper_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17464,8 +16400,6 @@
 			"typed": "minecraft:exposed_cut_copper_stairs"
 		},
 		{
-			"asMaterial": "minecraft:eye_armor_trim_smithing_template",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17488,11 +16422,10 @@
 			"fuel": false,
 			"itemRarity": "RARE",
 			"key": "minecraft:eye_armor_trim_smithing_template",
-			"material": "EYE_ARMOR_TRIM_SMITHING_TEMPLATE",
+			"material": "minecraft:eye_armor_trim_smithing_template",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "RARE",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17501,8 +16434,7 @@
 			"typed": "minecraft:eye_armor_trim_smithing_template"
 		},
 		{
-			"asMaterial": "minecraft:farmland",
-			"blockType": true,
+			"blockType": "minecraft:farmland",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17525,11 +16457,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:farmland",
-			"material": "FARMLAND",
+			"material": "minecraft:farmland",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17538,8 +16469,6 @@
 			"typed": "minecraft:farmland"
 		},
 		{
-			"asMaterial": "minecraft:feather",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17562,11 +16491,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:feather",
-			"material": "FEATHER",
+			"material": "minecraft:feather",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17575,8 +16503,6 @@
 			"typed": "minecraft:feather"
 		},
 		{
-			"asMaterial": "minecraft:fermented_spider_eye",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17599,11 +16525,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:fermented_spider_eye",
-			"material": "FERMENTED_SPIDER_EYE",
+			"material": "minecraft:fermented_spider_eye",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17612,8 +16537,7 @@
 			"typed": "minecraft:fermented_spider_eye"
 		},
 		{
-			"asMaterial": "minecraft:fern",
-			"blockType": true,
+			"blockType": "minecraft:fern",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -17637,11 +16561,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:fern",
-			"material": "FERN",
+			"material": "minecraft:fern",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17650,8 +16573,6 @@
 			"typed": "minecraft:fern"
 		},
 		{
-			"asMaterial": "minecraft:field_masoned_banner_pattern",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17675,11 +16596,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:field_masoned_banner_pattern",
-			"material": "FIELD_MASONED_BANNER_PATTERN",
+			"material": "minecraft:field_masoned_banner_pattern",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17688,8 +16608,6 @@
 			"typed": "minecraft:field_masoned_banner_pattern"
 		},
 		{
-			"asMaterial": "minecraft:filled_map",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17714,11 +16632,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:filled_map",
-			"material": "FILLED_MAP",
+			"material": "minecraft:filled_map",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "MapMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17727,8 +16644,6 @@
 			"typed": "minecraft:filled_map"
 		},
 		{
-			"asMaterial": "minecraft:fire_charge",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17751,11 +16666,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:fire_charge",
-			"material": "FIRE_CHARGE",
+			"material": "minecraft:fire_charge",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17764,8 +16678,7 @@
 			"typed": "minecraft:fire_charge"
 		},
 		{
-			"asMaterial": "minecraft:fire_coral",
-			"blockType": true,
+			"blockType": "minecraft:fire_coral",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17788,11 +16701,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:fire_coral",
-			"material": "FIRE_CORAL",
+			"material": "minecraft:fire_coral",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17801,8 +16713,7 @@
 			"typed": "minecraft:fire_coral"
 		},
 		{
-			"asMaterial": "minecraft:fire_coral_block",
-			"blockType": true,
+			"blockType": "minecraft:fire_coral_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17825,11 +16736,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:fire_coral_block",
-			"material": "FIRE_CORAL_BLOCK",
+			"material": "minecraft:fire_coral_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17838,8 +16748,7 @@
 			"typed": "minecraft:fire_coral_block"
 		},
 		{
-			"asMaterial": "minecraft:fire_coral_fan",
-			"blockType": true,
+			"blockType": "minecraft:fire_coral_fan",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17862,11 +16771,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:fire_coral_fan",
-			"material": "FIRE_CORAL_FAN",
+			"material": "minecraft:fire_coral_fan",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17875,8 +16783,7 @@
 			"typed": "minecraft:fire_coral_fan"
 		},
 		{
-			"asMaterial": "minecraft:firefly_bush",
-			"blockType": true,
+			"blockType": "minecraft:firefly_bush",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -17900,11 +16807,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:firefly_bush",
-			"material": "FIREFLY_BUSH",
+			"material": "minecraft:firefly_bush",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17913,8 +16819,6 @@
 			"typed": "minecraft:firefly_bush"
 		},
 		{
-			"asMaterial": "minecraft:firework_rocket",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17938,11 +16842,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:firework_rocket",
-			"material": "FIREWORK_ROCKET",
+			"material": "minecraft:firework_rocket",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "FireworkMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17951,8 +16854,6 @@
 			"typed": "minecraft:firework_rocket"
 		},
 		{
-			"asMaterial": "minecraft:firework_star",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -17975,11 +16876,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:firework_star",
-			"material": "FIREWORK_STAR",
+			"material": "minecraft:firework_star",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "FireworkEffectMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -17988,8 +16888,6 @@
 			"typed": "minecraft:firework_star"
 		},
 		{
-			"asMaterial": "minecraft:fishing_rod",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18015,11 +16913,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:fishing_rod",
-			"material": "FISHING_ROD",
+			"material": "minecraft:fishing_rod",
 			"maxDurability": 64,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18028,8 +16925,7 @@
 			"typed": "minecraft:fishing_rod"
 		},
 		{
-			"asMaterial": "minecraft:fletching_table",
-			"blockType": true,
+			"blockType": "minecraft:fletching_table",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18052,11 +16948,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:fletching_table",
-			"material": "FLETCHING_TABLE",
+			"material": "minecraft:fletching_table",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18065,8 +16960,6 @@
 			"typed": "minecraft:fletching_table"
 		},
 		{
-			"asMaterial": "minecraft:flint",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18089,11 +16982,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:flint",
-			"material": "FLINT",
+			"material": "minecraft:flint",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18102,8 +16994,6 @@
 			"typed": "minecraft:flint"
 		},
 		{
-			"asMaterial": "minecraft:flint_and_steel",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18128,11 +17018,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:flint_and_steel",
-			"material": "FLINT_AND_STEEL",
+			"material": "minecraft:flint_and_steel",
 			"maxDurability": 64,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18141,8 +17030,6 @@
 			"typed": "minecraft:flint_and_steel"
 		},
 		{
-			"asMaterial": "minecraft:flow_armor_trim_smithing_template",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18165,11 +17052,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:flow_armor_trim_smithing_template",
-			"material": "FLOW_ARMOR_TRIM_SMITHING_TEMPLATE",
+			"material": "minecraft:flow_armor_trim_smithing_template",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18178,8 +17064,6 @@
 			"typed": "minecraft:flow_armor_trim_smithing_template"
 		},
 		{
-			"asMaterial": "minecraft:flow_banner_pattern",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18203,11 +17087,10 @@
 			"fuel": false,
 			"itemRarity": "RARE",
 			"key": "minecraft:flow_banner_pattern",
-			"material": "FLOW_BANNER_PATTERN",
+			"material": "minecraft:flow_banner_pattern",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "RARE",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18216,8 +17099,6 @@
 			"typed": "minecraft:flow_banner_pattern"
 		},
 		{
-			"asMaterial": "minecraft:flow_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18240,11 +17121,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:flow_pottery_sherd",
-			"material": "FLOW_POTTERY_SHERD",
+			"material": "minecraft:flow_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18253,8 +17133,6 @@
 			"typed": "minecraft:flow_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:flower_banner_pattern",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18278,11 +17156,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:flower_banner_pattern",
-			"material": "FLOWER_BANNER_PATTERN",
+			"material": "minecraft:flower_banner_pattern",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18291,8 +17168,7 @@
 			"typed": "minecraft:flower_banner_pattern"
 		},
 		{
-			"asMaterial": "minecraft:flower_pot",
-			"blockType": true,
+			"blockType": "minecraft:flower_pot",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18315,11 +17191,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:flower_pot",
-			"material": "FLOWER_POT",
+			"material": "minecraft:flower_pot",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18328,8 +17203,7 @@
 			"typed": "minecraft:flower_pot"
 		},
 		{
-			"asMaterial": "minecraft:flowering_azalea",
-			"blockType": true,
+			"blockType": "minecraft:flowering_azalea",
 			"compostChance": "0.85F",
 			"compostable": true,
 			"createItemStack": {
@@ -18353,11 +17227,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:flowering_azalea",
-			"material": "FLOWERING_AZALEA",
+			"material": "minecraft:flowering_azalea",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18366,8 +17239,7 @@
 			"typed": "minecraft:flowering_azalea"
 		},
 		{
-			"asMaterial": "minecraft:flowering_azalea_leaves",
-			"blockType": true,
+			"blockType": "minecraft:flowering_azalea_leaves",
 			"compostChance": "0.5F",
 			"compostable": true,
 			"createItemStack": {
@@ -18391,11 +17263,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:flowering_azalea_leaves",
-			"material": "FLOWERING_AZALEA_LEAVES",
+			"material": "minecraft:flowering_azalea_leaves",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18404,8 +17275,6 @@
 			"typed": "minecraft:flowering_azalea_leaves"
 		},
 		{
-			"asMaterial": "minecraft:fox_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18428,11 +17297,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:fox_spawn_egg",
-			"material": "FOX_SPAWN_EGG",
+			"material": "minecraft:fox_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18441,8 +17309,6 @@
 			"typed": "minecraft:fox_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:friend_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18465,11 +17331,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:friend_pottery_sherd",
-			"material": "FRIEND_POTTERY_SHERD",
+			"material": "minecraft:friend_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18478,8 +17343,6 @@
 			"typed": "minecraft:friend_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:frog_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18502,11 +17365,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:frog_spawn_egg",
-			"material": "FROG_SPAWN_EGG",
+			"material": "minecraft:frog_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18515,8 +17377,7 @@
 			"typed": "minecraft:frog_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:frogspawn",
-			"blockType": true,
+			"blockType": "minecraft:frogspawn",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18539,11 +17400,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:frogspawn",
-			"material": "FROGSPAWN",
+			"material": "minecraft:frogspawn",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18552,8 +17412,7 @@
 			"typed": "minecraft:frogspawn"
 		},
 		{
-			"asMaterial": "minecraft:furnace",
-			"blockType": true,
+			"blockType": "minecraft:furnace",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18577,11 +17436,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:furnace",
-			"material": "FURNACE",
+			"material": "minecraft:furnace",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18590,8 +17448,6 @@
 			"typed": "minecraft:furnace"
 		},
 		{
-			"asMaterial": "minecraft:furnace_minecart",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18614,11 +17470,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:furnace_minecart",
-			"material": "FURNACE_MINECART",
+			"material": "minecraft:furnace_minecart",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18627,8 +17482,6 @@
 			"typed": "minecraft:furnace_minecart"
 		},
 		{
-			"asMaterial": "minecraft:ghast_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18651,11 +17504,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:ghast_spawn_egg",
-			"material": "GHAST_SPAWN_EGG",
+			"material": "minecraft:ghast_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18664,8 +17516,6 @@
 			"typed": "minecraft:ghast_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:ghast_tear",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18688,11 +17538,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:ghast_tear",
-			"material": "GHAST_TEAR",
+			"material": "minecraft:ghast_tear",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18701,8 +17550,7 @@
 			"typed": "minecraft:ghast_tear"
 		},
 		{
-			"asMaterial": "minecraft:gilded_blackstone",
-			"blockType": true,
+			"blockType": "minecraft:gilded_blackstone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18725,11 +17573,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:gilded_blackstone",
-			"material": "GILDED_BLACKSTONE",
+			"material": "minecraft:gilded_blackstone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18738,8 +17585,7 @@
 			"typed": "minecraft:gilded_blackstone"
 		},
 		{
-			"asMaterial": "minecraft:glass",
-			"blockType": true,
+			"blockType": "minecraft:glass",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18762,11 +17608,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:glass",
-			"material": "GLASS",
+			"material": "minecraft:glass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18775,8 +17620,6 @@
 			"typed": "minecraft:glass"
 		},
 		{
-			"asMaterial": "minecraft:glass_bottle",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18799,11 +17642,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:glass_bottle",
-			"material": "GLASS_BOTTLE",
+			"material": "minecraft:glass_bottle",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18812,8 +17654,7 @@
 			"typed": "minecraft:glass_bottle"
 		},
 		{
-			"asMaterial": "minecraft:glass_pane",
-			"blockType": true,
+			"blockType": "minecraft:glass_pane",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18836,11 +17677,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:glass_pane",
-			"material": "GLASS_PANE",
+			"material": "minecraft:glass_pane",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18849,8 +17689,6 @@
 			"typed": "minecraft:glass_pane"
 		},
 		{
-			"asMaterial": "minecraft:glistering_melon_slice",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18873,11 +17711,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:glistering_melon_slice",
-			"material": "GLISTERING_MELON_SLICE",
+			"material": "minecraft:glistering_melon_slice",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18886,8 +17723,6 @@
 			"typed": "minecraft:glistering_melon_slice"
 		},
 		{
-			"asMaterial": "minecraft:globe_banner_pattern",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18911,11 +17746,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:globe_banner_pattern",
-			"material": "GLOBE_BANNER_PATTERN",
+			"material": "minecraft:globe_banner_pattern",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18924,8 +17758,7 @@
 			"typed": "minecraft:globe_banner_pattern"
 		},
 		{
-			"asMaterial": "minecraft:glow_berries",
-			"blockType": true,
+			"blockType": "minecraft:cave_vines",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -18951,11 +17784,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:glow_berries",
-			"material": "GLOW_BERRIES",
+			"material": "minecraft:glow_berries",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -18964,8 +17796,6 @@
 			"typed": "minecraft:glow_berries"
 		},
 		{
-			"asMaterial": "minecraft:glow_ink_sac",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -18988,11 +17818,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:glow_ink_sac",
-			"material": "GLOW_INK_SAC",
+			"material": "minecraft:glow_ink_sac",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19001,8 +17830,6 @@
 			"typed": "minecraft:glow_ink_sac"
 		},
 		{
-			"asMaterial": "minecraft:glow_item_frame",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19025,11 +17852,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:glow_item_frame",
-			"material": "GLOW_ITEM_FRAME",
+			"material": "minecraft:glow_item_frame",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19038,8 +17864,7 @@
 			"typed": "minecraft:glow_item_frame"
 		},
 		{
-			"asMaterial": "minecraft:glow_lichen",
-			"blockType": true,
+			"blockType": "minecraft:glow_lichen",
 			"compostChance": "0.5F",
 			"compostable": true,
 			"createItemStack": {
@@ -19063,11 +17888,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:glow_lichen",
-			"material": "GLOW_LICHEN",
+			"material": "minecraft:glow_lichen",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19076,8 +17900,6 @@
 			"typed": "minecraft:glow_lichen"
 		},
 		{
-			"asMaterial": "minecraft:glow_squid_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19100,11 +17922,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:glow_squid_spawn_egg",
-			"material": "GLOW_SQUID_SPAWN_EGG",
+			"material": "minecraft:glow_squid_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19113,8 +17934,7 @@
 			"typed": "minecraft:glow_squid_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:glowstone",
-			"blockType": true,
+			"blockType": "minecraft:glowstone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19137,11 +17957,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:glowstone",
-			"material": "GLOWSTONE",
+			"material": "minecraft:glowstone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19150,8 +17969,6 @@
 			"typed": "minecraft:glowstone"
 		},
 		{
-			"asMaterial": "minecraft:glowstone_dust",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19174,11 +17991,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:glowstone_dust",
-			"material": "GLOWSTONE_DUST",
+			"material": "minecraft:glowstone_dust",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19187,8 +18003,6 @@
 			"typed": "minecraft:glowstone_dust"
 		},
 		{
-			"asMaterial": "minecraft:goat_horn",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19212,11 +18026,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:goat_horn",
-			"material": "GOAT_HORN",
+			"material": "minecraft:goat_horn",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "MusicInstrumentMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19225,8 +18038,6 @@
 			"typed": "minecraft:goat_horn"
 		},
 		{
-			"asMaterial": "minecraft:goat_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19249,11 +18060,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:goat_spawn_egg",
-			"material": "GOAT_SPAWN_EGG",
+			"material": "minecraft:goat_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19262,8 +18072,7 @@
 			"typed": "minecraft:goat_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:gold_block",
-			"blockType": true,
+			"blockType": "minecraft:gold_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19286,11 +18095,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:gold_block",
-			"material": "GOLD_BLOCK",
+			"material": "minecraft:gold_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19299,8 +18107,6 @@
 			"typed": "minecraft:gold_block"
 		},
 		{
-			"asMaterial": "minecraft:gold_ingot",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19324,11 +18130,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:gold_ingot",
-			"material": "GOLD_INGOT",
+			"material": "minecraft:gold_ingot",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19337,8 +18142,6 @@
 			"typed": "minecraft:gold_ingot"
 		},
 		{
-			"asMaterial": "minecraft:gold_nugget",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19361,11 +18164,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:gold_nugget",
-			"material": "GOLD_NUGGET",
+			"material": "minecraft:gold_nugget",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19374,8 +18176,7 @@
 			"typed": "minecraft:gold_nugget"
 		},
 		{
-			"asMaterial": "minecraft:gold_ore",
-			"blockType": true,
+			"blockType": "minecraft:gold_ore",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19398,11 +18199,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:gold_ore",
-			"material": "GOLD_ORE",
+			"material": "minecraft:gold_ore",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19411,8 +18211,6 @@
 			"typed": "minecraft:gold_ore"
 		},
 		{
-			"asMaterial": "minecraft:golden_apple",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19437,11 +18235,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:golden_apple",
-			"material": "GOLDEN_APPLE",
+			"material": "minecraft:golden_apple",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19450,8 +18247,6 @@
 			"typed": "minecraft:golden_apple"
 		},
 		{
-			"asMaterial": "minecraft:golden_axe",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19480,11 +18275,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:golden_axe",
-			"material": "GOLDEN_AXE",
+			"material": "minecraft:golden_axe",
 			"maxDurability": 32,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19493,8 +18287,6 @@
 			"typed": "minecraft:golden_axe"
 		},
 		{
-			"asMaterial": "minecraft:golden_boots",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19522,11 +18314,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:golden_boots",
-			"material": "GOLDEN_BOOTS",
+			"material": "minecraft:golden_boots",
 			"maxDurability": 91,
 			"maxStackSize": 1,
 			"metaClass": "ArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19535,8 +18326,6 @@
 			"typed": "minecraft:golden_boots"
 		},
 		{
-			"asMaterial": "minecraft:golden_carrot",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19561,11 +18350,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:golden_carrot",
-			"material": "GOLDEN_CARROT",
+			"material": "minecraft:golden_carrot",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19574,8 +18362,6 @@
 			"typed": "minecraft:golden_carrot"
 		},
 		{
-			"asMaterial": "minecraft:golden_chestplate",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19603,11 +18389,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:golden_chestplate",
-			"material": "GOLDEN_CHESTPLATE",
+			"material": "minecraft:golden_chestplate",
 			"maxDurability": 112,
 			"maxStackSize": 1,
 			"metaClass": "ArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19616,8 +18401,6 @@
 			"typed": "minecraft:golden_chestplate"
 		},
 		{
-			"asMaterial": "minecraft:golden_helmet",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19645,11 +18428,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:golden_helmet",
-			"material": "GOLDEN_HELMET",
+			"material": "minecraft:golden_helmet",
 			"maxDurability": 77,
 			"maxStackSize": 1,
 			"metaClass": "ArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19658,8 +18440,6 @@
 			"typed": "minecraft:golden_helmet"
 		},
 		{
-			"asMaterial": "minecraft:golden_hoe",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19688,11 +18468,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:golden_hoe",
-			"material": "GOLDEN_HOE",
+			"material": "minecraft:golden_hoe",
 			"maxDurability": 32,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19701,8 +18480,6 @@
 			"typed": "minecraft:golden_hoe"
 		},
 		{
-			"asMaterial": "minecraft:golden_horse_armor",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19726,11 +18503,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:golden_horse_armor",
-			"material": "GOLDEN_HORSE_ARMOR",
+			"material": "minecraft:golden_horse_armor",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19739,8 +18515,6 @@
 			"typed": "minecraft:golden_horse_armor"
 		},
 		{
-			"asMaterial": "minecraft:golden_leggings",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19768,11 +18542,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:golden_leggings",
-			"material": "GOLDEN_LEGGINGS",
+			"material": "minecraft:golden_leggings",
 			"maxDurability": 105,
 			"maxStackSize": 1,
 			"metaClass": "ArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19781,8 +18554,6 @@
 			"typed": "minecraft:golden_leggings"
 		},
 		{
-			"asMaterial": "minecraft:golden_pickaxe",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19811,11 +18582,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:golden_pickaxe",
-			"material": "GOLDEN_PICKAXE",
+			"material": "minecraft:golden_pickaxe",
 			"maxDurability": 32,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19824,8 +18594,6 @@
 			"typed": "minecraft:golden_pickaxe"
 		},
 		{
-			"asMaterial": "minecraft:golden_shovel",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19854,11 +18622,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:golden_shovel",
-			"material": "GOLDEN_SHOVEL",
+			"material": "minecraft:golden_shovel",
 			"maxDurability": 32,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19867,8 +18634,6 @@
 			"typed": "minecraft:golden_shovel"
 		},
 		{
-			"asMaterial": "minecraft:golden_sword",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19897,11 +18662,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:golden_sword",
-			"material": "GOLDEN_SWORD",
+			"material": "minecraft:golden_sword",
 			"maxDurability": 32,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19910,8 +18674,7 @@
 			"typed": "minecraft:golden_sword"
 		},
 		{
-			"asMaterial": "minecraft:granite",
-			"blockType": true,
+			"blockType": "minecraft:granite",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19934,11 +18697,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:granite",
-			"material": "GRANITE",
+			"material": "minecraft:granite",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19947,8 +18709,7 @@
 			"typed": "minecraft:granite"
 		},
 		{
-			"asMaterial": "minecraft:granite_slab",
-			"blockType": true,
+			"blockType": "minecraft:granite_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -19971,11 +18732,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:granite_slab",
-			"material": "GRANITE_SLAB",
+			"material": "minecraft:granite_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -19984,8 +18744,7 @@
 			"typed": "minecraft:granite_slab"
 		},
 		{
-			"asMaterial": "minecraft:granite_stairs",
-			"blockType": true,
+			"blockType": "minecraft:granite_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20008,11 +18767,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:granite_stairs",
-			"material": "GRANITE_STAIRS",
+			"material": "minecraft:granite_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20021,8 +18779,7 @@
 			"typed": "minecraft:granite_stairs"
 		},
 		{
-			"asMaterial": "minecraft:granite_wall",
-			"blockType": true,
+			"blockType": "minecraft:granite_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20045,11 +18802,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:granite_wall",
-			"material": "GRANITE_WALL",
+			"material": "minecraft:granite_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20058,8 +18814,7 @@
 			"typed": "minecraft:granite_wall"
 		},
 		{
-			"asMaterial": "minecraft:grass_block",
-			"blockType": true,
+			"blockType": "minecraft:grass_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20082,11 +18837,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:grass_block",
-			"material": "GRASS_BLOCK",
+			"material": "minecraft:grass_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20095,8 +18849,7 @@
 			"typed": "minecraft:grass_block"
 		},
 		{
-			"asMaterial": "minecraft:gravel",
-			"blockType": true,
+			"blockType": "minecraft:gravel",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20119,11 +18872,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:gravel",
-			"material": "GRAVEL",
+			"material": "minecraft:gravel",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20132,8 +18884,7 @@
 			"typed": "minecraft:gravel"
 		},
 		{
-			"asMaterial": "minecraft:gray_banner",
-			"blockType": true,
+			"blockType": "minecraft:gray_banner",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20157,11 +18908,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:gray_banner",
-			"material": "GRAY_BANNER",
+			"material": "minecraft:gray_banner",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BannerMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20170,8 +18920,7 @@
 			"typed": "minecraft:gray_banner"
 		},
 		{
-			"asMaterial": "minecraft:gray_bed",
-			"blockType": true,
+			"blockType": "minecraft:gray_bed",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20194,11 +18943,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:gray_bed",
-			"material": "GRAY_BED",
+			"material": "minecraft:gray_bed",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20207,8 +18955,6 @@
 			"typed": "minecraft:gray_bed"
 		},
 		{
-			"asMaterial": "minecraft:gray_bundle",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20232,11 +18978,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:gray_bundle",
-			"material": "GRAY_BUNDLE",
+			"material": "minecraft:gray_bundle",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BundleMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20245,8 +18990,7 @@
 			"typed": "minecraft:gray_bundle"
 		},
 		{
-			"asMaterial": "minecraft:gray_candle",
-			"blockType": true,
+			"blockType": "minecraft:gray_candle",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20269,11 +19013,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:gray_candle",
-			"material": "GRAY_CANDLE",
+			"material": "minecraft:gray_candle",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20282,8 +19025,7 @@
 			"typed": "minecraft:gray_candle"
 		},
 		{
-			"asMaterial": "minecraft:gray_carpet",
-			"blockType": true,
+			"blockType": "minecraft:gray_carpet",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20307,11 +19049,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:gray_carpet",
-			"material": "GRAY_CARPET",
+			"material": "minecraft:gray_carpet",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20320,8 +19061,7 @@
 			"typed": "minecraft:gray_carpet"
 		},
 		{
-			"asMaterial": "minecraft:gray_concrete",
-			"blockType": true,
+			"blockType": "minecraft:gray_concrete",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20344,11 +19084,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:gray_concrete",
-			"material": "GRAY_CONCRETE",
+			"material": "minecraft:gray_concrete",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20357,8 +19096,7 @@
 			"typed": "minecraft:gray_concrete"
 		},
 		{
-			"asMaterial": "minecraft:gray_concrete_powder",
-			"blockType": true,
+			"blockType": "minecraft:gray_concrete_powder",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20381,11 +19119,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:gray_concrete_powder",
-			"material": "GRAY_CONCRETE_POWDER",
+			"material": "minecraft:gray_concrete_powder",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20394,8 +19131,6 @@
 			"typed": "minecraft:gray_concrete_powder"
 		},
 		{
-			"asMaterial": "minecraft:gray_dye",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20418,11 +19153,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:gray_dye",
-			"material": "GRAY_DYE",
+			"material": "minecraft:gray_dye",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20431,8 +19165,7 @@
 			"typed": "minecraft:gray_dye"
 		},
 		{
-			"asMaterial": "minecraft:gray_glazed_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:gray_glazed_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20455,11 +19188,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:gray_glazed_terracotta",
-			"material": "GRAY_GLAZED_TERRACOTTA",
+			"material": "minecraft:gray_glazed_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20468,8 +19200,7 @@
 			"typed": "minecraft:gray_glazed_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:gray_shulker_box",
-			"blockType": true,
+			"blockType": "minecraft:gray_shulker_box",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20493,11 +19224,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:gray_shulker_box",
-			"material": "GRAY_SHULKER_BOX",
+			"material": "minecraft:gray_shulker_box",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20506,8 +19236,7 @@
 			"typed": "minecraft:gray_shulker_box"
 		},
 		{
-			"asMaterial": "minecraft:gray_stained_glass",
-			"blockType": true,
+			"blockType": "minecraft:gray_stained_glass",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20530,11 +19259,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:gray_stained_glass",
-			"material": "GRAY_STAINED_GLASS",
+			"material": "minecraft:gray_stained_glass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20543,8 +19271,7 @@
 			"typed": "minecraft:gray_stained_glass"
 		},
 		{
-			"asMaterial": "minecraft:gray_stained_glass_pane",
-			"blockType": true,
+			"blockType": "minecraft:gray_stained_glass_pane",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20567,11 +19294,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:gray_stained_glass_pane",
-			"material": "GRAY_STAINED_GLASS_PANE",
+			"material": "minecraft:gray_stained_glass_pane",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20580,8 +19306,7 @@
 			"typed": "minecraft:gray_stained_glass_pane"
 		},
 		{
-			"asMaterial": "minecraft:gray_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:gray_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20604,11 +19329,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:gray_terracotta",
-			"material": "GRAY_TERRACOTTA",
+			"material": "minecraft:gray_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20617,8 +19341,7 @@
 			"typed": "minecraft:gray_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:gray_wool",
-			"blockType": true,
+			"blockType": "minecraft:gray_wool",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20641,11 +19364,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:gray_wool",
-			"material": "GRAY_WOOL",
+			"material": "minecraft:gray_wool",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20654,8 +19376,7 @@
 			"typed": "minecraft:gray_wool"
 		},
 		{
-			"asMaterial": "minecraft:green_banner",
-			"blockType": true,
+			"blockType": "minecraft:green_banner",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20679,11 +19400,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:green_banner",
-			"material": "GREEN_BANNER",
+			"material": "minecraft:green_banner",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BannerMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20692,8 +19412,7 @@
 			"typed": "minecraft:green_banner"
 		},
 		{
-			"asMaterial": "minecraft:green_bed",
-			"blockType": true,
+			"blockType": "minecraft:green_bed",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20716,11 +19435,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:green_bed",
-			"material": "GREEN_BED",
+			"material": "minecraft:green_bed",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20729,8 +19447,6 @@
 			"typed": "minecraft:green_bed"
 		},
 		{
-			"asMaterial": "minecraft:green_bundle",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20754,11 +19470,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:green_bundle",
-			"material": "GREEN_BUNDLE",
+			"material": "minecraft:green_bundle",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BundleMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20767,8 +19482,7 @@
 			"typed": "minecraft:green_bundle"
 		},
 		{
-			"asMaterial": "minecraft:green_candle",
-			"blockType": true,
+			"blockType": "minecraft:green_candle",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20791,11 +19505,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:green_candle",
-			"material": "GREEN_CANDLE",
+			"material": "minecraft:green_candle",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20804,8 +19517,7 @@
 			"typed": "minecraft:green_candle"
 		},
 		{
-			"asMaterial": "minecraft:green_carpet",
-			"blockType": true,
+			"blockType": "minecraft:green_carpet",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20829,11 +19541,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:green_carpet",
-			"material": "GREEN_CARPET",
+			"material": "minecraft:green_carpet",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20842,8 +19553,7 @@
 			"typed": "minecraft:green_carpet"
 		},
 		{
-			"asMaterial": "minecraft:green_concrete",
-			"blockType": true,
+			"blockType": "minecraft:green_concrete",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20866,11 +19576,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:green_concrete",
-			"material": "GREEN_CONCRETE",
+			"material": "minecraft:green_concrete",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20879,8 +19588,7 @@
 			"typed": "minecraft:green_concrete"
 		},
 		{
-			"asMaterial": "minecraft:green_concrete_powder",
-			"blockType": true,
+			"blockType": "minecraft:green_concrete_powder",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20903,11 +19611,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:green_concrete_powder",
-			"material": "GREEN_CONCRETE_POWDER",
+			"material": "minecraft:green_concrete_powder",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20916,8 +19623,6 @@
 			"typed": "minecraft:green_concrete_powder"
 		},
 		{
-			"asMaterial": "minecraft:green_dye",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20940,11 +19645,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:green_dye",
-			"material": "GREEN_DYE",
+			"material": "minecraft:green_dye",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20953,8 +19657,7 @@
 			"typed": "minecraft:green_dye"
 		},
 		{
-			"asMaterial": "minecraft:green_glazed_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:green_glazed_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -20977,11 +19680,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:green_glazed_terracotta",
-			"material": "GREEN_GLAZED_TERRACOTTA",
+			"material": "minecraft:green_glazed_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -20990,8 +19692,7 @@
 			"typed": "minecraft:green_glazed_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:green_shulker_box",
-			"blockType": true,
+			"blockType": "minecraft:green_shulker_box",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21015,11 +19716,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:green_shulker_box",
-			"material": "GREEN_SHULKER_BOX",
+			"material": "minecraft:green_shulker_box",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21028,8 +19728,7 @@
 			"typed": "minecraft:green_shulker_box"
 		},
 		{
-			"asMaterial": "minecraft:green_stained_glass",
-			"blockType": true,
+			"blockType": "minecraft:green_stained_glass",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21052,11 +19751,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:green_stained_glass",
-			"material": "GREEN_STAINED_GLASS",
+			"material": "minecraft:green_stained_glass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21065,8 +19763,7 @@
 			"typed": "minecraft:green_stained_glass"
 		},
 		{
-			"asMaterial": "minecraft:green_stained_glass_pane",
-			"blockType": true,
+			"blockType": "minecraft:green_stained_glass_pane",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21089,11 +19786,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:green_stained_glass_pane",
-			"material": "GREEN_STAINED_GLASS_PANE",
+			"material": "minecraft:green_stained_glass_pane",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21102,8 +19798,7 @@
 			"typed": "minecraft:green_stained_glass_pane"
 		},
 		{
-			"asMaterial": "minecraft:green_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:green_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21126,11 +19821,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:green_terracotta",
-			"material": "GREEN_TERRACOTTA",
+			"material": "minecraft:green_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21139,8 +19833,7 @@
 			"typed": "minecraft:green_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:green_wool",
-			"blockType": true,
+			"blockType": "minecraft:green_wool",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21163,11 +19856,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:green_wool",
-			"material": "GREEN_WOOL",
+			"material": "minecraft:green_wool",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21176,8 +19868,7 @@
 			"typed": "minecraft:green_wool"
 		},
 		{
-			"asMaterial": "minecraft:grindstone",
-			"blockType": true,
+			"blockType": "minecraft:grindstone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21200,11 +19891,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:grindstone",
-			"material": "GRINDSTONE",
+			"material": "minecraft:grindstone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21213,8 +19903,6 @@
 			"typed": "minecraft:grindstone"
 		},
 		{
-			"asMaterial": "minecraft:guardian_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21237,11 +19925,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:guardian_spawn_egg",
-			"material": "GUARDIAN_SPAWN_EGG",
+			"material": "minecraft:guardian_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21250,8 +19937,6 @@
 			"typed": "minecraft:guardian_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:gunpowder",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21274,11 +19959,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:gunpowder",
-			"material": "GUNPOWDER",
+			"material": "minecraft:gunpowder",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21287,8 +19971,6 @@
 			"typed": "minecraft:gunpowder"
 		},
 		{
-			"asMaterial": "minecraft:guster_banner_pattern",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21312,11 +19994,10 @@
 			"fuel": false,
 			"itemRarity": "RARE",
 			"key": "minecraft:guster_banner_pattern",
-			"material": "GUSTER_BANNER_PATTERN",
+			"material": "minecraft:guster_banner_pattern",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "RARE",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21325,8 +20006,6 @@
 			"typed": "minecraft:guster_banner_pattern"
 		},
 		{
-			"asMaterial": "minecraft:guster_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21349,11 +20028,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:guster_pottery_sherd",
-			"material": "GUSTER_POTTERY_SHERD",
+			"material": "minecraft:guster_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21362,8 +20040,7 @@
 			"typed": "minecraft:guster_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:hanging_roots",
-			"blockType": true,
+			"blockType": "minecraft:hanging_roots",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -21387,11 +20064,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:hanging_roots",
-			"material": "HANGING_ROOTS",
+			"material": "minecraft:hanging_roots",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21400,8 +20076,7 @@
 			"typed": "minecraft:hanging_roots"
 		},
 		{
-			"asMaterial": "minecraft:hay_block",
-			"blockType": true,
+			"blockType": "minecraft:hay_block",
 			"compostChance": "0.85F",
 			"compostable": true,
 			"createItemStack": {
@@ -21425,11 +20100,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:hay_block",
-			"material": "HAY_BLOCK",
+			"material": "minecraft:hay_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21438,8 +20112,6 @@
 			"typed": "minecraft:hay_block"
 		},
 		{
-			"asMaterial": "minecraft:heart_of_the_sea",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21462,11 +20134,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:heart_of_the_sea",
-			"material": "HEART_OF_THE_SEA",
+			"material": "minecraft:heart_of_the_sea",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21475,8 +20146,6 @@
 			"typed": "minecraft:heart_of_the_sea"
 		},
 		{
-			"asMaterial": "minecraft:heart_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21499,11 +20168,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:heart_pottery_sherd",
-			"material": "HEART_POTTERY_SHERD",
+			"material": "minecraft:heart_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21512,8 +20180,6 @@
 			"typed": "minecraft:heart_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:heartbreak_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21536,11 +20202,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:heartbreak_pottery_sherd",
-			"material": "HEARTBREAK_POTTERY_SHERD",
+			"material": "minecraft:heartbreak_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21549,8 +20214,7 @@
 			"typed": "minecraft:heartbreak_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:heavy_core",
-			"blockType": true,
+			"blockType": "minecraft:heavy_core",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21573,11 +20237,10 @@
 			"fuel": false,
 			"itemRarity": "EPIC",
 			"key": "minecraft:heavy_core",
-			"material": "HEAVY_CORE",
+			"material": "minecraft:heavy_core",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "EPIC",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21586,8 +20249,7 @@
 			"typed": "minecraft:heavy_core"
 		},
 		{
-			"asMaterial": "minecraft:heavy_weighted_pressure_plate",
-			"blockType": true,
+			"blockType": "minecraft:heavy_weighted_pressure_plate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21610,11 +20272,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:heavy_weighted_pressure_plate",
-			"material": "HEAVY_WEIGHTED_PRESSURE_PLATE",
+			"material": "minecraft:heavy_weighted_pressure_plate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21623,8 +20284,6 @@
 			"typed": "minecraft:heavy_weighted_pressure_plate"
 		},
 		{
-			"asMaterial": "minecraft:hoglin_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21647,11 +20306,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:hoglin_spawn_egg",
-			"material": "HOGLIN_SPAWN_EGG",
+			"material": "minecraft:hoglin_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21660,8 +20318,7 @@
 			"typed": "minecraft:hoglin_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:honey_block",
-			"blockType": true,
+			"blockType": "minecraft:honey_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21684,11 +20341,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:honey_block",
-			"material": "HONEY_BLOCK",
+			"material": "minecraft:honey_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21697,8 +20353,6 @@
 			"typed": "minecraft:honey_block"
 		},
 		{
-			"asMaterial": "minecraft:honey_bottle",
-			"blockType": false,
 			"compostable": false,
 			"craftingRemainingItem": "minecraft:glass_bottle",
 			"createItemStack": {
@@ -21725,11 +20379,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:honey_bottle",
-			"material": "HONEY_BOTTLE",
+			"material": "minecraft:honey_bottle",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21738,8 +20391,6 @@
 			"typed": "minecraft:honey_bottle"
 		},
 		{
-			"asMaterial": "minecraft:honeycomb",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21762,11 +20413,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:honeycomb",
-			"material": "HONEYCOMB",
+			"material": "minecraft:honeycomb",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21775,8 +20425,7 @@
 			"typed": "minecraft:honeycomb"
 		},
 		{
-			"asMaterial": "minecraft:honeycomb_block",
-			"blockType": true,
+			"blockType": "minecraft:honeycomb_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21799,11 +20448,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:honeycomb_block",
-			"material": "HONEYCOMB_BLOCK",
+			"material": "minecraft:honeycomb_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21812,8 +20460,7 @@
 			"typed": "minecraft:honeycomb_block"
 		},
 		{
-			"asMaterial": "minecraft:hopper",
-			"blockType": true,
+			"blockType": "minecraft:hopper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21837,11 +20484,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:hopper",
-			"material": "HOPPER",
+			"material": "minecraft:hopper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21850,8 +20496,6 @@
 			"typed": "minecraft:hopper"
 		},
 		{
-			"asMaterial": "minecraft:hopper_minecart",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21874,11 +20518,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:hopper_minecart",
-			"material": "HOPPER_MINECART",
+			"material": "minecraft:hopper_minecart",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21887,8 +20530,7 @@
 			"typed": "minecraft:hopper_minecart"
 		},
 		{
-			"asMaterial": "minecraft:horn_coral",
-			"blockType": true,
+			"blockType": "minecraft:horn_coral",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21911,11 +20553,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:horn_coral",
-			"material": "HORN_CORAL",
+			"material": "minecraft:horn_coral",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21924,8 +20565,7 @@
 			"typed": "minecraft:horn_coral"
 		},
 		{
-			"asMaterial": "minecraft:horn_coral_block",
-			"blockType": true,
+			"blockType": "minecraft:horn_coral_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21948,11 +20588,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:horn_coral_block",
-			"material": "HORN_CORAL_BLOCK",
+			"material": "minecraft:horn_coral_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21961,8 +20600,7 @@
 			"typed": "minecraft:horn_coral_block"
 		},
 		{
-			"asMaterial": "minecraft:horn_coral_fan",
-			"blockType": true,
+			"blockType": "minecraft:horn_coral_fan",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -21985,11 +20623,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:horn_coral_fan",
-			"material": "HORN_CORAL_FAN",
+			"material": "minecraft:horn_coral_fan",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -21998,8 +20635,6 @@
 			"typed": "minecraft:horn_coral_fan"
 		},
 		{
-			"asMaterial": "minecraft:horse_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22022,11 +20657,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:horse_spawn_egg",
-			"material": "HORSE_SPAWN_EGG",
+			"material": "minecraft:horse_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22035,8 +20669,6 @@
 			"typed": "minecraft:horse_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:host_armor_trim_smithing_template",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22059,11 +20691,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:host_armor_trim_smithing_template",
-			"material": "HOST_ARMOR_TRIM_SMITHING_TEMPLATE",
+			"material": "minecraft:host_armor_trim_smithing_template",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22072,8 +20703,6 @@
 			"typed": "minecraft:host_armor_trim_smithing_template"
 		},
 		{
-			"asMaterial": "minecraft:howl_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22096,11 +20725,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:howl_pottery_sherd",
-			"material": "HOWL_POTTERY_SHERD",
+			"material": "minecraft:howl_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22109,8 +20737,6 @@
 			"typed": "minecraft:howl_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:husk_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22133,11 +20759,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:husk_spawn_egg",
-			"material": "HUSK_SPAWN_EGG",
+			"material": "minecraft:husk_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22146,8 +20771,7 @@
 			"typed": "minecraft:husk_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:ice",
-			"blockType": true,
+			"blockType": "minecraft:ice",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22170,11 +20794,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:ice",
-			"material": "ICE",
+			"material": "minecraft:ice",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22183,8 +20806,7 @@
 			"typed": "minecraft:ice"
 		},
 		{
-			"asMaterial": "minecraft:infested_chiseled_stone_bricks",
-			"blockType": true,
+			"blockType": "minecraft:infested_chiseled_stone_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22207,11 +20829,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:infested_chiseled_stone_bricks",
-			"material": "INFESTED_CHISELED_STONE_BRICKS",
+			"material": "minecraft:infested_chiseled_stone_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22220,8 +20841,7 @@
 			"typed": "minecraft:infested_chiseled_stone_bricks"
 		},
 		{
-			"asMaterial": "minecraft:infested_cobblestone",
-			"blockType": true,
+			"blockType": "minecraft:infested_cobblestone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22244,11 +20864,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:infested_cobblestone",
-			"material": "INFESTED_COBBLESTONE",
+			"material": "minecraft:infested_cobblestone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22257,8 +20876,7 @@
 			"typed": "minecraft:infested_cobblestone"
 		},
 		{
-			"asMaterial": "minecraft:infested_cracked_stone_bricks",
-			"blockType": true,
+			"blockType": "minecraft:infested_cracked_stone_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22281,11 +20899,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:infested_cracked_stone_bricks",
-			"material": "INFESTED_CRACKED_STONE_BRICKS",
+			"material": "minecraft:infested_cracked_stone_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22294,8 +20911,7 @@
 			"typed": "minecraft:infested_cracked_stone_bricks"
 		},
 		{
-			"asMaterial": "minecraft:infested_deepslate",
-			"blockType": true,
+			"blockType": "minecraft:infested_deepslate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22318,11 +20934,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:infested_deepslate",
-			"material": "INFESTED_DEEPSLATE",
+			"material": "minecraft:infested_deepslate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22331,8 +20946,7 @@
 			"typed": "minecraft:infested_deepslate"
 		},
 		{
-			"asMaterial": "minecraft:infested_mossy_stone_bricks",
-			"blockType": true,
+			"blockType": "minecraft:infested_mossy_stone_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22355,11 +20969,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:infested_mossy_stone_bricks",
-			"material": "INFESTED_MOSSY_STONE_BRICKS",
+			"material": "minecraft:infested_mossy_stone_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22368,8 +20981,7 @@
 			"typed": "minecraft:infested_mossy_stone_bricks"
 		},
 		{
-			"asMaterial": "minecraft:infested_stone",
-			"blockType": true,
+			"blockType": "minecraft:infested_stone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22392,11 +21004,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:infested_stone",
-			"material": "INFESTED_STONE",
+			"material": "minecraft:infested_stone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22405,8 +21016,7 @@
 			"typed": "minecraft:infested_stone"
 		},
 		{
-			"asMaterial": "minecraft:infested_stone_bricks",
-			"blockType": true,
+			"blockType": "minecraft:infested_stone_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22429,11 +21039,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:infested_stone_bricks",
-			"material": "INFESTED_STONE_BRICKS",
+			"material": "minecraft:infested_stone_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22442,8 +21051,6 @@
 			"typed": "minecraft:infested_stone_bricks"
 		},
 		{
-			"asMaterial": "minecraft:ink_sac",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22466,11 +21073,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:ink_sac",
-			"material": "INK_SAC",
+			"material": "minecraft:ink_sac",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22479,8 +21085,6 @@
 			"typed": "minecraft:ink_sac"
 		},
 		{
-			"asMaterial": "minecraft:iron_axe",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22509,11 +21113,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:iron_axe",
-			"material": "IRON_AXE",
+			"material": "minecraft:iron_axe",
 			"maxDurability": 250,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22522,8 +21125,7 @@
 			"typed": "minecraft:iron_axe"
 		},
 		{
-			"asMaterial": "minecraft:iron_bars",
-			"blockType": true,
+			"blockType": "minecraft:iron_bars",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22546,11 +21148,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:iron_bars",
-			"material": "IRON_BARS",
+			"material": "minecraft:iron_bars",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22559,8 +21160,7 @@
 			"typed": "minecraft:iron_bars"
 		},
 		{
-			"asMaterial": "minecraft:iron_block",
-			"blockType": true,
+			"blockType": "minecraft:iron_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22583,11 +21183,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:iron_block",
-			"material": "IRON_BLOCK",
+			"material": "minecraft:iron_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22596,8 +21195,6 @@
 			"typed": "minecraft:iron_block"
 		},
 		{
-			"asMaterial": "minecraft:iron_boots",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22625,11 +21222,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:iron_boots",
-			"material": "IRON_BOOTS",
+			"material": "minecraft:iron_boots",
 			"maxDurability": 195,
 			"maxStackSize": 1,
 			"metaClass": "ArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22638,8 +21234,6 @@
 			"typed": "minecraft:iron_boots"
 		},
 		{
-			"asMaterial": "minecraft:iron_chestplate",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22667,11 +21261,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:iron_chestplate",
-			"material": "IRON_CHESTPLATE",
+			"material": "minecraft:iron_chestplate",
 			"maxDurability": 240,
 			"maxStackSize": 1,
 			"metaClass": "ArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22680,8 +21273,7 @@
 			"typed": "minecraft:iron_chestplate"
 		},
 		{
-			"asMaterial": "minecraft:iron_door",
-			"blockType": true,
+			"blockType": "minecraft:iron_door",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22704,11 +21296,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:iron_door",
-			"material": "IRON_DOOR",
+			"material": "minecraft:iron_door",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22717,8 +21308,6 @@
 			"typed": "minecraft:iron_door"
 		},
 		{
-			"asMaterial": "minecraft:iron_golem_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22741,11 +21330,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:iron_golem_spawn_egg",
-			"material": "IRON_GOLEM_SPAWN_EGG",
+			"material": "minecraft:iron_golem_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22754,8 +21342,6 @@
 			"typed": "minecraft:iron_golem_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:iron_helmet",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22783,11 +21369,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:iron_helmet",
-			"material": "IRON_HELMET",
+			"material": "minecraft:iron_helmet",
 			"maxDurability": 165,
 			"maxStackSize": 1,
 			"metaClass": "ArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22796,8 +21381,6 @@
 			"typed": "minecraft:iron_helmet"
 		},
 		{
-			"asMaterial": "minecraft:iron_hoe",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22826,11 +21409,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:iron_hoe",
-			"material": "IRON_HOE",
+			"material": "minecraft:iron_hoe",
 			"maxDurability": 250,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22839,8 +21421,6 @@
 			"typed": "minecraft:iron_hoe"
 		},
 		{
-			"asMaterial": "minecraft:iron_horse_armor",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22864,11 +21444,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:iron_horse_armor",
-			"material": "IRON_HORSE_ARMOR",
+			"material": "minecraft:iron_horse_armor",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22877,8 +21456,6 @@
 			"typed": "minecraft:iron_horse_armor"
 		},
 		{
-			"asMaterial": "minecraft:iron_ingot",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22902,11 +21479,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:iron_ingot",
-			"material": "IRON_INGOT",
+			"material": "minecraft:iron_ingot",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22915,8 +21491,6 @@
 			"typed": "minecraft:iron_ingot"
 		},
 		{
-			"asMaterial": "minecraft:iron_leggings",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22944,11 +21518,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:iron_leggings",
-			"material": "IRON_LEGGINGS",
+			"material": "minecraft:iron_leggings",
 			"maxDurability": 225,
 			"maxStackSize": 1,
 			"metaClass": "ArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22957,8 +21530,6 @@
 			"typed": "minecraft:iron_leggings"
 		},
 		{
-			"asMaterial": "minecraft:iron_nugget",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -22981,11 +21552,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:iron_nugget",
-			"material": "IRON_NUGGET",
+			"material": "minecraft:iron_nugget",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -22994,8 +21564,7 @@
 			"typed": "minecraft:iron_nugget"
 		},
 		{
-			"asMaterial": "minecraft:iron_ore",
-			"blockType": true,
+			"blockType": "minecraft:iron_ore",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23018,11 +21587,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:iron_ore",
-			"material": "IRON_ORE",
+			"material": "minecraft:iron_ore",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23031,8 +21599,6 @@
 			"typed": "minecraft:iron_ore"
 		},
 		{
-			"asMaterial": "minecraft:iron_pickaxe",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23061,11 +21627,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:iron_pickaxe",
-			"material": "IRON_PICKAXE",
+			"material": "minecraft:iron_pickaxe",
 			"maxDurability": 250,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23074,8 +21639,6 @@
 			"typed": "minecraft:iron_pickaxe"
 		},
 		{
-			"asMaterial": "minecraft:iron_shovel",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23104,11 +21667,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:iron_shovel",
-			"material": "IRON_SHOVEL",
+			"material": "minecraft:iron_shovel",
 			"maxDurability": 250,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23117,8 +21679,6 @@
 			"typed": "minecraft:iron_shovel"
 		},
 		{
-			"asMaterial": "minecraft:iron_sword",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23147,11 +21707,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:iron_sword",
-			"material": "IRON_SWORD",
+			"material": "minecraft:iron_sword",
 			"maxDurability": 250,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23160,8 +21719,7 @@
 			"typed": "minecraft:iron_sword"
 		},
 		{
-			"asMaterial": "minecraft:iron_trapdoor",
-			"blockType": true,
+			"blockType": "minecraft:iron_trapdoor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23184,11 +21742,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:iron_trapdoor",
-			"material": "IRON_TRAPDOOR",
+			"material": "minecraft:iron_trapdoor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23197,8 +21754,6 @@
 			"typed": "minecraft:iron_trapdoor"
 		},
 		{
-			"asMaterial": "minecraft:item_frame",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23221,11 +21776,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:item_frame",
-			"material": "ITEM_FRAME",
+			"material": "minecraft:item_frame",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23234,8 +21788,7 @@
 			"typed": "minecraft:item_frame"
 		},
 		{
-			"asMaterial": "minecraft:jack_o_lantern",
-			"blockType": true,
+			"blockType": "minecraft:jack_o_lantern",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23258,11 +21811,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:jack_o_lantern",
-			"material": "JACK_O_LANTERN",
+			"material": "minecraft:jack_o_lantern",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23271,8 +21823,7 @@
 			"typed": "minecraft:jack_o_lantern"
 		},
 		{
-			"asMaterial": "minecraft:jigsaw",
-			"blockType": true,
+			"blockType": "minecraft:jigsaw",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23295,11 +21846,10 @@
 			"fuel": false,
 			"itemRarity": "EPIC",
 			"key": "minecraft:jigsaw",
-			"material": "JIGSAW",
+			"material": "minecraft:jigsaw",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "EPIC",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23308,8 +21858,7 @@
 			"typed": "minecraft:jigsaw"
 		},
 		{
-			"asMaterial": "minecraft:jukebox",
-			"blockType": true,
+			"blockType": "minecraft:jukebox",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23332,11 +21881,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:jukebox",
-			"material": "JUKEBOX",
+			"material": "minecraft:jukebox",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23345,8 +21893,6 @@
 			"typed": "minecraft:jukebox"
 		},
 		{
-			"asMaterial": "minecraft:jungle_boat",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23369,11 +21915,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:jungle_boat",
-			"material": "JUNGLE_BOAT",
+			"material": "minecraft:jungle_boat",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23382,8 +21927,7 @@
 			"typed": "minecraft:jungle_boat"
 		},
 		{
-			"asMaterial": "minecraft:jungle_button",
-			"blockType": true,
+			"blockType": "minecraft:jungle_button",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23406,11 +21950,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:jungle_button",
-			"material": "JUNGLE_BUTTON",
+			"material": "minecraft:jungle_button",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23419,8 +21962,6 @@
 			"typed": "minecraft:jungle_button"
 		},
 		{
-			"asMaterial": "minecraft:jungle_chest_boat",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23443,11 +21984,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:jungle_chest_boat",
-			"material": "JUNGLE_CHEST_BOAT",
+			"material": "minecraft:jungle_chest_boat",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23456,8 +21996,7 @@
 			"typed": "minecraft:jungle_chest_boat"
 		},
 		{
-			"asMaterial": "minecraft:jungle_door",
-			"blockType": true,
+			"blockType": "minecraft:jungle_door",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23480,11 +22019,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:jungle_door",
-			"material": "JUNGLE_DOOR",
+			"material": "minecraft:jungle_door",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23493,8 +22031,7 @@
 			"typed": "minecraft:jungle_door"
 		},
 		{
-			"asMaterial": "minecraft:jungle_fence",
-			"blockType": true,
+			"blockType": "minecraft:jungle_fence",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23517,11 +22054,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:jungle_fence",
-			"material": "JUNGLE_FENCE",
+			"material": "minecraft:jungle_fence",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23530,8 +22066,7 @@
 			"typed": "minecraft:jungle_fence"
 		},
 		{
-			"asMaterial": "minecraft:jungle_fence_gate",
-			"blockType": true,
+			"blockType": "minecraft:jungle_fence_gate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23554,11 +22089,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:jungle_fence_gate",
-			"material": "JUNGLE_FENCE_GATE",
+			"material": "minecraft:jungle_fence_gate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23567,8 +22101,7 @@
 			"typed": "minecraft:jungle_fence_gate"
 		},
 		{
-			"asMaterial": "minecraft:jungle_hanging_sign",
-			"blockType": true,
+			"blockType": "minecraft:jungle_hanging_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23591,11 +22124,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:jungle_hanging_sign",
-			"material": "JUNGLE_HANGING_SIGN",
+			"material": "minecraft:jungle_hanging_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23604,8 +22136,7 @@
 			"typed": "minecraft:jungle_hanging_sign"
 		},
 		{
-			"asMaterial": "minecraft:jungle_leaves",
-			"blockType": true,
+			"blockType": "minecraft:jungle_leaves",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -23629,11 +22160,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:jungle_leaves",
-			"material": "JUNGLE_LEAVES",
+			"material": "minecraft:jungle_leaves",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23642,8 +22172,7 @@
 			"typed": "minecraft:jungle_leaves"
 		},
 		{
-			"asMaterial": "minecraft:jungle_log",
-			"blockType": true,
+			"blockType": "minecraft:jungle_log",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23666,11 +22195,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:jungle_log",
-			"material": "JUNGLE_LOG",
+			"material": "minecraft:jungle_log",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23679,8 +22207,7 @@
 			"typed": "minecraft:jungle_log"
 		},
 		{
-			"asMaterial": "minecraft:jungle_planks",
-			"blockType": true,
+			"blockType": "minecraft:jungle_planks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23703,11 +22230,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:jungle_planks",
-			"material": "JUNGLE_PLANKS",
+			"material": "minecraft:jungle_planks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23716,8 +22242,7 @@
 			"typed": "minecraft:jungle_planks"
 		},
 		{
-			"asMaterial": "minecraft:jungle_pressure_plate",
-			"blockType": true,
+			"blockType": "minecraft:jungle_pressure_plate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23740,11 +22265,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:jungle_pressure_plate",
-			"material": "JUNGLE_PRESSURE_PLATE",
+			"material": "minecraft:jungle_pressure_plate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23753,8 +22277,7 @@
 			"typed": "minecraft:jungle_pressure_plate"
 		},
 		{
-			"asMaterial": "minecraft:jungle_sapling",
-			"blockType": true,
+			"blockType": "minecraft:jungle_sapling",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -23778,11 +22301,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:jungle_sapling",
-			"material": "JUNGLE_SAPLING",
+			"material": "minecraft:jungle_sapling",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23791,8 +22313,7 @@
 			"typed": "minecraft:jungle_sapling"
 		},
 		{
-			"asMaterial": "minecraft:jungle_sign",
-			"blockType": true,
+			"blockType": "minecraft:jungle_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23815,11 +22336,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:jungle_sign",
-			"material": "JUNGLE_SIGN",
+			"material": "minecraft:jungle_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23828,8 +22348,7 @@
 			"typed": "minecraft:jungle_sign"
 		},
 		{
-			"asMaterial": "minecraft:jungle_slab",
-			"blockType": true,
+			"blockType": "minecraft:jungle_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23852,11 +22371,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:jungle_slab",
-			"material": "JUNGLE_SLAB",
+			"material": "minecraft:jungle_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23865,8 +22383,7 @@
 			"typed": "minecraft:jungle_slab"
 		},
 		{
-			"asMaterial": "minecraft:jungle_stairs",
-			"blockType": true,
+			"blockType": "minecraft:jungle_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23889,11 +22406,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:jungle_stairs",
-			"material": "JUNGLE_STAIRS",
+			"material": "minecraft:jungle_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23902,8 +22418,7 @@
 			"typed": "minecraft:jungle_stairs"
 		},
 		{
-			"asMaterial": "minecraft:jungle_trapdoor",
-			"blockType": true,
+			"blockType": "minecraft:jungle_trapdoor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23926,11 +22441,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:jungle_trapdoor",
-			"material": "JUNGLE_TRAPDOOR",
+			"material": "minecraft:jungle_trapdoor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23939,8 +22453,7 @@
 			"typed": "minecraft:jungle_trapdoor"
 		},
 		{
-			"asMaterial": "minecraft:jungle_wood",
-			"blockType": true,
+			"blockType": "minecraft:jungle_wood",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -23963,11 +22476,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:jungle_wood",
-			"material": "JUNGLE_WOOD",
+			"material": "minecraft:jungle_wood",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -23976,8 +22488,7 @@
 			"typed": "minecraft:jungle_wood"
 		},
 		{
-			"asMaterial": "minecraft:kelp",
-			"blockType": true,
+			"blockType": "minecraft:kelp",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -24001,11 +22512,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:kelp",
-			"material": "KELP",
+			"material": "minecraft:kelp",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24014,8 +22524,6 @@
 			"typed": "minecraft:kelp"
 		},
 		{
-			"asMaterial": "minecraft:knowledge_book",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24039,11 +22547,10 @@
 			"fuel": false,
 			"itemRarity": "EPIC",
 			"key": "minecraft:knowledge_book",
-			"material": "KNOWLEDGE_BOOK",
+			"material": "minecraft:knowledge_book",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "KnowledgeBookMeta",
-			"rarity": "EPIC",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24052,8 +22559,7 @@
 			"typed": "minecraft:knowledge_book"
 		},
 		{
-			"asMaterial": "minecraft:ladder",
-			"blockType": true,
+			"blockType": "minecraft:ladder",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24076,11 +22582,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:ladder",
-			"material": "LADDER",
+			"material": "minecraft:ladder",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24089,8 +22594,7 @@
 			"typed": "minecraft:ladder"
 		},
 		{
-			"asMaterial": "minecraft:lantern",
-			"blockType": true,
+			"blockType": "minecraft:lantern",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24113,11 +22617,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lantern",
-			"material": "LANTERN",
+			"material": "minecraft:lantern",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24126,8 +22629,7 @@
 			"typed": "minecraft:lantern"
 		},
 		{
-			"asMaterial": "minecraft:lapis_block",
-			"blockType": true,
+			"blockType": "minecraft:lapis_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24150,11 +22652,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lapis_block",
-			"material": "LAPIS_BLOCK",
+			"material": "minecraft:lapis_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24163,8 +22664,6 @@
 			"typed": "minecraft:lapis_block"
 		},
 		{
-			"asMaterial": "minecraft:lapis_lazuli",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24188,11 +22687,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lapis_lazuli",
-			"material": "LAPIS_LAZULI",
+			"material": "minecraft:lapis_lazuli",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24201,8 +22699,7 @@
 			"typed": "minecraft:lapis_lazuli"
 		},
 		{
-			"asMaterial": "minecraft:lapis_ore",
-			"blockType": true,
+			"blockType": "minecraft:lapis_ore",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24225,11 +22722,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lapis_ore",
-			"material": "LAPIS_ORE",
+			"material": "minecraft:lapis_ore",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24238,8 +22734,7 @@
 			"typed": "minecraft:lapis_ore"
 		},
 		{
-			"asMaterial": "minecraft:large_amethyst_bud",
-			"blockType": true,
+			"blockType": "minecraft:large_amethyst_bud",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24262,11 +22757,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:large_amethyst_bud",
-			"material": "LARGE_AMETHYST_BUD",
+			"material": "minecraft:large_amethyst_bud",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24275,8 +22769,7 @@
 			"typed": "minecraft:large_amethyst_bud"
 		},
 		{
-			"asMaterial": "minecraft:large_fern",
-			"blockType": true,
+			"blockType": "minecraft:large_fern",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -24300,11 +22793,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:large_fern",
-			"material": "LARGE_FERN",
+			"material": "minecraft:large_fern",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24313,8 +22805,6 @@
 			"typed": "minecraft:large_fern"
 		},
 		{
-			"asMaterial": "minecraft:lava_bucket",
-			"blockType": false,
 			"compostable": false,
 			"craftingRemainingItem": "minecraft:bucket",
 			"createItemStack": {
@@ -24338,11 +22828,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lava_bucket",
-			"material": "LAVA_BUCKET",
+			"material": "minecraft:lava_bucket",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24351,8 +22840,6 @@
 			"typed": "minecraft:lava_bucket"
 		},
 		{
-			"asMaterial": "minecraft:lead",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24375,11 +22862,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lead",
-			"material": "LEAD",
+			"material": "minecraft:lead",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24388,8 +22874,7 @@
 			"typed": "minecraft:lead"
 		},
 		{
-			"asMaterial": "minecraft:leaf_litter",
-			"blockType": true,
+			"blockType": "minecraft:leaf_litter",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -24413,11 +22898,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:leaf_litter",
-			"material": "LEAF_LITTER",
+			"material": "minecraft:leaf_litter",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24426,8 +22910,6 @@
 			"typed": "minecraft:leaf_litter"
 		},
 		{
-			"asMaterial": "minecraft:leather",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24450,11 +22932,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:leather",
-			"material": "LEATHER",
+			"material": "minecraft:leather",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24463,8 +22944,6 @@
 			"typed": "minecraft:leather"
 		},
 		{
-			"asMaterial": "minecraft:leather_boots",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24492,11 +22971,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:leather_boots",
-			"material": "LEATHER_BOOTS",
+			"material": "minecraft:leather_boots",
 			"maxDurability": 65,
 			"maxStackSize": 1,
 			"metaClass": "ColorableArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24505,8 +22983,6 @@
 			"typed": "minecraft:leather_boots"
 		},
 		{
-			"asMaterial": "minecraft:leather_chestplate",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24534,11 +23010,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:leather_chestplate",
-			"material": "LEATHER_CHESTPLATE",
+			"material": "minecraft:leather_chestplate",
 			"maxDurability": 80,
 			"maxStackSize": 1,
 			"metaClass": "ColorableArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24547,8 +23022,6 @@
 			"typed": "minecraft:leather_chestplate"
 		},
 		{
-			"asMaterial": "minecraft:leather_helmet",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24576,11 +23049,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:leather_helmet",
-			"material": "LEATHER_HELMET",
+			"material": "minecraft:leather_helmet",
 			"maxDurability": 55,
 			"maxStackSize": 1,
 			"metaClass": "ColorableArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24589,8 +23061,6 @@
 			"typed": "minecraft:leather_helmet"
 		},
 		{
-			"asMaterial": "minecraft:leather_horse_armor",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24614,11 +23084,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:leather_horse_armor",
-			"material": "LEATHER_HORSE_ARMOR",
+			"material": "minecraft:leather_horse_armor",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "LeatherArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24627,8 +23096,6 @@
 			"typed": "minecraft:leather_horse_armor"
 		},
 		{
-			"asMaterial": "minecraft:leather_leggings",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24656,11 +23123,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:leather_leggings",
-			"material": "LEATHER_LEGGINGS",
+			"material": "minecraft:leather_leggings",
 			"maxDurability": 75,
 			"maxStackSize": 1,
 			"metaClass": "ColorableArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24669,8 +23135,7 @@
 			"typed": "minecraft:leather_leggings"
 		},
 		{
-			"asMaterial": "minecraft:lectern",
-			"blockType": true,
+			"blockType": "minecraft:lectern",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24693,11 +23158,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lectern",
-			"material": "LECTERN",
+			"material": "minecraft:lectern",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24706,8 +23170,7 @@
 			"typed": "minecraft:lectern"
 		},
 		{
-			"asMaterial": "minecraft:lever",
-			"blockType": true,
+			"blockType": "minecraft:lever",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24730,11 +23193,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lever",
-			"material": "LEVER",
+			"material": "minecraft:lever",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24743,8 +23205,7 @@
 			"typed": "minecraft:lever"
 		},
 		{
-			"asMaterial": "minecraft:light",
-			"blockType": true,
+			"blockType": "minecraft:light",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24768,11 +23229,10 @@
 			"fuel": false,
 			"itemRarity": "EPIC",
 			"key": "minecraft:light",
-			"material": "LIGHT",
+			"material": "minecraft:light",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "EPIC",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24781,8 +23241,7 @@
 			"typed": "minecraft:light"
 		},
 		{
-			"asMaterial": "minecraft:light_blue_banner",
-			"blockType": true,
+			"blockType": "minecraft:light_blue_banner",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24806,11 +23265,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_blue_banner",
-			"material": "LIGHT_BLUE_BANNER",
+			"material": "minecraft:light_blue_banner",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BannerMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24819,8 +23277,7 @@
 			"typed": "minecraft:light_blue_banner"
 		},
 		{
-			"asMaterial": "minecraft:light_blue_bed",
-			"blockType": true,
+			"blockType": "minecraft:light_blue_bed",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24843,11 +23300,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_blue_bed",
-			"material": "LIGHT_BLUE_BED",
+			"material": "minecraft:light_blue_bed",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24856,8 +23312,6 @@
 			"typed": "minecraft:light_blue_bed"
 		},
 		{
-			"asMaterial": "minecraft:light_blue_bundle",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24881,11 +23335,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_blue_bundle",
-			"material": "LIGHT_BLUE_BUNDLE",
+			"material": "minecraft:light_blue_bundle",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BundleMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24894,8 +23347,7 @@
 			"typed": "minecraft:light_blue_bundle"
 		},
 		{
-			"asMaterial": "minecraft:light_blue_candle",
-			"blockType": true,
+			"blockType": "minecraft:light_blue_candle",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24918,11 +23370,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_blue_candle",
-			"material": "LIGHT_BLUE_CANDLE",
+			"material": "minecraft:light_blue_candle",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24931,8 +23382,7 @@
 			"typed": "minecraft:light_blue_candle"
 		},
 		{
-			"asMaterial": "minecraft:light_blue_carpet",
-			"blockType": true,
+			"blockType": "minecraft:light_blue_carpet",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24956,11 +23406,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_blue_carpet",
-			"material": "LIGHT_BLUE_CARPET",
+			"material": "minecraft:light_blue_carpet",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -24969,8 +23418,7 @@
 			"typed": "minecraft:light_blue_carpet"
 		},
 		{
-			"asMaterial": "minecraft:light_blue_concrete",
-			"blockType": true,
+			"blockType": "minecraft:light_blue_concrete",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -24993,11 +23441,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_blue_concrete",
-			"material": "LIGHT_BLUE_CONCRETE",
+			"material": "minecraft:light_blue_concrete",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25006,8 +23453,7 @@
 			"typed": "minecraft:light_blue_concrete"
 		},
 		{
-			"asMaterial": "minecraft:light_blue_concrete_powder",
-			"blockType": true,
+			"blockType": "minecraft:light_blue_concrete_powder",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25030,11 +23476,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_blue_concrete_powder",
-			"material": "LIGHT_BLUE_CONCRETE_POWDER",
+			"material": "minecraft:light_blue_concrete_powder",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25043,8 +23488,6 @@
 			"typed": "minecraft:light_blue_concrete_powder"
 		},
 		{
-			"asMaterial": "minecraft:light_blue_dye",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25067,11 +23510,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_blue_dye",
-			"material": "LIGHT_BLUE_DYE",
+			"material": "minecraft:light_blue_dye",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25080,8 +23522,7 @@
 			"typed": "minecraft:light_blue_dye"
 		},
 		{
-			"asMaterial": "minecraft:light_blue_glazed_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:light_blue_glazed_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25104,11 +23545,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_blue_glazed_terracotta",
-			"material": "LIGHT_BLUE_GLAZED_TERRACOTTA",
+			"material": "minecraft:light_blue_glazed_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25117,8 +23557,7 @@
 			"typed": "minecraft:light_blue_glazed_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:light_blue_shulker_box",
-			"blockType": true,
+			"blockType": "minecraft:light_blue_shulker_box",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25142,11 +23581,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_blue_shulker_box",
-			"material": "LIGHT_BLUE_SHULKER_BOX",
+			"material": "minecraft:light_blue_shulker_box",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25155,8 +23593,7 @@
 			"typed": "minecraft:light_blue_shulker_box"
 		},
 		{
-			"asMaterial": "minecraft:light_blue_stained_glass",
-			"blockType": true,
+			"blockType": "minecraft:light_blue_stained_glass",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25179,11 +23616,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_blue_stained_glass",
-			"material": "LIGHT_BLUE_STAINED_GLASS",
+			"material": "minecraft:light_blue_stained_glass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25192,8 +23628,7 @@
 			"typed": "minecraft:light_blue_stained_glass"
 		},
 		{
-			"asMaterial": "minecraft:light_blue_stained_glass_pane",
-			"blockType": true,
+			"blockType": "minecraft:light_blue_stained_glass_pane",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25216,11 +23651,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_blue_stained_glass_pane",
-			"material": "LIGHT_BLUE_STAINED_GLASS_PANE",
+			"material": "minecraft:light_blue_stained_glass_pane",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25229,8 +23663,7 @@
 			"typed": "minecraft:light_blue_stained_glass_pane"
 		},
 		{
-			"asMaterial": "minecraft:light_blue_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:light_blue_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25253,11 +23686,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_blue_terracotta",
-			"material": "LIGHT_BLUE_TERRACOTTA",
+			"material": "minecraft:light_blue_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25266,8 +23698,7 @@
 			"typed": "minecraft:light_blue_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:light_blue_wool",
-			"blockType": true,
+			"blockType": "minecraft:light_blue_wool",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25290,11 +23721,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_blue_wool",
-			"material": "LIGHT_BLUE_WOOL",
+			"material": "minecraft:light_blue_wool",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25303,8 +23733,7 @@
 			"typed": "minecraft:light_blue_wool"
 		},
 		{
-			"asMaterial": "minecraft:light_gray_banner",
-			"blockType": true,
+			"blockType": "minecraft:light_gray_banner",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25328,11 +23757,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_gray_banner",
-			"material": "LIGHT_GRAY_BANNER",
+			"material": "minecraft:light_gray_banner",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BannerMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25341,8 +23769,7 @@
 			"typed": "minecraft:light_gray_banner"
 		},
 		{
-			"asMaterial": "minecraft:light_gray_bed",
-			"blockType": true,
+			"blockType": "minecraft:light_gray_bed",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25365,11 +23792,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_gray_bed",
-			"material": "LIGHT_GRAY_BED",
+			"material": "minecraft:light_gray_bed",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25378,8 +23804,6 @@
 			"typed": "minecraft:light_gray_bed"
 		},
 		{
-			"asMaterial": "minecraft:light_gray_bundle",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25403,11 +23827,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_gray_bundle",
-			"material": "LIGHT_GRAY_BUNDLE",
+			"material": "minecraft:light_gray_bundle",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BundleMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25416,8 +23839,7 @@
 			"typed": "minecraft:light_gray_bundle"
 		},
 		{
-			"asMaterial": "minecraft:light_gray_candle",
-			"blockType": true,
+			"blockType": "minecraft:light_gray_candle",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25440,11 +23862,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_gray_candle",
-			"material": "LIGHT_GRAY_CANDLE",
+			"material": "minecraft:light_gray_candle",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25453,8 +23874,7 @@
 			"typed": "minecraft:light_gray_candle"
 		},
 		{
-			"asMaterial": "minecraft:light_gray_carpet",
-			"blockType": true,
+			"blockType": "minecraft:light_gray_carpet",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25478,11 +23898,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_gray_carpet",
-			"material": "LIGHT_GRAY_CARPET",
+			"material": "minecraft:light_gray_carpet",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25491,8 +23910,7 @@
 			"typed": "minecraft:light_gray_carpet"
 		},
 		{
-			"asMaterial": "minecraft:light_gray_concrete",
-			"blockType": true,
+			"blockType": "minecraft:light_gray_concrete",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25515,11 +23933,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_gray_concrete",
-			"material": "LIGHT_GRAY_CONCRETE",
+			"material": "minecraft:light_gray_concrete",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25528,8 +23945,7 @@
 			"typed": "minecraft:light_gray_concrete"
 		},
 		{
-			"asMaterial": "minecraft:light_gray_concrete_powder",
-			"blockType": true,
+			"blockType": "minecraft:light_gray_concrete_powder",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25552,11 +23968,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_gray_concrete_powder",
-			"material": "LIGHT_GRAY_CONCRETE_POWDER",
+			"material": "minecraft:light_gray_concrete_powder",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25565,8 +23980,6 @@
 			"typed": "minecraft:light_gray_concrete_powder"
 		},
 		{
-			"asMaterial": "minecraft:light_gray_dye",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25589,11 +24002,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_gray_dye",
-			"material": "LIGHT_GRAY_DYE",
+			"material": "minecraft:light_gray_dye",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25602,8 +24014,7 @@
 			"typed": "minecraft:light_gray_dye"
 		},
 		{
-			"asMaterial": "minecraft:light_gray_glazed_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:light_gray_glazed_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25626,11 +24037,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_gray_glazed_terracotta",
-			"material": "LIGHT_GRAY_GLAZED_TERRACOTTA",
+			"material": "minecraft:light_gray_glazed_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25639,8 +24049,7 @@
 			"typed": "minecraft:light_gray_glazed_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:light_gray_shulker_box",
-			"blockType": true,
+			"blockType": "minecraft:light_gray_shulker_box",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25664,11 +24073,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_gray_shulker_box",
-			"material": "LIGHT_GRAY_SHULKER_BOX",
+			"material": "minecraft:light_gray_shulker_box",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25677,8 +24085,7 @@
 			"typed": "minecraft:light_gray_shulker_box"
 		},
 		{
-			"asMaterial": "minecraft:light_gray_stained_glass",
-			"blockType": true,
+			"blockType": "minecraft:light_gray_stained_glass",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25701,11 +24108,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_gray_stained_glass",
-			"material": "LIGHT_GRAY_STAINED_GLASS",
+			"material": "minecraft:light_gray_stained_glass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25714,8 +24120,7 @@
 			"typed": "minecraft:light_gray_stained_glass"
 		},
 		{
-			"asMaterial": "minecraft:light_gray_stained_glass_pane",
-			"blockType": true,
+			"blockType": "minecraft:light_gray_stained_glass_pane",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25738,11 +24143,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_gray_stained_glass_pane",
-			"material": "LIGHT_GRAY_STAINED_GLASS_PANE",
+			"material": "minecraft:light_gray_stained_glass_pane",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25751,8 +24155,7 @@
 			"typed": "minecraft:light_gray_stained_glass_pane"
 		},
 		{
-			"asMaterial": "minecraft:light_gray_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:light_gray_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25775,11 +24178,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_gray_terracotta",
-			"material": "LIGHT_GRAY_TERRACOTTA",
+			"material": "minecraft:light_gray_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25788,8 +24190,7 @@
 			"typed": "minecraft:light_gray_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:light_gray_wool",
-			"blockType": true,
+			"blockType": "minecraft:light_gray_wool",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25812,11 +24213,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_gray_wool",
-			"material": "LIGHT_GRAY_WOOL",
+			"material": "minecraft:light_gray_wool",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25825,8 +24225,7 @@
 			"typed": "minecraft:light_gray_wool"
 		},
 		{
-			"asMaterial": "minecraft:light_weighted_pressure_plate",
-			"blockType": true,
+			"blockType": "minecraft:light_weighted_pressure_plate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25849,11 +24248,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:light_weighted_pressure_plate",
-			"material": "LIGHT_WEIGHTED_PRESSURE_PLATE",
+			"material": "minecraft:light_weighted_pressure_plate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25862,8 +24260,7 @@
 			"typed": "minecraft:light_weighted_pressure_plate"
 		},
 		{
-			"asMaterial": "minecraft:lightning_rod",
-			"blockType": true,
+			"blockType": "minecraft:lightning_rod",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -25886,11 +24283,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lightning_rod",
-			"material": "LIGHTNING_ROD",
+			"material": "minecraft:lightning_rod",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25899,8 +24295,7 @@
 			"typed": "minecraft:lightning_rod"
 		},
 		{
-			"asMaterial": "minecraft:lilac",
-			"blockType": true,
+			"blockType": "minecraft:lilac",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -25924,11 +24319,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lilac",
-			"material": "LILAC",
+			"material": "minecraft:lilac",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25937,8 +24331,7 @@
 			"typed": "minecraft:lilac"
 		},
 		{
-			"asMaterial": "minecraft:lily_of_the_valley",
-			"blockType": true,
+			"blockType": "minecraft:lily_of_the_valley",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -25962,11 +24355,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lily_of_the_valley",
-			"material": "LILY_OF_THE_VALLEY",
+			"material": "minecraft:lily_of_the_valley",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -25975,8 +24367,7 @@
 			"typed": "minecraft:lily_of_the_valley"
 		},
 		{
-			"asMaterial": "minecraft:lily_pad",
-			"blockType": true,
+			"blockType": "minecraft:lily_pad",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -26000,11 +24391,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lily_pad",
-			"material": "LILY_PAD",
+			"material": "minecraft:lily_pad",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26013,8 +24403,7 @@
 			"typed": "minecraft:lily_pad"
 		},
 		{
-			"asMaterial": "minecraft:lime_banner",
-			"blockType": true,
+			"blockType": "minecraft:lime_banner",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26038,11 +24427,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lime_banner",
-			"material": "LIME_BANNER",
+			"material": "minecraft:lime_banner",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BannerMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26051,8 +24439,7 @@
 			"typed": "minecraft:lime_banner"
 		},
 		{
-			"asMaterial": "minecraft:lime_bed",
-			"blockType": true,
+			"blockType": "minecraft:lime_bed",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26075,11 +24462,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lime_bed",
-			"material": "LIME_BED",
+			"material": "minecraft:lime_bed",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26088,8 +24474,6 @@
 			"typed": "minecraft:lime_bed"
 		},
 		{
-			"asMaterial": "minecraft:lime_bundle",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26113,11 +24497,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lime_bundle",
-			"material": "LIME_BUNDLE",
+			"material": "minecraft:lime_bundle",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BundleMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26126,8 +24509,7 @@
 			"typed": "minecraft:lime_bundle"
 		},
 		{
-			"asMaterial": "minecraft:lime_candle",
-			"blockType": true,
+			"blockType": "minecraft:lime_candle",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26150,11 +24532,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lime_candle",
-			"material": "LIME_CANDLE",
+			"material": "minecraft:lime_candle",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26163,8 +24544,7 @@
 			"typed": "minecraft:lime_candle"
 		},
 		{
-			"asMaterial": "minecraft:lime_carpet",
-			"blockType": true,
+			"blockType": "minecraft:lime_carpet",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26188,11 +24568,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lime_carpet",
-			"material": "LIME_CARPET",
+			"material": "minecraft:lime_carpet",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26201,8 +24580,7 @@
 			"typed": "minecraft:lime_carpet"
 		},
 		{
-			"asMaterial": "minecraft:lime_concrete",
-			"blockType": true,
+			"blockType": "minecraft:lime_concrete",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26225,11 +24603,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lime_concrete",
-			"material": "LIME_CONCRETE",
+			"material": "minecraft:lime_concrete",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26238,8 +24615,7 @@
 			"typed": "minecraft:lime_concrete"
 		},
 		{
-			"asMaterial": "minecraft:lime_concrete_powder",
-			"blockType": true,
+			"blockType": "minecraft:lime_concrete_powder",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26262,11 +24638,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lime_concrete_powder",
-			"material": "LIME_CONCRETE_POWDER",
+			"material": "minecraft:lime_concrete_powder",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26275,8 +24650,6 @@
 			"typed": "minecraft:lime_concrete_powder"
 		},
 		{
-			"asMaterial": "minecraft:lime_dye",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26299,11 +24672,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lime_dye",
-			"material": "LIME_DYE",
+			"material": "minecraft:lime_dye",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26312,8 +24684,7 @@
 			"typed": "minecraft:lime_dye"
 		},
 		{
-			"asMaterial": "minecraft:lime_glazed_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:lime_glazed_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26336,11 +24707,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lime_glazed_terracotta",
-			"material": "LIME_GLAZED_TERRACOTTA",
+			"material": "minecraft:lime_glazed_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26349,8 +24719,7 @@
 			"typed": "minecraft:lime_glazed_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:lime_shulker_box",
-			"blockType": true,
+			"blockType": "minecraft:lime_shulker_box",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26374,11 +24743,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lime_shulker_box",
-			"material": "LIME_SHULKER_BOX",
+			"material": "minecraft:lime_shulker_box",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26387,8 +24755,7 @@
 			"typed": "minecraft:lime_shulker_box"
 		},
 		{
-			"asMaterial": "minecraft:lime_stained_glass",
-			"blockType": true,
+			"blockType": "minecraft:lime_stained_glass",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26411,11 +24778,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lime_stained_glass",
-			"material": "LIME_STAINED_GLASS",
+			"material": "minecraft:lime_stained_glass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26424,8 +24790,7 @@
 			"typed": "minecraft:lime_stained_glass"
 		},
 		{
-			"asMaterial": "minecraft:lime_stained_glass_pane",
-			"blockType": true,
+			"blockType": "minecraft:lime_stained_glass_pane",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26448,11 +24813,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lime_stained_glass_pane",
-			"material": "LIME_STAINED_GLASS_PANE",
+			"material": "minecraft:lime_stained_glass_pane",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26461,8 +24825,7 @@
 			"typed": "minecraft:lime_stained_glass_pane"
 		},
 		{
-			"asMaterial": "minecraft:lime_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:lime_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26485,11 +24848,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lime_terracotta",
-			"material": "LIME_TERRACOTTA",
+			"material": "minecraft:lime_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26498,8 +24860,7 @@
 			"typed": "minecraft:lime_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:lime_wool",
-			"blockType": true,
+			"blockType": "minecraft:lime_wool",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26522,11 +24883,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lime_wool",
-			"material": "LIME_WOOL",
+			"material": "minecraft:lime_wool",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26535,8 +24895,6 @@
 			"typed": "minecraft:lime_wool"
 		},
 		{
-			"asMaterial": "minecraft:lingering_potion",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26561,11 +24919,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lingering_potion",
-			"material": "LINGERING_POTION",
+			"material": "minecraft:lingering_potion",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "PotionMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26574,8 +24931,6 @@
 			"typed": "minecraft:lingering_potion"
 		},
 		{
-			"asMaterial": "minecraft:llama_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26598,11 +24953,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:llama_spawn_egg",
-			"material": "LLAMA_SPAWN_EGG",
+			"material": "minecraft:llama_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26611,8 +24965,7 @@
 			"typed": "minecraft:llama_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:lodestone",
-			"blockType": true,
+			"blockType": "minecraft:lodestone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26635,11 +24988,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:lodestone",
-			"material": "LODESTONE",
+			"material": "minecraft:lodestone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26648,8 +25000,7 @@
 			"typed": "minecraft:lodestone"
 		},
 		{
-			"asMaterial": "minecraft:loom",
-			"blockType": true,
+			"blockType": "minecraft:loom",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26672,11 +25023,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:loom",
-			"material": "LOOM",
+			"material": "minecraft:loom",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26685,8 +25035,6 @@
 			"typed": "minecraft:loom"
 		},
 		{
-			"asMaterial": "minecraft:mace",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26715,11 +25063,10 @@
 			"fuel": false,
 			"itemRarity": "EPIC",
 			"key": "minecraft:mace",
-			"material": "MACE",
+			"material": "minecraft:mace",
 			"maxDurability": 500,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "EPIC",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26728,8 +25075,7 @@
 			"typed": "minecraft:mace"
 		},
 		{
-			"asMaterial": "minecraft:magenta_banner",
-			"blockType": true,
+			"blockType": "minecraft:magenta_banner",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26753,11 +25099,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:magenta_banner",
-			"material": "MAGENTA_BANNER",
+			"material": "minecraft:magenta_banner",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BannerMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26766,8 +25111,7 @@
 			"typed": "minecraft:magenta_banner"
 		},
 		{
-			"asMaterial": "minecraft:magenta_bed",
-			"blockType": true,
+			"blockType": "minecraft:magenta_bed",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26790,11 +25134,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:magenta_bed",
-			"material": "MAGENTA_BED",
+			"material": "minecraft:magenta_bed",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26803,8 +25146,6 @@
 			"typed": "minecraft:magenta_bed"
 		},
 		{
-			"asMaterial": "minecraft:magenta_bundle",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26828,11 +25169,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:magenta_bundle",
-			"material": "MAGENTA_BUNDLE",
+			"material": "minecraft:magenta_bundle",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BundleMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26841,8 +25181,7 @@
 			"typed": "minecraft:magenta_bundle"
 		},
 		{
-			"asMaterial": "minecraft:magenta_candle",
-			"blockType": true,
+			"blockType": "minecraft:magenta_candle",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26865,11 +25204,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:magenta_candle",
-			"material": "MAGENTA_CANDLE",
+			"material": "minecraft:magenta_candle",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26878,8 +25216,7 @@
 			"typed": "minecraft:magenta_candle"
 		},
 		{
-			"asMaterial": "minecraft:magenta_carpet",
-			"blockType": true,
+			"blockType": "minecraft:magenta_carpet",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26903,11 +25240,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:magenta_carpet",
-			"material": "MAGENTA_CARPET",
+			"material": "minecraft:magenta_carpet",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26916,8 +25252,7 @@
 			"typed": "minecraft:magenta_carpet"
 		},
 		{
-			"asMaterial": "minecraft:magenta_concrete",
-			"blockType": true,
+			"blockType": "minecraft:magenta_concrete",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26940,11 +25275,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:magenta_concrete",
-			"material": "MAGENTA_CONCRETE",
+			"material": "minecraft:magenta_concrete",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26953,8 +25287,7 @@
 			"typed": "minecraft:magenta_concrete"
 		},
 		{
-			"asMaterial": "minecraft:magenta_concrete_powder",
-			"blockType": true,
+			"blockType": "minecraft:magenta_concrete_powder",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -26977,11 +25310,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:magenta_concrete_powder",
-			"material": "MAGENTA_CONCRETE_POWDER",
+			"material": "minecraft:magenta_concrete_powder",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -26990,8 +25322,6 @@
 			"typed": "minecraft:magenta_concrete_powder"
 		},
 		{
-			"asMaterial": "minecraft:magenta_dye",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27014,11 +25344,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:magenta_dye",
-			"material": "MAGENTA_DYE",
+			"material": "minecraft:magenta_dye",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27027,8 +25356,7 @@
 			"typed": "minecraft:magenta_dye"
 		},
 		{
-			"asMaterial": "minecraft:magenta_glazed_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:magenta_glazed_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27051,11 +25379,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:magenta_glazed_terracotta",
-			"material": "MAGENTA_GLAZED_TERRACOTTA",
+			"material": "minecraft:magenta_glazed_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27064,8 +25391,7 @@
 			"typed": "minecraft:magenta_glazed_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:magenta_shulker_box",
-			"blockType": true,
+			"blockType": "minecraft:magenta_shulker_box",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27089,11 +25415,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:magenta_shulker_box",
-			"material": "MAGENTA_SHULKER_BOX",
+			"material": "minecraft:magenta_shulker_box",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27102,8 +25427,7 @@
 			"typed": "minecraft:magenta_shulker_box"
 		},
 		{
-			"asMaterial": "minecraft:magenta_stained_glass",
-			"blockType": true,
+			"blockType": "minecraft:magenta_stained_glass",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27126,11 +25450,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:magenta_stained_glass",
-			"material": "MAGENTA_STAINED_GLASS",
+			"material": "minecraft:magenta_stained_glass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27139,8 +25462,7 @@
 			"typed": "minecraft:magenta_stained_glass"
 		},
 		{
-			"asMaterial": "minecraft:magenta_stained_glass_pane",
-			"blockType": true,
+			"blockType": "minecraft:magenta_stained_glass_pane",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27163,11 +25485,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:magenta_stained_glass_pane",
-			"material": "MAGENTA_STAINED_GLASS_PANE",
+			"material": "minecraft:magenta_stained_glass_pane",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27176,8 +25497,7 @@
 			"typed": "minecraft:magenta_stained_glass_pane"
 		},
 		{
-			"asMaterial": "minecraft:magenta_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:magenta_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27200,11 +25520,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:magenta_terracotta",
-			"material": "MAGENTA_TERRACOTTA",
+			"material": "minecraft:magenta_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27213,8 +25532,7 @@
 			"typed": "minecraft:magenta_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:magenta_wool",
-			"blockType": true,
+			"blockType": "minecraft:magenta_wool",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27237,11 +25555,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:magenta_wool",
-			"material": "MAGENTA_WOOL",
+			"material": "minecraft:magenta_wool",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27250,8 +25567,7 @@
 			"typed": "minecraft:magenta_wool"
 		},
 		{
-			"asMaterial": "minecraft:magma_block",
-			"blockType": true,
+			"blockType": "minecraft:magma_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27274,11 +25590,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:magma_block",
-			"material": "MAGMA_BLOCK",
+			"material": "minecraft:magma_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27287,8 +25602,6 @@
 			"typed": "minecraft:magma_block"
 		},
 		{
-			"asMaterial": "minecraft:magma_cream",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27311,11 +25624,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:magma_cream",
-			"material": "MAGMA_CREAM",
+			"material": "minecraft:magma_cream",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27324,8 +25636,6 @@
 			"typed": "minecraft:magma_cream"
 		},
 		{
-			"asMaterial": "minecraft:magma_cube_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27348,11 +25658,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:magma_cube_spawn_egg",
-			"material": "MAGMA_CUBE_SPAWN_EGG",
+			"material": "minecraft:magma_cube_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27361,8 +25670,6 @@
 			"typed": "minecraft:magma_cube_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:mangrove_boat",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27385,11 +25692,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mangrove_boat",
-			"material": "MANGROVE_BOAT",
+			"material": "minecraft:mangrove_boat",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27398,8 +25704,7 @@
 			"typed": "minecraft:mangrove_boat"
 		},
 		{
-			"asMaterial": "minecraft:mangrove_button",
-			"blockType": true,
+			"blockType": "minecraft:mangrove_button",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27422,11 +25727,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mangrove_button",
-			"material": "MANGROVE_BUTTON",
+			"material": "minecraft:mangrove_button",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27435,8 +25739,6 @@
 			"typed": "minecraft:mangrove_button"
 		},
 		{
-			"asMaterial": "minecraft:mangrove_chest_boat",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27459,11 +25761,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mangrove_chest_boat",
-			"material": "MANGROVE_CHEST_BOAT",
+			"material": "minecraft:mangrove_chest_boat",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27472,8 +25773,7 @@
 			"typed": "minecraft:mangrove_chest_boat"
 		},
 		{
-			"asMaterial": "minecraft:mangrove_door",
-			"blockType": true,
+			"blockType": "minecraft:mangrove_door",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27496,11 +25796,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mangrove_door",
-			"material": "MANGROVE_DOOR",
+			"material": "minecraft:mangrove_door",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27509,8 +25808,7 @@
 			"typed": "minecraft:mangrove_door"
 		},
 		{
-			"asMaterial": "minecraft:mangrove_fence",
-			"blockType": true,
+			"blockType": "minecraft:mangrove_fence",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27533,11 +25831,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mangrove_fence",
-			"material": "MANGROVE_FENCE",
+			"material": "minecraft:mangrove_fence",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27546,8 +25843,7 @@
 			"typed": "minecraft:mangrove_fence"
 		},
 		{
-			"asMaterial": "minecraft:mangrove_fence_gate",
-			"blockType": true,
+			"blockType": "minecraft:mangrove_fence_gate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27570,11 +25866,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mangrove_fence_gate",
-			"material": "MANGROVE_FENCE_GATE",
+			"material": "minecraft:mangrove_fence_gate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27583,8 +25878,7 @@
 			"typed": "minecraft:mangrove_fence_gate"
 		},
 		{
-			"asMaterial": "minecraft:mangrove_hanging_sign",
-			"blockType": true,
+			"blockType": "minecraft:mangrove_hanging_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27607,11 +25901,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mangrove_hanging_sign",
-			"material": "MANGROVE_HANGING_SIGN",
+			"material": "minecraft:mangrove_hanging_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27620,8 +25913,7 @@
 			"typed": "minecraft:mangrove_hanging_sign"
 		},
 		{
-			"asMaterial": "minecraft:mangrove_leaves",
-			"blockType": true,
+			"blockType": "minecraft:mangrove_leaves",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -27645,11 +25937,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mangrove_leaves",
-			"material": "MANGROVE_LEAVES",
+			"material": "minecraft:mangrove_leaves",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27658,8 +25949,7 @@
 			"typed": "minecraft:mangrove_leaves"
 		},
 		{
-			"asMaterial": "minecraft:mangrove_log",
-			"blockType": true,
+			"blockType": "minecraft:mangrove_log",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27682,11 +25972,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mangrove_log",
-			"material": "MANGROVE_LOG",
+			"material": "minecraft:mangrove_log",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27695,8 +25984,7 @@
 			"typed": "minecraft:mangrove_log"
 		},
 		{
-			"asMaterial": "minecraft:mangrove_planks",
-			"blockType": true,
+			"blockType": "minecraft:mangrove_planks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27719,11 +26007,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mangrove_planks",
-			"material": "MANGROVE_PLANKS",
+			"material": "minecraft:mangrove_planks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27732,8 +26019,7 @@
 			"typed": "minecraft:mangrove_planks"
 		},
 		{
-			"asMaterial": "minecraft:mangrove_pressure_plate",
-			"blockType": true,
+			"blockType": "minecraft:mangrove_pressure_plate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27756,11 +26042,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mangrove_pressure_plate",
-			"material": "MANGROVE_PRESSURE_PLATE",
+			"material": "minecraft:mangrove_pressure_plate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27769,8 +26054,7 @@
 			"typed": "minecraft:mangrove_pressure_plate"
 		},
 		{
-			"asMaterial": "minecraft:mangrove_propagule",
-			"blockType": true,
+			"blockType": "minecraft:mangrove_propagule",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -27794,11 +26078,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mangrove_propagule",
-			"material": "MANGROVE_PROPAGULE",
+			"material": "minecraft:mangrove_propagule",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27807,8 +26090,7 @@
 			"typed": "minecraft:mangrove_propagule"
 		},
 		{
-			"asMaterial": "minecraft:mangrove_roots",
-			"blockType": true,
+			"blockType": "minecraft:mangrove_roots",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -27832,11 +26114,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mangrove_roots",
-			"material": "MANGROVE_ROOTS",
+			"material": "minecraft:mangrove_roots",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27845,8 +26126,7 @@
 			"typed": "minecraft:mangrove_roots"
 		},
 		{
-			"asMaterial": "minecraft:mangrove_sign",
-			"blockType": true,
+			"blockType": "minecraft:mangrove_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27869,11 +26149,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mangrove_sign",
-			"material": "MANGROVE_SIGN",
+			"material": "minecraft:mangrove_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27882,8 +26161,7 @@
 			"typed": "minecraft:mangrove_sign"
 		},
 		{
-			"asMaterial": "minecraft:mangrove_slab",
-			"blockType": true,
+			"blockType": "minecraft:mangrove_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27906,11 +26184,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mangrove_slab",
-			"material": "MANGROVE_SLAB",
+			"material": "minecraft:mangrove_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27919,8 +26196,7 @@
 			"typed": "minecraft:mangrove_slab"
 		},
 		{
-			"asMaterial": "minecraft:mangrove_stairs",
-			"blockType": true,
+			"blockType": "minecraft:mangrove_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27943,11 +26219,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mangrove_stairs",
-			"material": "MANGROVE_STAIRS",
+			"material": "minecraft:mangrove_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27956,8 +26231,7 @@
 			"typed": "minecraft:mangrove_stairs"
 		},
 		{
-			"asMaterial": "minecraft:mangrove_trapdoor",
-			"blockType": true,
+			"blockType": "minecraft:mangrove_trapdoor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -27980,11 +26254,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mangrove_trapdoor",
-			"material": "MANGROVE_TRAPDOOR",
+			"material": "minecraft:mangrove_trapdoor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -27993,8 +26266,7 @@
 			"typed": "minecraft:mangrove_trapdoor"
 		},
 		{
-			"asMaterial": "minecraft:mangrove_wood",
-			"blockType": true,
+			"blockType": "minecraft:mangrove_wood",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -28017,11 +26289,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mangrove_wood",
-			"material": "MANGROVE_WOOD",
+			"material": "minecraft:mangrove_wood",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28030,8 +26301,6 @@
 			"typed": "minecraft:mangrove_wood"
 		},
 		{
-			"asMaterial": "minecraft:map",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -28054,11 +26323,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:map",
-			"material": "MAP",
+			"material": "minecraft:map",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28067,8 +26335,7 @@
 			"typed": "minecraft:map"
 		},
 		{
-			"asMaterial": "minecraft:medium_amethyst_bud",
-			"blockType": true,
+			"blockType": "minecraft:medium_amethyst_bud",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -28091,11 +26358,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:medium_amethyst_bud",
-			"material": "MEDIUM_AMETHYST_BUD",
+			"material": "minecraft:medium_amethyst_bud",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28104,8 +26370,7 @@
 			"typed": "minecraft:medium_amethyst_bud"
 		},
 		{
-			"asMaterial": "minecraft:melon",
-			"blockType": true,
+			"blockType": "minecraft:melon",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -28129,11 +26394,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:melon",
-			"material": "MELON",
+			"material": "minecraft:melon",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28142,8 +26406,7 @@
 			"typed": "minecraft:melon"
 		},
 		{
-			"asMaterial": "minecraft:melon_seeds",
-			"blockType": true,
+			"blockType": "minecraft:melon_stem",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -28167,11 +26430,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:melon_seeds",
-			"material": "MELON_SEEDS",
+			"material": "minecraft:melon_seeds",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28180,8 +26442,6 @@
 			"typed": "minecraft:melon_seeds"
 		},
 		{
-			"asMaterial": "minecraft:melon_slice",
-			"blockType": false,
 			"compostChance": "0.5F",
 			"compostable": true,
 			"createItemStack": {
@@ -28207,11 +26467,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:melon_slice",
-			"material": "MELON_SLICE",
+			"material": "minecraft:melon_slice",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28220,8 +26479,6 @@
 			"typed": "minecraft:melon_slice"
 		},
 		{
-			"asMaterial": "minecraft:milk_bucket",
-			"blockType": false,
 			"compostable": false,
 			"craftingRemainingItem": "minecraft:bucket",
 			"createItemStack": {
@@ -28247,11 +26504,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:milk_bucket",
-			"material": "MILK_BUCKET",
+			"material": "minecraft:milk_bucket",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28260,8 +26516,6 @@
 			"typed": "minecraft:milk_bucket"
 		},
 		{
-			"asMaterial": "minecraft:minecart",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -28284,11 +26538,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:minecart",
-			"material": "MINECART",
+			"material": "minecraft:minecart",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28297,8 +26550,6 @@
 			"typed": "minecraft:minecart"
 		},
 		{
-			"asMaterial": "minecraft:miner_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -28321,11 +26572,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:miner_pottery_sherd",
-			"material": "MINER_POTTERY_SHERD",
+			"material": "minecraft:miner_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28334,8 +26584,6 @@
 			"typed": "minecraft:miner_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:mojang_banner_pattern",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -28359,11 +26607,10 @@
 			"fuel": false,
 			"itemRarity": "RARE",
 			"key": "minecraft:mojang_banner_pattern",
-			"material": "MOJANG_BANNER_PATTERN",
+			"material": "minecraft:mojang_banner_pattern",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "RARE",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28372,8 +26619,6 @@
 			"typed": "minecraft:mojang_banner_pattern"
 		},
 		{
-			"asMaterial": "minecraft:mooshroom_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -28396,11 +26641,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mooshroom_spawn_egg",
-			"material": "MOOSHROOM_SPAWN_EGG",
+			"material": "minecraft:mooshroom_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28409,8 +26653,7 @@
 			"typed": "minecraft:mooshroom_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:moss_block",
-			"blockType": true,
+			"blockType": "minecraft:moss_block",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -28434,11 +26677,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:moss_block",
-			"material": "MOSS_BLOCK",
+			"material": "minecraft:moss_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28447,8 +26689,7 @@
 			"typed": "minecraft:moss_block"
 		},
 		{
-			"asMaterial": "minecraft:moss_carpet",
-			"blockType": true,
+			"blockType": "minecraft:moss_carpet",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -28472,11 +26713,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:moss_carpet",
-			"material": "MOSS_CARPET",
+			"material": "minecraft:moss_carpet",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28485,8 +26725,7 @@
 			"typed": "minecraft:moss_carpet"
 		},
 		{
-			"asMaterial": "minecraft:mossy_cobblestone",
-			"blockType": true,
+			"blockType": "minecraft:mossy_cobblestone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -28509,11 +26748,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mossy_cobblestone",
-			"material": "MOSSY_COBBLESTONE",
+			"material": "minecraft:mossy_cobblestone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28522,8 +26760,7 @@
 			"typed": "minecraft:mossy_cobblestone"
 		},
 		{
-			"asMaterial": "minecraft:mossy_cobblestone_slab",
-			"blockType": true,
+			"blockType": "minecraft:mossy_cobblestone_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -28546,11 +26783,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mossy_cobblestone_slab",
-			"material": "MOSSY_COBBLESTONE_SLAB",
+			"material": "minecraft:mossy_cobblestone_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28559,8 +26795,7 @@
 			"typed": "minecraft:mossy_cobblestone_slab"
 		},
 		{
-			"asMaterial": "minecraft:mossy_cobblestone_stairs",
-			"blockType": true,
+			"blockType": "minecraft:mossy_cobblestone_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -28583,11 +26818,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mossy_cobblestone_stairs",
-			"material": "MOSSY_COBBLESTONE_STAIRS",
+			"material": "minecraft:mossy_cobblestone_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28596,8 +26830,7 @@
 			"typed": "minecraft:mossy_cobblestone_stairs"
 		},
 		{
-			"asMaterial": "minecraft:mossy_cobblestone_wall",
-			"blockType": true,
+			"blockType": "minecraft:mossy_cobblestone_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -28620,11 +26853,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mossy_cobblestone_wall",
-			"material": "MOSSY_COBBLESTONE_WALL",
+			"material": "minecraft:mossy_cobblestone_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28633,8 +26865,7 @@
 			"typed": "minecraft:mossy_cobblestone_wall"
 		},
 		{
-			"asMaterial": "minecraft:mossy_stone_brick_slab",
-			"blockType": true,
+			"blockType": "minecraft:mossy_stone_brick_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -28657,11 +26888,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mossy_stone_brick_slab",
-			"material": "MOSSY_STONE_BRICK_SLAB",
+			"material": "minecraft:mossy_stone_brick_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28670,8 +26900,7 @@
 			"typed": "minecraft:mossy_stone_brick_slab"
 		},
 		{
-			"asMaterial": "minecraft:mossy_stone_brick_stairs",
-			"blockType": true,
+			"blockType": "minecraft:mossy_stone_brick_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -28694,11 +26923,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mossy_stone_brick_stairs",
-			"material": "MOSSY_STONE_BRICK_STAIRS",
+			"material": "minecraft:mossy_stone_brick_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28707,8 +26935,7 @@
 			"typed": "minecraft:mossy_stone_brick_stairs"
 		},
 		{
-			"asMaterial": "minecraft:mossy_stone_brick_wall",
-			"blockType": true,
+			"blockType": "minecraft:mossy_stone_brick_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -28731,11 +26958,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mossy_stone_brick_wall",
-			"material": "MOSSY_STONE_BRICK_WALL",
+			"material": "minecraft:mossy_stone_brick_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28744,8 +26970,7 @@
 			"typed": "minecraft:mossy_stone_brick_wall"
 		},
 		{
-			"asMaterial": "minecraft:mossy_stone_bricks",
-			"blockType": true,
+			"blockType": "minecraft:mossy_stone_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -28768,11 +26993,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mossy_stone_bricks",
-			"material": "MOSSY_STONE_BRICKS",
+			"material": "minecraft:mossy_stone_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28781,8 +27005,6 @@
 			"typed": "minecraft:mossy_stone_bricks"
 		},
 		{
-			"asMaterial": "minecraft:mourner_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -28805,11 +27027,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:mourner_pottery_sherd",
-			"material": "MOURNER_POTTERY_SHERD",
+			"material": "minecraft:mourner_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28818,8 +27039,7 @@
 			"typed": "minecraft:mourner_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:mud",
-			"blockType": true,
+			"blockType": "minecraft:mud",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -28842,11 +27062,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mud",
-			"material": "MUD",
+			"material": "minecraft:mud",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28855,8 +27074,7 @@
 			"typed": "minecraft:mud"
 		},
 		{
-			"asMaterial": "minecraft:mud_brick_slab",
-			"blockType": true,
+			"blockType": "minecraft:mud_brick_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -28879,11 +27097,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mud_brick_slab",
-			"material": "MUD_BRICK_SLAB",
+			"material": "minecraft:mud_brick_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28892,8 +27109,7 @@
 			"typed": "minecraft:mud_brick_slab"
 		},
 		{
-			"asMaterial": "minecraft:mud_brick_stairs",
-			"blockType": true,
+			"blockType": "minecraft:mud_brick_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -28916,11 +27132,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mud_brick_stairs",
-			"material": "MUD_BRICK_STAIRS",
+			"material": "minecraft:mud_brick_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28929,8 +27144,7 @@
 			"typed": "minecraft:mud_brick_stairs"
 		},
 		{
-			"asMaterial": "minecraft:mud_brick_wall",
-			"blockType": true,
+			"blockType": "minecraft:mud_brick_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -28953,11 +27167,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mud_brick_wall",
-			"material": "MUD_BRICK_WALL",
+			"material": "minecraft:mud_brick_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -28966,8 +27179,7 @@
 			"typed": "minecraft:mud_brick_wall"
 		},
 		{
-			"asMaterial": "minecraft:mud_bricks",
-			"blockType": true,
+			"blockType": "minecraft:mud_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -28990,11 +27202,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mud_bricks",
-			"material": "MUD_BRICKS",
+			"material": "minecraft:mud_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29003,8 +27214,7 @@
 			"typed": "minecraft:mud_bricks"
 		},
 		{
-			"asMaterial": "minecraft:muddy_mangrove_roots",
-			"blockType": true,
+			"blockType": "minecraft:muddy_mangrove_roots",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29027,11 +27237,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:muddy_mangrove_roots",
-			"material": "MUDDY_MANGROVE_ROOTS",
+			"material": "minecraft:muddy_mangrove_roots",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29040,8 +27249,6 @@
 			"typed": "minecraft:muddy_mangrove_roots"
 		},
 		{
-			"asMaterial": "minecraft:mule_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29064,11 +27271,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mule_spawn_egg",
-			"material": "MULE_SPAWN_EGG",
+			"material": "minecraft:mule_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29077,8 +27283,7 @@
 			"typed": "minecraft:mule_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:mushroom_stem",
-			"blockType": true,
+			"blockType": "minecraft:mushroom_stem",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -29102,11 +27307,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mushroom_stem",
-			"material": "MUSHROOM_STEM",
+			"material": "minecraft:mushroom_stem",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29115,8 +27319,6 @@
 			"typed": "minecraft:mushroom_stem"
 		},
 		{
-			"asMaterial": "minecraft:mushroom_stew",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29142,11 +27344,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mushroom_stew",
-			"material": "MUSHROOM_STEW",
+			"material": "minecraft:mushroom_stew",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29155,8 +27356,6 @@
 			"typed": "minecraft:mushroom_stew"
 		},
 		{
-			"asMaterial": "minecraft:music_disc_11",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29180,11 +27379,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:music_disc_11",
-			"material": "MUSIC_DISC_11",
+			"material": "minecraft:music_disc_11",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29193,8 +27391,6 @@
 			"typed": "minecraft:music_disc_11"
 		},
 		{
-			"asMaterial": "minecraft:music_disc_13",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29218,11 +27414,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:music_disc_13",
-			"material": "MUSIC_DISC_13",
+			"material": "minecraft:music_disc_13",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29231,8 +27426,6 @@
 			"typed": "minecraft:music_disc_13"
 		},
 		{
-			"asMaterial": "minecraft:music_disc_5",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29256,11 +27449,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:music_disc_5",
-			"material": "MUSIC_DISC_5",
+			"material": "minecraft:music_disc_5",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29269,8 +27461,6 @@
 			"typed": "minecraft:music_disc_5"
 		},
 		{
-			"asMaterial": "minecraft:music_disc_blocks",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29294,11 +27484,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:music_disc_blocks",
-			"material": "MUSIC_DISC_BLOCKS",
+			"material": "minecraft:music_disc_blocks",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29307,8 +27496,6 @@
 			"typed": "minecraft:music_disc_blocks"
 		},
 		{
-			"asMaterial": "minecraft:music_disc_cat",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29332,11 +27519,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:music_disc_cat",
-			"material": "MUSIC_DISC_CAT",
+			"material": "minecraft:music_disc_cat",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29345,8 +27531,6 @@
 			"typed": "minecraft:music_disc_cat"
 		},
 		{
-			"asMaterial": "minecraft:music_disc_chirp",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29370,11 +27554,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:music_disc_chirp",
-			"material": "MUSIC_DISC_CHIRP",
+			"material": "minecraft:music_disc_chirp",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29383,8 +27566,6 @@
 			"typed": "minecraft:music_disc_chirp"
 		},
 		{
-			"asMaterial": "minecraft:music_disc_creator",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29408,11 +27589,10 @@
 			"fuel": false,
 			"itemRarity": "RARE",
 			"key": "minecraft:music_disc_creator",
-			"material": "MUSIC_DISC_CREATOR",
+			"material": "minecraft:music_disc_creator",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "RARE",
 			"record": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29421,8 +27601,6 @@
 			"typed": "minecraft:music_disc_creator"
 		},
 		{
-			"asMaterial": "minecraft:music_disc_creator_music_box",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29446,11 +27624,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:music_disc_creator_music_box",
-			"material": "MUSIC_DISC_CREATOR_MUSIC_BOX",
+			"material": "minecraft:music_disc_creator_music_box",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29459,8 +27636,6 @@
 			"typed": "minecraft:music_disc_creator_music_box"
 		},
 		{
-			"asMaterial": "minecraft:music_disc_far",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29484,11 +27659,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:music_disc_far",
-			"material": "MUSIC_DISC_FAR",
+			"material": "minecraft:music_disc_far",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29497,8 +27671,6 @@
 			"typed": "minecraft:music_disc_far"
 		},
 		{
-			"asMaterial": "minecraft:music_disc_mall",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29522,11 +27694,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:music_disc_mall",
-			"material": "MUSIC_DISC_MALL",
+			"material": "minecraft:music_disc_mall",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29535,8 +27706,6 @@
 			"typed": "minecraft:music_disc_mall"
 		},
 		{
-			"asMaterial": "minecraft:music_disc_mellohi",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29560,11 +27729,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:music_disc_mellohi",
-			"material": "MUSIC_DISC_MELLOHI",
+			"material": "minecraft:music_disc_mellohi",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29573,8 +27741,6 @@
 			"typed": "minecraft:music_disc_mellohi"
 		},
 		{
-			"asMaterial": "minecraft:music_disc_otherside",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29598,11 +27764,10 @@
 			"fuel": false,
 			"itemRarity": "RARE",
 			"key": "minecraft:music_disc_otherside",
-			"material": "MUSIC_DISC_OTHERSIDE",
+			"material": "minecraft:music_disc_otherside",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "RARE",
 			"record": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29611,8 +27776,6 @@
 			"typed": "minecraft:music_disc_otherside"
 		},
 		{
-			"asMaterial": "minecraft:music_disc_pigstep",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29636,11 +27799,10 @@
 			"fuel": false,
 			"itemRarity": "RARE",
 			"key": "minecraft:music_disc_pigstep",
-			"material": "MUSIC_DISC_PIGSTEP",
+			"material": "minecraft:music_disc_pigstep",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "RARE",
 			"record": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29649,8 +27811,6 @@
 			"typed": "minecraft:music_disc_pigstep"
 		},
 		{
-			"asMaterial": "minecraft:music_disc_precipice",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29674,11 +27834,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:music_disc_precipice",
-			"material": "MUSIC_DISC_PRECIPICE",
+			"material": "minecraft:music_disc_precipice",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29687,8 +27846,6 @@
 			"typed": "minecraft:music_disc_precipice"
 		},
 		{
-			"asMaterial": "minecraft:music_disc_relic",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29712,11 +27869,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:music_disc_relic",
-			"material": "MUSIC_DISC_RELIC",
+			"material": "minecraft:music_disc_relic",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29725,8 +27881,6 @@
 			"typed": "minecraft:music_disc_relic"
 		},
 		{
-			"asMaterial": "minecraft:music_disc_stal",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29750,11 +27904,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:music_disc_stal",
-			"material": "MUSIC_DISC_STAL",
+			"material": "minecraft:music_disc_stal",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29763,8 +27916,6 @@
 			"typed": "minecraft:music_disc_stal"
 		},
 		{
-			"asMaterial": "minecraft:music_disc_strad",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29788,11 +27939,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:music_disc_strad",
-			"material": "MUSIC_DISC_STRAD",
+			"material": "minecraft:music_disc_strad",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29801,8 +27951,6 @@
 			"typed": "minecraft:music_disc_strad"
 		},
 		{
-			"asMaterial": "minecraft:music_disc_wait",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29826,11 +27974,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:music_disc_wait",
-			"material": "MUSIC_DISC_WAIT",
+			"material": "minecraft:music_disc_wait",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29839,8 +27986,6 @@
 			"typed": "minecraft:music_disc_wait"
 		},
 		{
-			"asMaterial": "minecraft:music_disc_ward",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29864,11 +28009,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:music_disc_ward",
-			"material": "MUSIC_DISC_WARD",
+			"material": "minecraft:music_disc_ward",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": true,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29877,8 +28021,6 @@
 			"typed": "minecraft:music_disc_ward"
 		},
 		{
-			"asMaterial": "minecraft:mutton",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29903,11 +28045,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mutton",
-			"material": "MUTTON",
+			"material": "minecraft:mutton",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29916,8 +28057,7 @@
 			"typed": "minecraft:mutton"
 		},
 		{
-			"asMaterial": "minecraft:mycelium",
-			"blockType": true,
+			"blockType": "minecraft:mycelium",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29940,11 +28080,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:mycelium",
-			"material": "MYCELIUM",
+			"material": "minecraft:mycelium",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29953,8 +28092,6 @@
 			"typed": "minecraft:mycelium"
 		},
 		{
-			"asMaterial": "minecraft:name_tag",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -29977,11 +28114,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:name_tag",
-			"material": "NAME_TAG",
+			"material": "minecraft:name_tag",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -29990,8 +28126,6 @@
 			"typed": "minecraft:name_tag"
 		},
 		{
-			"asMaterial": "minecraft:nautilus_shell",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -30014,11 +28148,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:nautilus_shell",
-			"material": "NAUTILUS_SHELL",
+			"material": "minecraft:nautilus_shell",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30027,8 +28160,6 @@
 			"typed": "minecraft:nautilus_shell"
 		},
 		{
-			"asMaterial": "minecraft:nether_brick",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -30051,11 +28182,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:nether_brick",
-			"material": "NETHER_BRICK",
+			"material": "minecraft:nether_brick",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30064,8 +28194,7 @@
 			"typed": "minecraft:nether_brick"
 		},
 		{
-			"asMaterial": "minecraft:nether_brick_fence",
-			"blockType": true,
+			"blockType": "minecraft:nether_brick_fence",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -30088,11 +28217,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:nether_brick_fence",
-			"material": "NETHER_BRICK_FENCE",
+			"material": "minecraft:nether_brick_fence",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30101,8 +28229,7 @@
 			"typed": "minecraft:nether_brick_fence"
 		},
 		{
-			"asMaterial": "minecraft:nether_brick_slab",
-			"blockType": true,
+			"blockType": "minecraft:nether_brick_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -30125,11 +28252,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:nether_brick_slab",
-			"material": "NETHER_BRICK_SLAB",
+			"material": "minecraft:nether_brick_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30138,8 +28264,7 @@
 			"typed": "minecraft:nether_brick_slab"
 		},
 		{
-			"asMaterial": "minecraft:nether_brick_stairs",
-			"blockType": true,
+			"blockType": "minecraft:nether_brick_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -30162,11 +28287,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:nether_brick_stairs",
-			"material": "NETHER_BRICK_STAIRS",
+			"material": "minecraft:nether_brick_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30175,8 +28299,7 @@
 			"typed": "minecraft:nether_brick_stairs"
 		},
 		{
-			"asMaterial": "minecraft:nether_brick_wall",
-			"blockType": true,
+			"blockType": "minecraft:nether_brick_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -30199,11 +28322,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:nether_brick_wall",
-			"material": "NETHER_BRICK_WALL",
+			"material": "minecraft:nether_brick_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30212,8 +28334,7 @@
 			"typed": "minecraft:nether_brick_wall"
 		},
 		{
-			"asMaterial": "minecraft:nether_bricks",
-			"blockType": true,
+			"blockType": "minecraft:nether_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -30236,11 +28357,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:nether_bricks",
-			"material": "NETHER_BRICKS",
+			"material": "minecraft:nether_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30249,8 +28369,7 @@
 			"typed": "minecraft:nether_bricks"
 		},
 		{
-			"asMaterial": "minecraft:nether_gold_ore",
-			"blockType": true,
+			"blockType": "minecraft:nether_gold_ore",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -30273,11 +28392,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:nether_gold_ore",
-			"material": "NETHER_GOLD_ORE",
+			"material": "minecraft:nether_gold_ore",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30286,8 +28404,7 @@
 			"typed": "minecraft:nether_gold_ore"
 		},
 		{
-			"asMaterial": "minecraft:nether_quartz_ore",
-			"blockType": true,
+			"blockType": "minecraft:nether_quartz_ore",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -30310,11 +28427,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:nether_quartz_ore",
-			"material": "NETHER_QUARTZ_ORE",
+			"material": "minecraft:nether_quartz_ore",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30323,8 +28439,7 @@
 			"typed": "minecraft:nether_quartz_ore"
 		},
 		{
-			"asMaterial": "minecraft:nether_sprouts",
-			"blockType": true,
+			"blockType": "minecraft:nether_sprouts",
 			"compostChance": "0.5F",
 			"compostable": true,
 			"createItemStack": {
@@ -30348,11 +28463,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:nether_sprouts",
-			"material": "NETHER_SPROUTS",
+			"material": "minecraft:nether_sprouts",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30361,8 +28475,6 @@
 			"typed": "minecraft:nether_sprouts"
 		},
 		{
-			"asMaterial": "minecraft:nether_star",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -30387,11 +28499,10 @@
 			"fuel": false,
 			"itemRarity": "RARE",
 			"key": "minecraft:nether_star",
-			"material": "NETHER_STAR",
+			"material": "minecraft:nether_star",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "RARE",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30400,8 +28511,7 @@
 			"typed": "minecraft:nether_star"
 		},
 		{
-			"asMaterial": "minecraft:nether_wart",
-			"blockType": true,
+			"blockType": "minecraft:nether_wart",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -30425,11 +28535,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:nether_wart",
-			"material": "NETHER_WART",
+			"material": "minecraft:nether_wart",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30438,8 +28547,7 @@
 			"typed": "minecraft:nether_wart"
 		},
 		{
-			"asMaterial": "minecraft:nether_wart_block",
-			"blockType": true,
+			"blockType": "minecraft:nether_wart_block",
 			"compostChance": "0.85F",
 			"compostable": true,
 			"createItemStack": {
@@ -30463,11 +28571,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:nether_wart_block",
-			"material": "NETHER_WART_BLOCK",
+			"material": "minecraft:nether_wart_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30476,8 +28583,6 @@
 			"typed": "minecraft:nether_wart_block"
 		},
 		{
-			"asMaterial": "minecraft:netherite_axe",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -30507,11 +28612,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:netherite_axe",
-			"material": "NETHERITE_AXE",
+			"material": "minecraft:netherite_axe",
 			"maxDurability": 2031,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30520,8 +28624,7 @@
 			"typed": "minecraft:netherite_axe"
 		},
 		{
-			"asMaterial": "minecraft:netherite_block",
-			"blockType": true,
+			"blockType": "minecraft:netherite_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -30545,11 +28648,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:netherite_block",
-			"material": "NETHERITE_BLOCK",
+			"material": "minecraft:netherite_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30558,8 +28660,6 @@
 			"typed": "minecraft:netherite_block"
 		},
 		{
-			"asMaterial": "minecraft:netherite_boots",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -30588,11 +28688,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:netherite_boots",
-			"material": "NETHERITE_BOOTS",
+			"material": "minecraft:netherite_boots",
 			"maxDurability": 481,
 			"maxStackSize": 1,
 			"metaClass": "ArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30601,8 +28700,6 @@
 			"typed": "minecraft:netherite_boots"
 		},
 		{
-			"asMaterial": "minecraft:netherite_chestplate",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -30631,11 +28728,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:netherite_chestplate",
-			"material": "NETHERITE_CHESTPLATE",
+			"material": "minecraft:netherite_chestplate",
 			"maxDurability": 592,
 			"maxStackSize": 1,
 			"metaClass": "ArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30644,8 +28740,6 @@
 			"typed": "minecraft:netherite_chestplate"
 		},
 		{
-			"asMaterial": "minecraft:netherite_helmet",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -30674,11 +28768,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:netherite_helmet",
-			"material": "NETHERITE_HELMET",
+			"material": "minecraft:netherite_helmet",
 			"maxDurability": 407,
 			"maxStackSize": 1,
 			"metaClass": "ArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30687,8 +28780,6 @@
 			"typed": "minecraft:netherite_helmet"
 		},
 		{
-			"asMaterial": "minecraft:netherite_hoe",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -30718,11 +28809,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:netherite_hoe",
-			"material": "NETHERITE_HOE",
+			"material": "minecraft:netherite_hoe",
 			"maxDurability": 2031,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30731,8 +28821,6 @@
 			"typed": "minecraft:netherite_hoe"
 		},
 		{
-			"asMaterial": "minecraft:netherite_ingot",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -30757,11 +28845,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:netherite_ingot",
-			"material": "NETHERITE_INGOT",
+			"material": "minecraft:netherite_ingot",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30770,8 +28857,6 @@
 			"typed": "minecraft:netherite_ingot"
 		},
 		{
-			"asMaterial": "minecraft:netherite_leggings",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -30800,11 +28885,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:netherite_leggings",
-			"material": "NETHERITE_LEGGINGS",
+			"material": "minecraft:netherite_leggings",
 			"maxDurability": 555,
 			"maxStackSize": 1,
 			"metaClass": "ArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30813,8 +28897,6 @@
 			"typed": "minecraft:netherite_leggings"
 		},
 		{
-			"asMaterial": "minecraft:netherite_pickaxe",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -30844,11 +28926,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:netherite_pickaxe",
-			"material": "NETHERITE_PICKAXE",
+			"material": "minecraft:netherite_pickaxe",
 			"maxDurability": 2031,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30857,8 +28938,6 @@
 			"typed": "minecraft:netherite_pickaxe"
 		},
 		{
-			"asMaterial": "minecraft:netherite_scrap",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -30882,11 +28961,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:netherite_scrap",
-			"material": "NETHERITE_SCRAP",
+			"material": "minecraft:netherite_scrap",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30895,8 +28973,6 @@
 			"typed": "minecraft:netherite_scrap"
 		},
 		{
-			"asMaterial": "minecraft:netherite_shovel",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -30926,11 +29002,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:netherite_shovel",
-			"material": "NETHERITE_SHOVEL",
+			"material": "minecraft:netherite_shovel",
 			"maxDurability": 2031,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30939,8 +29014,6 @@
 			"typed": "minecraft:netherite_shovel"
 		},
 		{
-			"asMaterial": "minecraft:netherite_sword",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -30970,11 +29043,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:netherite_sword",
-			"material": "NETHERITE_SWORD",
+			"material": "minecraft:netherite_sword",
 			"maxDurability": 2031,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -30983,8 +29055,6 @@
 			"typed": "minecraft:netherite_sword"
 		},
 		{
-			"asMaterial": "minecraft:netherite_upgrade_smithing_template",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31007,11 +29077,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:netherite_upgrade_smithing_template",
-			"material": "NETHERITE_UPGRADE_SMITHING_TEMPLATE",
+			"material": "minecraft:netherite_upgrade_smithing_template",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31020,8 +29089,7 @@
 			"typed": "minecraft:netherite_upgrade_smithing_template"
 		},
 		{
-			"asMaterial": "minecraft:netherrack",
-			"blockType": true,
+			"blockType": "minecraft:netherrack",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31044,11 +29112,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:netherrack",
-			"material": "NETHERRACK",
+			"material": "minecraft:netherrack",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31057,8 +29124,7 @@
 			"typed": "minecraft:netherrack"
 		},
 		{
-			"asMaterial": "minecraft:note_block",
-			"blockType": true,
+			"blockType": "minecraft:note_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31081,11 +29147,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:note_block",
-			"material": "NOTE_BLOCK",
+			"material": "minecraft:note_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31094,8 +29159,6 @@
 			"typed": "minecraft:note_block"
 		},
 		{
-			"asMaterial": "minecraft:oak_boat",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31118,11 +29181,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oak_boat",
-			"material": "OAK_BOAT",
+			"material": "minecraft:oak_boat",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31131,8 +29193,7 @@
 			"typed": "minecraft:oak_boat"
 		},
 		{
-			"asMaterial": "minecraft:oak_button",
-			"blockType": true,
+			"blockType": "minecraft:oak_button",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31155,11 +29216,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oak_button",
-			"material": "OAK_BUTTON",
+			"material": "minecraft:oak_button",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31168,8 +29228,6 @@
 			"typed": "minecraft:oak_button"
 		},
 		{
-			"asMaterial": "minecraft:oak_chest_boat",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31192,11 +29250,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oak_chest_boat",
-			"material": "OAK_CHEST_BOAT",
+			"material": "minecraft:oak_chest_boat",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31205,8 +29262,7 @@
 			"typed": "minecraft:oak_chest_boat"
 		},
 		{
-			"asMaterial": "minecraft:oak_door",
-			"blockType": true,
+			"blockType": "minecraft:oak_door",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31229,11 +29285,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oak_door",
-			"material": "OAK_DOOR",
+			"material": "minecraft:oak_door",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31242,8 +29297,7 @@
 			"typed": "minecraft:oak_door"
 		},
 		{
-			"asMaterial": "minecraft:oak_fence",
-			"blockType": true,
+			"blockType": "minecraft:oak_fence",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31266,11 +29320,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oak_fence",
-			"material": "OAK_FENCE",
+			"material": "minecraft:oak_fence",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31279,8 +29332,7 @@
 			"typed": "minecraft:oak_fence"
 		},
 		{
-			"asMaterial": "minecraft:oak_fence_gate",
-			"blockType": true,
+			"blockType": "minecraft:oak_fence_gate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31303,11 +29355,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oak_fence_gate",
-			"material": "OAK_FENCE_GATE",
+			"material": "minecraft:oak_fence_gate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31316,8 +29367,7 @@
 			"typed": "minecraft:oak_fence_gate"
 		},
 		{
-			"asMaterial": "minecraft:oak_hanging_sign",
-			"blockType": true,
+			"blockType": "minecraft:oak_hanging_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31340,11 +29390,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oak_hanging_sign",
-			"material": "OAK_HANGING_SIGN",
+			"material": "minecraft:oak_hanging_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31353,8 +29402,7 @@
 			"typed": "minecraft:oak_hanging_sign"
 		},
 		{
-			"asMaterial": "minecraft:oak_leaves",
-			"blockType": true,
+			"blockType": "minecraft:oak_leaves",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -31378,11 +29426,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oak_leaves",
-			"material": "OAK_LEAVES",
+			"material": "minecraft:oak_leaves",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31391,8 +29438,7 @@
 			"typed": "minecraft:oak_leaves"
 		},
 		{
-			"asMaterial": "minecraft:oak_log",
-			"blockType": true,
+			"blockType": "minecraft:oak_log",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31415,11 +29461,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oak_log",
-			"material": "OAK_LOG",
+			"material": "minecraft:oak_log",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31428,8 +29473,7 @@
 			"typed": "minecraft:oak_log"
 		},
 		{
-			"asMaterial": "minecraft:oak_planks",
-			"blockType": true,
+			"blockType": "minecraft:oak_planks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31452,11 +29496,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oak_planks",
-			"material": "OAK_PLANKS",
+			"material": "minecraft:oak_planks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31465,8 +29508,7 @@
 			"typed": "minecraft:oak_planks"
 		},
 		{
-			"asMaterial": "minecraft:oak_pressure_plate",
-			"blockType": true,
+			"blockType": "minecraft:oak_pressure_plate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31489,11 +29531,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oak_pressure_plate",
-			"material": "OAK_PRESSURE_PLATE",
+			"material": "minecraft:oak_pressure_plate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31502,8 +29543,7 @@
 			"typed": "minecraft:oak_pressure_plate"
 		},
 		{
-			"asMaterial": "minecraft:oak_sapling",
-			"blockType": true,
+			"blockType": "minecraft:oak_sapling",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -31527,11 +29567,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oak_sapling",
-			"material": "OAK_SAPLING",
+			"material": "minecraft:oak_sapling",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31540,8 +29579,7 @@
 			"typed": "minecraft:oak_sapling"
 		},
 		{
-			"asMaterial": "minecraft:oak_sign",
-			"blockType": true,
+			"blockType": "minecraft:oak_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31564,11 +29602,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oak_sign",
-			"material": "OAK_SIGN",
+			"material": "minecraft:oak_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31577,8 +29614,7 @@
 			"typed": "minecraft:oak_sign"
 		},
 		{
-			"asMaterial": "minecraft:oak_slab",
-			"blockType": true,
+			"blockType": "minecraft:oak_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31601,11 +29637,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oak_slab",
-			"material": "OAK_SLAB",
+			"material": "minecraft:oak_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31614,8 +29649,7 @@
 			"typed": "minecraft:oak_slab"
 		},
 		{
-			"asMaterial": "minecraft:oak_stairs",
-			"blockType": true,
+			"blockType": "minecraft:oak_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31638,11 +29672,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oak_stairs",
-			"material": "OAK_STAIRS",
+			"material": "minecraft:oak_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31651,8 +29684,7 @@
 			"typed": "minecraft:oak_stairs"
 		},
 		{
-			"asMaterial": "minecraft:oak_trapdoor",
-			"blockType": true,
+			"blockType": "minecraft:oak_trapdoor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31675,11 +29707,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oak_trapdoor",
-			"material": "OAK_TRAPDOOR",
+			"material": "minecraft:oak_trapdoor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31688,8 +29719,7 @@
 			"typed": "minecraft:oak_trapdoor"
 		},
 		{
-			"asMaterial": "minecraft:oak_wood",
-			"blockType": true,
+			"blockType": "minecraft:oak_wood",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31712,11 +29742,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oak_wood",
-			"material": "OAK_WOOD",
+			"material": "minecraft:oak_wood",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31725,8 +29754,7 @@
 			"typed": "minecraft:oak_wood"
 		},
 		{
-			"asMaterial": "minecraft:observer",
-			"blockType": true,
+			"blockType": "minecraft:observer",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31749,11 +29777,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:observer",
-			"material": "OBSERVER",
+			"material": "minecraft:observer",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31762,8 +29789,7 @@
 			"typed": "minecraft:observer"
 		},
 		{
-			"asMaterial": "minecraft:obsidian",
-			"blockType": true,
+			"blockType": "minecraft:obsidian",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31786,11 +29812,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:obsidian",
-			"material": "OBSIDIAN",
+			"material": "minecraft:obsidian",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31799,8 +29824,6 @@
 			"typed": "minecraft:obsidian"
 		},
 		{
-			"asMaterial": "minecraft:ocelot_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31823,11 +29846,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:ocelot_spawn_egg",
-			"material": "OCELOT_SPAWN_EGG",
+			"material": "minecraft:ocelot_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31836,8 +29858,7 @@
 			"typed": "minecraft:ocelot_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:ochre_froglight",
-			"blockType": true,
+			"blockType": "minecraft:ochre_froglight",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31860,11 +29881,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:ochre_froglight",
-			"material": "OCHRE_FROGLIGHT",
+			"material": "minecraft:ochre_froglight",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31873,8 +29893,6 @@
 			"typed": "minecraft:ochre_froglight"
 		},
 		{
-			"asMaterial": "minecraft:ominous_bottle",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31899,11 +29917,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:ominous_bottle",
-			"material": "OMINOUS_BOTTLE",
+			"material": "minecraft:ominous_bottle",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "OminousBottleMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31912,8 +29929,6 @@
 			"typed": "minecraft:ominous_bottle"
 		},
 		{
-			"asMaterial": "minecraft:ominous_trial_key",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -31936,11 +29951,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:ominous_trial_key",
-			"material": "OMINOUS_TRIAL_KEY",
+			"material": "minecraft:ominous_trial_key",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31949,8 +29963,7 @@
 			"typed": "minecraft:ominous_trial_key"
 		},
 		{
-			"asMaterial": "minecraft:open_eyeblossom",
-			"blockType": true,
+			"blockType": "minecraft:open_eyeblossom",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -31974,11 +29987,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:open_eyeblossom",
-			"material": "OPEN_EYEBLOSSOM",
+			"material": "minecraft:open_eyeblossom",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -31987,8 +29999,7 @@
 			"typed": "minecraft:open_eyeblossom"
 		},
 		{
-			"asMaterial": "minecraft:orange_banner",
-			"blockType": true,
+			"blockType": "minecraft:orange_banner",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32012,11 +30023,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:orange_banner",
-			"material": "ORANGE_BANNER",
+			"material": "minecraft:orange_banner",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BannerMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32025,8 +30035,7 @@
 			"typed": "minecraft:orange_banner"
 		},
 		{
-			"asMaterial": "minecraft:orange_bed",
-			"blockType": true,
+			"blockType": "minecraft:orange_bed",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32049,11 +30058,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:orange_bed",
-			"material": "ORANGE_BED",
+			"material": "minecraft:orange_bed",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32062,8 +30070,6 @@
 			"typed": "minecraft:orange_bed"
 		},
 		{
-			"asMaterial": "minecraft:orange_bundle",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32087,11 +30093,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:orange_bundle",
-			"material": "ORANGE_BUNDLE",
+			"material": "minecraft:orange_bundle",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BundleMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32100,8 +30105,7 @@
 			"typed": "minecraft:orange_bundle"
 		},
 		{
-			"asMaterial": "minecraft:orange_candle",
-			"blockType": true,
+			"blockType": "minecraft:orange_candle",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32124,11 +30128,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:orange_candle",
-			"material": "ORANGE_CANDLE",
+			"material": "minecraft:orange_candle",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32137,8 +30140,7 @@
 			"typed": "minecraft:orange_candle"
 		},
 		{
-			"asMaterial": "minecraft:orange_carpet",
-			"blockType": true,
+			"blockType": "minecraft:orange_carpet",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32162,11 +30164,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:orange_carpet",
-			"material": "ORANGE_CARPET",
+			"material": "minecraft:orange_carpet",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32175,8 +30176,7 @@
 			"typed": "minecraft:orange_carpet"
 		},
 		{
-			"asMaterial": "minecraft:orange_concrete",
-			"blockType": true,
+			"blockType": "minecraft:orange_concrete",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32199,11 +30199,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:orange_concrete",
-			"material": "ORANGE_CONCRETE",
+			"material": "minecraft:orange_concrete",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32212,8 +30211,7 @@
 			"typed": "minecraft:orange_concrete"
 		},
 		{
-			"asMaterial": "minecraft:orange_concrete_powder",
-			"blockType": true,
+			"blockType": "minecraft:orange_concrete_powder",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32236,11 +30234,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:orange_concrete_powder",
-			"material": "ORANGE_CONCRETE_POWDER",
+			"material": "minecraft:orange_concrete_powder",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32249,8 +30246,6 @@
 			"typed": "minecraft:orange_concrete_powder"
 		},
 		{
-			"asMaterial": "minecraft:orange_dye",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32273,11 +30268,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:orange_dye",
-			"material": "ORANGE_DYE",
+			"material": "minecraft:orange_dye",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32286,8 +30280,7 @@
 			"typed": "minecraft:orange_dye"
 		},
 		{
-			"asMaterial": "minecraft:orange_glazed_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:orange_glazed_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32310,11 +30303,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:orange_glazed_terracotta",
-			"material": "ORANGE_GLAZED_TERRACOTTA",
+			"material": "minecraft:orange_glazed_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32323,8 +30315,7 @@
 			"typed": "minecraft:orange_glazed_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:orange_shulker_box",
-			"blockType": true,
+			"blockType": "minecraft:orange_shulker_box",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32348,11 +30339,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:orange_shulker_box",
-			"material": "ORANGE_SHULKER_BOX",
+			"material": "minecraft:orange_shulker_box",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32361,8 +30351,7 @@
 			"typed": "minecraft:orange_shulker_box"
 		},
 		{
-			"asMaterial": "minecraft:orange_stained_glass",
-			"blockType": true,
+			"blockType": "minecraft:orange_stained_glass",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32385,11 +30374,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:orange_stained_glass",
-			"material": "ORANGE_STAINED_GLASS",
+			"material": "minecraft:orange_stained_glass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32398,8 +30386,7 @@
 			"typed": "minecraft:orange_stained_glass"
 		},
 		{
-			"asMaterial": "minecraft:orange_stained_glass_pane",
-			"blockType": true,
+			"blockType": "minecraft:orange_stained_glass_pane",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32422,11 +30409,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:orange_stained_glass_pane",
-			"material": "ORANGE_STAINED_GLASS_PANE",
+			"material": "minecraft:orange_stained_glass_pane",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32435,8 +30421,7 @@
 			"typed": "minecraft:orange_stained_glass_pane"
 		},
 		{
-			"asMaterial": "minecraft:orange_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:orange_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32459,11 +30444,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:orange_terracotta",
-			"material": "ORANGE_TERRACOTTA",
+			"material": "minecraft:orange_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32472,8 +30456,7 @@
 			"typed": "minecraft:orange_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:orange_tulip",
-			"blockType": true,
+			"blockType": "minecraft:orange_tulip",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -32497,11 +30480,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:orange_tulip",
-			"material": "ORANGE_TULIP",
+			"material": "minecraft:orange_tulip",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32510,8 +30492,7 @@
 			"typed": "minecraft:orange_tulip"
 		},
 		{
-			"asMaterial": "minecraft:orange_wool",
-			"blockType": true,
+			"blockType": "minecraft:orange_wool",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32534,11 +30515,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:orange_wool",
-			"material": "ORANGE_WOOL",
+			"material": "minecraft:orange_wool",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32547,8 +30527,7 @@
 			"typed": "minecraft:orange_wool"
 		},
 		{
-			"asMaterial": "minecraft:oxeye_daisy",
-			"blockType": true,
+			"blockType": "minecraft:oxeye_daisy",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -32572,11 +30551,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oxeye_daisy",
-			"material": "OXEYE_DAISY",
+			"material": "minecraft:oxeye_daisy",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32585,8 +30563,7 @@
 			"typed": "minecraft:oxeye_daisy"
 		},
 		{
-			"asMaterial": "minecraft:oxidized_chiseled_copper",
-			"blockType": true,
+			"blockType": "minecraft:oxidized_chiseled_copper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32609,11 +30586,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oxidized_chiseled_copper",
-			"material": "OXIDIZED_CHISELED_COPPER",
+			"material": "minecraft:oxidized_chiseled_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32622,8 +30598,7 @@
 			"typed": "minecraft:oxidized_chiseled_copper"
 		},
 		{
-			"asMaterial": "minecraft:oxidized_copper",
-			"blockType": true,
+			"blockType": "minecraft:oxidized_copper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32646,11 +30621,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oxidized_copper",
-			"material": "OXIDIZED_COPPER",
+			"material": "minecraft:oxidized_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32659,8 +30633,7 @@
 			"typed": "minecraft:oxidized_copper"
 		},
 		{
-			"asMaterial": "minecraft:oxidized_copper_bulb",
-			"blockType": true,
+			"blockType": "minecraft:oxidized_copper_bulb",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32683,11 +30656,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oxidized_copper_bulb",
-			"material": "OXIDIZED_COPPER_BULB",
+			"material": "minecraft:oxidized_copper_bulb",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32696,8 +30668,7 @@
 			"typed": "minecraft:oxidized_copper_bulb"
 		},
 		{
-			"asMaterial": "minecraft:oxidized_copper_door",
-			"blockType": true,
+			"blockType": "minecraft:oxidized_copper_door",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32720,11 +30691,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oxidized_copper_door",
-			"material": "OXIDIZED_COPPER_DOOR",
+			"material": "minecraft:oxidized_copper_door",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32733,8 +30703,7 @@
 			"typed": "minecraft:oxidized_copper_door"
 		},
 		{
-			"asMaterial": "minecraft:oxidized_copper_grate",
-			"blockType": true,
+			"blockType": "minecraft:oxidized_copper_grate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32757,11 +30726,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oxidized_copper_grate",
-			"material": "OXIDIZED_COPPER_GRATE",
+			"material": "minecraft:oxidized_copper_grate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32770,8 +30738,7 @@
 			"typed": "minecraft:oxidized_copper_grate"
 		},
 		{
-			"asMaterial": "minecraft:oxidized_copper_trapdoor",
-			"blockType": true,
+			"blockType": "minecraft:oxidized_copper_trapdoor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32794,11 +30761,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oxidized_copper_trapdoor",
-			"material": "OXIDIZED_COPPER_TRAPDOOR",
+			"material": "minecraft:oxidized_copper_trapdoor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32807,8 +30773,7 @@
 			"typed": "minecraft:oxidized_copper_trapdoor"
 		},
 		{
-			"asMaterial": "minecraft:oxidized_cut_copper",
-			"blockType": true,
+			"blockType": "minecraft:oxidized_cut_copper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32831,11 +30796,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oxidized_cut_copper",
-			"material": "OXIDIZED_CUT_COPPER",
+			"material": "minecraft:oxidized_cut_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32844,8 +30808,7 @@
 			"typed": "minecraft:oxidized_cut_copper"
 		},
 		{
-			"asMaterial": "minecraft:oxidized_cut_copper_slab",
-			"blockType": true,
+			"blockType": "minecraft:oxidized_cut_copper_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32868,11 +30831,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oxidized_cut_copper_slab",
-			"material": "OXIDIZED_CUT_COPPER_SLAB",
+			"material": "minecraft:oxidized_cut_copper_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32881,8 +30843,7 @@
 			"typed": "minecraft:oxidized_cut_copper_slab"
 		},
 		{
-			"asMaterial": "minecraft:oxidized_cut_copper_stairs",
-			"blockType": true,
+			"blockType": "minecraft:oxidized_cut_copper_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32905,11 +30866,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:oxidized_cut_copper_stairs",
-			"material": "OXIDIZED_CUT_COPPER_STAIRS",
+			"material": "minecraft:oxidized_cut_copper_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32918,8 +30878,7 @@
 			"typed": "minecraft:oxidized_cut_copper_stairs"
 		},
 		{
-			"asMaterial": "minecraft:packed_ice",
-			"blockType": true,
+			"blockType": "minecraft:packed_ice",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32942,11 +30901,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:packed_ice",
-			"material": "PACKED_ICE",
+			"material": "minecraft:packed_ice",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32955,8 +30913,7 @@
 			"typed": "minecraft:packed_ice"
 		},
 		{
-			"asMaterial": "minecraft:packed_mud",
-			"blockType": true,
+			"blockType": "minecraft:packed_mud",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -32979,11 +30936,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:packed_mud",
-			"material": "PACKED_MUD",
+			"material": "minecraft:packed_mud",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -32992,8 +30948,6 @@
 			"typed": "minecraft:packed_mud"
 		},
 		{
-			"asMaterial": "minecraft:painting",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -33016,11 +30970,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:painting",
-			"material": "PAINTING",
+			"material": "minecraft:painting",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33029,8 +30982,7 @@
 			"typed": "minecraft:painting"
 		},
 		{
-			"asMaterial": "minecraft:pale_hanging_moss",
-			"blockType": true,
+			"blockType": "minecraft:pale_hanging_moss",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -33054,11 +31006,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pale_hanging_moss",
-			"material": "PALE_HANGING_MOSS",
+			"material": "minecraft:pale_hanging_moss",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33067,8 +31018,7 @@
 			"typed": "minecraft:pale_hanging_moss"
 		},
 		{
-			"asMaterial": "minecraft:pale_moss_block",
-			"blockType": true,
+			"blockType": "minecraft:pale_moss_block",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -33092,11 +31042,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pale_moss_block",
-			"material": "PALE_MOSS_BLOCK",
+			"material": "minecraft:pale_moss_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33105,8 +31054,7 @@
 			"typed": "minecraft:pale_moss_block"
 		},
 		{
-			"asMaterial": "minecraft:pale_moss_carpet",
-			"blockType": true,
+			"blockType": "minecraft:pale_moss_carpet",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -33130,11 +31078,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pale_moss_carpet",
-			"material": "PALE_MOSS_CARPET",
+			"material": "minecraft:pale_moss_carpet",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33143,8 +31090,6 @@
 			"typed": "minecraft:pale_moss_carpet"
 		},
 		{
-			"asMaterial": "minecraft:pale_oak_boat",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -33167,11 +31112,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pale_oak_boat",
-			"material": "PALE_OAK_BOAT",
+			"material": "minecraft:pale_oak_boat",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33180,8 +31124,7 @@
 			"typed": "minecraft:pale_oak_boat"
 		},
 		{
-			"asMaterial": "minecraft:pale_oak_button",
-			"blockType": true,
+			"blockType": "minecraft:pale_oak_button",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -33204,11 +31147,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pale_oak_button",
-			"material": "PALE_OAK_BUTTON",
+			"material": "minecraft:pale_oak_button",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33217,8 +31159,6 @@
 			"typed": "minecraft:pale_oak_button"
 		},
 		{
-			"asMaterial": "minecraft:pale_oak_chest_boat",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -33241,11 +31181,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pale_oak_chest_boat",
-			"material": "PALE_OAK_CHEST_BOAT",
+			"material": "minecraft:pale_oak_chest_boat",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33254,8 +31193,7 @@
 			"typed": "minecraft:pale_oak_chest_boat"
 		},
 		{
-			"asMaterial": "minecraft:pale_oak_door",
-			"blockType": true,
+			"blockType": "minecraft:pale_oak_door",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -33278,11 +31216,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pale_oak_door",
-			"material": "PALE_OAK_DOOR",
+			"material": "minecraft:pale_oak_door",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33291,8 +31228,7 @@
 			"typed": "minecraft:pale_oak_door"
 		},
 		{
-			"asMaterial": "minecraft:pale_oak_fence",
-			"blockType": true,
+			"blockType": "minecraft:pale_oak_fence",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -33315,11 +31251,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pale_oak_fence",
-			"material": "PALE_OAK_FENCE",
+			"material": "minecraft:pale_oak_fence",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33328,8 +31263,7 @@
 			"typed": "minecraft:pale_oak_fence"
 		},
 		{
-			"asMaterial": "minecraft:pale_oak_fence_gate",
-			"blockType": true,
+			"blockType": "minecraft:pale_oak_fence_gate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -33352,11 +31286,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pale_oak_fence_gate",
-			"material": "PALE_OAK_FENCE_GATE",
+			"material": "minecraft:pale_oak_fence_gate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33365,8 +31298,7 @@
 			"typed": "minecraft:pale_oak_fence_gate"
 		},
 		{
-			"asMaterial": "minecraft:pale_oak_hanging_sign",
-			"blockType": true,
+			"blockType": "minecraft:pale_oak_hanging_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -33389,11 +31321,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pale_oak_hanging_sign",
-			"material": "PALE_OAK_HANGING_SIGN",
+			"material": "minecraft:pale_oak_hanging_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33402,8 +31333,7 @@
 			"typed": "minecraft:pale_oak_hanging_sign"
 		},
 		{
-			"asMaterial": "minecraft:pale_oak_leaves",
-			"blockType": true,
+			"blockType": "minecraft:pale_oak_leaves",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -33427,11 +31357,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pale_oak_leaves",
-			"material": "PALE_OAK_LEAVES",
+			"material": "minecraft:pale_oak_leaves",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33440,8 +31369,7 @@
 			"typed": "minecraft:pale_oak_leaves"
 		},
 		{
-			"asMaterial": "minecraft:pale_oak_log",
-			"blockType": true,
+			"blockType": "minecraft:pale_oak_log",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -33464,11 +31392,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pale_oak_log",
-			"material": "PALE_OAK_LOG",
+			"material": "minecraft:pale_oak_log",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33477,8 +31404,7 @@
 			"typed": "minecraft:pale_oak_log"
 		},
 		{
-			"asMaterial": "minecraft:pale_oak_planks",
-			"blockType": true,
+			"blockType": "minecraft:pale_oak_planks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -33501,11 +31427,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pale_oak_planks",
-			"material": "PALE_OAK_PLANKS",
+			"material": "minecraft:pale_oak_planks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33514,8 +31439,7 @@
 			"typed": "minecraft:pale_oak_planks"
 		},
 		{
-			"asMaterial": "minecraft:pale_oak_pressure_plate",
-			"blockType": true,
+			"blockType": "minecraft:pale_oak_pressure_plate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -33538,11 +31462,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pale_oak_pressure_plate",
-			"material": "PALE_OAK_PRESSURE_PLATE",
+			"material": "minecraft:pale_oak_pressure_plate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33551,8 +31474,7 @@
 			"typed": "minecraft:pale_oak_pressure_plate"
 		},
 		{
-			"asMaterial": "minecraft:pale_oak_sapling",
-			"blockType": true,
+			"blockType": "minecraft:pale_oak_sapling",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -33576,11 +31498,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pale_oak_sapling",
-			"material": "PALE_OAK_SAPLING",
+			"material": "minecraft:pale_oak_sapling",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33589,8 +31510,7 @@
 			"typed": "minecraft:pale_oak_sapling"
 		},
 		{
-			"asMaterial": "minecraft:pale_oak_sign",
-			"blockType": true,
+			"blockType": "minecraft:pale_oak_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -33613,11 +31533,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pale_oak_sign",
-			"material": "PALE_OAK_SIGN",
+			"material": "minecraft:pale_oak_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33626,8 +31545,7 @@
 			"typed": "minecraft:pale_oak_sign"
 		},
 		{
-			"asMaterial": "minecraft:pale_oak_slab",
-			"blockType": true,
+			"blockType": "minecraft:pale_oak_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -33650,11 +31568,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pale_oak_slab",
-			"material": "PALE_OAK_SLAB",
+			"material": "minecraft:pale_oak_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33663,8 +31580,7 @@
 			"typed": "minecraft:pale_oak_slab"
 		},
 		{
-			"asMaterial": "minecraft:pale_oak_stairs",
-			"blockType": true,
+			"blockType": "minecraft:pale_oak_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -33687,11 +31603,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pale_oak_stairs",
-			"material": "PALE_OAK_STAIRS",
+			"material": "minecraft:pale_oak_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33700,8 +31615,7 @@
 			"typed": "minecraft:pale_oak_stairs"
 		},
 		{
-			"asMaterial": "minecraft:pale_oak_trapdoor",
-			"blockType": true,
+			"blockType": "minecraft:pale_oak_trapdoor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -33724,11 +31638,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pale_oak_trapdoor",
-			"material": "PALE_OAK_TRAPDOOR",
+			"material": "minecraft:pale_oak_trapdoor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33737,8 +31650,7 @@
 			"typed": "minecraft:pale_oak_trapdoor"
 		},
 		{
-			"asMaterial": "minecraft:pale_oak_wood",
-			"blockType": true,
+			"blockType": "minecraft:pale_oak_wood",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -33761,11 +31673,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pale_oak_wood",
-			"material": "PALE_OAK_WOOD",
+			"material": "minecraft:pale_oak_wood",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33774,8 +31685,6 @@
 			"typed": "minecraft:pale_oak_wood"
 		},
 		{
-			"asMaterial": "minecraft:panda_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -33798,11 +31707,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:panda_spawn_egg",
-			"material": "PANDA_SPAWN_EGG",
+			"material": "minecraft:panda_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33811,8 +31719,6 @@
 			"typed": "minecraft:panda_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:paper",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -33835,11 +31741,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:paper",
-			"material": "PAPER",
+			"material": "minecraft:paper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33848,8 +31753,6 @@
 			"typed": "minecraft:paper"
 		},
 		{
-			"asMaterial": "minecraft:parrot_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -33872,11 +31775,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:parrot_spawn_egg",
-			"material": "PARROT_SPAWN_EGG",
+			"material": "minecraft:parrot_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33885,8 +31787,7 @@
 			"typed": "minecraft:parrot_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:pearlescent_froglight",
-			"blockType": true,
+			"blockType": "minecraft:pearlescent_froglight",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -33909,11 +31810,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pearlescent_froglight",
-			"material": "PEARLESCENT_FROGLIGHT",
+			"material": "minecraft:pearlescent_froglight",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33922,8 +31822,7 @@
 			"typed": "minecraft:pearlescent_froglight"
 		},
 		{
-			"asMaterial": "minecraft:peony",
-			"blockType": true,
+			"blockType": "minecraft:peony",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -33947,11 +31846,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:peony",
-			"material": "PEONY",
+			"material": "minecraft:peony",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33960,8 +31858,7 @@
 			"typed": "minecraft:peony"
 		},
 		{
-			"asMaterial": "minecraft:petrified_oak_slab",
-			"blockType": true,
+			"blockType": "minecraft:petrified_oak_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -33984,11 +31881,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:petrified_oak_slab",
-			"material": "PETRIFIED_OAK_SLAB",
+			"material": "minecraft:petrified_oak_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -33997,8 +31893,6 @@
 			"typed": "minecraft:petrified_oak_slab"
 		},
 		{
-			"asMaterial": "minecraft:phantom_membrane",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34021,11 +31915,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:phantom_membrane",
-			"material": "PHANTOM_MEMBRANE",
+			"material": "minecraft:phantom_membrane",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34034,8 +31927,6 @@
 			"typed": "minecraft:phantom_membrane"
 		},
 		{
-			"asMaterial": "minecraft:phantom_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34058,11 +31949,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:phantom_spawn_egg",
-			"material": "PHANTOM_SPAWN_EGG",
+			"material": "minecraft:phantom_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34071,8 +31961,6 @@
 			"typed": "minecraft:phantom_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:pig_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34095,11 +31983,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pig_spawn_egg",
-			"material": "PIG_SPAWN_EGG",
+			"material": "minecraft:pig_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34108,8 +31995,6 @@
 			"typed": "minecraft:pig_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:piglin_banner_pattern",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34133,11 +32018,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:piglin_banner_pattern",
-			"material": "PIGLIN_BANNER_PATTERN",
+			"material": "minecraft:piglin_banner_pattern",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34146,8 +32030,6 @@
 			"typed": "minecraft:piglin_banner_pattern"
 		},
 		{
-			"asMaterial": "minecraft:piglin_brute_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34170,11 +32052,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:piglin_brute_spawn_egg",
-			"material": "PIGLIN_BRUTE_SPAWN_EGG",
+			"material": "minecraft:piglin_brute_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34183,8 +32064,7 @@
 			"typed": "minecraft:piglin_brute_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:piglin_head",
-			"blockType": true,
+			"blockType": "minecraft:piglin_head",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34208,11 +32088,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:piglin_head",
-			"material": "PIGLIN_HEAD",
+			"material": "minecraft:piglin_head",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SkullMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34221,8 +32100,6 @@
 			"typed": "minecraft:piglin_head"
 		},
 		{
-			"asMaterial": "minecraft:piglin_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34245,11 +32122,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:piglin_spawn_egg",
-			"material": "PIGLIN_SPAWN_EGG",
+			"material": "minecraft:piglin_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34258,8 +32134,6 @@
 			"typed": "minecraft:piglin_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:pillager_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34282,11 +32156,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pillager_spawn_egg",
-			"material": "PILLAGER_SPAWN_EGG",
+			"material": "minecraft:pillager_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34295,8 +32168,7 @@
 			"typed": "minecraft:pillager_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:pink_banner",
-			"blockType": true,
+			"blockType": "minecraft:pink_banner",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34320,11 +32192,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pink_banner",
-			"material": "PINK_BANNER",
+			"material": "minecraft:pink_banner",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BannerMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34333,8 +32204,7 @@
 			"typed": "minecraft:pink_banner"
 		},
 		{
-			"asMaterial": "minecraft:pink_bed",
-			"blockType": true,
+			"blockType": "minecraft:pink_bed",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34357,11 +32227,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pink_bed",
-			"material": "PINK_BED",
+			"material": "minecraft:pink_bed",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34370,8 +32239,6 @@
 			"typed": "minecraft:pink_bed"
 		},
 		{
-			"asMaterial": "minecraft:pink_bundle",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34395,11 +32262,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pink_bundle",
-			"material": "PINK_BUNDLE",
+			"material": "minecraft:pink_bundle",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BundleMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34408,8 +32274,7 @@
 			"typed": "minecraft:pink_bundle"
 		},
 		{
-			"asMaterial": "minecraft:pink_candle",
-			"blockType": true,
+			"blockType": "minecraft:pink_candle",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34432,11 +32297,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pink_candle",
-			"material": "PINK_CANDLE",
+			"material": "minecraft:pink_candle",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34445,8 +32309,7 @@
 			"typed": "minecraft:pink_candle"
 		},
 		{
-			"asMaterial": "minecraft:pink_carpet",
-			"blockType": true,
+			"blockType": "minecraft:pink_carpet",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34470,11 +32333,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pink_carpet",
-			"material": "PINK_CARPET",
+			"material": "minecraft:pink_carpet",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34483,8 +32345,7 @@
 			"typed": "minecraft:pink_carpet"
 		},
 		{
-			"asMaterial": "minecraft:pink_concrete",
-			"blockType": true,
+			"blockType": "minecraft:pink_concrete",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34507,11 +32368,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pink_concrete",
-			"material": "PINK_CONCRETE",
+			"material": "minecraft:pink_concrete",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34520,8 +32380,7 @@
 			"typed": "minecraft:pink_concrete"
 		},
 		{
-			"asMaterial": "minecraft:pink_concrete_powder",
-			"blockType": true,
+			"blockType": "minecraft:pink_concrete_powder",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34544,11 +32403,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pink_concrete_powder",
-			"material": "PINK_CONCRETE_POWDER",
+			"material": "minecraft:pink_concrete_powder",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34557,8 +32415,6 @@
 			"typed": "minecraft:pink_concrete_powder"
 		},
 		{
-			"asMaterial": "minecraft:pink_dye",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34581,11 +32437,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pink_dye",
-			"material": "PINK_DYE",
+			"material": "minecraft:pink_dye",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34594,8 +32449,7 @@
 			"typed": "minecraft:pink_dye"
 		},
 		{
-			"asMaterial": "minecraft:pink_glazed_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:pink_glazed_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34618,11 +32472,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pink_glazed_terracotta",
-			"material": "PINK_GLAZED_TERRACOTTA",
+			"material": "minecraft:pink_glazed_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34631,8 +32484,7 @@
 			"typed": "minecraft:pink_glazed_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:pink_petals",
-			"blockType": true,
+			"blockType": "minecraft:pink_petals",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -34656,11 +32508,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pink_petals",
-			"material": "PINK_PETALS",
+			"material": "minecraft:pink_petals",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34669,8 +32520,7 @@
 			"typed": "minecraft:pink_petals"
 		},
 		{
-			"asMaterial": "minecraft:pink_shulker_box",
-			"blockType": true,
+			"blockType": "minecraft:pink_shulker_box",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34694,11 +32544,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pink_shulker_box",
-			"material": "PINK_SHULKER_BOX",
+			"material": "minecraft:pink_shulker_box",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34707,8 +32556,7 @@
 			"typed": "minecraft:pink_shulker_box"
 		},
 		{
-			"asMaterial": "minecraft:pink_stained_glass",
-			"blockType": true,
+			"blockType": "minecraft:pink_stained_glass",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34731,11 +32579,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pink_stained_glass",
-			"material": "PINK_STAINED_GLASS",
+			"material": "minecraft:pink_stained_glass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34744,8 +32591,7 @@
 			"typed": "minecraft:pink_stained_glass"
 		},
 		{
-			"asMaterial": "minecraft:pink_stained_glass_pane",
-			"blockType": true,
+			"blockType": "minecraft:pink_stained_glass_pane",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34768,11 +32614,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pink_stained_glass_pane",
-			"material": "PINK_STAINED_GLASS_PANE",
+			"material": "minecraft:pink_stained_glass_pane",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34781,8 +32626,7 @@
 			"typed": "minecraft:pink_stained_glass_pane"
 		},
 		{
-			"asMaterial": "minecraft:pink_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:pink_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34805,11 +32649,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pink_terracotta",
-			"material": "PINK_TERRACOTTA",
+			"material": "minecraft:pink_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34818,8 +32661,7 @@
 			"typed": "minecraft:pink_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:pink_tulip",
-			"blockType": true,
+			"blockType": "minecraft:pink_tulip",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -34843,11 +32685,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pink_tulip",
-			"material": "PINK_TULIP",
+			"material": "minecraft:pink_tulip",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34856,8 +32697,7 @@
 			"typed": "minecraft:pink_tulip"
 		},
 		{
-			"asMaterial": "minecraft:pink_wool",
-			"blockType": true,
+			"blockType": "minecraft:pink_wool",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34880,11 +32720,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pink_wool",
-			"material": "PINK_WOOL",
+			"material": "minecraft:pink_wool",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34893,8 +32732,7 @@
 			"typed": "minecraft:pink_wool"
 		},
 		{
-			"asMaterial": "minecraft:piston",
-			"blockType": true,
+			"blockType": "minecraft:piston",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -34917,11 +32755,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:piston",
-			"material": "PISTON",
+			"material": "minecraft:piston",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34930,8 +32767,7 @@
 			"typed": "minecraft:piston"
 		},
 		{
-			"asMaterial": "minecraft:pitcher_plant",
-			"blockType": true,
+			"blockType": "minecraft:pitcher_plant",
 			"compostChance": "0.85F",
 			"compostable": true,
 			"createItemStack": {
@@ -34955,11 +32791,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pitcher_plant",
-			"material": "PITCHER_PLANT",
+			"material": "minecraft:pitcher_plant",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -34968,8 +32803,7 @@
 			"typed": "minecraft:pitcher_plant"
 		},
 		{
-			"asMaterial": "minecraft:pitcher_pod",
-			"blockType": true,
+			"blockType": "minecraft:pitcher_crop",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -34993,11 +32827,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pitcher_pod",
-			"material": "PITCHER_POD",
+			"material": "minecraft:pitcher_pod",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35006,8 +32839,7 @@
 			"typed": "minecraft:pitcher_pod"
 		},
 		{
-			"asMaterial": "minecraft:player_head",
-			"blockType": true,
+			"blockType": "minecraft:player_head",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35031,11 +32863,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:player_head",
-			"material": "PLAYER_HEAD",
+			"material": "minecraft:player_head",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SkullMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35044,8 +32875,6 @@
 			"typed": "minecraft:player_head"
 		},
 		{
-			"asMaterial": "minecraft:plenty_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35068,11 +32897,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:plenty_pottery_sherd",
-			"material": "PLENTY_POTTERY_SHERD",
+			"material": "minecraft:plenty_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35081,8 +32909,7 @@
 			"typed": "minecraft:plenty_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:podzol",
-			"blockType": true,
+			"blockType": "minecraft:podzol",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35105,11 +32932,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:podzol",
-			"material": "PODZOL",
+			"material": "minecraft:podzol",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35118,8 +32944,7 @@
 			"typed": "minecraft:podzol"
 		},
 		{
-			"asMaterial": "minecraft:pointed_dripstone",
-			"blockType": true,
+			"blockType": "minecraft:pointed_dripstone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35142,11 +32967,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pointed_dripstone",
-			"material": "POINTED_DRIPSTONE",
+			"material": "minecraft:pointed_dripstone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35155,8 +32979,6 @@
 			"typed": "minecraft:pointed_dripstone"
 		},
 		{
-			"asMaterial": "minecraft:poisonous_potato",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35181,11 +33003,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:poisonous_potato",
-			"material": "POISONOUS_POTATO",
+			"material": "minecraft:poisonous_potato",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35194,8 +33015,6 @@
 			"typed": "minecraft:poisonous_potato"
 		},
 		{
-			"asMaterial": "minecraft:polar_bear_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35218,11 +33037,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polar_bear_spawn_egg",
-			"material": "POLAR_BEAR_SPAWN_EGG",
+			"material": "minecraft:polar_bear_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35231,8 +33049,7 @@
 			"typed": "minecraft:polar_bear_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:polished_andesite",
-			"blockType": true,
+			"blockType": "minecraft:polished_andesite",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35255,11 +33072,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_andesite",
-			"material": "POLISHED_ANDESITE",
+			"material": "minecraft:polished_andesite",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35268,8 +33084,7 @@
 			"typed": "minecraft:polished_andesite"
 		},
 		{
-			"asMaterial": "minecraft:polished_andesite_slab",
-			"blockType": true,
+			"blockType": "minecraft:polished_andesite_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35292,11 +33107,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_andesite_slab",
-			"material": "POLISHED_ANDESITE_SLAB",
+			"material": "minecraft:polished_andesite_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35305,8 +33119,7 @@
 			"typed": "minecraft:polished_andesite_slab"
 		},
 		{
-			"asMaterial": "minecraft:polished_andesite_stairs",
-			"blockType": true,
+			"blockType": "minecraft:polished_andesite_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35329,11 +33142,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_andesite_stairs",
-			"material": "POLISHED_ANDESITE_STAIRS",
+			"material": "minecraft:polished_andesite_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35342,8 +33154,7 @@
 			"typed": "minecraft:polished_andesite_stairs"
 		},
 		{
-			"asMaterial": "minecraft:polished_basalt",
-			"blockType": true,
+			"blockType": "minecraft:polished_basalt",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35366,11 +33177,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_basalt",
-			"material": "POLISHED_BASALT",
+			"material": "minecraft:polished_basalt",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35379,8 +33189,7 @@
 			"typed": "minecraft:polished_basalt"
 		},
 		{
-			"asMaterial": "minecraft:polished_blackstone",
-			"blockType": true,
+			"blockType": "minecraft:polished_blackstone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35403,11 +33212,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_blackstone",
-			"material": "POLISHED_BLACKSTONE",
+			"material": "minecraft:polished_blackstone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35416,8 +33224,7 @@
 			"typed": "minecraft:polished_blackstone"
 		},
 		{
-			"asMaterial": "minecraft:polished_blackstone_brick_slab",
-			"blockType": true,
+			"blockType": "minecraft:polished_blackstone_brick_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35440,11 +33247,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_blackstone_brick_slab",
-			"material": "POLISHED_BLACKSTONE_BRICK_SLAB",
+			"material": "minecraft:polished_blackstone_brick_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35453,8 +33259,7 @@
 			"typed": "minecraft:polished_blackstone_brick_slab"
 		},
 		{
-			"asMaterial": "minecraft:polished_blackstone_brick_stairs",
-			"blockType": true,
+			"blockType": "minecraft:polished_blackstone_brick_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35477,11 +33282,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_blackstone_brick_stairs",
-			"material": "POLISHED_BLACKSTONE_BRICK_STAIRS",
+			"material": "minecraft:polished_blackstone_brick_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35490,8 +33294,7 @@
 			"typed": "minecraft:polished_blackstone_brick_stairs"
 		},
 		{
-			"asMaterial": "minecraft:polished_blackstone_brick_wall",
-			"blockType": true,
+			"blockType": "minecraft:polished_blackstone_brick_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35514,11 +33317,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_blackstone_brick_wall",
-			"material": "POLISHED_BLACKSTONE_BRICK_WALL",
+			"material": "minecraft:polished_blackstone_brick_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35527,8 +33329,7 @@
 			"typed": "minecraft:polished_blackstone_brick_wall"
 		},
 		{
-			"asMaterial": "minecraft:polished_blackstone_bricks",
-			"blockType": true,
+			"blockType": "minecraft:polished_blackstone_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35551,11 +33352,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_blackstone_bricks",
-			"material": "POLISHED_BLACKSTONE_BRICKS",
+			"material": "minecraft:polished_blackstone_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35564,8 +33364,7 @@
 			"typed": "minecraft:polished_blackstone_bricks"
 		},
 		{
-			"asMaterial": "minecraft:polished_blackstone_button",
-			"blockType": true,
+			"blockType": "minecraft:polished_blackstone_button",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35588,11 +33387,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_blackstone_button",
-			"material": "POLISHED_BLACKSTONE_BUTTON",
+			"material": "minecraft:polished_blackstone_button",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35601,8 +33399,7 @@
 			"typed": "minecraft:polished_blackstone_button"
 		},
 		{
-			"asMaterial": "minecraft:polished_blackstone_pressure_plate",
-			"blockType": true,
+			"blockType": "minecraft:polished_blackstone_pressure_plate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35625,11 +33422,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_blackstone_pressure_plate",
-			"material": "POLISHED_BLACKSTONE_PRESSURE_PLATE",
+			"material": "minecraft:polished_blackstone_pressure_plate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35638,8 +33434,7 @@
 			"typed": "minecraft:polished_blackstone_pressure_plate"
 		},
 		{
-			"asMaterial": "minecraft:polished_blackstone_slab",
-			"blockType": true,
+			"blockType": "minecraft:polished_blackstone_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35662,11 +33457,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_blackstone_slab",
-			"material": "POLISHED_BLACKSTONE_SLAB",
+			"material": "minecraft:polished_blackstone_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35675,8 +33469,7 @@
 			"typed": "minecraft:polished_blackstone_slab"
 		},
 		{
-			"asMaterial": "minecraft:polished_blackstone_stairs",
-			"blockType": true,
+			"blockType": "minecraft:polished_blackstone_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35699,11 +33492,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_blackstone_stairs",
-			"material": "POLISHED_BLACKSTONE_STAIRS",
+			"material": "minecraft:polished_blackstone_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35712,8 +33504,7 @@
 			"typed": "minecraft:polished_blackstone_stairs"
 		},
 		{
-			"asMaterial": "minecraft:polished_blackstone_wall",
-			"blockType": true,
+			"blockType": "minecraft:polished_blackstone_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35736,11 +33527,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_blackstone_wall",
-			"material": "POLISHED_BLACKSTONE_WALL",
+			"material": "minecraft:polished_blackstone_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35749,8 +33539,7 @@
 			"typed": "minecraft:polished_blackstone_wall"
 		},
 		{
-			"asMaterial": "minecraft:polished_deepslate",
-			"blockType": true,
+			"blockType": "minecraft:polished_deepslate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35773,11 +33562,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_deepslate",
-			"material": "POLISHED_DEEPSLATE",
+			"material": "minecraft:polished_deepslate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35786,8 +33574,7 @@
 			"typed": "minecraft:polished_deepslate"
 		},
 		{
-			"asMaterial": "minecraft:polished_deepslate_slab",
-			"blockType": true,
+			"blockType": "minecraft:polished_deepslate_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35810,11 +33597,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_deepslate_slab",
-			"material": "POLISHED_DEEPSLATE_SLAB",
+			"material": "minecraft:polished_deepslate_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35823,8 +33609,7 @@
 			"typed": "minecraft:polished_deepslate_slab"
 		},
 		{
-			"asMaterial": "minecraft:polished_deepslate_stairs",
-			"blockType": true,
+			"blockType": "minecraft:polished_deepslate_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35847,11 +33632,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_deepslate_stairs",
-			"material": "POLISHED_DEEPSLATE_STAIRS",
+			"material": "minecraft:polished_deepslate_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35860,8 +33644,7 @@
 			"typed": "minecraft:polished_deepslate_stairs"
 		},
 		{
-			"asMaterial": "minecraft:polished_deepslate_wall",
-			"blockType": true,
+			"blockType": "minecraft:polished_deepslate_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35884,11 +33667,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_deepslate_wall",
-			"material": "POLISHED_DEEPSLATE_WALL",
+			"material": "minecraft:polished_deepslate_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35897,8 +33679,7 @@
 			"typed": "minecraft:polished_deepslate_wall"
 		},
 		{
-			"asMaterial": "minecraft:polished_diorite",
-			"blockType": true,
+			"blockType": "minecraft:polished_diorite",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35921,11 +33702,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_diorite",
-			"material": "POLISHED_DIORITE",
+			"material": "minecraft:polished_diorite",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35934,8 +33714,7 @@
 			"typed": "minecraft:polished_diorite"
 		},
 		{
-			"asMaterial": "minecraft:polished_diorite_slab",
-			"blockType": true,
+			"blockType": "minecraft:polished_diorite_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35958,11 +33737,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_diorite_slab",
-			"material": "POLISHED_DIORITE_SLAB",
+			"material": "minecraft:polished_diorite_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -35971,8 +33749,7 @@
 			"typed": "minecraft:polished_diorite_slab"
 		},
 		{
-			"asMaterial": "minecraft:polished_diorite_stairs",
-			"blockType": true,
+			"blockType": "minecraft:polished_diorite_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -35995,11 +33772,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_diorite_stairs",
-			"material": "POLISHED_DIORITE_STAIRS",
+			"material": "minecraft:polished_diorite_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36008,8 +33784,7 @@
 			"typed": "minecraft:polished_diorite_stairs"
 		},
 		{
-			"asMaterial": "minecraft:polished_granite",
-			"blockType": true,
+			"blockType": "minecraft:polished_granite",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36032,11 +33807,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_granite",
-			"material": "POLISHED_GRANITE",
+			"material": "minecraft:polished_granite",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36045,8 +33819,7 @@
 			"typed": "minecraft:polished_granite"
 		},
 		{
-			"asMaterial": "minecraft:polished_granite_slab",
-			"blockType": true,
+			"blockType": "minecraft:polished_granite_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36069,11 +33842,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_granite_slab",
-			"material": "POLISHED_GRANITE_SLAB",
+			"material": "minecraft:polished_granite_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36082,8 +33854,7 @@
 			"typed": "minecraft:polished_granite_slab"
 		},
 		{
-			"asMaterial": "minecraft:polished_granite_stairs",
-			"blockType": true,
+			"blockType": "minecraft:polished_granite_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36106,11 +33877,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_granite_stairs",
-			"material": "POLISHED_GRANITE_STAIRS",
+			"material": "minecraft:polished_granite_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36119,8 +33889,7 @@
 			"typed": "minecraft:polished_granite_stairs"
 		},
 		{
-			"asMaterial": "minecraft:polished_tuff",
-			"blockType": true,
+			"blockType": "minecraft:polished_tuff",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36143,11 +33912,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_tuff",
-			"material": "POLISHED_TUFF",
+			"material": "minecraft:polished_tuff",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36156,8 +33924,7 @@
 			"typed": "minecraft:polished_tuff"
 		},
 		{
-			"asMaterial": "minecraft:polished_tuff_slab",
-			"blockType": true,
+			"blockType": "minecraft:polished_tuff_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36180,11 +33947,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_tuff_slab",
-			"material": "POLISHED_TUFF_SLAB",
+			"material": "minecraft:polished_tuff_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36193,8 +33959,7 @@
 			"typed": "minecraft:polished_tuff_slab"
 		},
 		{
-			"asMaterial": "minecraft:polished_tuff_stairs",
-			"blockType": true,
+			"blockType": "minecraft:polished_tuff_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36217,11 +33982,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_tuff_stairs",
-			"material": "POLISHED_TUFF_STAIRS",
+			"material": "minecraft:polished_tuff_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36230,8 +33994,7 @@
 			"typed": "minecraft:polished_tuff_stairs"
 		},
 		{
-			"asMaterial": "minecraft:polished_tuff_wall",
-			"blockType": true,
+			"blockType": "minecraft:polished_tuff_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36254,11 +34017,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:polished_tuff_wall",
-			"material": "POLISHED_TUFF_WALL",
+			"material": "minecraft:polished_tuff_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36267,8 +34029,6 @@
 			"typed": "minecraft:polished_tuff_wall"
 		},
 		{
-			"asMaterial": "minecraft:popped_chorus_fruit",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36291,11 +34051,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:popped_chorus_fruit",
-			"material": "POPPED_CHORUS_FRUIT",
+			"material": "minecraft:popped_chorus_fruit",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36304,8 +34063,7 @@
 			"typed": "minecraft:popped_chorus_fruit"
 		},
 		{
-			"asMaterial": "minecraft:poppy",
-			"blockType": true,
+			"blockType": "minecraft:poppy",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -36329,11 +34087,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:poppy",
-			"material": "POPPY",
+			"material": "minecraft:poppy",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36342,8 +34099,6 @@
 			"typed": "minecraft:poppy"
 		},
 		{
-			"asMaterial": "minecraft:porkchop",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36368,11 +34123,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:porkchop",
-			"material": "PORKCHOP",
+			"material": "minecraft:porkchop",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36381,8 +34135,7 @@
 			"typed": "minecraft:porkchop"
 		},
 		{
-			"asMaterial": "minecraft:potato",
-			"blockType": true,
+			"blockType": "minecraft:potatoes",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -36408,11 +34161,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:potato",
-			"material": "POTATO",
+			"material": "minecraft:potato",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36421,8 +34173,6 @@
 			"typed": "minecraft:potato"
 		},
 		{
-			"asMaterial": "minecraft:potion",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36448,11 +34198,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:potion",
-			"material": "POTION",
+			"material": "minecraft:potion",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "PotionMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36461,8 +34210,7 @@
 			"typed": "minecraft:potion"
 		},
 		{
-			"asMaterial": "minecraft:powder_snow_bucket",
-			"blockType": true,
+			"blockType": "minecraft:powder_snow",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36485,11 +34233,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:powder_snow_bucket",
-			"material": "POWDER_SNOW_BUCKET",
+			"material": "minecraft:powder_snow_bucket",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36498,8 +34245,7 @@
 			"typed": "minecraft:powder_snow_bucket"
 		},
 		{
-			"asMaterial": "minecraft:powered_rail",
-			"blockType": true,
+			"blockType": "minecraft:powered_rail",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36522,11 +34268,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:powered_rail",
-			"material": "POWERED_RAIL",
+			"material": "minecraft:powered_rail",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36535,8 +34280,7 @@
 			"typed": "minecraft:powered_rail"
 		},
 		{
-			"asMaterial": "minecraft:prismarine",
-			"blockType": true,
+			"blockType": "minecraft:prismarine",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36559,11 +34303,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:prismarine",
-			"material": "PRISMARINE",
+			"material": "minecraft:prismarine",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36572,8 +34315,7 @@
 			"typed": "minecraft:prismarine"
 		},
 		{
-			"asMaterial": "minecraft:prismarine_brick_slab",
-			"blockType": true,
+			"blockType": "minecraft:prismarine_brick_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36596,11 +34338,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:prismarine_brick_slab",
-			"material": "PRISMARINE_BRICK_SLAB",
+			"material": "minecraft:prismarine_brick_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36609,8 +34350,7 @@
 			"typed": "minecraft:prismarine_brick_slab"
 		},
 		{
-			"asMaterial": "minecraft:prismarine_brick_stairs",
-			"blockType": true,
+			"blockType": "minecraft:prismarine_brick_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36633,11 +34373,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:prismarine_brick_stairs",
-			"material": "PRISMARINE_BRICK_STAIRS",
+			"material": "minecraft:prismarine_brick_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36646,8 +34385,7 @@
 			"typed": "minecraft:prismarine_brick_stairs"
 		},
 		{
-			"asMaterial": "minecraft:prismarine_bricks",
-			"blockType": true,
+			"blockType": "minecraft:prismarine_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36670,11 +34408,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:prismarine_bricks",
-			"material": "PRISMARINE_BRICKS",
+			"material": "minecraft:prismarine_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36683,8 +34420,6 @@
 			"typed": "minecraft:prismarine_bricks"
 		},
 		{
-			"asMaterial": "minecraft:prismarine_crystals",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36707,11 +34442,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:prismarine_crystals",
-			"material": "PRISMARINE_CRYSTALS",
+			"material": "minecraft:prismarine_crystals",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36720,8 +34454,6 @@
 			"typed": "minecraft:prismarine_crystals"
 		},
 		{
-			"asMaterial": "minecraft:prismarine_shard",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36744,11 +34476,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:prismarine_shard",
-			"material": "PRISMARINE_SHARD",
+			"material": "minecraft:prismarine_shard",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36757,8 +34488,7 @@
 			"typed": "minecraft:prismarine_shard"
 		},
 		{
-			"asMaterial": "minecraft:prismarine_slab",
-			"blockType": true,
+			"blockType": "minecraft:prismarine_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36781,11 +34511,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:prismarine_slab",
-			"material": "PRISMARINE_SLAB",
+			"material": "minecraft:prismarine_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36794,8 +34523,7 @@
 			"typed": "minecraft:prismarine_slab"
 		},
 		{
-			"asMaterial": "minecraft:prismarine_stairs",
-			"blockType": true,
+			"blockType": "minecraft:prismarine_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36818,11 +34546,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:prismarine_stairs",
-			"material": "PRISMARINE_STAIRS",
+			"material": "minecraft:prismarine_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36831,8 +34558,7 @@
 			"typed": "minecraft:prismarine_stairs"
 		},
 		{
-			"asMaterial": "minecraft:prismarine_wall",
-			"blockType": true,
+			"blockType": "minecraft:prismarine_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36855,11 +34581,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:prismarine_wall",
-			"material": "PRISMARINE_WALL",
+			"material": "minecraft:prismarine_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36868,8 +34593,6 @@
 			"typed": "minecraft:prismarine_wall"
 		},
 		{
-			"asMaterial": "minecraft:prize_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36892,11 +34615,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:prize_pottery_sherd",
-			"material": "PRIZE_POTTERY_SHERD",
+			"material": "minecraft:prize_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36905,8 +34627,6 @@
 			"typed": "minecraft:prize_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:pufferfish",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36931,11 +34651,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pufferfish",
-			"material": "PUFFERFISH",
+			"material": "minecraft:pufferfish",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36944,8 +34663,6 @@
 			"typed": "minecraft:pufferfish"
 		},
 		{
-			"asMaterial": "minecraft:pufferfish_bucket",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -36969,11 +34686,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pufferfish_bucket",
-			"material": "PUFFERFISH_BUCKET",
+			"material": "minecraft:pufferfish_bucket",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -36982,8 +34698,6 @@
 			"typed": "minecraft:pufferfish_bucket"
 		},
 		{
-			"asMaterial": "minecraft:pufferfish_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37006,11 +34720,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pufferfish_spawn_egg",
-			"material": "PUFFERFISH_SPAWN_EGG",
+			"material": "minecraft:pufferfish_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37019,8 +34732,7 @@
 			"typed": "minecraft:pufferfish_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:pumpkin",
-			"blockType": true,
+			"blockType": "minecraft:pumpkin",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -37044,11 +34756,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pumpkin",
-			"material": "PUMPKIN",
+			"material": "minecraft:pumpkin",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37057,8 +34768,6 @@
 			"typed": "minecraft:pumpkin"
 		},
 		{
-			"asMaterial": "minecraft:pumpkin_pie",
-			"blockType": false,
 			"compostChance": "1.0F",
 			"compostable": true,
 			"createItemStack": {
@@ -37084,11 +34793,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pumpkin_pie",
-			"material": "PUMPKIN_PIE",
+			"material": "minecraft:pumpkin_pie",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37097,8 +34805,7 @@
 			"typed": "minecraft:pumpkin_pie"
 		},
 		{
-			"asMaterial": "minecraft:pumpkin_seeds",
-			"blockType": true,
+			"blockType": "minecraft:pumpkin_stem",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -37122,11 +34829,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:pumpkin_seeds",
-			"material": "PUMPKIN_SEEDS",
+			"material": "minecraft:pumpkin_seeds",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37135,8 +34841,7 @@
 			"typed": "minecraft:pumpkin_seeds"
 		},
 		{
-			"asMaterial": "minecraft:purple_banner",
-			"blockType": true,
+			"blockType": "minecraft:purple_banner",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37160,11 +34865,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:purple_banner",
-			"material": "PURPLE_BANNER",
+			"material": "minecraft:purple_banner",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BannerMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37173,8 +34877,7 @@
 			"typed": "minecraft:purple_banner"
 		},
 		{
-			"asMaterial": "minecraft:purple_bed",
-			"blockType": true,
+			"blockType": "minecraft:purple_bed",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37197,11 +34900,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:purple_bed",
-			"material": "PURPLE_BED",
+			"material": "minecraft:purple_bed",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37210,8 +34912,6 @@
 			"typed": "minecraft:purple_bed"
 		},
 		{
-			"asMaterial": "minecraft:purple_bundle",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37235,11 +34935,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:purple_bundle",
-			"material": "PURPLE_BUNDLE",
+			"material": "minecraft:purple_bundle",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BundleMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37248,8 +34947,7 @@
 			"typed": "minecraft:purple_bundle"
 		},
 		{
-			"asMaterial": "minecraft:purple_candle",
-			"blockType": true,
+			"blockType": "minecraft:purple_candle",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37272,11 +34970,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:purple_candle",
-			"material": "PURPLE_CANDLE",
+			"material": "minecraft:purple_candle",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37285,8 +34982,7 @@
 			"typed": "minecraft:purple_candle"
 		},
 		{
-			"asMaterial": "minecraft:purple_carpet",
-			"blockType": true,
+			"blockType": "minecraft:purple_carpet",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37310,11 +35006,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:purple_carpet",
-			"material": "PURPLE_CARPET",
+			"material": "minecraft:purple_carpet",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37323,8 +35018,7 @@
 			"typed": "minecraft:purple_carpet"
 		},
 		{
-			"asMaterial": "minecraft:purple_concrete",
-			"blockType": true,
+			"blockType": "minecraft:purple_concrete",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37347,11 +35041,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:purple_concrete",
-			"material": "PURPLE_CONCRETE",
+			"material": "minecraft:purple_concrete",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37360,8 +35053,7 @@
 			"typed": "minecraft:purple_concrete"
 		},
 		{
-			"asMaterial": "minecraft:purple_concrete_powder",
-			"blockType": true,
+			"blockType": "minecraft:purple_concrete_powder",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37384,11 +35076,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:purple_concrete_powder",
-			"material": "PURPLE_CONCRETE_POWDER",
+			"material": "minecraft:purple_concrete_powder",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37397,8 +35088,6 @@
 			"typed": "minecraft:purple_concrete_powder"
 		},
 		{
-			"asMaterial": "minecraft:purple_dye",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37421,11 +35110,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:purple_dye",
-			"material": "PURPLE_DYE",
+			"material": "minecraft:purple_dye",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37434,8 +35122,7 @@
 			"typed": "minecraft:purple_dye"
 		},
 		{
-			"asMaterial": "minecraft:purple_glazed_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:purple_glazed_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37458,11 +35145,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:purple_glazed_terracotta",
-			"material": "PURPLE_GLAZED_TERRACOTTA",
+			"material": "minecraft:purple_glazed_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37471,8 +35157,7 @@
 			"typed": "minecraft:purple_glazed_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:purple_shulker_box",
-			"blockType": true,
+			"blockType": "minecraft:purple_shulker_box",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37496,11 +35181,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:purple_shulker_box",
-			"material": "PURPLE_SHULKER_BOX",
+			"material": "minecraft:purple_shulker_box",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37509,8 +35193,7 @@
 			"typed": "minecraft:purple_shulker_box"
 		},
 		{
-			"asMaterial": "minecraft:purple_stained_glass",
-			"blockType": true,
+			"blockType": "minecraft:purple_stained_glass",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37533,11 +35216,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:purple_stained_glass",
-			"material": "PURPLE_STAINED_GLASS",
+			"material": "minecraft:purple_stained_glass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37546,8 +35228,7 @@
 			"typed": "minecraft:purple_stained_glass"
 		},
 		{
-			"asMaterial": "minecraft:purple_stained_glass_pane",
-			"blockType": true,
+			"blockType": "minecraft:purple_stained_glass_pane",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37570,11 +35251,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:purple_stained_glass_pane",
-			"material": "PURPLE_STAINED_GLASS_PANE",
+			"material": "minecraft:purple_stained_glass_pane",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37583,8 +35263,7 @@
 			"typed": "minecraft:purple_stained_glass_pane"
 		},
 		{
-			"asMaterial": "minecraft:purple_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:purple_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37607,11 +35286,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:purple_terracotta",
-			"material": "PURPLE_TERRACOTTA",
+			"material": "minecraft:purple_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37620,8 +35298,7 @@
 			"typed": "minecraft:purple_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:purple_wool",
-			"blockType": true,
+			"blockType": "minecraft:purple_wool",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37644,11 +35321,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:purple_wool",
-			"material": "PURPLE_WOOL",
+			"material": "minecraft:purple_wool",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37657,8 +35333,7 @@
 			"typed": "minecraft:purple_wool"
 		},
 		{
-			"asMaterial": "minecraft:purpur_block",
-			"blockType": true,
+			"blockType": "minecraft:purpur_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37681,11 +35356,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:purpur_block",
-			"material": "PURPUR_BLOCK",
+			"material": "minecraft:purpur_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37694,8 +35368,7 @@
 			"typed": "minecraft:purpur_block"
 		},
 		{
-			"asMaterial": "minecraft:purpur_pillar",
-			"blockType": true,
+			"blockType": "minecraft:purpur_pillar",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37718,11 +35391,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:purpur_pillar",
-			"material": "PURPUR_PILLAR",
+			"material": "minecraft:purpur_pillar",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37731,8 +35403,7 @@
 			"typed": "minecraft:purpur_pillar"
 		},
 		{
-			"asMaterial": "minecraft:purpur_slab",
-			"blockType": true,
+			"blockType": "minecraft:purpur_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37755,11 +35426,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:purpur_slab",
-			"material": "PURPUR_SLAB",
+			"material": "minecraft:purpur_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37768,8 +35438,7 @@
 			"typed": "minecraft:purpur_slab"
 		},
 		{
-			"asMaterial": "minecraft:purpur_stairs",
-			"blockType": true,
+			"blockType": "minecraft:purpur_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37792,11 +35461,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:purpur_stairs",
-			"material": "PURPUR_STAIRS",
+			"material": "minecraft:purpur_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37805,8 +35473,6 @@
 			"typed": "minecraft:purpur_stairs"
 		},
 		{
-			"asMaterial": "minecraft:quartz",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37830,11 +35496,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:quartz",
-			"material": "QUARTZ",
+			"material": "minecraft:quartz",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37843,8 +35508,7 @@
 			"typed": "minecraft:quartz"
 		},
 		{
-			"asMaterial": "minecraft:quartz_block",
-			"blockType": true,
+			"blockType": "minecraft:quartz_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37867,11 +35531,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:quartz_block",
-			"material": "QUARTZ_BLOCK",
+			"material": "minecraft:quartz_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37880,8 +35543,7 @@
 			"typed": "minecraft:quartz_block"
 		},
 		{
-			"asMaterial": "minecraft:quartz_bricks",
-			"blockType": true,
+			"blockType": "minecraft:quartz_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37904,11 +35566,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:quartz_bricks",
-			"material": "QUARTZ_BRICKS",
+			"material": "minecraft:quartz_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37917,8 +35578,7 @@
 			"typed": "minecraft:quartz_bricks"
 		},
 		{
-			"asMaterial": "minecraft:quartz_pillar",
-			"blockType": true,
+			"blockType": "minecraft:quartz_pillar",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37941,11 +35601,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:quartz_pillar",
-			"material": "QUARTZ_PILLAR",
+			"material": "minecraft:quartz_pillar",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37954,8 +35613,7 @@
 			"typed": "minecraft:quartz_pillar"
 		},
 		{
-			"asMaterial": "minecraft:quartz_slab",
-			"blockType": true,
+			"blockType": "minecraft:quartz_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -37978,11 +35636,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:quartz_slab",
-			"material": "QUARTZ_SLAB",
+			"material": "minecraft:quartz_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -37991,8 +35648,7 @@
 			"typed": "minecraft:quartz_slab"
 		},
 		{
-			"asMaterial": "minecraft:quartz_stairs",
-			"blockType": true,
+			"blockType": "minecraft:quartz_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38015,11 +35671,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:quartz_stairs",
-			"material": "QUARTZ_STAIRS",
+			"material": "minecraft:quartz_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38028,8 +35683,6 @@
 			"typed": "minecraft:quartz_stairs"
 		},
 		{
-			"asMaterial": "minecraft:rabbit",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38054,11 +35707,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:rabbit",
-			"material": "RABBIT",
+			"material": "minecraft:rabbit",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38067,8 +35719,6 @@
 			"typed": "minecraft:rabbit"
 		},
 		{
-			"asMaterial": "minecraft:rabbit_foot",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38091,11 +35741,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:rabbit_foot",
-			"material": "RABBIT_FOOT",
+			"material": "minecraft:rabbit_foot",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38104,8 +35753,6 @@
 			"typed": "minecraft:rabbit_foot"
 		},
 		{
-			"asMaterial": "minecraft:rabbit_hide",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38128,11 +35775,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:rabbit_hide",
-			"material": "RABBIT_HIDE",
+			"material": "minecraft:rabbit_hide",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38141,8 +35787,6 @@
 			"typed": "minecraft:rabbit_hide"
 		},
 		{
-			"asMaterial": "minecraft:rabbit_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38165,11 +35809,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:rabbit_spawn_egg",
-			"material": "RABBIT_SPAWN_EGG",
+			"material": "minecraft:rabbit_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38178,8 +35821,6 @@
 			"typed": "minecraft:rabbit_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:rabbit_stew",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38205,11 +35846,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:rabbit_stew",
-			"material": "RABBIT_STEW",
+			"material": "minecraft:rabbit_stew",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38218,8 +35858,7 @@
 			"typed": "minecraft:rabbit_stew"
 		},
 		{
-			"asMaterial": "minecraft:rail",
-			"blockType": true,
+			"blockType": "minecraft:rail",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38242,11 +35881,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:rail",
-			"material": "RAIL",
+			"material": "minecraft:rail",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38255,8 +35893,6 @@
 			"typed": "minecraft:rail"
 		},
 		{
-			"asMaterial": "minecraft:raiser_armor_trim_smithing_template",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38279,11 +35915,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:raiser_armor_trim_smithing_template",
-			"material": "RAISER_ARMOR_TRIM_SMITHING_TEMPLATE",
+			"material": "minecraft:raiser_armor_trim_smithing_template",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38292,8 +35927,6 @@
 			"typed": "minecraft:raiser_armor_trim_smithing_template"
 		},
 		{
-			"asMaterial": "minecraft:ravager_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38316,11 +35949,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:ravager_spawn_egg",
-			"material": "RAVAGER_SPAWN_EGG",
+			"material": "minecraft:ravager_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38329,8 +35961,6 @@
 			"typed": "minecraft:ravager_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:raw_copper",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38353,11 +35983,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:raw_copper",
-			"material": "RAW_COPPER",
+			"material": "minecraft:raw_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38366,8 +35995,7 @@
 			"typed": "minecraft:raw_copper"
 		},
 		{
-			"asMaterial": "minecraft:raw_copper_block",
-			"blockType": true,
+			"blockType": "minecraft:raw_copper_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38390,11 +36018,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:raw_copper_block",
-			"material": "RAW_COPPER_BLOCK",
+			"material": "minecraft:raw_copper_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38403,8 +36030,6 @@
 			"typed": "minecraft:raw_copper_block"
 		},
 		{
-			"asMaterial": "minecraft:raw_gold",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38427,11 +36052,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:raw_gold",
-			"material": "RAW_GOLD",
+			"material": "minecraft:raw_gold",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38440,8 +36064,7 @@
 			"typed": "minecraft:raw_gold"
 		},
 		{
-			"asMaterial": "minecraft:raw_gold_block",
-			"blockType": true,
+			"blockType": "minecraft:raw_gold_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38464,11 +36087,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:raw_gold_block",
-			"material": "RAW_GOLD_BLOCK",
+			"material": "minecraft:raw_gold_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38477,8 +36099,6 @@
 			"typed": "minecraft:raw_gold_block"
 		},
 		{
-			"asMaterial": "minecraft:raw_iron",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38501,11 +36121,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:raw_iron",
-			"material": "RAW_IRON",
+			"material": "minecraft:raw_iron",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38514,8 +36133,7 @@
 			"typed": "minecraft:raw_iron"
 		},
 		{
-			"asMaterial": "minecraft:raw_iron_block",
-			"blockType": true,
+			"blockType": "minecraft:raw_iron_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38538,11 +36156,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:raw_iron_block",
-			"material": "RAW_IRON_BLOCK",
+			"material": "minecraft:raw_iron_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38551,8 +36168,6 @@
 			"typed": "minecraft:raw_iron_block"
 		},
 		{
-			"asMaterial": "minecraft:recovery_compass",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38575,11 +36190,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:recovery_compass",
-			"material": "RECOVERY_COMPASS",
+			"material": "minecraft:recovery_compass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38588,8 +36202,7 @@
 			"typed": "minecraft:recovery_compass"
 		},
 		{
-			"asMaterial": "minecraft:red_banner",
-			"blockType": true,
+			"blockType": "minecraft:red_banner",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38613,11 +36226,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_banner",
-			"material": "RED_BANNER",
+			"material": "minecraft:red_banner",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BannerMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38626,8 +36238,7 @@
 			"typed": "minecraft:red_banner"
 		},
 		{
-			"asMaterial": "minecraft:red_bed",
-			"blockType": true,
+			"blockType": "minecraft:red_bed",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38650,11 +36261,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_bed",
-			"material": "RED_BED",
+			"material": "minecraft:red_bed",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38663,8 +36273,6 @@
 			"typed": "minecraft:red_bed"
 		},
 		{
-			"asMaterial": "minecraft:red_bundle",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38688,11 +36296,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_bundle",
-			"material": "RED_BUNDLE",
+			"material": "minecraft:red_bundle",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BundleMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38701,8 +36308,7 @@
 			"typed": "minecraft:red_bundle"
 		},
 		{
-			"asMaterial": "minecraft:red_candle",
-			"blockType": true,
+			"blockType": "minecraft:red_candle",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38725,11 +36331,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_candle",
-			"material": "RED_CANDLE",
+			"material": "minecraft:red_candle",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38738,8 +36343,7 @@
 			"typed": "minecraft:red_candle"
 		},
 		{
-			"asMaterial": "minecraft:red_carpet",
-			"blockType": true,
+			"blockType": "minecraft:red_carpet",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38763,11 +36367,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_carpet",
-			"material": "RED_CARPET",
+			"material": "minecraft:red_carpet",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38776,8 +36379,7 @@
 			"typed": "minecraft:red_carpet"
 		},
 		{
-			"asMaterial": "minecraft:red_concrete",
-			"blockType": true,
+			"blockType": "minecraft:red_concrete",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38800,11 +36402,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_concrete",
-			"material": "RED_CONCRETE",
+			"material": "minecraft:red_concrete",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38813,8 +36414,7 @@
 			"typed": "minecraft:red_concrete"
 		},
 		{
-			"asMaterial": "minecraft:red_concrete_powder",
-			"blockType": true,
+			"blockType": "minecraft:red_concrete_powder",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38837,11 +36437,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_concrete_powder",
-			"material": "RED_CONCRETE_POWDER",
+			"material": "minecraft:red_concrete_powder",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38850,8 +36449,6 @@
 			"typed": "minecraft:red_concrete_powder"
 		},
 		{
-			"asMaterial": "minecraft:red_dye",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38874,11 +36471,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_dye",
-			"material": "RED_DYE",
+			"material": "minecraft:red_dye",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38887,8 +36483,7 @@
 			"typed": "minecraft:red_dye"
 		},
 		{
-			"asMaterial": "minecraft:red_glazed_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:red_glazed_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -38911,11 +36506,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_glazed_terracotta",
-			"material": "RED_GLAZED_TERRACOTTA",
+			"material": "minecraft:red_glazed_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38924,8 +36518,7 @@
 			"typed": "minecraft:red_glazed_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:red_mushroom",
-			"blockType": true,
+			"blockType": "minecraft:red_mushroom",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -38949,11 +36542,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_mushroom",
-			"material": "RED_MUSHROOM",
+			"material": "minecraft:red_mushroom",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -38962,8 +36554,7 @@
 			"typed": "minecraft:red_mushroom"
 		},
 		{
-			"asMaterial": "minecraft:red_mushroom_block",
-			"blockType": true,
+			"blockType": "minecraft:red_mushroom_block",
 			"compostChance": "0.85F",
 			"compostable": true,
 			"createItemStack": {
@@ -38987,11 +36578,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_mushroom_block",
-			"material": "RED_MUSHROOM_BLOCK",
+			"material": "minecraft:red_mushroom_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39000,8 +36590,7 @@
 			"typed": "minecraft:red_mushroom_block"
 		},
 		{
-			"asMaterial": "minecraft:red_nether_brick_slab",
-			"blockType": true,
+			"blockType": "minecraft:red_nether_brick_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39024,11 +36613,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_nether_brick_slab",
-			"material": "RED_NETHER_BRICK_SLAB",
+			"material": "minecraft:red_nether_brick_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39037,8 +36625,7 @@
 			"typed": "minecraft:red_nether_brick_slab"
 		},
 		{
-			"asMaterial": "minecraft:red_nether_brick_stairs",
-			"blockType": true,
+			"blockType": "minecraft:red_nether_brick_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39061,11 +36648,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_nether_brick_stairs",
-			"material": "RED_NETHER_BRICK_STAIRS",
+			"material": "minecraft:red_nether_brick_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39074,8 +36660,7 @@
 			"typed": "minecraft:red_nether_brick_stairs"
 		},
 		{
-			"asMaterial": "minecraft:red_nether_brick_wall",
-			"blockType": true,
+			"blockType": "minecraft:red_nether_brick_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39098,11 +36683,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_nether_brick_wall",
-			"material": "RED_NETHER_BRICK_WALL",
+			"material": "minecraft:red_nether_brick_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39111,8 +36695,7 @@
 			"typed": "minecraft:red_nether_brick_wall"
 		},
 		{
-			"asMaterial": "minecraft:red_nether_bricks",
-			"blockType": true,
+			"blockType": "minecraft:red_nether_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39135,11 +36718,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_nether_bricks",
-			"material": "RED_NETHER_BRICKS",
+			"material": "minecraft:red_nether_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39148,8 +36730,7 @@
 			"typed": "minecraft:red_nether_bricks"
 		},
 		{
-			"asMaterial": "minecraft:red_sand",
-			"blockType": true,
+			"blockType": "minecraft:red_sand",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39172,11 +36753,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_sand",
-			"material": "RED_SAND",
+			"material": "minecraft:red_sand",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39185,8 +36765,7 @@
 			"typed": "minecraft:red_sand"
 		},
 		{
-			"asMaterial": "minecraft:red_sandstone",
-			"blockType": true,
+			"blockType": "minecraft:red_sandstone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39209,11 +36788,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_sandstone",
-			"material": "RED_SANDSTONE",
+			"material": "minecraft:red_sandstone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39222,8 +36800,7 @@
 			"typed": "minecraft:red_sandstone"
 		},
 		{
-			"asMaterial": "minecraft:red_sandstone_slab",
-			"blockType": true,
+			"blockType": "minecraft:red_sandstone_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39246,11 +36823,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_sandstone_slab",
-			"material": "RED_SANDSTONE_SLAB",
+			"material": "minecraft:red_sandstone_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39259,8 +36835,7 @@
 			"typed": "minecraft:red_sandstone_slab"
 		},
 		{
-			"asMaterial": "minecraft:red_sandstone_stairs",
-			"blockType": true,
+			"blockType": "minecraft:red_sandstone_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39283,11 +36858,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_sandstone_stairs",
-			"material": "RED_SANDSTONE_STAIRS",
+			"material": "minecraft:red_sandstone_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39296,8 +36870,7 @@
 			"typed": "minecraft:red_sandstone_stairs"
 		},
 		{
-			"asMaterial": "minecraft:red_sandstone_wall",
-			"blockType": true,
+			"blockType": "minecraft:red_sandstone_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39320,11 +36893,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_sandstone_wall",
-			"material": "RED_SANDSTONE_WALL",
+			"material": "minecraft:red_sandstone_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39333,8 +36905,7 @@
 			"typed": "minecraft:red_sandstone_wall"
 		},
 		{
-			"asMaterial": "minecraft:red_shulker_box",
-			"blockType": true,
+			"blockType": "minecraft:red_shulker_box",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39358,11 +36929,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_shulker_box",
-			"material": "RED_SHULKER_BOX",
+			"material": "minecraft:red_shulker_box",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39371,8 +36941,7 @@
 			"typed": "minecraft:red_shulker_box"
 		},
 		{
-			"asMaterial": "minecraft:red_stained_glass",
-			"blockType": true,
+			"blockType": "minecraft:red_stained_glass",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39395,11 +36964,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_stained_glass",
-			"material": "RED_STAINED_GLASS",
+			"material": "minecraft:red_stained_glass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39408,8 +36976,7 @@
 			"typed": "minecraft:red_stained_glass"
 		},
 		{
-			"asMaterial": "minecraft:red_stained_glass_pane",
-			"blockType": true,
+			"blockType": "minecraft:red_stained_glass_pane",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39432,11 +36999,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_stained_glass_pane",
-			"material": "RED_STAINED_GLASS_PANE",
+			"material": "minecraft:red_stained_glass_pane",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39445,8 +37011,7 @@
 			"typed": "minecraft:red_stained_glass_pane"
 		},
 		{
-			"asMaterial": "minecraft:red_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:red_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39469,11 +37034,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_terracotta",
-			"material": "RED_TERRACOTTA",
+			"material": "minecraft:red_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39482,8 +37046,7 @@
 			"typed": "minecraft:red_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:red_tulip",
-			"blockType": true,
+			"blockType": "minecraft:red_tulip",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -39507,11 +37070,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_tulip",
-			"material": "RED_TULIP",
+			"material": "minecraft:red_tulip",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39520,8 +37082,7 @@
 			"typed": "minecraft:red_tulip"
 		},
 		{
-			"asMaterial": "minecraft:red_wool",
-			"blockType": true,
+			"blockType": "minecraft:red_wool",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39544,11 +37105,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:red_wool",
-			"material": "RED_WOOL",
+			"material": "minecraft:red_wool",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39557,8 +37117,7 @@
 			"typed": "minecraft:red_wool"
 		},
 		{
-			"asMaterial": "minecraft:redstone",
-			"blockType": true,
+			"blockType": "minecraft:redstone_wire",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39582,11 +37141,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:redstone",
-			"material": "REDSTONE",
+			"material": "minecraft:redstone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39595,8 +37153,7 @@
 			"typed": "minecraft:redstone"
 		},
 		{
-			"asMaterial": "minecraft:redstone_block",
-			"blockType": true,
+			"blockType": "minecraft:redstone_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39619,11 +37176,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:redstone_block",
-			"material": "REDSTONE_BLOCK",
+			"material": "minecraft:redstone_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39632,8 +37188,7 @@
 			"typed": "minecraft:redstone_block"
 		},
 		{
-			"asMaterial": "minecraft:redstone_lamp",
-			"blockType": true,
+			"blockType": "minecraft:redstone_lamp",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39656,11 +37211,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:redstone_lamp",
-			"material": "REDSTONE_LAMP",
+			"material": "minecraft:redstone_lamp",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39669,8 +37223,7 @@
 			"typed": "minecraft:redstone_lamp"
 		},
 		{
-			"asMaterial": "minecraft:redstone_ore",
-			"blockType": true,
+			"blockType": "minecraft:redstone_ore",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39693,11 +37246,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:redstone_ore",
-			"material": "REDSTONE_ORE",
+			"material": "minecraft:redstone_ore",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39706,8 +37258,7 @@
 			"typed": "minecraft:redstone_ore"
 		},
 		{
-			"asMaterial": "minecraft:redstone_torch",
-			"blockType": true,
+			"blockType": "minecraft:redstone_torch",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39730,11 +37281,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:redstone_torch",
-			"material": "REDSTONE_TORCH",
+			"material": "minecraft:redstone_torch",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39743,8 +37293,7 @@
 			"typed": "minecraft:redstone_torch"
 		},
 		{
-			"asMaterial": "minecraft:reinforced_deepslate",
-			"blockType": true,
+			"blockType": "minecraft:reinforced_deepslate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39767,11 +37316,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:reinforced_deepslate",
-			"material": "REINFORCED_DEEPSLATE",
+			"material": "minecraft:reinforced_deepslate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39780,8 +37328,7 @@
 			"typed": "minecraft:reinforced_deepslate"
 		},
 		{
-			"asMaterial": "minecraft:repeater",
-			"blockType": true,
+			"blockType": "minecraft:repeater",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39804,11 +37351,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:repeater",
-			"material": "REPEATER",
+			"material": "minecraft:repeater",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39817,8 +37363,7 @@
 			"typed": "minecraft:repeater"
 		},
 		{
-			"asMaterial": "minecraft:repeating_command_block",
-			"blockType": true,
+			"blockType": "minecraft:repeating_command_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39841,11 +37386,10 @@
 			"fuel": false,
 			"itemRarity": "EPIC",
 			"key": "minecraft:repeating_command_block",
-			"material": "REPEATING_COMMAND_BLOCK",
+			"material": "minecraft:repeating_command_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "EPIC",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39854,8 +37398,7 @@
 			"typed": "minecraft:repeating_command_block"
 		},
 		{
-			"asMaterial": "minecraft:resin_block",
-			"blockType": true,
+			"blockType": "minecraft:resin_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39878,11 +37421,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:resin_block",
-			"material": "RESIN_BLOCK",
+			"material": "minecraft:resin_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39891,8 +37433,6 @@
 			"typed": "minecraft:resin_block"
 		},
 		{
-			"asMaterial": "minecraft:resin_brick",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39916,11 +37456,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:resin_brick",
-			"material": "RESIN_BRICK",
+			"material": "minecraft:resin_brick",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39929,8 +37468,7 @@
 			"typed": "minecraft:resin_brick"
 		},
 		{
-			"asMaterial": "minecraft:resin_brick_slab",
-			"blockType": true,
+			"blockType": "minecraft:resin_brick_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39953,11 +37491,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:resin_brick_slab",
-			"material": "RESIN_BRICK_SLAB",
+			"material": "minecraft:resin_brick_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -39966,8 +37503,7 @@
 			"typed": "minecraft:resin_brick_slab"
 		},
 		{
-			"asMaterial": "minecraft:resin_brick_stairs",
-			"blockType": true,
+			"blockType": "minecraft:resin_brick_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -39990,11 +37526,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:resin_brick_stairs",
-			"material": "RESIN_BRICK_STAIRS",
+			"material": "minecraft:resin_brick_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40003,8 +37538,7 @@
 			"typed": "minecraft:resin_brick_stairs"
 		},
 		{
-			"asMaterial": "minecraft:resin_brick_wall",
-			"blockType": true,
+			"blockType": "minecraft:resin_brick_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40027,11 +37561,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:resin_brick_wall",
-			"material": "RESIN_BRICK_WALL",
+			"material": "minecraft:resin_brick_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40040,8 +37573,7 @@
 			"typed": "minecraft:resin_brick_wall"
 		},
 		{
-			"asMaterial": "minecraft:resin_bricks",
-			"blockType": true,
+			"blockType": "minecraft:resin_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40064,11 +37596,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:resin_bricks",
-			"material": "RESIN_BRICKS",
+			"material": "minecraft:resin_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40077,8 +37608,7 @@
 			"typed": "minecraft:resin_bricks"
 		},
 		{
-			"asMaterial": "minecraft:resin_clump",
-			"blockType": true,
+			"blockType": "minecraft:resin_clump",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40101,11 +37631,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:resin_clump",
-			"material": "RESIN_CLUMP",
+			"material": "minecraft:resin_clump",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40114,8 +37643,7 @@
 			"typed": "minecraft:resin_clump"
 		},
 		{
-			"asMaterial": "minecraft:respawn_anchor",
-			"blockType": true,
+			"blockType": "minecraft:respawn_anchor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40138,11 +37666,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:respawn_anchor",
-			"material": "RESPAWN_ANCHOR",
+			"material": "minecraft:respawn_anchor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40151,8 +37678,6 @@
 			"typed": "minecraft:respawn_anchor"
 		},
 		{
-			"asMaterial": "minecraft:rib_armor_trim_smithing_template",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40175,11 +37700,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:rib_armor_trim_smithing_template",
-			"material": "RIB_ARMOR_TRIM_SMITHING_TEMPLATE",
+			"material": "minecraft:rib_armor_trim_smithing_template",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40188,8 +37712,7 @@
 			"typed": "minecraft:rib_armor_trim_smithing_template"
 		},
 		{
-			"asMaterial": "minecraft:rooted_dirt",
-			"blockType": true,
+			"blockType": "minecraft:rooted_dirt",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40212,11 +37735,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:rooted_dirt",
-			"material": "ROOTED_DIRT",
+			"material": "minecraft:rooted_dirt",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40225,8 +37747,7 @@
 			"typed": "minecraft:rooted_dirt"
 		},
 		{
-			"asMaterial": "minecraft:rose_bush",
-			"blockType": true,
+			"blockType": "minecraft:rose_bush",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -40250,11 +37771,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:rose_bush",
-			"material": "ROSE_BUSH",
+			"material": "minecraft:rose_bush",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40263,8 +37783,6 @@
 			"typed": "minecraft:rose_bush"
 		},
 		{
-			"asMaterial": "minecraft:rotten_flesh",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40289,11 +37807,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:rotten_flesh",
-			"material": "ROTTEN_FLESH",
+			"material": "minecraft:rotten_flesh",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40302,8 +37819,6 @@
 			"typed": "minecraft:rotten_flesh"
 		},
 		{
-			"asMaterial": "minecraft:saddle",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40327,11 +37842,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:saddle",
-			"material": "SADDLE",
+			"material": "minecraft:saddle",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40340,8 +37854,6 @@
 			"typed": "minecraft:saddle"
 		},
 		{
-			"asMaterial": "minecraft:salmon",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40366,11 +37878,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:salmon",
-			"material": "SALMON",
+			"material": "minecraft:salmon",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40379,8 +37890,6 @@
 			"typed": "minecraft:salmon"
 		},
 		{
-			"asMaterial": "minecraft:salmon_bucket",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40404,11 +37913,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:salmon_bucket",
-			"material": "SALMON_BUCKET",
+			"material": "minecraft:salmon_bucket",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40417,8 +37925,6 @@
 			"typed": "minecraft:salmon_bucket"
 		},
 		{
-			"asMaterial": "minecraft:salmon_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40441,11 +37947,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:salmon_spawn_egg",
-			"material": "SALMON_SPAWN_EGG",
+			"material": "minecraft:salmon_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40454,8 +37959,7 @@
 			"typed": "minecraft:salmon_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:sand",
-			"blockType": true,
+			"blockType": "minecraft:sand",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40478,11 +37982,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:sand",
-			"material": "SAND",
+			"material": "minecraft:sand",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40491,8 +37994,7 @@
 			"typed": "minecraft:sand"
 		},
 		{
-			"asMaterial": "minecraft:sandstone",
-			"blockType": true,
+			"blockType": "minecraft:sandstone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40515,11 +38017,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:sandstone",
-			"material": "SANDSTONE",
+			"material": "minecraft:sandstone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40528,8 +38029,7 @@
 			"typed": "minecraft:sandstone"
 		},
 		{
-			"asMaterial": "minecraft:sandstone_slab",
-			"blockType": true,
+			"blockType": "minecraft:sandstone_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40552,11 +38052,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:sandstone_slab",
-			"material": "SANDSTONE_SLAB",
+			"material": "minecraft:sandstone_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40565,8 +38064,7 @@
 			"typed": "minecraft:sandstone_slab"
 		},
 		{
-			"asMaterial": "minecraft:sandstone_stairs",
-			"blockType": true,
+			"blockType": "minecraft:sandstone_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40589,11 +38087,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:sandstone_stairs",
-			"material": "SANDSTONE_STAIRS",
+			"material": "minecraft:sandstone_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40602,8 +38099,7 @@
 			"typed": "minecraft:sandstone_stairs"
 		},
 		{
-			"asMaterial": "minecraft:sandstone_wall",
-			"blockType": true,
+			"blockType": "minecraft:sandstone_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40626,11 +38122,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:sandstone_wall",
-			"material": "SANDSTONE_WALL",
+			"material": "minecraft:sandstone_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40639,8 +38134,7 @@
 			"typed": "minecraft:sandstone_wall"
 		},
 		{
-			"asMaterial": "minecraft:scaffolding",
-			"blockType": true,
+			"blockType": "minecraft:scaffolding",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40663,11 +38157,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:scaffolding",
-			"material": "SCAFFOLDING",
+			"material": "minecraft:scaffolding",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40676,8 +38169,6 @@
 			"typed": "minecraft:scaffolding"
 		},
 		{
-			"asMaterial": "minecraft:scrape_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40700,11 +38191,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:scrape_pottery_sherd",
-			"material": "SCRAPE_POTTERY_SHERD",
+			"material": "minecraft:scrape_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40713,8 +38203,7 @@
 			"typed": "minecraft:scrape_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:sculk",
-			"blockType": true,
+			"blockType": "minecraft:sculk",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40737,11 +38226,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:sculk",
-			"material": "SCULK",
+			"material": "minecraft:sculk",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40750,8 +38238,7 @@
 			"typed": "minecraft:sculk"
 		},
 		{
-			"asMaterial": "minecraft:sculk_catalyst",
-			"blockType": true,
+			"blockType": "minecraft:sculk_catalyst",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40774,11 +38261,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:sculk_catalyst",
-			"material": "SCULK_CATALYST",
+			"material": "minecraft:sculk_catalyst",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40787,8 +38273,7 @@
 			"typed": "minecraft:sculk_catalyst"
 		},
 		{
-			"asMaterial": "minecraft:sculk_sensor",
-			"blockType": true,
+			"blockType": "minecraft:sculk_sensor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40811,11 +38296,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:sculk_sensor",
-			"material": "SCULK_SENSOR",
+			"material": "minecraft:sculk_sensor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40824,8 +38308,7 @@
 			"typed": "minecraft:sculk_sensor"
 		},
 		{
-			"asMaterial": "minecraft:sculk_shrieker",
-			"blockType": true,
+			"blockType": "minecraft:sculk_shrieker",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40848,11 +38331,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:sculk_shrieker",
-			"material": "SCULK_SHRIEKER",
+			"material": "minecraft:sculk_shrieker",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40861,8 +38343,7 @@
 			"typed": "minecraft:sculk_shrieker"
 		},
 		{
-			"asMaterial": "minecraft:sculk_vein",
-			"blockType": true,
+			"blockType": "minecraft:sculk_vein",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40885,11 +38366,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:sculk_vein",
-			"material": "SCULK_VEIN",
+			"material": "minecraft:sculk_vein",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40898,8 +38378,7 @@
 			"typed": "minecraft:sculk_vein"
 		},
 		{
-			"asMaterial": "minecraft:sea_lantern",
-			"blockType": true,
+			"blockType": "minecraft:sea_lantern",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -40922,11 +38401,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:sea_lantern",
-			"material": "SEA_LANTERN",
+			"material": "minecraft:sea_lantern",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40935,8 +38413,7 @@
 			"typed": "minecraft:sea_lantern"
 		},
 		{
-			"asMaterial": "minecraft:sea_pickle",
-			"blockType": true,
+			"blockType": "minecraft:sea_pickle",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -40960,11 +38437,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:sea_pickle",
-			"material": "SEA_PICKLE",
+			"material": "minecraft:sea_pickle",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -40973,8 +38449,7 @@
 			"typed": "minecraft:sea_pickle"
 		},
 		{
-			"asMaterial": "minecraft:seagrass",
-			"blockType": true,
+			"blockType": "minecraft:seagrass",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -40998,11 +38473,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:seagrass",
-			"material": "SEAGRASS",
+			"material": "minecraft:seagrass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41011,8 +38485,6 @@
 			"typed": "minecraft:seagrass"
 		},
 		{
-			"asMaterial": "minecraft:sentry_armor_trim_smithing_template",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -41035,11 +38507,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:sentry_armor_trim_smithing_template",
-			"material": "SENTRY_ARMOR_TRIM_SMITHING_TEMPLATE",
+			"material": "minecraft:sentry_armor_trim_smithing_template",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41048,8 +38519,6 @@
 			"typed": "minecraft:sentry_armor_trim_smithing_template"
 		},
 		{
-			"asMaterial": "minecraft:shaper_armor_trim_smithing_template",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -41072,11 +38541,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:shaper_armor_trim_smithing_template",
-			"material": "SHAPER_ARMOR_TRIM_SMITHING_TEMPLATE",
+			"material": "minecraft:shaper_armor_trim_smithing_template",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41085,8 +38553,6 @@
 			"typed": "minecraft:shaper_armor_trim_smithing_template"
 		},
 		{
-			"asMaterial": "minecraft:sheaf_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -41109,11 +38575,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:sheaf_pottery_sherd",
-			"material": "SHEAF_POTTERY_SHERD",
+			"material": "minecraft:sheaf_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41122,8 +38587,6 @@
 			"typed": "minecraft:sheaf_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:shears",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -41149,11 +38612,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:shears",
-			"material": "SHEARS",
+			"material": "minecraft:shears",
 			"maxDurability": 238,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41162,8 +38624,6 @@
 			"typed": "minecraft:shears"
 		},
 		{
-			"asMaterial": "minecraft:sheep_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -41186,11 +38646,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:sheep_spawn_egg",
-			"material": "SHEEP_SPAWN_EGG",
+			"material": "minecraft:sheep_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41199,8 +38658,6 @@
 			"typed": "minecraft:sheep_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:shelter_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -41223,11 +38680,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:shelter_pottery_sherd",
-			"material": "SHELTER_POTTERY_SHERD",
+			"material": "minecraft:shelter_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41236,8 +38692,6 @@
 			"typed": "minecraft:shelter_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:shield",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -41266,11 +38720,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:shield",
-			"material": "SHIELD",
+			"material": "minecraft:shield",
 			"maxDurability": 336,
 			"maxStackSize": 1,
 			"metaClass": "ShieldMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41279,8 +38732,7 @@
 			"typed": "minecraft:shield"
 		},
 		{
-			"asMaterial": "minecraft:short_dry_grass",
-			"blockType": true,
+			"blockType": "minecraft:short_dry_grass",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -41304,11 +38756,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:short_dry_grass",
-			"material": "SHORT_DRY_GRASS",
+			"material": "minecraft:short_dry_grass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41317,8 +38768,7 @@
 			"typed": "minecraft:short_dry_grass"
 		},
 		{
-			"asMaterial": "minecraft:short_grass",
-			"blockType": true,
+			"blockType": "minecraft:short_grass",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -41342,11 +38792,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:short_grass",
-			"material": "SHORT_GRASS",
+			"material": "minecraft:short_grass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41355,8 +38804,7 @@
 			"typed": "minecraft:short_grass"
 		},
 		{
-			"asMaterial": "minecraft:shroomlight",
-			"blockType": true,
+			"blockType": "minecraft:shroomlight",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -41380,11 +38828,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:shroomlight",
-			"material": "SHROOMLIGHT",
+			"material": "minecraft:shroomlight",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41393,8 +38840,7 @@
 			"typed": "minecraft:shroomlight"
 		},
 		{
-			"asMaterial": "minecraft:shulker_box",
-			"blockType": true,
+			"blockType": "minecraft:shulker_box",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -41418,11 +38864,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:shulker_box",
-			"material": "SHULKER_BOX",
+			"material": "minecraft:shulker_box",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41431,8 +38876,6 @@
 			"typed": "minecraft:shulker_box"
 		},
 		{
-			"asMaterial": "minecraft:shulker_shell",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -41455,11 +38898,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:shulker_shell",
-			"material": "SHULKER_SHELL",
+			"material": "minecraft:shulker_shell",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41468,8 +38910,6 @@
 			"typed": "minecraft:shulker_shell"
 		},
 		{
-			"asMaterial": "minecraft:shulker_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -41492,11 +38932,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:shulker_spawn_egg",
-			"material": "SHULKER_SPAWN_EGG",
+			"material": "minecraft:shulker_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41505,8 +38944,6 @@
 			"typed": "minecraft:shulker_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:silence_armor_trim_smithing_template",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -41529,11 +38966,10 @@
 			"fuel": false,
 			"itemRarity": "EPIC",
 			"key": "minecraft:silence_armor_trim_smithing_template",
-			"material": "SILENCE_ARMOR_TRIM_SMITHING_TEMPLATE",
+			"material": "minecraft:silence_armor_trim_smithing_template",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "EPIC",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41542,8 +38978,6 @@
 			"typed": "minecraft:silence_armor_trim_smithing_template"
 		},
 		{
-			"asMaterial": "minecraft:silverfish_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -41566,11 +39000,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:silverfish_spawn_egg",
-			"material": "SILVERFISH_SPAWN_EGG",
+			"material": "minecraft:silverfish_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41579,8 +39012,6 @@
 			"typed": "minecraft:silverfish_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:skeleton_horse_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -41603,11 +39034,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:skeleton_horse_spawn_egg",
-			"material": "SKELETON_HORSE_SPAWN_EGG",
+			"material": "minecraft:skeleton_horse_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41616,8 +39046,7 @@
 			"typed": "minecraft:skeleton_horse_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:skeleton_skull",
-			"blockType": true,
+			"blockType": "minecraft:skeleton_skull",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -41641,11 +39070,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:skeleton_skull",
-			"material": "SKELETON_SKULL",
+			"material": "minecraft:skeleton_skull",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SkullMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41654,8 +39082,6 @@
 			"typed": "minecraft:skeleton_skull"
 		},
 		{
-			"asMaterial": "minecraft:skeleton_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -41678,11 +39104,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:skeleton_spawn_egg",
-			"material": "SKELETON_SPAWN_EGG",
+			"material": "minecraft:skeleton_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41691,8 +39116,6 @@
 			"typed": "minecraft:skeleton_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:skull_banner_pattern",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -41716,11 +39139,10 @@
 			"fuel": false,
 			"itemRarity": "RARE",
 			"key": "minecraft:skull_banner_pattern",
-			"material": "SKULL_BANNER_PATTERN",
+			"material": "minecraft:skull_banner_pattern",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "RARE",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41729,8 +39151,6 @@
 			"typed": "minecraft:skull_banner_pattern"
 		},
 		{
-			"asMaterial": "minecraft:skull_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -41753,11 +39173,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:skull_pottery_sherd",
-			"material": "SKULL_POTTERY_SHERD",
+			"material": "minecraft:skull_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41766,8 +39185,6 @@
 			"typed": "minecraft:skull_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:slime_ball",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -41790,11 +39207,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:slime_ball",
-			"material": "SLIME_BALL",
+			"material": "minecraft:slime_ball",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41803,8 +39219,7 @@
 			"typed": "minecraft:slime_ball"
 		},
 		{
-			"asMaterial": "minecraft:slime_block",
-			"blockType": true,
+			"blockType": "minecraft:slime_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -41827,11 +39242,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:slime_block",
-			"material": "SLIME_BLOCK",
+			"material": "minecraft:slime_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41840,8 +39254,6 @@
 			"typed": "minecraft:slime_block"
 		},
 		{
-			"asMaterial": "minecraft:slime_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -41864,11 +39276,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:slime_spawn_egg",
-			"material": "SLIME_SPAWN_EGG",
+			"material": "minecraft:slime_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41877,8 +39288,7 @@
 			"typed": "minecraft:slime_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:small_amethyst_bud",
-			"blockType": true,
+			"blockType": "minecraft:small_amethyst_bud",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -41901,11 +39311,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:small_amethyst_bud",
-			"material": "SMALL_AMETHYST_BUD",
+			"material": "minecraft:small_amethyst_bud",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41914,8 +39323,7 @@
 			"typed": "minecraft:small_amethyst_bud"
 		},
 		{
-			"asMaterial": "minecraft:small_dripleaf",
-			"blockType": true,
+			"blockType": "minecraft:small_dripleaf",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -41939,11 +39347,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:small_dripleaf",
-			"material": "SMALL_DRIPLEAF",
+			"material": "minecraft:small_dripleaf",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41952,8 +39359,7 @@
 			"typed": "minecraft:small_dripleaf"
 		},
 		{
-			"asMaterial": "minecraft:smithing_table",
-			"blockType": true,
+			"blockType": "minecraft:smithing_table",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -41976,11 +39382,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:smithing_table",
-			"material": "SMITHING_TABLE",
+			"material": "minecraft:smithing_table",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -41989,8 +39394,7 @@
 			"typed": "minecraft:smithing_table"
 		},
 		{
-			"asMaterial": "minecraft:smoker",
-			"blockType": true,
+			"blockType": "minecraft:smoker",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42014,11 +39418,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:smoker",
-			"material": "SMOKER",
+			"material": "minecraft:smoker",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42027,8 +39430,7 @@
 			"typed": "minecraft:smoker"
 		},
 		{
-			"asMaterial": "minecraft:smooth_basalt",
-			"blockType": true,
+			"blockType": "minecraft:smooth_basalt",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42051,11 +39453,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:smooth_basalt",
-			"material": "SMOOTH_BASALT",
+			"material": "minecraft:smooth_basalt",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42064,8 +39465,7 @@
 			"typed": "minecraft:smooth_basalt"
 		},
 		{
-			"asMaterial": "minecraft:smooth_quartz",
-			"blockType": true,
+			"blockType": "minecraft:smooth_quartz",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42088,11 +39488,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:smooth_quartz",
-			"material": "SMOOTH_QUARTZ",
+			"material": "minecraft:smooth_quartz",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42101,8 +39500,7 @@
 			"typed": "minecraft:smooth_quartz"
 		},
 		{
-			"asMaterial": "minecraft:smooth_quartz_slab",
-			"blockType": true,
+			"blockType": "minecraft:smooth_quartz_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42125,11 +39523,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:smooth_quartz_slab",
-			"material": "SMOOTH_QUARTZ_SLAB",
+			"material": "minecraft:smooth_quartz_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42138,8 +39535,7 @@
 			"typed": "minecraft:smooth_quartz_slab"
 		},
 		{
-			"asMaterial": "minecraft:smooth_quartz_stairs",
-			"blockType": true,
+			"blockType": "minecraft:smooth_quartz_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42162,11 +39558,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:smooth_quartz_stairs",
-			"material": "SMOOTH_QUARTZ_STAIRS",
+			"material": "minecraft:smooth_quartz_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42175,8 +39570,7 @@
 			"typed": "minecraft:smooth_quartz_stairs"
 		},
 		{
-			"asMaterial": "minecraft:smooth_red_sandstone",
-			"blockType": true,
+			"blockType": "minecraft:smooth_red_sandstone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42199,11 +39593,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:smooth_red_sandstone",
-			"material": "SMOOTH_RED_SANDSTONE",
+			"material": "minecraft:smooth_red_sandstone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42212,8 +39605,7 @@
 			"typed": "minecraft:smooth_red_sandstone"
 		},
 		{
-			"asMaterial": "minecraft:smooth_red_sandstone_slab",
-			"blockType": true,
+			"blockType": "minecraft:smooth_red_sandstone_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42236,11 +39628,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:smooth_red_sandstone_slab",
-			"material": "SMOOTH_RED_SANDSTONE_SLAB",
+			"material": "minecraft:smooth_red_sandstone_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42249,8 +39640,7 @@
 			"typed": "minecraft:smooth_red_sandstone_slab"
 		},
 		{
-			"asMaterial": "minecraft:smooth_red_sandstone_stairs",
-			"blockType": true,
+			"blockType": "minecraft:smooth_red_sandstone_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42273,11 +39663,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:smooth_red_sandstone_stairs",
-			"material": "SMOOTH_RED_SANDSTONE_STAIRS",
+			"material": "minecraft:smooth_red_sandstone_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42286,8 +39675,7 @@
 			"typed": "minecraft:smooth_red_sandstone_stairs"
 		},
 		{
-			"asMaterial": "minecraft:smooth_sandstone",
-			"blockType": true,
+			"blockType": "minecraft:smooth_sandstone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42310,11 +39698,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:smooth_sandstone",
-			"material": "SMOOTH_SANDSTONE",
+			"material": "minecraft:smooth_sandstone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42323,8 +39710,7 @@
 			"typed": "minecraft:smooth_sandstone"
 		},
 		{
-			"asMaterial": "minecraft:smooth_sandstone_slab",
-			"blockType": true,
+			"blockType": "minecraft:smooth_sandstone_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42347,11 +39733,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:smooth_sandstone_slab",
-			"material": "SMOOTH_SANDSTONE_SLAB",
+			"material": "minecraft:smooth_sandstone_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42360,8 +39745,7 @@
 			"typed": "minecraft:smooth_sandstone_slab"
 		},
 		{
-			"asMaterial": "minecraft:smooth_sandstone_stairs",
-			"blockType": true,
+			"blockType": "minecraft:smooth_sandstone_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42384,11 +39768,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:smooth_sandstone_stairs",
-			"material": "SMOOTH_SANDSTONE_STAIRS",
+			"material": "minecraft:smooth_sandstone_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42397,8 +39780,7 @@
 			"typed": "minecraft:smooth_sandstone_stairs"
 		},
 		{
-			"asMaterial": "minecraft:smooth_stone",
-			"blockType": true,
+			"blockType": "minecraft:smooth_stone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42421,11 +39803,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:smooth_stone",
-			"material": "SMOOTH_STONE",
+			"material": "minecraft:smooth_stone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42434,8 +39815,7 @@
 			"typed": "minecraft:smooth_stone"
 		},
 		{
-			"asMaterial": "minecraft:smooth_stone_slab",
-			"blockType": true,
+			"blockType": "minecraft:smooth_stone_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42458,11 +39838,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:smooth_stone_slab",
-			"material": "SMOOTH_STONE_SLAB",
+			"material": "minecraft:smooth_stone_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42471,8 +39850,7 @@
 			"typed": "minecraft:smooth_stone_slab"
 		},
 		{
-			"asMaterial": "minecraft:sniffer_egg",
-			"blockType": true,
+			"blockType": "minecraft:sniffer_egg",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42495,11 +39873,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:sniffer_egg",
-			"material": "SNIFFER_EGG",
+			"material": "minecraft:sniffer_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42508,8 +39885,6 @@
 			"typed": "minecraft:sniffer_egg"
 		},
 		{
-			"asMaterial": "minecraft:sniffer_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42532,11 +39907,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:sniffer_spawn_egg",
-			"material": "SNIFFER_SPAWN_EGG",
+			"material": "minecraft:sniffer_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42545,8 +39919,6 @@
 			"typed": "minecraft:sniffer_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:snort_pottery_sherd",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42569,11 +39941,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:snort_pottery_sherd",
-			"material": "SNORT_POTTERY_SHERD",
+			"material": "minecraft:snort_pottery_sherd",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42582,8 +39953,6 @@
 			"typed": "minecraft:snort_pottery_sherd"
 		},
 		{
-			"asMaterial": "minecraft:snout_armor_trim_smithing_template",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42606,11 +39975,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:snout_armor_trim_smithing_template",
-			"material": "SNOUT_ARMOR_TRIM_SMITHING_TEMPLATE",
+			"material": "minecraft:snout_armor_trim_smithing_template",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42619,8 +39987,7 @@
 			"typed": "minecraft:snout_armor_trim_smithing_template"
 		},
 		{
-			"asMaterial": "minecraft:snow",
-			"blockType": true,
+			"blockType": "minecraft:snow",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42643,11 +40010,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:snow",
-			"material": "SNOW",
+			"material": "minecraft:snow",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42656,8 +40022,7 @@
 			"typed": "minecraft:snow"
 		},
 		{
-			"asMaterial": "minecraft:snow_block",
-			"blockType": true,
+			"blockType": "minecraft:snow_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42680,11 +40045,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:snow_block",
-			"material": "SNOW_BLOCK",
+			"material": "minecraft:snow_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42693,8 +40057,6 @@
 			"typed": "minecraft:snow_block"
 		},
 		{
-			"asMaterial": "minecraft:snow_golem_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42717,11 +40079,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:snow_golem_spawn_egg",
-			"material": "SNOW_GOLEM_SPAWN_EGG",
+			"material": "minecraft:snow_golem_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42730,8 +40091,6 @@
 			"typed": "minecraft:snow_golem_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:snowball",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42754,11 +40113,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:snowball",
-			"material": "SNOWBALL",
+			"material": "minecraft:snowball",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42767,8 +40125,7 @@
 			"typed": "minecraft:snowball"
 		},
 		{
-			"asMaterial": "minecraft:soul_campfire",
-			"blockType": true,
+			"blockType": "minecraft:soul_campfire",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42792,11 +40149,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:soul_campfire",
-			"material": "SOUL_CAMPFIRE",
+			"material": "minecraft:soul_campfire",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42805,8 +40161,7 @@
 			"typed": "minecraft:soul_campfire"
 		},
 		{
-			"asMaterial": "minecraft:soul_lantern",
-			"blockType": true,
+			"blockType": "minecraft:soul_lantern",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42829,11 +40184,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:soul_lantern",
-			"material": "SOUL_LANTERN",
+			"material": "minecraft:soul_lantern",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42842,8 +40196,7 @@
 			"typed": "minecraft:soul_lantern"
 		},
 		{
-			"asMaterial": "minecraft:soul_sand",
-			"blockType": true,
+			"blockType": "minecraft:soul_sand",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42866,11 +40219,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:soul_sand",
-			"material": "SOUL_SAND",
+			"material": "minecraft:soul_sand",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42879,8 +40231,7 @@
 			"typed": "minecraft:soul_sand"
 		},
 		{
-			"asMaterial": "minecraft:soul_soil",
-			"blockType": true,
+			"blockType": "minecraft:soul_soil",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42903,11 +40254,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:soul_soil",
-			"material": "SOUL_SOIL",
+			"material": "minecraft:soul_soil",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42916,8 +40266,7 @@
 			"typed": "minecraft:soul_soil"
 		},
 		{
-			"asMaterial": "minecraft:soul_torch",
-			"blockType": true,
+			"blockType": "minecraft:soul_torch",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42940,11 +40289,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:soul_torch",
-			"material": "SOUL_TORCH",
+			"material": "minecraft:soul_torch",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42953,8 +40301,7 @@
 			"typed": "minecraft:soul_torch"
 		},
 		{
-			"asMaterial": "minecraft:spawner",
-			"blockType": true,
+			"blockType": "minecraft:spawner",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -42977,11 +40324,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spawner",
-			"material": "SPAWNER",
+			"material": "minecraft:spawner",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -42990,8 +40336,6 @@
 			"typed": "minecraft:spawner"
 		},
 		{
-			"asMaterial": "minecraft:spectral_arrow",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43014,11 +40358,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spectral_arrow",
-			"material": "SPECTRAL_ARROW",
+			"material": "minecraft:spectral_arrow",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43027,8 +40370,6 @@
 			"typed": "minecraft:spectral_arrow"
 		},
 		{
-			"asMaterial": "minecraft:spider_eye",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43053,11 +40394,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spider_eye",
-			"material": "SPIDER_EYE",
+			"material": "minecraft:spider_eye",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43066,8 +40406,6 @@
 			"typed": "minecraft:spider_eye"
 		},
 		{
-			"asMaterial": "minecraft:spider_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43090,11 +40428,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spider_spawn_egg",
-			"material": "SPIDER_SPAWN_EGG",
+			"material": "minecraft:spider_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43103,8 +40440,6 @@
 			"typed": "minecraft:spider_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:spire_armor_trim_smithing_template",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43127,11 +40462,10 @@
 			"fuel": false,
 			"itemRarity": "RARE",
 			"key": "minecraft:spire_armor_trim_smithing_template",
-			"material": "SPIRE_ARMOR_TRIM_SMITHING_TEMPLATE",
+			"material": "minecraft:spire_armor_trim_smithing_template",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "RARE",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43140,8 +40474,6 @@
 			"typed": "minecraft:spire_armor_trim_smithing_template"
 		},
 		{
-			"asMaterial": "minecraft:splash_potion",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43165,11 +40497,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:splash_potion",
-			"material": "SPLASH_POTION",
+			"material": "minecraft:splash_potion",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "PotionMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43178,8 +40509,7 @@
 			"typed": "minecraft:splash_potion"
 		},
 		{
-			"asMaterial": "minecraft:sponge",
-			"blockType": true,
+			"blockType": "minecraft:sponge",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43202,11 +40532,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:sponge",
-			"material": "SPONGE",
+			"material": "minecraft:sponge",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43215,8 +40544,7 @@
 			"typed": "minecraft:sponge"
 		},
 		{
-			"asMaterial": "minecraft:spore_blossom",
-			"blockType": true,
+			"blockType": "minecraft:spore_blossom",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -43240,11 +40568,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spore_blossom",
-			"material": "SPORE_BLOSSOM",
+			"material": "minecraft:spore_blossom",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43253,8 +40580,6 @@
 			"typed": "minecraft:spore_blossom"
 		},
 		{
-			"asMaterial": "minecraft:spruce_boat",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43277,11 +40602,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spruce_boat",
-			"material": "SPRUCE_BOAT",
+			"material": "minecraft:spruce_boat",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43290,8 +40614,7 @@
 			"typed": "minecraft:spruce_boat"
 		},
 		{
-			"asMaterial": "minecraft:spruce_button",
-			"blockType": true,
+			"blockType": "minecraft:spruce_button",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43314,11 +40637,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spruce_button",
-			"material": "SPRUCE_BUTTON",
+			"material": "minecraft:spruce_button",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43327,8 +40649,6 @@
 			"typed": "minecraft:spruce_button"
 		},
 		{
-			"asMaterial": "minecraft:spruce_chest_boat",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43351,11 +40671,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spruce_chest_boat",
-			"material": "SPRUCE_CHEST_BOAT",
+			"material": "minecraft:spruce_chest_boat",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43364,8 +40683,7 @@
 			"typed": "minecraft:spruce_chest_boat"
 		},
 		{
-			"asMaterial": "minecraft:spruce_door",
-			"blockType": true,
+			"blockType": "minecraft:spruce_door",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43388,11 +40706,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spruce_door",
-			"material": "SPRUCE_DOOR",
+			"material": "minecraft:spruce_door",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43401,8 +40718,7 @@
 			"typed": "minecraft:spruce_door"
 		},
 		{
-			"asMaterial": "minecraft:spruce_fence",
-			"blockType": true,
+			"blockType": "minecraft:spruce_fence",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43425,11 +40741,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spruce_fence",
-			"material": "SPRUCE_FENCE",
+			"material": "minecraft:spruce_fence",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43438,8 +40753,7 @@
 			"typed": "minecraft:spruce_fence"
 		},
 		{
-			"asMaterial": "minecraft:spruce_fence_gate",
-			"blockType": true,
+			"blockType": "minecraft:spruce_fence_gate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43462,11 +40776,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spruce_fence_gate",
-			"material": "SPRUCE_FENCE_GATE",
+			"material": "minecraft:spruce_fence_gate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43475,8 +40788,7 @@
 			"typed": "minecraft:spruce_fence_gate"
 		},
 		{
-			"asMaterial": "minecraft:spruce_hanging_sign",
-			"blockType": true,
+			"blockType": "minecraft:spruce_hanging_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43499,11 +40811,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spruce_hanging_sign",
-			"material": "SPRUCE_HANGING_SIGN",
+			"material": "minecraft:spruce_hanging_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43512,8 +40823,7 @@
 			"typed": "minecraft:spruce_hanging_sign"
 		},
 		{
-			"asMaterial": "minecraft:spruce_leaves",
-			"blockType": true,
+			"blockType": "minecraft:spruce_leaves",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -43537,11 +40847,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spruce_leaves",
-			"material": "SPRUCE_LEAVES",
+			"material": "minecraft:spruce_leaves",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43550,8 +40859,7 @@
 			"typed": "minecraft:spruce_leaves"
 		},
 		{
-			"asMaterial": "minecraft:spruce_log",
-			"blockType": true,
+			"blockType": "minecraft:spruce_log",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43574,11 +40882,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spruce_log",
-			"material": "SPRUCE_LOG",
+			"material": "minecraft:spruce_log",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43587,8 +40894,7 @@
 			"typed": "minecraft:spruce_log"
 		},
 		{
-			"asMaterial": "minecraft:spruce_planks",
-			"blockType": true,
+			"blockType": "minecraft:spruce_planks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43611,11 +40917,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spruce_planks",
-			"material": "SPRUCE_PLANKS",
+			"material": "minecraft:spruce_planks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43624,8 +40929,7 @@
 			"typed": "minecraft:spruce_planks"
 		},
 		{
-			"asMaterial": "minecraft:spruce_pressure_plate",
-			"blockType": true,
+			"blockType": "minecraft:spruce_pressure_plate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43648,11 +40952,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spruce_pressure_plate",
-			"material": "SPRUCE_PRESSURE_PLATE",
+			"material": "minecraft:spruce_pressure_plate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43661,8 +40964,7 @@
 			"typed": "minecraft:spruce_pressure_plate"
 		},
 		{
-			"asMaterial": "minecraft:spruce_sapling",
-			"blockType": true,
+			"blockType": "minecraft:spruce_sapling",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -43686,11 +40988,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spruce_sapling",
-			"material": "SPRUCE_SAPLING",
+			"material": "minecraft:spruce_sapling",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43699,8 +41000,7 @@
 			"typed": "minecraft:spruce_sapling"
 		},
 		{
-			"asMaterial": "minecraft:spruce_sign",
-			"blockType": true,
+			"blockType": "minecraft:spruce_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43723,11 +41023,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spruce_sign",
-			"material": "SPRUCE_SIGN",
+			"material": "minecraft:spruce_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43736,8 +41035,7 @@
 			"typed": "minecraft:spruce_sign"
 		},
 		{
-			"asMaterial": "minecraft:spruce_slab",
-			"blockType": true,
+			"blockType": "minecraft:spruce_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43760,11 +41058,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spruce_slab",
-			"material": "SPRUCE_SLAB",
+			"material": "minecraft:spruce_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43773,8 +41070,7 @@
 			"typed": "minecraft:spruce_slab"
 		},
 		{
-			"asMaterial": "minecraft:spruce_stairs",
-			"blockType": true,
+			"blockType": "minecraft:spruce_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43797,11 +41093,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spruce_stairs",
-			"material": "SPRUCE_STAIRS",
+			"material": "minecraft:spruce_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43810,8 +41105,7 @@
 			"typed": "minecraft:spruce_stairs"
 		},
 		{
-			"asMaterial": "minecraft:spruce_trapdoor",
-			"blockType": true,
+			"blockType": "minecraft:spruce_trapdoor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43834,11 +41128,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spruce_trapdoor",
-			"material": "SPRUCE_TRAPDOOR",
+			"material": "minecraft:spruce_trapdoor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43847,8 +41140,7 @@
 			"typed": "minecraft:spruce_trapdoor"
 		},
 		{
-			"asMaterial": "minecraft:spruce_wood",
-			"blockType": true,
+			"blockType": "minecraft:spruce_wood",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43871,11 +41163,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spruce_wood",
-			"material": "SPRUCE_WOOD",
+			"material": "minecraft:spruce_wood",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43884,8 +41175,6 @@
 			"typed": "minecraft:spruce_wood"
 		},
 		{
-			"asMaterial": "minecraft:spyglass",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43908,11 +41197,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:spyglass",
-			"material": "SPYGLASS",
+			"material": "minecraft:spyglass",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43921,8 +41209,6 @@
 			"typed": "minecraft:spyglass"
 		},
 		{
-			"asMaterial": "minecraft:squid_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43945,11 +41231,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:squid_spawn_egg",
-			"material": "SQUID_SPAWN_EGG",
+			"material": "minecraft:squid_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43958,8 +41243,6 @@
 			"typed": "minecraft:squid_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:stick",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -43982,11 +41265,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stick",
-			"material": "STICK",
+			"material": "minecraft:stick",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -43995,8 +41277,7 @@
 			"typed": "minecraft:stick"
 		},
 		{
-			"asMaterial": "minecraft:sticky_piston",
-			"blockType": true,
+			"blockType": "minecraft:sticky_piston",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44019,11 +41300,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:sticky_piston",
-			"material": "STICKY_PISTON",
+			"material": "minecraft:sticky_piston",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44032,8 +41312,7 @@
 			"typed": "minecraft:sticky_piston"
 		},
 		{
-			"asMaterial": "minecraft:stone",
-			"blockType": true,
+			"blockType": "minecraft:stone",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44056,11 +41335,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stone",
-			"material": "STONE",
+			"material": "minecraft:stone",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44069,8 +41347,6 @@
 			"typed": "minecraft:stone"
 		},
 		{
-			"asMaterial": "minecraft:stone_axe",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44099,11 +41375,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stone_axe",
-			"material": "STONE_AXE",
+			"material": "minecraft:stone_axe",
 			"maxDurability": 131,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44112,8 +41387,7 @@
 			"typed": "minecraft:stone_axe"
 		},
 		{
-			"asMaterial": "minecraft:stone_brick_slab",
-			"blockType": true,
+			"blockType": "minecraft:stone_brick_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44136,11 +41410,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stone_brick_slab",
-			"material": "STONE_BRICK_SLAB",
+			"material": "minecraft:stone_brick_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44149,8 +41422,7 @@
 			"typed": "minecraft:stone_brick_slab"
 		},
 		{
-			"asMaterial": "minecraft:stone_brick_stairs",
-			"blockType": true,
+			"blockType": "minecraft:stone_brick_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44173,11 +41445,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stone_brick_stairs",
-			"material": "STONE_BRICK_STAIRS",
+			"material": "minecraft:stone_brick_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44186,8 +41457,7 @@
 			"typed": "minecraft:stone_brick_stairs"
 		},
 		{
-			"asMaterial": "minecraft:stone_brick_wall",
-			"blockType": true,
+			"blockType": "minecraft:stone_brick_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44210,11 +41480,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stone_brick_wall",
-			"material": "STONE_BRICK_WALL",
+			"material": "minecraft:stone_brick_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44223,8 +41492,7 @@
 			"typed": "minecraft:stone_brick_wall"
 		},
 		{
-			"asMaterial": "minecraft:stone_bricks",
-			"blockType": true,
+			"blockType": "minecraft:stone_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44247,11 +41515,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stone_bricks",
-			"material": "STONE_BRICKS",
+			"material": "minecraft:stone_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44260,8 +41527,7 @@
 			"typed": "minecraft:stone_bricks"
 		},
 		{
-			"asMaterial": "minecraft:stone_button",
-			"blockType": true,
+			"blockType": "minecraft:stone_button",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44284,11 +41550,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stone_button",
-			"material": "STONE_BUTTON",
+			"material": "minecraft:stone_button",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44297,8 +41562,6 @@
 			"typed": "minecraft:stone_button"
 		},
 		{
-			"asMaterial": "minecraft:stone_hoe",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44327,11 +41590,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stone_hoe",
-			"material": "STONE_HOE",
+			"material": "minecraft:stone_hoe",
 			"maxDurability": 131,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44340,8 +41602,6 @@
 			"typed": "minecraft:stone_hoe"
 		},
 		{
-			"asMaterial": "minecraft:stone_pickaxe",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44370,11 +41630,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stone_pickaxe",
-			"material": "STONE_PICKAXE",
+			"material": "minecraft:stone_pickaxe",
 			"maxDurability": 131,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44383,8 +41642,7 @@
 			"typed": "minecraft:stone_pickaxe"
 		},
 		{
-			"asMaterial": "minecraft:stone_pressure_plate",
-			"blockType": true,
+			"blockType": "minecraft:stone_pressure_plate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44407,11 +41665,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stone_pressure_plate",
-			"material": "STONE_PRESSURE_PLATE",
+			"material": "minecraft:stone_pressure_plate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44420,8 +41677,6 @@
 			"typed": "minecraft:stone_pressure_plate"
 		},
 		{
-			"asMaterial": "minecraft:stone_shovel",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44450,11 +41705,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stone_shovel",
-			"material": "STONE_SHOVEL",
+			"material": "minecraft:stone_shovel",
 			"maxDurability": 131,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44463,8 +41717,7 @@
 			"typed": "minecraft:stone_shovel"
 		},
 		{
-			"asMaterial": "minecraft:stone_slab",
-			"blockType": true,
+			"blockType": "minecraft:stone_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44487,11 +41740,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stone_slab",
-			"material": "STONE_SLAB",
+			"material": "minecraft:stone_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44500,8 +41752,7 @@
 			"typed": "minecraft:stone_slab"
 		},
 		{
-			"asMaterial": "minecraft:stone_stairs",
-			"blockType": true,
+			"blockType": "minecraft:stone_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44524,11 +41775,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stone_stairs",
-			"material": "STONE_STAIRS",
+			"material": "minecraft:stone_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44537,8 +41787,6 @@
 			"typed": "minecraft:stone_stairs"
 		},
 		{
-			"asMaterial": "minecraft:stone_sword",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44567,11 +41815,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stone_sword",
-			"material": "STONE_SWORD",
+			"material": "minecraft:stone_sword",
 			"maxDurability": 131,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44580,8 +41827,7 @@
 			"typed": "minecraft:stone_sword"
 		},
 		{
-			"asMaterial": "minecraft:stonecutter",
-			"blockType": true,
+			"blockType": "minecraft:stonecutter",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44604,11 +41850,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stonecutter",
-			"material": "STONECUTTER",
+			"material": "minecraft:stonecutter",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44617,8 +41862,6 @@
 			"typed": "minecraft:stonecutter"
 		},
 		{
-			"asMaterial": "minecraft:stray_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44641,11 +41884,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stray_spawn_egg",
-			"material": "STRAY_SPAWN_EGG",
+			"material": "minecraft:stray_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44654,8 +41896,6 @@
 			"typed": "minecraft:stray_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:strider_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44678,11 +41918,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:strider_spawn_egg",
-			"material": "STRIDER_SPAWN_EGG",
+			"material": "minecraft:strider_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44691,8 +41930,7 @@
 			"typed": "minecraft:strider_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:string",
-			"blockType": true,
+			"blockType": "minecraft:tripwire",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44715,11 +41953,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:string",
-			"material": "STRING",
+			"material": "minecraft:string",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44728,8 +41965,7 @@
 			"typed": "minecraft:string"
 		},
 		{
-			"asMaterial": "minecraft:stripped_acacia_log",
-			"blockType": true,
+			"blockType": "minecraft:stripped_acacia_log",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44752,11 +41988,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_acacia_log",
-			"material": "STRIPPED_ACACIA_LOG",
+			"material": "minecraft:stripped_acacia_log",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44765,8 +42000,7 @@
 			"typed": "minecraft:stripped_acacia_log"
 		},
 		{
-			"asMaterial": "minecraft:stripped_acacia_wood",
-			"blockType": true,
+			"blockType": "minecraft:stripped_acacia_wood",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44789,11 +42023,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_acacia_wood",
-			"material": "STRIPPED_ACACIA_WOOD",
+			"material": "minecraft:stripped_acacia_wood",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44802,8 +42035,7 @@
 			"typed": "minecraft:stripped_acacia_wood"
 		},
 		{
-			"asMaterial": "minecraft:stripped_bamboo_block",
-			"blockType": true,
+			"blockType": "minecraft:stripped_bamboo_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44826,11 +42058,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_bamboo_block",
-			"material": "STRIPPED_BAMBOO_BLOCK",
+			"material": "minecraft:stripped_bamboo_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44839,8 +42070,7 @@
 			"typed": "minecraft:stripped_bamboo_block"
 		},
 		{
-			"asMaterial": "minecraft:stripped_birch_log",
-			"blockType": true,
+			"blockType": "minecraft:stripped_birch_log",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44863,11 +42093,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_birch_log",
-			"material": "STRIPPED_BIRCH_LOG",
+			"material": "minecraft:stripped_birch_log",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44876,8 +42105,7 @@
 			"typed": "minecraft:stripped_birch_log"
 		},
 		{
-			"asMaterial": "minecraft:stripped_birch_wood",
-			"blockType": true,
+			"blockType": "minecraft:stripped_birch_wood",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44900,11 +42128,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_birch_wood",
-			"material": "STRIPPED_BIRCH_WOOD",
+			"material": "minecraft:stripped_birch_wood",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44913,8 +42140,7 @@
 			"typed": "minecraft:stripped_birch_wood"
 		},
 		{
-			"asMaterial": "minecraft:stripped_cherry_log",
-			"blockType": true,
+			"blockType": "minecraft:stripped_cherry_log",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44937,11 +42163,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_cherry_log",
-			"material": "STRIPPED_CHERRY_LOG",
+			"material": "minecraft:stripped_cherry_log",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44950,8 +42175,7 @@
 			"typed": "minecraft:stripped_cherry_log"
 		},
 		{
-			"asMaterial": "minecraft:stripped_cherry_wood",
-			"blockType": true,
+			"blockType": "minecraft:stripped_cherry_wood",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -44974,11 +42198,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_cherry_wood",
-			"material": "STRIPPED_CHERRY_WOOD",
+			"material": "minecraft:stripped_cherry_wood",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -44987,8 +42210,7 @@
 			"typed": "minecraft:stripped_cherry_wood"
 		},
 		{
-			"asMaterial": "minecraft:stripped_crimson_hyphae",
-			"blockType": true,
+			"blockType": "minecraft:stripped_crimson_hyphae",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45011,11 +42233,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_crimson_hyphae",
-			"material": "STRIPPED_CRIMSON_HYPHAE",
+			"material": "minecraft:stripped_crimson_hyphae",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45024,8 +42245,7 @@
 			"typed": "minecraft:stripped_crimson_hyphae"
 		},
 		{
-			"asMaterial": "minecraft:stripped_crimson_stem",
-			"blockType": true,
+			"blockType": "minecraft:stripped_crimson_stem",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45048,11 +42268,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_crimson_stem",
-			"material": "STRIPPED_CRIMSON_STEM",
+			"material": "minecraft:stripped_crimson_stem",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45061,8 +42280,7 @@
 			"typed": "minecraft:stripped_crimson_stem"
 		},
 		{
-			"asMaterial": "minecraft:stripped_dark_oak_log",
-			"blockType": true,
+			"blockType": "minecraft:stripped_dark_oak_log",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45085,11 +42303,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_dark_oak_log",
-			"material": "STRIPPED_DARK_OAK_LOG",
+			"material": "minecraft:stripped_dark_oak_log",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45098,8 +42315,7 @@
 			"typed": "minecraft:stripped_dark_oak_log"
 		},
 		{
-			"asMaterial": "minecraft:stripped_dark_oak_wood",
-			"blockType": true,
+			"blockType": "minecraft:stripped_dark_oak_wood",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45122,11 +42338,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_dark_oak_wood",
-			"material": "STRIPPED_DARK_OAK_WOOD",
+			"material": "minecraft:stripped_dark_oak_wood",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45135,8 +42350,7 @@
 			"typed": "minecraft:stripped_dark_oak_wood"
 		},
 		{
-			"asMaterial": "minecraft:stripped_jungle_log",
-			"blockType": true,
+			"blockType": "minecraft:stripped_jungle_log",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45159,11 +42373,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_jungle_log",
-			"material": "STRIPPED_JUNGLE_LOG",
+			"material": "minecraft:stripped_jungle_log",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45172,8 +42385,7 @@
 			"typed": "minecraft:stripped_jungle_log"
 		},
 		{
-			"asMaterial": "minecraft:stripped_jungle_wood",
-			"blockType": true,
+			"blockType": "minecraft:stripped_jungle_wood",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45196,11 +42408,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_jungle_wood",
-			"material": "STRIPPED_JUNGLE_WOOD",
+			"material": "minecraft:stripped_jungle_wood",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45209,8 +42420,7 @@
 			"typed": "minecraft:stripped_jungle_wood"
 		},
 		{
-			"asMaterial": "minecraft:stripped_mangrove_log",
-			"blockType": true,
+			"blockType": "minecraft:stripped_mangrove_log",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45233,11 +42443,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_mangrove_log",
-			"material": "STRIPPED_MANGROVE_LOG",
+			"material": "minecraft:stripped_mangrove_log",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45246,8 +42455,7 @@
 			"typed": "minecraft:stripped_mangrove_log"
 		},
 		{
-			"asMaterial": "minecraft:stripped_mangrove_wood",
-			"blockType": true,
+			"blockType": "minecraft:stripped_mangrove_wood",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45270,11 +42478,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_mangrove_wood",
-			"material": "STRIPPED_MANGROVE_WOOD",
+			"material": "minecraft:stripped_mangrove_wood",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45283,8 +42490,7 @@
 			"typed": "minecraft:stripped_mangrove_wood"
 		},
 		{
-			"asMaterial": "minecraft:stripped_oak_log",
-			"blockType": true,
+			"blockType": "minecraft:stripped_oak_log",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45307,11 +42513,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_oak_log",
-			"material": "STRIPPED_OAK_LOG",
+			"material": "minecraft:stripped_oak_log",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45320,8 +42525,7 @@
 			"typed": "minecraft:stripped_oak_log"
 		},
 		{
-			"asMaterial": "minecraft:stripped_oak_wood",
-			"blockType": true,
+			"blockType": "minecraft:stripped_oak_wood",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45344,11 +42548,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_oak_wood",
-			"material": "STRIPPED_OAK_WOOD",
+			"material": "minecraft:stripped_oak_wood",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45357,8 +42560,7 @@
 			"typed": "minecraft:stripped_oak_wood"
 		},
 		{
-			"asMaterial": "minecraft:stripped_pale_oak_log",
-			"blockType": true,
+			"blockType": "minecraft:stripped_pale_oak_log",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45381,11 +42583,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_pale_oak_log",
-			"material": "STRIPPED_PALE_OAK_LOG",
+			"material": "minecraft:stripped_pale_oak_log",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45394,8 +42595,7 @@
 			"typed": "minecraft:stripped_pale_oak_log"
 		},
 		{
-			"asMaterial": "minecraft:stripped_pale_oak_wood",
-			"blockType": true,
+			"blockType": "minecraft:stripped_pale_oak_wood",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45418,11 +42618,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_pale_oak_wood",
-			"material": "STRIPPED_PALE_OAK_WOOD",
+			"material": "minecraft:stripped_pale_oak_wood",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45431,8 +42630,7 @@
 			"typed": "minecraft:stripped_pale_oak_wood"
 		},
 		{
-			"asMaterial": "minecraft:stripped_spruce_log",
-			"blockType": true,
+			"blockType": "minecraft:stripped_spruce_log",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45455,11 +42653,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_spruce_log",
-			"material": "STRIPPED_SPRUCE_LOG",
+			"material": "minecraft:stripped_spruce_log",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45468,8 +42665,7 @@
 			"typed": "minecraft:stripped_spruce_log"
 		},
 		{
-			"asMaterial": "minecraft:stripped_spruce_wood",
-			"blockType": true,
+			"blockType": "minecraft:stripped_spruce_wood",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45492,11 +42688,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_spruce_wood",
-			"material": "STRIPPED_SPRUCE_WOOD",
+			"material": "minecraft:stripped_spruce_wood",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45505,8 +42700,7 @@
 			"typed": "minecraft:stripped_spruce_wood"
 		},
 		{
-			"asMaterial": "minecraft:stripped_warped_hyphae",
-			"blockType": true,
+			"blockType": "minecraft:stripped_warped_hyphae",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45529,11 +42723,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_warped_hyphae",
-			"material": "STRIPPED_WARPED_HYPHAE",
+			"material": "minecraft:stripped_warped_hyphae",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45542,8 +42735,7 @@
 			"typed": "minecraft:stripped_warped_hyphae"
 		},
 		{
-			"asMaterial": "minecraft:stripped_warped_stem",
-			"blockType": true,
+			"blockType": "minecraft:stripped_warped_stem",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45566,11 +42758,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:stripped_warped_stem",
-			"material": "STRIPPED_WARPED_STEM",
+			"material": "minecraft:stripped_warped_stem",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45579,8 +42770,7 @@
 			"typed": "minecraft:stripped_warped_stem"
 		},
 		{
-			"asMaterial": "minecraft:structure_block",
-			"blockType": true,
+			"blockType": "minecraft:structure_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45603,11 +42793,10 @@
 			"fuel": false,
 			"itemRarity": "EPIC",
 			"key": "minecraft:structure_block",
-			"material": "STRUCTURE_BLOCK",
+			"material": "minecraft:structure_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "EPIC",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45616,8 +42805,7 @@
 			"typed": "minecraft:structure_block"
 		},
 		{
-			"asMaterial": "minecraft:structure_void",
-			"blockType": true,
+			"blockType": "minecraft:structure_void",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45640,11 +42828,10 @@
 			"fuel": false,
 			"itemRarity": "EPIC",
 			"key": "minecraft:structure_void",
-			"material": "STRUCTURE_VOID",
+			"material": "minecraft:structure_void",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "EPIC",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45653,8 +42840,6 @@
 			"typed": "minecraft:structure_void"
 		},
 		{
-			"asMaterial": "minecraft:sugar",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45677,11 +42862,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:sugar",
-			"material": "SUGAR",
+			"material": "minecraft:sugar",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45690,8 +42874,7 @@
 			"typed": "minecraft:sugar"
 		},
 		{
-			"asMaterial": "minecraft:sugar_cane",
-			"blockType": true,
+			"blockType": "minecraft:sugar_cane",
 			"compostChance": "0.5F",
 			"compostable": true,
 			"createItemStack": {
@@ -45715,11 +42898,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:sugar_cane",
-			"material": "SUGAR_CANE",
+			"material": "minecraft:sugar_cane",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45728,8 +42910,7 @@
 			"typed": "minecraft:sugar_cane"
 		},
 		{
-			"asMaterial": "minecraft:sunflower",
-			"blockType": true,
+			"blockType": "minecraft:sunflower",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -45753,11 +42934,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:sunflower",
-			"material": "SUNFLOWER",
+			"material": "minecraft:sunflower",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45766,8 +42946,7 @@
 			"typed": "minecraft:sunflower"
 		},
 		{
-			"asMaterial": "minecraft:suspicious_gravel",
-			"blockType": true,
+			"blockType": "minecraft:suspicious_gravel",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45790,11 +42969,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:suspicious_gravel",
-			"material": "SUSPICIOUS_GRAVEL",
+			"material": "minecraft:suspicious_gravel",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45803,8 +42981,7 @@
 			"typed": "minecraft:suspicious_gravel"
 		},
 		{
-			"asMaterial": "minecraft:suspicious_sand",
-			"blockType": true,
+			"blockType": "minecraft:suspicious_sand",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45827,11 +43004,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:suspicious_sand",
-			"material": "SUSPICIOUS_SAND",
+			"material": "minecraft:suspicious_sand",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45840,8 +43016,6 @@
 			"typed": "minecraft:suspicious_sand"
 		},
 		{
-			"asMaterial": "minecraft:suspicious_stew",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45868,11 +43042,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:suspicious_stew",
-			"material": "SUSPICIOUS_STEW",
+			"material": "minecraft:suspicious_stew",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "SuspiciousStewMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45881,8 +43054,7 @@
 			"typed": "minecraft:suspicious_stew"
 		},
 		{
-			"asMaterial": "minecraft:sweet_berries",
-			"blockType": true,
+			"blockType": "minecraft:sweet_berry_bush",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -45908,11 +43080,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:sweet_berries",
-			"material": "SWEET_BERRIES",
+			"material": "minecraft:sweet_berries",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45921,8 +43092,6 @@
 			"typed": "minecraft:sweet_berries"
 		},
 		{
-			"asMaterial": "minecraft:tadpole_bucket",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45946,11 +43115,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tadpole_bucket",
-			"material": "TADPOLE_BUCKET",
+			"material": "minecraft:tadpole_bucket",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45959,8 +43127,6 @@
 			"typed": "minecraft:tadpole_bucket"
 		},
 		{
-			"asMaterial": "minecraft:tadpole_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -45983,11 +43149,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tadpole_spawn_egg",
-			"material": "TADPOLE_SPAWN_EGG",
+			"material": "minecraft:tadpole_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -45996,8 +43161,7 @@
 			"typed": "minecraft:tadpole_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:tall_dry_grass",
-			"blockType": true,
+			"blockType": "minecraft:tall_dry_grass",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -46021,11 +43185,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tall_dry_grass",
-			"material": "TALL_DRY_GRASS",
+			"material": "minecraft:tall_dry_grass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46034,8 +43197,7 @@
 			"typed": "minecraft:tall_dry_grass"
 		},
 		{
-			"asMaterial": "minecraft:tall_grass",
-			"blockType": true,
+			"blockType": "minecraft:tall_grass",
 			"compostChance": "0.5F",
 			"compostable": true,
 			"createItemStack": {
@@ -46059,11 +43221,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tall_grass",
-			"material": "TALL_GRASS",
+			"material": "minecraft:tall_grass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46072,8 +43233,7 @@
 			"typed": "minecraft:tall_grass"
 		},
 		{
-			"asMaterial": "minecraft:target",
-			"blockType": true,
+			"blockType": "minecraft:target",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46096,11 +43256,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:target",
-			"material": "TARGET",
+			"material": "minecraft:target",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46109,8 +43268,7 @@
 			"typed": "minecraft:target"
 		},
 		{
-			"asMaterial": "minecraft:terracotta",
-			"blockType": true,
+			"blockType": "minecraft:terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46133,11 +43291,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:terracotta",
-			"material": "TERRACOTTA",
+			"material": "minecraft:terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46146,8 +43303,7 @@
 			"typed": "minecraft:terracotta"
 		},
 		{
-			"asMaterial": "minecraft:test_block",
-			"blockType": true,
+			"blockType": "minecraft:test_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46171,11 +43327,10 @@
 			"fuel": false,
 			"itemRarity": "EPIC",
 			"key": "minecraft:test_block",
-			"material": "TEST_BLOCK",
+			"material": "minecraft:test_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "EPIC",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46184,8 +43339,7 @@
 			"typed": "minecraft:test_block"
 		},
 		{
-			"asMaterial": "minecraft:test_instance_block",
-			"blockType": true,
+			"blockType": "minecraft:test_instance_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46208,11 +43362,10 @@
 			"fuel": false,
 			"itemRarity": "EPIC",
 			"key": "minecraft:test_instance_block",
-			"material": "TEST_INSTANCE_BLOCK",
+			"material": "minecraft:test_instance_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "EPIC",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46221,8 +43374,6 @@
 			"typed": "minecraft:test_instance_block"
 		},
 		{
-			"asMaterial": "minecraft:tide_armor_trim_smithing_template",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46245,11 +43396,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:tide_armor_trim_smithing_template",
-			"material": "TIDE_ARMOR_TRIM_SMITHING_TEMPLATE",
+			"material": "minecraft:tide_armor_trim_smithing_template",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46258,8 +43408,7 @@
 			"typed": "minecraft:tide_armor_trim_smithing_template"
 		},
 		{
-			"asMaterial": "minecraft:tinted_glass",
-			"blockType": true,
+			"blockType": "minecraft:tinted_glass",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46282,11 +43431,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tinted_glass",
-			"material": "TINTED_GLASS",
+			"material": "minecraft:tinted_glass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46295,8 +43443,6 @@
 			"typed": "minecraft:tinted_glass"
 		},
 		{
-			"asMaterial": "minecraft:tipped_arrow",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46321,11 +43467,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tipped_arrow",
-			"material": "TIPPED_ARROW",
+			"material": "minecraft:tipped_arrow",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "PotionMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46334,8 +43479,7 @@
 			"typed": "minecraft:tipped_arrow"
 		},
 		{
-			"asMaterial": "minecraft:tnt",
-			"blockType": true,
+			"blockType": "minecraft:tnt",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46358,11 +43502,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tnt",
-			"material": "TNT",
+			"material": "minecraft:tnt",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46371,8 +43514,6 @@
 			"typed": "minecraft:tnt"
 		},
 		{
-			"asMaterial": "minecraft:tnt_minecart",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46395,11 +43536,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tnt_minecart",
-			"material": "TNT_MINECART",
+			"material": "minecraft:tnt_minecart",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46408,8 +43548,7 @@
 			"typed": "minecraft:tnt_minecart"
 		},
 		{
-			"asMaterial": "minecraft:torch",
-			"blockType": true,
+			"blockType": "minecraft:torch",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46432,11 +43571,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:torch",
-			"material": "TORCH",
+			"material": "minecraft:torch",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46445,8 +43583,7 @@
 			"typed": "minecraft:torch"
 		},
 		{
-			"asMaterial": "minecraft:torchflower",
-			"blockType": true,
+			"blockType": "minecraft:torchflower",
 			"compostChance": "0.85F",
 			"compostable": true,
 			"createItemStack": {
@@ -46470,11 +43607,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:torchflower",
-			"material": "TORCHFLOWER",
+			"material": "minecraft:torchflower",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46483,8 +43619,7 @@
 			"typed": "minecraft:torchflower"
 		},
 		{
-			"asMaterial": "minecraft:torchflower_seeds",
-			"blockType": true,
+			"blockType": "minecraft:torchflower_crop",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -46508,11 +43643,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:torchflower_seeds",
-			"material": "TORCHFLOWER_SEEDS",
+			"material": "minecraft:torchflower_seeds",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46521,8 +43655,6 @@
 			"typed": "minecraft:torchflower_seeds"
 		},
 		{
-			"asMaterial": "minecraft:totem_of_undying",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46546,11 +43678,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:totem_of_undying",
-			"material": "TOTEM_OF_UNDYING",
+			"material": "minecraft:totem_of_undying",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46559,8 +43690,6 @@
 			"typed": "minecraft:totem_of_undying"
 		},
 		{
-			"asMaterial": "minecraft:trader_llama_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46583,11 +43712,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:trader_llama_spawn_egg",
-			"material": "TRADER_LLAMA_SPAWN_EGG",
+			"material": "minecraft:trader_llama_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46596,8 +43724,7 @@
 			"typed": "minecraft:trader_llama_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:trapped_chest",
-			"blockType": true,
+			"blockType": "minecraft:trapped_chest",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46621,11 +43748,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:trapped_chest",
-			"material": "TRAPPED_CHEST",
+			"material": "minecraft:trapped_chest",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46634,8 +43760,6 @@
 			"typed": "minecraft:trapped_chest"
 		},
 		{
-			"asMaterial": "minecraft:trial_key",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46658,11 +43782,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:trial_key",
-			"material": "TRIAL_KEY",
+			"material": "minecraft:trial_key",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46671,8 +43794,7 @@
 			"typed": "minecraft:trial_key"
 		},
 		{
-			"asMaterial": "minecraft:trial_spawner",
-			"blockType": true,
+			"blockType": "minecraft:trial_spawner",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46695,11 +43817,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:trial_spawner",
-			"material": "TRIAL_SPAWNER",
+			"material": "minecraft:trial_spawner",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46708,8 +43829,6 @@
 			"typed": "minecraft:trial_spawner"
 		},
 		{
-			"asMaterial": "minecraft:trident",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46737,11 +43856,10 @@
 			"fuel": false,
 			"itemRarity": "RARE",
 			"key": "minecraft:trident",
-			"material": "TRIDENT",
+			"material": "minecraft:trident",
 			"maxDurability": 250,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "RARE",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46750,8 +43868,7 @@
 			"typed": "minecraft:trident"
 		},
 		{
-			"asMaterial": "minecraft:tripwire_hook",
-			"blockType": true,
+			"blockType": "minecraft:tripwire_hook",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46774,11 +43891,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tripwire_hook",
-			"material": "TRIPWIRE_HOOK",
+			"material": "minecraft:tripwire_hook",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46787,8 +43903,6 @@
 			"typed": "minecraft:tripwire_hook"
 		},
 		{
-			"asMaterial": "minecraft:tropical_fish",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46813,11 +43927,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tropical_fish",
-			"material": "TROPICAL_FISH",
+			"material": "minecraft:tropical_fish",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46826,8 +43939,6 @@
 			"typed": "minecraft:tropical_fish"
 		},
 		{
-			"asMaterial": "minecraft:tropical_fish_bucket",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46851,11 +43962,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tropical_fish_bucket",
-			"material": "TROPICAL_FISH_BUCKET",
+			"material": "minecraft:tropical_fish_bucket",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "TropicalFishBucketMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46864,8 +43974,6 @@
 			"typed": "minecraft:tropical_fish_bucket"
 		},
 		{
-			"asMaterial": "minecraft:tropical_fish_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46888,11 +43996,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tropical_fish_spawn_egg",
-			"material": "TROPICAL_FISH_SPAWN_EGG",
+			"material": "minecraft:tropical_fish_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46901,8 +44008,7 @@
 			"typed": "minecraft:tropical_fish_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:tube_coral",
-			"blockType": true,
+			"blockType": "minecraft:tube_coral",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46925,11 +44031,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tube_coral",
-			"material": "TUBE_CORAL",
+			"material": "minecraft:tube_coral",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46938,8 +44043,7 @@
 			"typed": "minecraft:tube_coral"
 		},
 		{
-			"asMaterial": "minecraft:tube_coral_block",
-			"blockType": true,
+			"blockType": "minecraft:tube_coral_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46962,11 +44066,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tube_coral_block",
-			"material": "TUBE_CORAL_BLOCK",
+			"material": "minecraft:tube_coral_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -46975,8 +44078,7 @@
 			"typed": "minecraft:tube_coral_block"
 		},
 		{
-			"asMaterial": "minecraft:tube_coral_fan",
-			"blockType": true,
+			"blockType": "minecraft:tube_coral_fan",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -46999,11 +44101,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tube_coral_fan",
-			"material": "TUBE_CORAL_FAN",
+			"material": "minecraft:tube_coral_fan",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47012,8 +44113,7 @@
 			"typed": "minecraft:tube_coral_fan"
 		},
 		{
-			"asMaterial": "minecraft:tuff",
-			"blockType": true,
+			"blockType": "minecraft:tuff",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47036,11 +44136,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tuff",
-			"material": "TUFF",
+			"material": "minecraft:tuff",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47049,8 +44148,7 @@
 			"typed": "minecraft:tuff"
 		},
 		{
-			"asMaterial": "minecraft:tuff_brick_slab",
-			"blockType": true,
+			"blockType": "minecraft:tuff_brick_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47073,11 +44171,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tuff_brick_slab",
-			"material": "TUFF_BRICK_SLAB",
+			"material": "minecraft:tuff_brick_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47086,8 +44183,7 @@
 			"typed": "minecraft:tuff_brick_slab"
 		},
 		{
-			"asMaterial": "minecraft:tuff_brick_stairs",
-			"blockType": true,
+			"blockType": "minecraft:tuff_brick_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47110,11 +44206,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tuff_brick_stairs",
-			"material": "TUFF_BRICK_STAIRS",
+			"material": "minecraft:tuff_brick_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47123,8 +44218,7 @@
 			"typed": "minecraft:tuff_brick_stairs"
 		},
 		{
-			"asMaterial": "minecraft:tuff_brick_wall",
-			"blockType": true,
+			"blockType": "minecraft:tuff_brick_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47147,11 +44241,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tuff_brick_wall",
-			"material": "TUFF_BRICK_WALL",
+			"material": "minecraft:tuff_brick_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47160,8 +44253,7 @@
 			"typed": "minecraft:tuff_brick_wall"
 		},
 		{
-			"asMaterial": "minecraft:tuff_bricks",
-			"blockType": true,
+			"blockType": "minecraft:tuff_bricks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47184,11 +44276,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tuff_bricks",
-			"material": "TUFF_BRICKS",
+			"material": "minecraft:tuff_bricks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47197,8 +44288,7 @@
 			"typed": "minecraft:tuff_bricks"
 		},
 		{
-			"asMaterial": "minecraft:tuff_slab",
-			"blockType": true,
+			"blockType": "minecraft:tuff_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47221,11 +44311,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tuff_slab",
-			"material": "TUFF_SLAB",
+			"material": "minecraft:tuff_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47234,8 +44323,7 @@
 			"typed": "minecraft:tuff_slab"
 		},
 		{
-			"asMaterial": "minecraft:tuff_stairs",
-			"blockType": true,
+			"blockType": "minecraft:tuff_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47258,11 +44346,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tuff_stairs",
-			"material": "TUFF_STAIRS",
+			"material": "minecraft:tuff_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47271,8 +44358,7 @@
 			"typed": "minecraft:tuff_stairs"
 		},
 		{
-			"asMaterial": "minecraft:tuff_wall",
-			"blockType": true,
+			"blockType": "minecraft:tuff_wall",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47295,11 +44381,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:tuff_wall",
-			"material": "TUFF_WALL",
+			"material": "minecraft:tuff_wall",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47308,8 +44393,7 @@
 			"typed": "minecraft:tuff_wall"
 		},
 		{
-			"asMaterial": "minecraft:turtle_egg",
-			"blockType": true,
+			"blockType": "minecraft:turtle_egg",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47332,11 +44416,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:turtle_egg",
-			"material": "TURTLE_EGG",
+			"material": "minecraft:turtle_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47345,8 +44428,6 @@
 			"typed": "minecraft:turtle_egg"
 		},
 		{
-			"asMaterial": "minecraft:turtle_helmet",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47374,11 +44455,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:turtle_helmet",
-			"material": "TURTLE_HELMET",
+			"material": "minecraft:turtle_helmet",
 			"maxDurability": 275,
 			"maxStackSize": 1,
 			"metaClass": "ArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47387,8 +44467,6 @@
 			"typed": "minecraft:turtle_helmet"
 		},
 		{
-			"asMaterial": "minecraft:turtle_scute",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47411,11 +44489,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:turtle_scute",
-			"material": "TURTLE_SCUTE",
+			"material": "minecraft:turtle_scute",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47424,8 +44501,6 @@
 			"typed": "minecraft:turtle_scute"
 		},
 		{
-			"asMaterial": "minecraft:turtle_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47448,11 +44523,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:turtle_spawn_egg",
-			"material": "TURTLE_SPAWN_EGG",
+			"material": "minecraft:turtle_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47461,8 +44535,7 @@
 			"typed": "minecraft:turtle_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:twisting_vines",
-			"blockType": true,
+			"blockType": "minecraft:twisting_vines",
 			"compostChance": "0.5F",
 			"compostable": true,
 			"createItemStack": {
@@ -47486,11 +44559,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:twisting_vines",
-			"material": "TWISTING_VINES",
+			"material": "minecraft:twisting_vines",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47499,8 +44571,7 @@
 			"typed": "minecraft:twisting_vines"
 		},
 		{
-			"asMaterial": "minecraft:vault",
-			"blockType": true,
+			"blockType": "minecraft:vault",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47523,11 +44594,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:vault",
-			"material": "VAULT",
+			"material": "minecraft:vault",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47536,8 +44606,7 @@
 			"typed": "minecraft:vault"
 		},
 		{
-			"asMaterial": "minecraft:verdant_froglight",
-			"blockType": true,
+			"blockType": "minecraft:verdant_froglight",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47560,11 +44629,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:verdant_froglight",
-			"material": "VERDANT_FROGLIGHT",
+			"material": "minecraft:verdant_froglight",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47573,8 +44641,6 @@
 			"typed": "minecraft:verdant_froglight"
 		},
 		{
-			"asMaterial": "minecraft:vex_armor_trim_smithing_template",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47597,11 +44663,10 @@
 			"fuel": false,
 			"itemRarity": "RARE",
 			"key": "minecraft:vex_armor_trim_smithing_template",
-			"material": "VEX_ARMOR_TRIM_SMITHING_TEMPLATE",
+			"material": "minecraft:vex_armor_trim_smithing_template",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "RARE",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47610,8 +44675,6 @@
 			"typed": "minecraft:vex_armor_trim_smithing_template"
 		},
 		{
-			"asMaterial": "minecraft:vex_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47634,11 +44697,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:vex_spawn_egg",
-			"material": "VEX_SPAWN_EGG",
+			"material": "minecraft:vex_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47647,8 +44709,6 @@
 			"typed": "minecraft:vex_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:villager_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47671,11 +44731,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:villager_spawn_egg",
-			"material": "VILLAGER_SPAWN_EGG",
+			"material": "minecraft:villager_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47684,8 +44743,6 @@
 			"typed": "minecraft:villager_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:vindicator_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47708,11 +44765,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:vindicator_spawn_egg",
-			"material": "VINDICATOR_SPAWN_EGG",
+			"material": "minecraft:vindicator_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47721,8 +44777,7 @@
 			"typed": "minecraft:vindicator_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:vine",
-			"blockType": true,
+			"blockType": "minecraft:vine",
 			"compostChance": "0.5F",
 			"compostable": true,
 			"createItemStack": {
@@ -47746,11 +44801,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:vine",
-			"material": "VINE",
+			"material": "minecraft:vine",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47759,8 +44813,6 @@
 			"typed": "minecraft:vine"
 		},
 		{
-			"asMaterial": "minecraft:wandering_trader_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47783,11 +44835,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:wandering_trader_spawn_egg",
-			"material": "WANDERING_TRADER_SPAWN_EGG",
+			"material": "minecraft:wandering_trader_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47796,8 +44847,6 @@
 			"typed": "minecraft:wandering_trader_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:ward_armor_trim_smithing_template",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47820,11 +44869,10 @@
 			"fuel": false,
 			"itemRarity": "RARE",
 			"key": "minecraft:ward_armor_trim_smithing_template",
-			"material": "WARD_ARMOR_TRIM_SMITHING_TEMPLATE",
+			"material": "minecraft:ward_armor_trim_smithing_template",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "RARE",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47833,8 +44881,6 @@
 			"typed": "minecraft:ward_armor_trim_smithing_template"
 		},
 		{
-			"asMaterial": "minecraft:warden_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47857,11 +44903,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:warden_spawn_egg",
-			"material": "WARDEN_SPAWN_EGG",
+			"material": "minecraft:warden_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47870,8 +44915,7 @@
 			"typed": "minecraft:warden_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:warped_button",
-			"blockType": true,
+			"blockType": "minecraft:warped_button",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47894,11 +44938,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:warped_button",
-			"material": "WARPED_BUTTON",
+			"material": "minecraft:warped_button",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47907,8 +44950,7 @@
 			"typed": "minecraft:warped_button"
 		},
 		{
-			"asMaterial": "minecraft:warped_door",
-			"blockType": true,
+			"blockType": "minecraft:warped_door",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47931,11 +44973,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:warped_door",
-			"material": "WARPED_DOOR",
+			"material": "minecraft:warped_door",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47944,8 +44985,7 @@
 			"typed": "minecraft:warped_door"
 		},
 		{
-			"asMaterial": "minecraft:warped_fence",
-			"blockType": true,
+			"blockType": "minecraft:warped_fence",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -47968,11 +45008,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:warped_fence",
-			"material": "WARPED_FENCE",
+			"material": "minecraft:warped_fence",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -47981,8 +45020,7 @@
 			"typed": "minecraft:warped_fence"
 		},
 		{
-			"asMaterial": "minecraft:warped_fence_gate",
-			"blockType": true,
+			"blockType": "minecraft:warped_fence_gate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48005,11 +45043,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:warped_fence_gate",
-			"material": "WARPED_FENCE_GATE",
+			"material": "minecraft:warped_fence_gate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48018,8 +45055,7 @@
 			"typed": "minecraft:warped_fence_gate"
 		},
 		{
-			"asMaterial": "minecraft:warped_fungus",
-			"blockType": true,
+			"blockType": "minecraft:warped_fungus",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -48043,11 +45079,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:warped_fungus",
-			"material": "WARPED_FUNGUS",
+			"material": "minecraft:warped_fungus",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48056,8 +45091,6 @@
 			"typed": "minecraft:warped_fungus"
 		},
 		{
-			"asMaterial": "minecraft:warped_fungus_on_a_stick",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48082,11 +45115,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:warped_fungus_on_a_stick",
-			"material": "WARPED_FUNGUS_ON_A_STICK",
+			"material": "minecraft:warped_fungus_on_a_stick",
 			"maxDurability": 100,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48095,8 +45127,7 @@
 			"typed": "minecraft:warped_fungus_on_a_stick"
 		},
 		{
-			"asMaterial": "minecraft:warped_hanging_sign",
-			"blockType": true,
+			"blockType": "minecraft:warped_hanging_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48119,11 +45150,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:warped_hanging_sign",
-			"material": "WARPED_HANGING_SIGN",
+			"material": "minecraft:warped_hanging_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48132,8 +45162,7 @@
 			"typed": "minecraft:warped_hanging_sign"
 		},
 		{
-			"asMaterial": "minecraft:warped_hyphae",
-			"blockType": true,
+			"blockType": "minecraft:warped_hyphae",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48156,11 +45185,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:warped_hyphae",
-			"material": "WARPED_HYPHAE",
+			"material": "minecraft:warped_hyphae",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48169,8 +45197,7 @@
 			"typed": "minecraft:warped_hyphae"
 		},
 		{
-			"asMaterial": "minecraft:warped_nylium",
-			"blockType": true,
+			"blockType": "minecraft:warped_nylium",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48193,11 +45220,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:warped_nylium",
-			"material": "WARPED_NYLIUM",
+			"material": "minecraft:warped_nylium",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48206,8 +45232,7 @@
 			"typed": "minecraft:warped_nylium"
 		},
 		{
-			"asMaterial": "minecraft:warped_planks",
-			"blockType": true,
+			"blockType": "minecraft:warped_planks",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48230,11 +45255,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:warped_planks",
-			"material": "WARPED_PLANKS",
+			"material": "minecraft:warped_planks",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48243,8 +45267,7 @@
 			"typed": "minecraft:warped_planks"
 		},
 		{
-			"asMaterial": "minecraft:warped_pressure_plate",
-			"blockType": true,
+			"blockType": "minecraft:warped_pressure_plate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48267,11 +45290,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:warped_pressure_plate",
-			"material": "WARPED_PRESSURE_PLATE",
+			"material": "minecraft:warped_pressure_plate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48280,8 +45302,7 @@
 			"typed": "minecraft:warped_pressure_plate"
 		},
 		{
-			"asMaterial": "minecraft:warped_roots",
-			"blockType": true,
+			"blockType": "minecraft:warped_roots",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -48305,11 +45326,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:warped_roots",
-			"material": "WARPED_ROOTS",
+			"material": "minecraft:warped_roots",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48318,8 +45338,7 @@
 			"typed": "minecraft:warped_roots"
 		},
 		{
-			"asMaterial": "minecraft:warped_sign",
-			"blockType": true,
+			"blockType": "minecraft:warped_sign",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48342,11 +45361,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:warped_sign",
-			"material": "WARPED_SIGN",
+			"material": "minecraft:warped_sign",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48355,8 +45373,7 @@
 			"typed": "minecraft:warped_sign"
 		},
 		{
-			"asMaterial": "minecraft:warped_slab",
-			"blockType": true,
+			"blockType": "minecraft:warped_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48379,11 +45396,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:warped_slab",
-			"material": "WARPED_SLAB",
+			"material": "minecraft:warped_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48392,8 +45408,7 @@
 			"typed": "minecraft:warped_slab"
 		},
 		{
-			"asMaterial": "minecraft:warped_stairs",
-			"blockType": true,
+			"blockType": "minecraft:warped_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48416,11 +45431,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:warped_stairs",
-			"material": "WARPED_STAIRS",
+			"material": "minecraft:warped_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48429,8 +45443,7 @@
 			"typed": "minecraft:warped_stairs"
 		},
 		{
-			"asMaterial": "minecraft:warped_stem",
-			"blockType": true,
+			"blockType": "minecraft:warped_stem",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48453,11 +45466,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:warped_stem",
-			"material": "WARPED_STEM",
+			"material": "minecraft:warped_stem",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48466,8 +45478,7 @@
 			"typed": "minecraft:warped_stem"
 		},
 		{
-			"asMaterial": "minecraft:warped_trapdoor",
-			"blockType": true,
+			"blockType": "minecraft:warped_trapdoor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48490,11 +45501,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:warped_trapdoor",
-			"material": "WARPED_TRAPDOOR",
+			"material": "minecraft:warped_trapdoor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48503,8 +45513,7 @@
 			"typed": "minecraft:warped_trapdoor"
 		},
 		{
-			"asMaterial": "minecraft:warped_wart_block",
-			"blockType": true,
+			"blockType": "minecraft:warped_wart_block",
 			"compostChance": "0.85F",
 			"compostable": true,
 			"createItemStack": {
@@ -48528,11 +45537,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:warped_wart_block",
-			"material": "WARPED_WART_BLOCK",
+			"material": "minecraft:warped_wart_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48541,8 +45549,6 @@
 			"typed": "minecraft:warped_wart_block"
 		},
 		{
-			"asMaterial": "minecraft:water_bucket",
-			"blockType": false,
 			"compostable": false,
 			"craftingRemainingItem": "minecraft:bucket",
 			"createItemStack": {
@@ -48566,11 +45572,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:water_bucket",
-			"material": "WATER_BUCKET",
+			"material": "minecraft:water_bucket",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48579,8 +45584,7 @@
 			"typed": "minecraft:water_bucket"
 		},
 		{
-			"asMaterial": "minecraft:waxed_chiseled_copper",
-			"blockType": true,
+			"blockType": "minecraft:waxed_chiseled_copper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48603,11 +45607,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_chiseled_copper",
-			"material": "WAXED_CHISELED_COPPER",
+			"material": "minecraft:waxed_chiseled_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48616,8 +45619,7 @@
 			"typed": "minecraft:waxed_chiseled_copper"
 		},
 		{
-			"asMaterial": "minecraft:waxed_copper_block",
-			"blockType": true,
+			"blockType": "minecraft:waxed_copper_block",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48640,11 +45642,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_copper_block",
-			"material": "WAXED_COPPER_BLOCK",
+			"material": "minecraft:waxed_copper_block",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48653,8 +45654,7 @@
 			"typed": "minecraft:waxed_copper_block"
 		},
 		{
-			"asMaterial": "minecraft:waxed_copper_bulb",
-			"blockType": true,
+			"blockType": "minecraft:waxed_copper_bulb",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48677,11 +45677,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_copper_bulb",
-			"material": "WAXED_COPPER_BULB",
+			"material": "minecraft:waxed_copper_bulb",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48690,8 +45689,7 @@
 			"typed": "minecraft:waxed_copper_bulb"
 		},
 		{
-			"asMaterial": "minecraft:waxed_copper_door",
-			"blockType": true,
+			"blockType": "minecraft:waxed_copper_door",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48714,11 +45712,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_copper_door",
-			"material": "WAXED_COPPER_DOOR",
+			"material": "minecraft:waxed_copper_door",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48727,8 +45724,7 @@
 			"typed": "minecraft:waxed_copper_door"
 		},
 		{
-			"asMaterial": "minecraft:waxed_copper_grate",
-			"blockType": true,
+			"blockType": "minecraft:waxed_copper_grate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48751,11 +45747,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_copper_grate",
-			"material": "WAXED_COPPER_GRATE",
+			"material": "minecraft:waxed_copper_grate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48764,8 +45759,7 @@
 			"typed": "minecraft:waxed_copper_grate"
 		},
 		{
-			"asMaterial": "minecraft:waxed_copper_trapdoor",
-			"blockType": true,
+			"blockType": "minecraft:waxed_copper_trapdoor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48788,11 +45782,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_copper_trapdoor",
-			"material": "WAXED_COPPER_TRAPDOOR",
+			"material": "minecraft:waxed_copper_trapdoor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48801,8 +45794,7 @@
 			"typed": "minecraft:waxed_copper_trapdoor"
 		},
 		{
-			"asMaterial": "minecraft:waxed_cut_copper",
-			"blockType": true,
+			"blockType": "minecraft:waxed_cut_copper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48825,11 +45817,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_cut_copper",
-			"material": "WAXED_CUT_COPPER",
+			"material": "minecraft:waxed_cut_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48838,8 +45829,7 @@
 			"typed": "minecraft:waxed_cut_copper"
 		},
 		{
-			"asMaterial": "minecraft:waxed_cut_copper_slab",
-			"blockType": true,
+			"blockType": "minecraft:waxed_cut_copper_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48862,11 +45852,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_cut_copper_slab",
-			"material": "WAXED_CUT_COPPER_SLAB",
+			"material": "minecraft:waxed_cut_copper_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48875,8 +45864,7 @@
 			"typed": "minecraft:waxed_cut_copper_slab"
 		},
 		{
-			"asMaterial": "minecraft:waxed_cut_copper_stairs",
-			"blockType": true,
+			"blockType": "minecraft:waxed_cut_copper_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48899,11 +45887,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_cut_copper_stairs",
-			"material": "WAXED_CUT_COPPER_STAIRS",
+			"material": "minecraft:waxed_cut_copper_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48912,8 +45899,7 @@
 			"typed": "minecraft:waxed_cut_copper_stairs"
 		},
 		{
-			"asMaterial": "minecraft:waxed_exposed_chiseled_copper",
-			"blockType": true,
+			"blockType": "minecraft:waxed_exposed_chiseled_copper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48936,11 +45922,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_exposed_chiseled_copper",
-			"material": "WAXED_EXPOSED_CHISELED_COPPER",
+			"material": "minecraft:waxed_exposed_chiseled_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48949,8 +45934,7 @@
 			"typed": "minecraft:waxed_exposed_chiseled_copper"
 		},
 		{
-			"asMaterial": "minecraft:waxed_exposed_copper",
-			"blockType": true,
+			"blockType": "minecraft:waxed_exposed_copper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -48973,11 +45957,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_exposed_copper",
-			"material": "WAXED_EXPOSED_COPPER",
+			"material": "minecraft:waxed_exposed_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -48986,8 +45969,7 @@
 			"typed": "minecraft:waxed_exposed_copper"
 		},
 		{
-			"asMaterial": "minecraft:waxed_exposed_copper_bulb",
-			"blockType": true,
+			"blockType": "minecraft:waxed_exposed_copper_bulb",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49010,11 +45992,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_exposed_copper_bulb",
-			"material": "WAXED_EXPOSED_COPPER_BULB",
+			"material": "minecraft:waxed_exposed_copper_bulb",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49023,8 +46004,7 @@
 			"typed": "minecraft:waxed_exposed_copper_bulb"
 		},
 		{
-			"asMaterial": "minecraft:waxed_exposed_copper_door",
-			"blockType": true,
+			"blockType": "minecraft:waxed_exposed_copper_door",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49047,11 +46027,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_exposed_copper_door",
-			"material": "WAXED_EXPOSED_COPPER_DOOR",
+			"material": "minecraft:waxed_exposed_copper_door",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49060,8 +46039,7 @@
 			"typed": "minecraft:waxed_exposed_copper_door"
 		},
 		{
-			"asMaterial": "minecraft:waxed_exposed_copper_grate",
-			"blockType": true,
+			"blockType": "minecraft:waxed_exposed_copper_grate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49084,11 +46062,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_exposed_copper_grate",
-			"material": "WAXED_EXPOSED_COPPER_GRATE",
+			"material": "minecraft:waxed_exposed_copper_grate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49097,8 +46074,7 @@
 			"typed": "minecraft:waxed_exposed_copper_grate"
 		},
 		{
-			"asMaterial": "minecraft:waxed_exposed_copper_trapdoor",
-			"blockType": true,
+			"blockType": "minecraft:waxed_exposed_copper_trapdoor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49121,11 +46097,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_exposed_copper_trapdoor",
-			"material": "WAXED_EXPOSED_COPPER_TRAPDOOR",
+			"material": "minecraft:waxed_exposed_copper_trapdoor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49134,8 +46109,7 @@
 			"typed": "minecraft:waxed_exposed_copper_trapdoor"
 		},
 		{
-			"asMaterial": "minecraft:waxed_exposed_cut_copper",
-			"blockType": true,
+			"blockType": "minecraft:waxed_exposed_cut_copper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49158,11 +46132,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_exposed_cut_copper",
-			"material": "WAXED_EXPOSED_CUT_COPPER",
+			"material": "minecraft:waxed_exposed_cut_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49171,8 +46144,7 @@
 			"typed": "minecraft:waxed_exposed_cut_copper"
 		},
 		{
-			"asMaterial": "minecraft:waxed_exposed_cut_copper_slab",
-			"blockType": true,
+			"blockType": "minecraft:waxed_exposed_cut_copper_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49195,11 +46167,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_exposed_cut_copper_slab",
-			"material": "WAXED_EXPOSED_CUT_COPPER_SLAB",
+			"material": "minecraft:waxed_exposed_cut_copper_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49208,8 +46179,7 @@
 			"typed": "minecraft:waxed_exposed_cut_copper_slab"
 		},
 		{
-			"asMaterial": "minecraft:waxed_exposed_cut_copper_stairs",
-			"blockType": true,
+			"blockType": "minecraft:waxed_exposed_cut_copper_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49232,11 +46202,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_exposed_cut_copper_stairs",
-			"material": "WAXED_EXPOSED_CUT_COPPER_STAIRS",
+			"material": "minecraft:waxed_exposed_cut_copper_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49245,8 +46214,7 @@
 			"typed": "minecraft:waxed_exposed_cut_copper_stairs"
 		},
 		{
-			"asMaterial": "minecraft:waxed_oxidized_chiseled_copper",
-			"blockType": true,
+			"blockType": "minecraft:waxed_oxidized_chiseled_copper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49269,11 +46237,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_oxidized_chiseled_copper",
-			"material": "WAXED_OXIDIZED_CHISELED_COPPER",
+			"material": "minecraft:waxed_oxidized_chiseled_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49282,8 +46249,7 @@
 			"typed": "minecraft:waxed_oxidized_chiseled_copper"
 		},
 		{
-			"asMaterial": "minecraft:waxed_oxidized_copper",
-			"blockType": true,
+			"blockType": "minecraft:waxed_oxidized_copper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49306,11 +46272,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_oxidized_copper",
-			"material": "WAXED_OXIDIZED_COPPER",
+			"material": "minecraft:waxed_oxidized_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49319,8 +46284,7 @@
 			"typed": "minecraft:waxed_oxidized_copper"
 		},
 		{
-			"asMaterial": "minecraft:waxed_oxidized_copper_bulb",
-			"blockType": true,
+			"blockType": "minecraft:waxed_oxidized_copper_bulb",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49343,11 +46307,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_oxidized_copper_bulb",
-			"material": "WAXED_OXIDIZED_COPPER_BULB",
+			"material": "minecraft:waxed_oxidized_copper_bulb",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49356,8 +46319,7 @@
 			"typed": "minecraft:waxed_oxidized_copper_bulb"
 		},
 		{
-			"asMaterial": "minecraft:waxed_oxidized_copper_door",
-			"blockType": true,
+			"blockType": "minecraft:waxed_oxidized_copper_door",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49380,11 +46342,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_oxidized_copper_door",
-			"material": "WAXED_OXIDIZED_COPPER_DOOR",
+			"material": "minecraft:waxed_oxidized_copper_door",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49393,8 +46354,7 @@
 			"typed": "minecraft:waxed_oxidized_copper_door"
 		},
 		{
-			"asMaterial": "minecraft:waxed_oxidized_copper_grate",
-			"blockType": true,
+			"blockType": "minecraft:waxed_oxidized_copper_grate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49417,11 +46377,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_oxidized_copper_grate",
-			"material": "WAXED_OXIDIZED_COPPER_GRATE",
+			"material": "minecraft:waxed_oxidized_copper_grate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49430,8 +46389,7 @@
 			"typed": "minecraft:waxed_oxidized_copper_grate"
 		},
 		{
-			"asMaterial": "minecraft:waxed_oxidized_copper_trapdoor",
-			"blockType": true,
+			"blockType": "minecraft:waxed_oxidized_copper_trapdoor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49454,11 +46412,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_oxidized_copper_trapdoor",
-			"material": "WAXED_OXIDIZED_COPPER_TRAPDOOR",
+			"material": "minecraft:waxed_oxidized_copper_trapdoor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49467,8 +46424,7 @@
 			"typed": "minecraft:waxed_oxidized_copper_trapdoor"
 		},
 		{
-			"asMaterial": "minecraft:waxed_oxidized_cut_copper",
-			"blockType": true,
+			"blockType": "minecraft:waxed_oxidized_cut_copper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49491,11 +46447,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_oxidized_cut_copper",
-			"material": "WAXED_OXIDIZED_CUT_COPPER",
+			"material": "minecraft:waxed_oxidized_cut_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49504,8 +46459,7 @@
 			"typed": "minecraft:waxed_oxidized_cut_copper"
 		},
 		{
-			"asMaterial": "minecraft:waxed_oxidized_cut_copper_slab",
-			"blockType": true,
+			"blockType": "minecraft:waxed_oxidized_cut_copper_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49528,11 +46482,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_oxidized_cut_copper_slab",
-			"material": "WAXED_OXIDIZED_CUT_COPPER_SLAB",
+			"material": "minecraft:waxed_oxidized_cut_copper_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49541,8 +46494,7 @@
 			"typed": "minecraft:waxed_oxidized_cut_copper_slab"
 		},
 		{
-			"asMaterial": "minecraft:waxed_oxidized_cut_copper_stairs",
-			"blockType": true,
+			"blockType": "minecraft:waxed_oxidized_cut_copper_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49565,11 +46517,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_oxidized_cut_copper_stairs",
-			"material": "WAXED_OXIDIZED_CUT_COPPER_STAIRS",
+			"material": "minecraft:waxed_oxidized_cut_copper_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49578,8 +46529,7 @@
 			"typed": "minecraft:waxed_oxidized_cut_copper_stairs"
 		},
 		{
-			"asMaterial": "minecraft:waxed_weathered_chiseled_copper",
-			"blockType": true,
+			"blockType": "minecraft:waxed_weathered_chiseled_copper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49602,11 +46552,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_weathered_chiseled_copper",
-			"material": "WAXED_WEATHERED_CHISELED_COPPER",
+			"material": "minecraft:waxed_weathered_chiseled_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49615,8 +46564,7 @@
 			"typed": "minecraft:waxed_weathered_chiseled_copper"
 		},
 		{
-			"asMaterial": "minecraft:waxed_weathered_copper",
-			"blockType": true,
+			"blockType": "minecraft:waxed_weathered_copper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49639,11 +46587,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_weathered_copper",
-			"material": "WAXED_WEATHERED_COPPER",
+			"material": "minecraft:waxed_weathered_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49652,8 +46599,7 @@
 			"typed": "minecraft:waxed_weathered_copper"
 		},
 		{
-			"asMaterial": "minecraft:waxed_weathered_copper_bulb",
-			"blockType": true,
+			"blockType": "minecraft:waxed_weathered_copper_bulb",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49676,11 +46622,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_weathered_copper_bulb",
-			"material": "WAXED_WEATHERED_COPPER_BULB",
+			"material": "minecraft:waxed_weathered_copper_bulb",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49689,8 +46634,7 @@
 			"typed": "minecraft:waxed_weathered_copper_bulb"
 		},
 		{
-			"asMaterial": "minecraft:waxed_weathered_copper_door",
-			"blockType": true,
+			"blockType": "minecraft:waxed_weathered_copper_door",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49713,11 +46657,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_weathered_copper_door",
-			"material": "WAXED_WEATHERED_COPPER_DOOR",
+			"material": "minecraft:waxed_weathered_copper_door",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49726,8 +46669,7 @@
 			"typed": "minecraft:waxed_weathered_copper_door"
 		},
 		{
-			"asMaterial": "minecraft:waxed_weathered_copper_grate",
-			"blockType": true,
+			"blockType": "minecraft:waxed_weathered_copper_grate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49750,11 +46692,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_weathered_copper_grate",
-			"material": "WAXED_WEATHERED_COPPER_GRATE",
+			"material": "minecraft:waxed_weathered_copper_grate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49763,8 +46704,7 @@
 			"typed": "minecraft:waxed_weathered_copper_grate"
 		},
 		{
-			"asMaterial": "minecraft:waxed_weathered_copper_trapdoor",
-			"blockType": true,
+			"blockType": "minecraft:waxed_weathered_copper_trapdoor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49787,11 +46727,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_weathered_copper_trapdoor",
-			"material": "WAXED_WEATHERED_COPPER_TRAPDOOR",
+			"material": "minecraft:waxed_weathered_copper_trapdoor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49800,8 +46739,7 @@
 			"typed": "minecraft:waxed_weathered_copper_trapdoor"
 		},
 		{
-			"asMaterial": "minecraft:waxed_weathered_cut_copper",
-			"blockType": true,
+			"blockType": "minecraft:waxed_weathered_cut_copper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49824,11 +46762,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_weathered_cut_copper",
-			"material": "WAXED_WEATHERED_CUT_COPPER",
+			"material": "minecraft:waxed_weathered_cut_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49837,8 +46774,7 @@
 			"typed": "minecraft:waxed_weathered_cut_copper"
 		},
 		{
-			"asMaterial": "minecraft:waxed_weathered_cut_copper_slab",
-			"blockType": true,
+			"blockType": "minecraft:waxed_weathered_cut_copper_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49861,11 +46797,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_weathered_cut_copper_slab",
-			"material": "WAXED_WEATHERED_CUT_COPPER_SLAB",
+			"material": "minecraft:waxed_weathered_cut_copper_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49874,8 +46809,7 @@
 			"typed": "minecraft:waxed_weathered_cut_copper_slab"
 		},
 		{
-			"asMaterial": "minecraft:waxed_weathered_cut_copper_stairs",
-			"blockType": true,
+			"blockType": "minecraft:waxed_weathered_cut_copper_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49898,11 +46832,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:waxed_weathered_cut_copper_stairs",
-			"material": "WAXED_WEATHERED_CUT_COPPER_STAIRS",
+			"material": "minecraft:waxed_weathered_cut_copper_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49911,8 +46844,6 @@
 			"typed": "minecraft:waxed_weathered_cut_copper_stairs"
 		},
 		{
-			"asMaterial": "minecraft:wayfinder_armor_trim_smithing_template",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49935,11 +46866,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:wayfinder_armor_trim_smithing_template",
-			"material": "WAYFINDER_ARMOR_TRIM_SMITHING_TEMPLATE",
+			"material": "minecraft:wayfinder_armor_trim_smithing_template",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49948,8 +46878,7 @@
 			"typed": "minecraft:wayfinder_armor_trim_smithing_template"
 		},
 		{
-			"asMaterial": "minecraft:weathered_chiseled_copper",
-			"blockType": true,
+			"blockType": "minecraft:weathered_chiseled_copper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -49972,11 +46901,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:weathered_chiseled_copper",
-			"material": "WEATHERED_CHISELED_COPPER",
+			"material": "minecraft:weathered_chiseled_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -49985,8 +46913,7 @@
 			"typed": "minecraft:weathered_chiseled_copper"
 		},
 		{
-			"asMaterial": "minecraft:weathered_copper",
-			"blockType": true,
+			"blockType": "minecraft:weathered_copper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50009,11 +46936,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:weathered_copper",
-			"material": "WEATHERED_COPPER",
+			"material": "minecraft:weathered_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50022,8 +46948,7 @@
 			"typed": "minecraft:weathered_copper"
 		},
 		{
-			"asMaterial": "minecraft:weathered_copper_bulb",
-			"blockType": true,
+			"blockType": "minecraft:weathered_copper_bulb",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50046,11 +46971,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:weathered_copper_bulb",
-			"material": "WEATHERED_COPPER_BULB",
+			"material": "minecraft:weathered_copper_bulb",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50059,8 +46983,7 @@
 			"typed": "minecraft:weathered_copper_bulb"
 		},
 		{
-			"asMaterial": "minecraft:weathered_copper_door",
-			"blockType": true,
+			"blockType": "minecraft:weathered_copper_door",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50083,11 +47006,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:weathered_copper_door",
-			"material": "WEATHERED_COPPER_DOOR",
+			"material": "minecraft:weathered_copper_door",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50096,8 +47018,7 @@
 			"typed": "minecraft:weathered_copper_door"
 		},
 		{
-			"asMaterial": "minecraft:weathered_copper_grate",
-			"blockType": true,
+			"blockType": "minecraft:weathered_copper_grate",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50120,11 +47041,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:weathered_copper_grate",
-			"material": "WEATHERED_COPPER_GRATE",
+			"material": "minecraft:weathered_copper_grate",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50133,8 +47053,7 @@
 			"typed": "minecraft:weathered_copper_grate"
 		},
 		{
-			"asMaterial": "minecraft:weathered_copper_trapdoor",
-			"blockType": true,
+			"blockType": "minecraft:weathered_copper_trapdoor",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50157,11 +47076,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:weathered_copper_trapdoor",
-			"material": "WEATHERED_COPPER_TRAPDOOR",
+			"material": "minecraft:weathered_copper_trapdoor",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50170,8 +47088,7 @@
 			"typed": "minecraft:weathered_copper_trapdoor"
 		},
 		{
-			"asMaterial": "minecraft:weathered_cut_copper",
-			"blockType": true,
+			"blockType": "minecraft:weathered_cut_copper",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50194,11 +47111,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:weathered_cut_copper",
-			"material": "WEATHERED_CUT_COPPER",
+			"material": "minecraft:weathered_cut_copper",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50207,8 +47123,7 @@
 			"typed": "minecraft:weathered_cut_copper"
 		},
 		{
-			"asMaterial": "minecraft:weathered_cut_copper_slab",
-			"blockType": true,
+			"blockType": "minecraft:weathered_cut_copper_slab",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50231,11 +47146,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:weathered_cut_copper_slab",
-			"material": "WEATHERED_CUT_COPPER_SLAB",
+			"material": "minecraft:weathered_cut_copper_slab",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50244,8 +47158,7 @@
 			"typed": "minecraft:weathered_cut_copper_slab"
 		},
 		{
-			"asMaterial": "minecraft:weathered_cut_copper_stairs",
-			"blockType": true,
+			"blockType": "minecraft:weathered_cut_copper_stairs",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50268,11 +47181,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:weathered_cut_copper_stairs",
-			"material": "WEATHERED_CUT_COPPER_STAIRS",
+			"material": "minecraft:weathered_cut_copper_stairs",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50281,8 +47193,7 @@
 			"typed": "minecraft:weathered_cut_copper_stairs"
 		},
 		{
-			"asMaterial": "minecraft:weeping_vines",
-			"blockType": true,
+			"blockType": "minecraft:weeping_vines",
 			"compostChance": "0.5F",
 			"compostable": true,
 			"createItemStack": {
@@ -50306,11 +47217,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:weeping_vines",
-			"material": "WEEPING_VINES",
+			"material": "minecraft:weeping_vines",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50319,8 +47229,7 @@
 			"typed": "minecraft:weeping_vines"
 		},
 		{
-			"asMaterial": "minecraft:wet_sponge",
-			"blockType": true,
+			"blockType": "minecraft:wet_sponge",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50343,11 +47252,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:wet_sponge",
-			"material": "WET_SPONGE",
+			"material": "minecraft:wet_sponge",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50356,8 +47264,6 @@
 			"typed": "minecraft:wet_sponge"
 		},
 		{
-			"asMaterial": "minecraft:wheat",
-			"blockType": false,
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -50381,11 +47287,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:wheat",
-			"material": "WHEAT",
+			"material": "minecraft:wheat",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50394,8 +47299,7 @@
 			"typed": "minecraft:wheat"
 		},
 		{
-			"asMaterial": "minecraft:wheat_seeds",
-			"blockType": true,
+			"blockType": "minecraft:wheat",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -50419,11 +47323,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:wheat_seeds",
-			"material": "WHEAT_SEEDS",
+			"material": "minecraft:wheat_seeds",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50432,8 +47335,7 @@
 			"typed": "minecraft:wheat_seeds"
 		},
 		{
-			"asMaterial": "minecraft:white_banner",
-			"blockType": true,
+			"blockType": "minecraft:white_banner",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50457,11 +47359,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:white_banner",
-			"material": "WHITE_BANNER",
+			"material": "minecraft:white_banner",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BannerMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50470,8 +47371,7 @@
 			"typed": "minecraft:white_banner"
 		},
 		{
-			"asMaterial": "minecraft:white_bed",
-			"blockType": true,
+			"blockType": "minecraft:white_bed",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50494,11 +47394,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:white_bed",
-			"material": "WHITE_BED",
+			"material": "minecraft:white_bed",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50507,8 +47406,6 @@
 			"typed": "minecraft:white_bed"
 		},
 		{
-			"asMaterial": "minecraft:white_bundle",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50532,11 +47429,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:white_bundle",
-			"material": "WHITE_BUNDLE",
+			"material": "minecraft:white_bundle",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BundleMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50545,8 +47441,7 @@
 			"typed": "minecraft:white_bundle"
 		},
 		{
-			"asMaterial": "minecraft:white_candle",
-			"blockType": true,
+			"blockType": "minecraft:white_candle",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50569,11 +47464,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:white_candle",
-			"material": "WHITE_CANDLE",
+			"material": "minecraft:white_candle",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50582,8 +47476,7 @@
 			"typed": "minecraft:white_candle"
 		},
 		{
-			"asMaterial": "minecraft:white_carpet",
-			"blockType": true,
+			"blockType": "minecraft:white_carpet",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50607,11 +47500,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:white_carpet",
-			"material": "WHITE_CARPET",
+			"material": "minecraft:white_carpet",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50620,8 +47512,7 @@
 			"typed": "minecraft:white_carpet"
 		},
 		{
-			"asMaterial": "minecraft:white_concrete",
-			"blockType": true,
+			"blockType": "minecraft:white_concrete",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50644,11 +47535,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:white_concrete",
-			"material": "WHITE_CONCRETE",
+			"material": "minecraft:white_concrete",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50657,8 +47547,7 @@
 			"typed": "minecraft:white_concrete"
 		},
 		{
-			"asMaterial": "minecraft:white_concrete_powder",
-			"blockType": true,
+			"blockType": "minecraft:white_concrete_powder",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50681,11 +47570,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:white_concrete_powder",
-			"material": "WHITE_CONCRETE_POWDER",
+			"material": "minecraft:white_concrete_powder",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50694,8 +47582,6 @@
 			"typed": "minecraft:white_concrete_powder"
 		},
 		{
-			"asMaterial": "minecraft:white_dye",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50718,11 +47604,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:white_dye",
-			"material": "WHITE_DYE",
+			"material": "minecraft:white_dye",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50731,8 +47616,7 @@
 			"typed": "minecraft:white_dye"
 		},
 		{
-			"asMaterial": "minecraft:white_glazed_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:white_glazed_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50755,11 +47639,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:white_glazed_terracotta",
-			"material": "WHITE_GLAZED_TERRACOTTA",
+			"material": "minecraft:white_glazed_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50768,8 +47651,7 @@
 			"typed": "minecraft:white_glazed_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:white_shulker_box",
-			"blockType": true,
+			"blockType": "minecraft:white_shulker_box",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50793,11 +47675,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:white_shulker_box",
-			"material": "WHITE_SHULKER_BOX",
+			"material": "minecraft:white_shulker_box",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50806,8 +47687,7 @@
 			"typed": "minecraft:white_shulker_box"
 		},
 		{
-			"asMaterial": "minecraft:white_stained_glass",
-			"blockType": true,
+			"blockType": "minecraft:white_stained_glass",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50830,11 +47710,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:white_stained_glass",
-			"material": "WHITE_STAINED_GLASS",
+			"material": "minecraft:white_stained_glass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50843,8 +47722,7 @@
 			"typed": "minecraft:white_stained_glass"
 		},
 		{
-			"asMaterial": "minecraft:white_stained_glass_pane",
-			"blockType": true,
+			"blockType": "minecraft:white_stained_glass_pane",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50867,11 +47745,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:white_stained_glass_pane",
-			"material": "WHITE_STAINED_GLASS_PANE",
+			"material": "minecraft:white_stained_glass_pane",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50880,8 +47757,7 @@
 			"typed": "minecraft:white_stained_glass_pane"
 		},
 		{
-			"asMaterial": "minecraft:white_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:white_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50904,11 +47780,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:white_terracotta",
-			"material": "WHITE_TERRACOTTA",
+			"material": "minecraft:white_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50917,8 +47792,7 @@
 			"typed": "minecraft:white_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:white_tulip",
-			"blockType": true,
+			"blockType": "minecraft:white_tulip",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -50942,11 +47816,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:white_tulip",
-			"material": "WHITE_TULIP",
+			"material": "minecraft:white_tulip",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50955,8 +47828,7 @@
 			"typed": "minecraft:white_tulip"
 		},
 		{
-			"asMaterial": "minecraft:white_wool",
-			"blockType": true,
+			"blockType": "minecraft:white_wool",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -50979,11 +47851,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:white_wool",
-			"material": "WHITE_WOOL",
+			"material": "minecraft:white_wool",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -50992,8 +47863,6 @@
 			"typed": "minecraft:white_wool"
 		},
 		{
-			"asMaterial": "minecraft:wild_armor_trim_smithing_template",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51016,11 +47885,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:wild_armor_trim_smithing_template",
-			"material": "WILD_ARMOR_TRIM_SMITHING_TEMPLATE",
+			"material": "minecraft:wild_armor_trim_smithing_template",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51029,8 +47897,7 @@
 			"typed": "minecraft:wild_armor_trim_smithing_template"
 		},
 		{
-			"asMaterial": "minecraft:wildflowers",
-			"blockType": true,
+			"blockType": "minecraft:wildflowers",
 			"compostChance": "0.3F",
 			"compostable": true,
 			"createItemStack": {
@@ -51054,11 +47921,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:wildflowers",
-			"material": "WILDFLOWERS",
+			"material": "minecraft:wildflowers",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51067,8 +47933,6 @@
 			"typed": "minecraft:wildflowers"
 		},
 		{
-			"asMaterial": "minecraft:wind_charge",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51092,11 +47956,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:wind_charge",
-			"material": "WIND_CHARGE",
+			"material": "minecraft:wind_charge",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51105,8 +47968,6 @@
 			"typed": "minecraft:wind_charge"
 		},
 		{
-			"asMaterial": "minecraft:witch_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51129,11 +47990,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:witch_spawn_egg",
-			"material": "WITCH_SPAWN_EGG",
+			"material": "minecraft:witch_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51142,8 +48002,7 @@
 			"typed": "minecraft:witch_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:wither_rose",
-			"blockType": true,
+			"blockType": "minecraft:wither_rose",
 			"compostChance": "0.65F",
 			"compostable": true,
 			"createItemStack": {
@@ -51167,11 +48026,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:wither_rose",
-			"material": "WITHER_ROSE",
+			"material": "minecraft:wither_rose",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51180,8 +48038,7 @@
 			"typed": "minecraft:wither_rose"
 		},
 		{
-			"asMaterial": "minecraft:wither_skeleton_skull",
-			"blockType": true,
+			"blockType": "minecraft:wither_skeleton_skull",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51205,11 +48062,10 @@
 			"fuel": false,
 			"itemRarity": "RARE",
 			"key": "minecraft:wither_skeleton_skull",
-			"material": "WITHER_SKELETON_SKULL",
+			"material": "minecraft:wither_skeleton_skull",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SkullMeta",
-			"rarity": "RARE",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51218,8 +48074,6 @@
 			"typed": "minecraft:wither_skeleton_skull"
 		},
 		{
-			"asMaterial": "minecraft:wither_skeleton_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51242,11 +48096,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:wither_skeleton_spawn_egg",
-			"material": "WITHER_SKELETON_SPAWN_EGG",
+			"material": "minecraft:wither_skeleton_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51255,8 +48108,6 @@
 			"typed": "minecraft:wither_skeleton_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:wither_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51279,11 +48130,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:wither_spawn_egg",
-			"material": "WITHER_SPAWN_EGG",
+			"material": "minecraft:wither_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51292,8 +48142,6 @@
 			"typed": "minecraft:wither_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:wolf_armor",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51320,11 +48168,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:wolf_armor",
-			"material": "WOLF_ARMOR",
+			"material": "minecraft:wolf_armor",
 			"maxDurability": 64,
 			"maxStackSize": 1,
 			"metaClass": "ColorableArmorMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51333,8 +48180,6 @@
 			"typed": "minecraft:wolf_armor"
 		},
 		{
-			"asMaterial": "minecraft:wolf_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51357,11 +48202,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:wolf_spawn_egg",
-			"material": "WOLF_SPAWN_EGG",
+			"material": "minecraft:wolf_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51370,8 +48214,6 @@
 			"typed": "minecraft:wolf_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:wooden_axe",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51400,11 +48242,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:wooden_axe",
-			"material": "WOODEN_AXE",
+			"material": "minecraft:wooden_axe",
 			"maxDurability": 59,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51413,8 +48254,6 @@
 			"typed": "minecraft:wooden_axe"
 		},
 		{
-			"asMaterial": "minecraft:wooden_hoe",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51443,11 +48282,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:wooden_hoe",
-			"material": "WOODEN_HOE",
+			"material": "minecraft:wooden_hoe",
 			"maxDurability": 59,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51456,8 +48294,6 @@
 			"typed": "minecraft:wooden_hoe"
 		},
 		{
-			"asMaterial": "minecraft:wooden_pickaxe",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51486,11 +48322,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:wooden_pickaxe",
-			"material": "WOODEN_PICKAXE",
+			"material": "minecraft:wooden_pickaxe",
 			"maxDurability": 59,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51499,8 +48334,6 @@
 			"typed": "minecraft:wooden_pickaxe"
 		},
 		{
-			"asMaterial": "minecraft:wooden_shovel",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51529,11 +48362,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:wooden_shovel",
-			"material": "WOODEN_SHOVEL",
+			"material": "minecraft:wooden_shovel",
 			"maxDurability": 59,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51542,8 +48374,6 @@
 			"typed": "minecraft:wooden_shovel"
 		},
 		{
-			"asMaterial": "minecraft:wooden_sword",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51572,11 +48402,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:wooden_sword",
-			"material": "WOODEN_SWORD",
+			"material": "minecraft:wooden_sword",
 			"maxDurability": 59,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51585,8 +48414,6 @@
 			"typed": "minecraft:wooden_sword"
 		},
 		{
-			"asMaterial": "minecraft:writable_book",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51610,11 +48437,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:writable_book",
-			"material": "WRITABLE_BOOK",
+			"material": "minecraft:writable_book",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BookMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51623,8 +48449,6 @@
 			"typed": "minecraft:writable_book"
 		},
 		{
-			"asMaterial": "minecraft:written_book",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51648,11 +48472,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:written_book",
-			"material": "WRITTEN_BOOK",
+			"material": "minecraft:written_book",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BookMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51661,8 +48484,7 @@
 			"typed": "minecraft:written_book"
 		},
 		{
-			"asMaterial": "minecraft:yellow_banner",
-			"blockType": true,
+			"blockType": "minecraft:yellow_banner",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51686,11 +48508,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:yellow_banner",
-			"material": "YELLOW_BANNER",
+			"material": "minecraft:yellow_banner",
 			"maxDurability": 0,
 			"maxStackSize": 16,
 			"metaClass": "BannerMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51699,8 +48520,7 @@
 			"typed": "minecraft:yellow_banner"
 		},
 		{
-			"asMaterial": "minecraft:yellow_bed",
-			"blockType": true,
+			"blockType": "minecraft:yellow_bed",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51723,11 +48543,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:yellow_bed",
-			"material": "YELLOW_BED",
+			"material": "minecraft:yellow_bed",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51736,8 +48555,6 @@
 			"typed": "minecraft:yellow_bed"
 		},
 		{
-			"asMaterial": "minecraft:yellow_bundle",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51761,11 +48578,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:yellow_bundle",
-			"material": "YELLOW_BUNDLE",
+			"material": "minecraft:yellow_bundle",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BundleMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51774,8 +48590,7 @@
 			"typed": "minecraft:yellow_bundle"
 		},
 		{
-			"asMaterial": "minecraft:yellow_candle",
-			"blockType": true,
+			"blockType": "minecraft:yellow_candle",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51798,11 +48613,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:yellow_candle",
-			"material": "YELLOW_CANDLE",
+			"material": "minecraft:yellow_candle",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51811,8 +48625,7 @@
 			"typed": "minecraft:yellow_candle"
 		},
 		{
-			"asMaterial": "minecraft:yellow_carpet",
-			"blockType": true,
+			"blockType": "minecraft:yellow_carpet",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51836,11 +48649,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:yellow_carpet",
-			"material": "YELLOW_CARPET",
+			"material": "minecraft:yellow_carpet",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51849,8 +48661,7 @@
 			"typed": "minecraft:yellow_carpet"
 		},
 		{
-			"asMaterial": "minecraft:yellow_concrete",
-			"blockType": true,
+			"blockType": "minecraft:yellow_concrete",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51873,11 +48684,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:yellow_concrete",
-			"material": "YELLOW_CONCRETE",
+			"material": "minecraft:yellow_concrete",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51886,8 +48696,7 @@
 			"typed": "minecraft:yellow_concrete"
 		},
 		{
-			"asMaterial": "minecraft:yellow_concrete_powder",
-			"blockType": true,
+			"blockType": "minecraft:yellow_concrete_powder",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51910,11 +48719,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:yellow_concrete_powder",
-			"material": "YELLOW_CONCRETE_POWDER",
+			"material": "minecraft:yellow_concrete_powder",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51923,8 +48731,6 @@
 			"typed": "minecraft:yellow_concrete_powder"
 		},
 		{
-			"asMaterial": "minecraft:yellow_dye",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51947,11 +48753,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:yellow_dye",
-			"material": "YELLOW_DYE",
+			"material": "minecraft:yellow_dye",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51960,8 +48765,7 @@
 			"typed": "minecraft:yellow_dye"
 		},
 		{
-			"asMaterial": "minecraft:yellow_glazed_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:yellow_glazed_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -51984,11 +48788,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:yellow_glazed_terracotta",
-			"material": "YELLOW_GLAZED_TERRACOTTA",
+			"material": "minecraft:yellow_glazed_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -51997,8 +48800,7 @@
 			"typed": "minecraft:yellow_glazed_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:yellow_shulker_box",
-			"blockType": true,
+			"blockType": "minecraft:yellow_shulker_box",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -52022,11 +48824,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:yellow_shulker_box",
-			"material": "YELLOW_SHULKER_BOX",
+			"material": "minecraft:yellow_shulker_box",
 			"maxDurability": 0,
 			"maxStackSize": 1,
 			"metaClass": "BlockStateMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -52035,8 +48836,7 @@
 			"typed": "minecraft:yellow_shulker_box"
 		},
 		{
-			"asMaterial": "minecraft:yellow_stained_glass",
-			"blockType": true,
+			"blockType": "minecraft:yellow_stained_glass",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -52059,11 +48859,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:yellow_stained_glass",
-			"material": "YELLOW_STAINED_GLASS",
+			"material": "minecraft:yellow_stained_glass",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -52072,8 +48871,7 @@
 			"typed": "minecraft:yellow_stained_glass"
 		},
 		{
-			"asMaterial": "minecraft:yellow_stained_glass_pane",
-			"blockType": true,
+			"blockType": "minecraft:yellow_stained_glass_pane",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -52096,11 +48894,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:yellow_stained_glass_pane",
-			"material": "YELLOW_STAINED_GLASS_PANE",
+			"material": "minecraft:yellow_stained_glass_pane",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -52109,8 +48906,7 @@
 			"typed": "minecraft:yellow_stained_glass_pane"
 		},
 		{
-			"asMaterial": "minecraft:yellow_terracotta",
-			"blockType": true,
+			"blockType": "minecraft:yellow_terracotta",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -52133,11 +48929,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:yellow_terracotta",
-			"material": "YELLOW_TERRACOTTA",
+			"material": "minecraft:yellow_terracotta",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -52146,8 +48941,7 @@
 			"typed": "minecraft:yellow_terracotta"
 		},
 		{
-			"asMaterial": "minecraft:yellow_wool",
-			"blockType": true,
+			"blockType": "minecraft:yellow_wool",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -52170,11 +48964,10 @@
 			"fuel": true,
 			"itemRarity": "COMMON",
 			"key": "minecraft:yellow_wool",
-			"material": "YELLOW_WOOL",
+			"material": "minecraft:yellow_wool",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "ItemMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -52183,8 +48976,6 @@
 			"typed": "minecraft:yellow_wool"
 		},
 		{
-			"asMaterial": "minecraft:zoglin_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -52207,11 +48998,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:zoglin_spawn_egg",
-			"material": "ZOGLIN_SPAWN_EGG",
+			"material": "minecraft:zoglin_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -52220,8 +49010,7 @@
 			"typed": "minecraft:zoglin_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:zombie_head",
-			"blockType": true,
+			"blockType": "minecraft:zombie_head",
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -52245,11 +49034,10 @@
 			"fuel": false,
 			"itemRarity": "UNCOMMON",
 			"key": "minecraft:zombie_head",
-			"material": "ZOMBIE_HEAD",
+			"material": "minecraft:zombie_head",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SkullMeta",
-			"rarity": "UNCOMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -52258,8 +49046,6 @@
 			"typed": "minecraft:zombie_head"
 		},
 		{
-			"asMaterial": "minecraft:zombie_horse_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -52282,11 +49068,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:zombie_horse_spawn_egg",
-			"material": "ZOMBIE_HORSE_SPAWN_EGG",
+			"material": "minecraft:zombie_horse_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -52295,8 +49080,6 @@
 			"typed": "minecraft:zombie_horse_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:zombie_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -52319,11 +49102,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:zombie_spawn_egg",
-			"material": "ZOMBIE_SPAWN_EGG",
+			"material": "minecraft:zombie_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -52332,8 +49114,6 @@
 			"typed": "minecraft:zombie_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:zombie_villager_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -52356,11 +49136,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:zombie_villager_spawn_egg",
-			"material": "ZOMBIE_VILLAGER_SPAWN_EGG",
+			"material": "minecraft:zombie_villager_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"
@@ -52369,8 +49148,6 @@
 			"typed": "minecraft:zombie_villager_spawn_egg"
 		},
 		{
-			"asMaterial": "minecraft:zombified_piglin_spawn_egg",
-			"blockType": false,
 			"compostable": false,
 			"createItemStack": {
 				"amount": 1,
@@ -52393,11 +49170,10 @@
 			"fuel": false,
 			"itemRarity": "COMMON",
 			"key": "minecraft:zombified_piglin_spawn_egg",
-			"material": "ZOMBIFIED_PIGLIN_SPAWN_EGG",
+			"material": "minecraft:zombified_piglin_spawn_egg",
 			"maxDurability": 0,
 			"maxStackSize": 64,
 			"metaClass": "SpawnEggMeta",
-			"rarity": "COMMON",
 			"record": false,
 			"requiredFeatures": [
 				"minecraft:vanilla"


### PR DESCRIPTION
# Description
Currently metaminer retrieves all the public methods of each entry of each keyed resource and then stores the return value  (by my weird choice) in a shortened form // without has/is/get/as. The issue is that doing this will create some conflicts for methods with the same classifier (whatever comes after has/is/.../get is called). This does not fix that issue, but it does make it so that only one value gets chosen when get and has are both available for the class.

# Checklist
The following items should be checked before the pull request can be merged.
- [n/a] Code follows existing style.
- [n/a] Unit tests added (if applicable).
