### PR TITLE
Fix block data keys overriding each other for deserialization

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
@@ -25,11 +25,12 @@ import org.bukkit.block.data.type.TestBlock;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
+import java.util.Arrays;
 import java.util.Locale;
-import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * Stores all {@link BlockData} keys.
@@ -120,7 +121,7 @@ public enum BlockDataKey
 
 	CANDLES("candles", Integer::parseInt, Candle.class::isInstance);
 
-	private static final Map<String, BlockDataKey> KEY_TO_BLOCK_DATA_KEY_RELATION = compileKeyRelation();
+	private static final Set<String> KEYS = compileKeys();
 
 
 	private String key;
@@ -141,22 +142,26 @@ public enum BlockDataKey
 
 	public static boolean isRegistered(String key)
 	{
-		return KEY_TO_BLOCK_DATA_KEY_RELATION.containsKey(key);
+		return KEYS.contains(key);
 	}
 
-	private static Map<String, BlockDataKey> compileKeyRelation()
+	private static Set<String> compileKeys()
 	{
-		Map<String, BlockDataKey> output = new HashMap<>();
+		return Arrays.stream(BlockDataKey.values())
+				.map(BlockDataKey::key)
+				.collect(Collectors.toSet());
+	}
+
+	public static @Nullable BlockDataKey fromKey(String key, BlockDataMock blockDataMock)
+	{
 		for (BlockDataKey blockDataKey : BlockDataKey.values())
 		{
-			output.put(blockDataKey.key(), blockDataKey);
+			if (blockDataKey.key().equals(key) && blockDataKey.appliesTo(blockDataMock))
+			{
+				return blockDataKey;
+			}
 		}
-		return output;
-	}
-
-	public static @Nullable BlockDataKey fromKey(String key)
-	{
-		return KEY_TO_BLOCK_DATA_KEY_RELATION.get(key);
+		return null;
 	}
 
 	public Object constructValue(String valueString)

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMock.java
@@ -151,8 +151,8 @@ public class BlockDataMock implements BlockData
 			String key = split[0].strip();
 			String valueString = split[1].strip();
 			Preconditions.checkArgument(BlockDataKey.isRegistered(key), "Unknown block data key: " + key);
-			BlockDataKey blockDataKey = BlockDataKey.fromKey(key);
-			Preconditions.checkArgument(blockDataKey.appliesTo(blockData), "Can not apply block data key to '" + blockKey + "': " + key);
+			BlockDataKey blockDataKey = BlockDataKey.fromKey(key, blockData);
+			Preconditions.checkArgument(blockDataKey != null, "Can not apply block data key to '" + blockKey + "': " + key);
 			Object value = blockDataKey.constructValue(valueString);
 			Preconditions.checkArgument(value != null, "Unknown block data value: " + valueString);
 			data.put(key, value);

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/RailDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/RailDataMockTest.java
@@ -15,10 +15,12 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockBukkitExtension.class)
 class RailDataMockTest
 {
+
 	private RailDataMock rail;
 
 	@BeforeEach
@@ -70,7 +72,7 @@ class RailDataMockTest
 		}
 
 		@ParameterizedTest
-		@ValueSource(booleans = {true, false})
+		@ValueSource(booleans = { true, false })
 		void givenPossibleValues(boolean isWaterLogged)
 		{
 			rail.setWaterlogged(isWaterLogged);
@@ -82,6 +84,9 @@ class RailDataMockTest
 	@Test
 	void deserialize()
 	{
-		BlockDataMock.newData(null, "minecraft:rail[shape=south_east, waterlogged=true]");
+		RailDataMock blockDataMock = (RailDataMock) BlockDataMock.newData(null, "minecraft:rail[shape=south_east, waterlogged=true]");
+		assertEquals(Rail.Shape.SOUTH_EAST, blockDataMock.getShape());
+		assertTrue(blockDataMock.isWaterlogged());
 	}
+
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/RailDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/RailDataMockTest.java
@@ -78,4 +78,10 @@ class RailDataMockTest
 		}
 
 	}
+
+	@Test
+	void deserialize()
+	{
+		BlockDataMock.newData(null, "minecraft:rail[shape=south_east, waterlogged=true]");
+	}
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/StairsDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/StairsDataMockTest.java
@@ -1,14 +1,15 @@
 package org.mockbukkit.mockbukkit.block.data;
 
-import org.mockbukkit.mockbukkit.MockBukkitExtension;
 import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockType;
 import org.bukkit.block.data.Bisected;
 import org.bukkit.block.data.type.Stairs;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -135,6 +136,12 @@ class StairsDataMockTest
 		{
 			assertInstanceOf(StairsDataMock.class, BlockDataMock.mock(material));
 		}
+	}
+
+	@Test
+	void deserialize()
+	{
+		BlockDataMock.newData(null, "minecraft:oak_stairs[facing=east, half=top, shape=inner_left, waterlogged=true]");
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/StairsDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/StairsDataMockTest.java
@@ -3,7 +3,6 @@ package org.mockbukkit.mockbukkit.block.data;
 import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.block.BlockFace;
-import org.bukkit.block.BlockType;
 import org.bukkit.block.data.Bisected;
 import org.bukkit.block.data.type.Stairs;
 import org.junit.jupiter.api.BeforeEach;
@@ -141,7 +140,11 @@ class StairsDataMockTest
 	@Test
 	void deserialize()
 	{
-		BlockDataMock.newData(null, "minecraft:oak_stairs[facing=east, half=top, shape=inner_left, waterlogged=true]");
+		StairsDataMock stairsDataMock = (StairsDataMock) BlockDataMock.newData(null, "minecraft:oak_stairs[facing=east, half=top, shape=inner_left, waterlogged=true]");
+		assertEquals(BlockFace.EAST, stairsDataMock.getFacing());
+		assertEquals(Bisected.Half.TOP, stairsDataMock.getHalf());
+		assertEquals(Stairs.Shape.INNER_LEFT, stairsDataMock.getShape());
+		assertTrue(stairsDataMock.isWaterlogged());
 	}
 
 }


### PR DESCRIPTION
# Description
There's two separate types of block data keys, "shape" for rails and "shape" for stairs. Both have the same key there, which is going to mean either of them will override each other.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
