### PR TITLE
Implement Brushable block data and block state

### DIFF
--- a/metaminer/src/main/java/org/mockbukkit/metaminer/internal/MaterialDataGenerator.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/internal/MaterialDataGenerator.java
@@ -7,6 +7,7 @@ import org.bukkit.Material;
 import org.bukkit.block.data.Ageable;
 import org.bukkit.block.data.AnaloguePowerable;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Brushable;
 import org.bukkit.block.data.Directional;
 import org.bukkit.block.data.Levelled;
 import org.bukkit.block.data.MultipleFacing;
@@ -113,6 +114,11 @@ public class MaterialDataGenerator implements DataGenerator
 		{
 			obj.addProperty("maxLevel", String.valueOf(levelled.getMaximumLevel()));
 			obj.addProperty("minLevel", String.valueOf(levelled.getMinimumLevel()));
+		}
+
+		if (data instanceof Brushable brushable)
+		{
+			obj.addProperty("maxDusted", String.valueOf(brushable.getMaximumDusted()));
 		}
 
 		if (data instanceof Directional directional)

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
@@ -7,6 +7,7 @@ import org.bukkit.block.data.Ageable;
 import org.bukkit.block.data.AnaloguePowerable;
 import org.bukkit.block.data.Bisected;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Brushable;
 import org.bukkit.block.data.Directional;
 import org.bukkit.block.data.FaceAttachable;
 import org.bukkit.block.data.Levelled;
@@ -160,6 +161,7 @@ public enum BlockDataKey
 	RAIL_SHAPE("shape", string -> Rail.Shape.valueOf(string.toUpperCase(Locale.ROOT)), Rail.class::isInstance),
 
 	LEVEL("level", Integer::parseInt, Levelled.class::isInstance),
+	DUSTED("dusted", Integer::parseInt, Brushable.class::isInstance),
 	MODE("mode", string -> TestBlock.Mode.valueOf(string.toUpperCase(Locale.ROOT)), TestBlock.class::isInstance),
 
 	CANDLES("candles", Integer::parseInt, Candle.class::isInstance),

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataLimitation.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataLimitation.java
@@ -63,6 +63,7 @@ public class BlockDataLimitation<T, U>
 		public static final Type<Integer, Integer> MAX_POWER = new Type<>("maxPower", jsonElement -> BlockDataLimitation.fromValueLesserThan(jsonElement.getAsInt()));
 		public static final Type<Integer, Integer> MAX_STAGE = new Type<>("maxStage", jsonElement -> BlockDataLimitation.fromValueLesserThan(jsonElement.getAsInt()));
 		public static final Type<Integer, Integer> MAX_LEVEL = new Type<>("maxLevel", jsonElement -> BlockDataLimitation.fromValueLesserThan(jsonElement.getAsInt()));
