### PR TITLE
Implement setAffectsSpawning and setFlySpeed in PlayerMock

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
@@ -176,6 +176,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	private @Nullable Component playerListFooter = null;
 	private int expTotal = 0;
 	private float exp = 0;
+	private float flySpeed = 0.1F;
 	private int expCooldown = 0;
 	private int deathScreenScore = 0;
 	private int playerListOrder = 0;
@@ -2236,15 +2237,15 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public float getFlySpeed()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.flySpeed;
 	}
 
 	@Override
 	public void setFlySpeed(float value)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkArgument(value <= 1f && value >= -1f, "Speed value (%s) need to be between -1f and 1f", value);
+
+		this.flySpeed = value;
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
@@ -188,6 +188,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	private boolean sleepingIgnored = false;
 	private boolean seenWinScreen = false;
 	private boolean relativeTime = true;
+	private boolean affectsSpawning = true;
 	private long timeOffset = 0;
 	private double healthScale = 20;
 	private Location compassTarget;
@@ -2662,15 +2663,13 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public boolean getAffectsSpawning()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.affectsSpawning;
 	}
 
 	@Override
 	public void setAffectsSpawning(boolean affects)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.affectsSpawning = affects;
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
@@ -3302,4 +3302,33 @@ class PlayerMockTest
 
 	}
 
+	@Nested
+	class SetFlySpeed
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(0.1F, player.getFlySpeed());
+		}
+
+		@ParameterizedTest
+		@ValueSource(floats = {-1.0F, -0.5F, 0.0F, 0.5F, 1.0F})
+		void givenPossibleValue(float value)
+		{
+
+			player.setFlySpeed(value);
+
+			assertEquals(value, player.getFlySpeed());
+		}
+
+		@ParameterizedTest
+		@ValueSource(floats = {-1.001F, 1.001F})
+		void givenNonPossibleValue(float value)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> player.setFlySpeed(value));
+			assertEquals(String.format("Speed value (%s) need to be between -1f and 1f", value), e.getMessage());
+		}
+	}
+
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
@@ -3331,4 +3331,26 @@ class PlayerMockTest
 		}
 	}
 
+	@Nested
+	class SetAffectsSpawning
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertTrue(player.getAffectsSpawning());
+		}
+
+		@ParameterizedTest
+		@ValueSource(booleans = {true, false})
+		void givenPossibleValue(boolean value)
+		{
+
+			player.setAffectsSpawning(value);
+
+			assertEquals(value, player.getAffectsSpawning());
+		}
+
+	}
+
 }


### PR DESCRIPTION
# Description
Implements the method _setAffectsSpawning_ and _setFlySpeed_ in _PlayerMock_.

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
