### PR TITLE
Replace `UnimplementedOperationException` with null return

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -291,7 +291,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		if (attributes.containsKey(attribute))
 			return attributes.get(attribute);
 		else
-			throw new UnimplementedOperationException();
+			return null;
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -288,10 +288,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	@Override
 	public AttributeInstance getAttribute(@NotNull Attribute attribute)
 	{
-		if (attributes.containsKey(attribute))
-			return attributes.get(attribute);
-		else
-			return null;
+		return attributes.getOrDefault(attribute, null);
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
@@ -2,6 +2,7 @@ package org.mockbukkit.mockbukkit.entity;
 
 import net.kyori.adventure.util.TriState;
 import org.bukkit.Location;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.DragonFireball;
 import org.bukkit.entity.Egg;
@@ -480,6 +481,12 @@ class LivingEntityMockTest
 		assertEquals(10, livingEntity.getHealth(), 0);
 		assertFalse(livingEntity.isDead());
 		assertNull(livingEntity.getKiller());
+	}
+
+	@Test
+	void getAttribute_WhenAttributeIsNotPresent()
+	{
+		assertNull(this.livingEntity.getAttribute(Attribute.ARMOR));
 	}
 
 }


### PR DESCRIPTION
# Description
Replaced `UnimplementedOperationException` with a `null` return, as per the expected behavior.

# Checklist

The following items should be checked before the pull request can be merged.

- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
