### PR TITLE
Add refresh dependency to checkstyle

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Run checkstyle in source code
-        run: ./gradlew checkstyleMain
+        run: ./gradlew checkstyleMain --refresh-dependencies
 
       - name: Run checkstyle in test code
-        run: ./gradlew checkstyleTest
+        run: ./gradlew checkstyleTest --refresh-dependencies


### PR DESCRIPTION
This PR adds the refresh dependencies to the pipeline, so that we can have paper version updated.