+		public static final Type<Integer, Integer> MAX_DUSTED = new Type<>("maxDusted", jsonElement -> BlockDataLimitation.fromValueLesserThan(jsonElement.getAsInt()));
 		public static final Type<Integer, Integer> MIN_LEVEL = new Type<>("minLevel", jsonElement -> BlockDataLimitation.fromValueGreaterThan(jsonElement.getAsInt()));
 		public static final Type<Set<BlockFace>, BlockFace> FACES = new Type<>("faces", jsonElement -> BlockDataLimitation.fromSet(
 				jsonElement.getAsJsonArray()

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
@@ -8,6 +8,7 @@ import org.bukkit.block.data.Ageable;
 import org.bukkit.block.data.AnaloguePowerable;
 import org.bukkit.block.data.Bisected;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Brushable;
 import org.bukkit.block.data.Levelled;
 import org.bukkit.block.data.Lightable;
 import org.bukkit.block.data.Orientable;
@@ -67,6 +68,7 @@ public final class BlockDataMockFactory
 	private static final Map<Class<? extends BlockData>, Function<Material, BlockDataMock>> FACTORIES_BY_BLOCK_DATA = ImmutableMap.<Class<? extends BlockData>, Function<Material, BlockDataMock>>builder()
 			.put(AmethystCluster.class, AmethystClusterDataMock::new)
 			.put(Bamboo.class, m -> new BambooDataMock())
+			.put(Brushable.class, BrushableDataMock::new)
 			.put(Chest.class, ChestDataMock::new)
 			.put(Crafter.class, CrafterDataMock::new)
 			.put(DecoratedPot.class, m -> new DecoratedPotDataMock())

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BrushableDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BrushableDataMock.java
@@ -1,0 +1,45 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Material;
+import org.bukkit.block.data.Brushable;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Mock implementation of {@link Brushable}.
+ *
+ * @see BlockDataMock
+ */
+public class BrushableDataMock extends BlockDataMock implements Brushable
+{
+
+	/**
+	 * Constructs a new {@link BrushableDataMock} for the provided {@link Material}.
+	 *
+	 * @param material The material this data is for.
+	 */
+	public BrushableDataMock(@NotNull Material material)
+	{
+		super(material);
+	}
+
+	@Override
+	public int getDusted()
+	{
+		return get(BlockDataKey.DUSTED);
+	}
+
+	@Override
+	public void setDusted(int dusted)
+	{
+		Preconditions.checkArgument(0 <= dusted && dusted <= this.getMaximumDusted(), "Dusted level should be between 0 and %s", this.getMaximumDusted());
+		this.set(BlockDataKey.DUSTED, dusted);
+	}
+
+	@Override
+	public int getMaximumDusted()
+	{
+		return this.getLimitationValue(BlockDataLimitation.Type.MAX_DUSTED);
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/BlockStateMockFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/BlockStateMockFactory.java
@@ -64,6 +64,8 @@ public class BlockStateMockFactory
 			.put(Material.SOUL_CAMPFIRE, with(CampfireStateMock::new, CampfireStateMock::new))
 			.put(Material.SPAWNER, with(CreatureSpawnerStateMock::new, CreatureSpawnerStateMock::new))
 			.put(Material.STRUCTURE_BLOCK, with(StructureStateMock::new, StructureStateMock::new))
+			.put(Material.SUSPICIOUS_GRAVEL, with(BrushableBlockStateMock::new, BrushableBlockStateMock::new))
+			.put(Material.SUSPICIOUS_SAND, with(BrushableBlockStateMock::new, BrushableBlockStateMock::new))
 			.put(Material.TEST_BLOCK, with(TestBlockStateMock::new, TestBlockStateMock::new))
 			.put(Material.TEST_INSTANCE_BLOCK, with(TestInstanceBlockStateMock::new, TestInstanceBlockStateMock::new))
 			.put(Material.TRAPPED_CHEST, with(ChestStateMock::new, ChestStateMock::new))

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/BrushableBlockStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/BrushableBlockStateMock.java
@@ -1,0 +1,114 @@
+package org.mockbukkit.mockbukkit.block.state;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BrushableBlock;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.loot.LootTable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
+
+import java.util.Objects;
+
+/**
+ * Mock implementation of a {@link BrushableBlock}.
+ *
+ * @see TileStateMock
+ */
+public class BrushableBlockStateMock extends TileStateMock implements BrushableBlock
+{
+	private @NotNull ItemStack item = ItemStack.empty();
+
+	protected BrushableBlockStateMock(@NotNull Block block)
+	{
+		super(block);
+	}
+
+	protected BrushableBlockStateMock(@NotNull Material material)
+	{
+		super(material);
+	}
+
+	protected BrushableBlockStateMock(@NotNull BrushableBlockStateMock state)
+	{
+		super(state);
+		this.item = state.item.clone();
+	}
+
+	@Override
+	public @NotNull ItemStack getItem()
+	{
+		return this.item.clone();
+	}
+
+	@Override
+	public void setItem(@Nullable ItemStack item)
+	{
+		this.item = (item == null) ? ItemStack.empty() : item.clone();
+	}
+
+	@Override
+	public void setLootTable(@Nullable LootTable table)
+	{
+		this.setLootTable(table, this.getSeed());
+	}
+
+	@Override
+	public void setLootTable(@Nullable LootTable table, long seed)
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public @Nullable LootTable getLootTable()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public void setSeed(long seed)
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public long getSeed()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public @NotNull BrushableBlockStateMock getSnapshot()
+	{
+		return new BrushableBlockStateMock(this);
+	}
+
+	@Override
+	public final boolean equals(Object o)
+	{
+		if (this == o)
+		{
+			return true;
+		}
+
+		if (!(o instanceof BrushableBlockStateMock that))
+		{
+			return false;
+		}
+
+		if (!super.equals(o))
+		{
+			return false;
+		}
+
+		return item.equals(that.item);
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash(super.hashCode(), this.item);
+	}
+
+}

--- a/src/main/resources-autogenerated/materials/material_data.json
+++ b/src/main/resources-autogenerated/materials/material_data.json
@@ -7165,13 +7165,17 @@
 		}
 	},
 	"minecraft:suspicious_gravel": {
-		"allowedStates": {},
+		"allowedStates": {
+			"maxDusted": "3"
+		},
 		"defaultStates": {
 			"dusted": "0"
 		}
 	},
 	"minecraft:suspicious_sand": {
-		"allowedStates": {},
+		"allowedStates": {
+			"maxDusted": "3"
+		},
 		"defaultStates": {
 			"dusted": "0"
 		}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
@@ -636,7 +636,6 @@ class BlockTypeMockTest
 		}
 
 		@Test
-		@Disabled("Not implemented yet #1088")
 		void givenBrushable()
 		{
 			Brushable data = BlockType.SUSPICIOUS_SAND.createBlockData();

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/BrushableDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/BrushableDataMockTest.java
@@ -1,0 +1,60 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockBukkitExtension.class)
+class BrushableDataMockTest
+{
+
+	private final BrushableDataMock brushable = new BrushableDataMock(Material.SUSPICIOUS_GRAVEL);
+
+	@Nested
+	class SetDusted
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(0, brushable.getDusted());
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = { 0, 1, 2, 3 })
+		void givenLevelChange(int level)
+		{
+			brushable.setDusted(level);
+			assertEquals(level, brushable.getDusted());
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = { -2, -1, 4, 5 })
+		void givenInvalidValues(int level)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> brushable.setDusted(level));
+			assertEquals("Dusted level should be between 0 and 3", e.getMessage());
+		}
+
+	}
+
+	@Nested
+	class GetMaximumDusted
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(3, brushable.getMaximumDusted());
+		}
+
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/state/BrushableBlockStateMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/state/BrushableBlockStateMockTest.java
@@ -1,0 +1,83 @@
+package org.mockbukkit.mockbukkit.block.state;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+@ExtendWith(MockBukkitExtension.class)
+class BrushableBlockStateMockTest
+{
+
+	private final BrushableBlockStateMock state = new BrushableBlockStateMock(Material.SUSPICIOUS_SAND);
+
+	@Nested
+	class SetItem
+	{
+		@Test
+		void defaultValueShouldBeEmpty()
+		{
+			assertEquals(ItemStack.empty(), state.getItem());
+		}
+
+		@Test
+		void givenNull()
+		{
+			state.setItem(null);
+
+			@NotNull ItemStack actual = state.getItem();
+
+			assertEquals(ItemStack.empty(), actual);
+		}
+
+		@Test
+		void givenCustomItem()
+		{
+			ItemStack item = ItemStack.of(Material.DIAMOND, 5);
+			state.setItem(item);
+
+			@NotNull ItemStack actual = state.getItem();
+
+			assertEquals(item, actual);
+			assertNotSame(item, actual);
+		}
+
+	}
+
+	@Nested
+	class GetSnapshot
+	{
+		@Test
+		void givenEqualStates()
+		{
+			ItemStack item = ItemStack.of(Material.DIAMOND, 5);
+
+			state.setItem(item);
+
+			@NotNull BrushableBlockStateMock newState = state.getSnapshot();
+
+			assertEquals(item, newState.getItem());
+			assertEquals(state, newState);
+		}
+
+		@Test
+		void givenDifferentStates()
+		{
+			ItemStack item = ItemStack.of(Material.DIAMOND, 5);
+
+			@NotNull BrushableBlockStateMock newState = state.getSnapshot();
+			newState.setItem(item);
+
+			assertNotEquals(state, newState);
+		}
+
+	}
+
+}

--- a/src/test/resources-autogenerated/blocks/block_states.csv
+++ b/src/test/resources-autogenerated/blocks/block_states.csv
@@ -955,8 +955,8 @@ STRUCTURE_BLOCK, org.bukkit.block.Structure
 STRUCTURE_VOID, org.bukkit.block.BlockState
 SUGAR_CANE, org.bukkit.block.BlockState
 SUNFLOWER, org.bukkit.block.BlockState
-SUSPICIOUS_GRAVEL, org.bukkit.block.BlockState
-SUSPICIOUS_SAND, org.bukkit.block.BlockState
+SUSPICIOUS_GRAVEL, org.bukkit.block.BrushableBlock
+SUSPICIOUS_SAND, org.bukkit.block.BrushableBlock
 SWEET_BERRY_BUSH, org.bukkit.block.BlockState
 TALL_DRY_GRASS, org.bukkit.block.BlockState
 TALL_GRASS, org.bukkit.block.BlockState


### PR DESCRIPTION
# Description
This is a PR related with issue #1088 and implements the Brushable block data and state.

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
