### PR TITLE
Add support for Shaped Recipes

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
@@ -347,6 +347,22 @@ public class RecipeManager
 		return false;
 	}
 
+	/**
+	 * Retrieves the character from the specified position in a shaped recipe grid.
+	 * <p>
+	 * The recipe shape is represented as an array of strings, where each string corresponds to a row
+	 * in the crafting grid. This method interprets the position as an index in a 3x3 grid (0 to 8),
+	 * and returns the character at that position if it exists in the shape. If the shape does not
+	 * extend to that column in the specified row, {@code null} is returned.
+	 * <p>
+	 * For example, position 4 corresponds to the center of the 3x3 grid.
+	 *
+	 * @param shape    the recipe shape as an array of strings; must not be {@code null}
+	 * @param position the index in the 3x3 grid (0–8) to retrieve the character from
+	 * @return the character at the specified position in the shape, or {@code null} if the position
+	 *         is outside the bounds of the shape
+	 * @throws IllegalArgumentException if the shape is {@code null} or the position is not in [0, 8]
+	 */
 	public static Character getChoiceAt(String[] shape, int position)
 	{
 		Preconditions.checkArgument(shape != null, "Must provide a shape");
@@ -381,6 +397,26 @@ public class RecipeManager
 		return lastLen;
 	}
 
+	/**
+	 * Generates all possible placements of a shaped crafting recipe within a 3x3 crafting grid.
+	 * <p>
+	 * This method takes a recipe shape represented as an array of strings, where each string is a row
+	 * and each character represents a crafting ingredient. It returns a list of maps, where each map
+	 * represents a valid placement of the recipe in the 3x3 grid. The keys in the map are slot indices
+	 * (from 0 to 8, left to right, top to bottom), and the values are the characters from the shape.
+	 * <p>
+	 * The method accounts for:
+	 * <ul>
+	 *   <li>All valid top-left positions where the shape can fit in the 3x3 grid</li>
+	 *   <li>Horizontal flipping of the shape</li>
+	 * </ul>
+	 *
+	 * @param shape an array of strings representing the recipe shape; must be 1 to 3 rows tall,
+	 *              and each row must be 1 to 3 characters wide and of equal length
+	 * @return a list of maps, each representing a valid placement of the recipe in the 3x3 grid
+	 * @throws IllegalArgumentException if the shape is null, has invalid dimensions,
+	 *                                  or rows are not of equal length
+	 */
 	public static List<Map<Integer, Character>> getShapedRecipePossiblePositions(String[] shape)
 	{
 		Preconditions.checkArgument(shape != null, "Must provide a shape");
@@ -760,7 +796,7 @@ public class RecipeManager
 			}
 		}
 
-		throw new UnsupportedOperationException("Crafting recipes must be rectangular");
+		throw new IllegalArgumentException("Crafting recipes must be rectangular");
 	}
 
 	static boolean matches(@NotNull ComplexRecipe complexRecipe, @NotNull ItemStack @NotNull [] items)

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
@@ -407,6 +407,7 @@ public class RecipeManager
 		{
 			if (shapeWidth == 3)
 			{
+				// Normal
 				results.add(Map.of(
 					0, pos0.get(),
 					1, pos1.get(),
@@ -418,10 +419,23 @@ public class RecipeManager
 					7, pos7.get(),
 					8, pos8.get())
 				);
+				// Flip Horizontally
+				results.add(Map.of(
+					0, pos2.get(),
+					1, pos1.get(),
+					2, pos0.get(),
+					3, pos5.get(),
+					4, pos4.get(),
+					5, pos3.get(),
+					6, pos8.get(),
+					7, pos7.get(),
+					8, pos6.get())
+				);
 				return results;
 			}
 			else if (shapeWidth == 2)
 			{
+				// Normal
 				results.add(Map.of(
 						0, pos0.get(),
 						1, pos1.get(),
@@ -438,10 +452,28 @@ public class RecipeManager
 						7, pos6.get(),
 						8, pos7.get())
 				);
+				// Flip Horizontally
+				results.add(Map.of(
+						0, pos3.get(),
+						1, pos1.get(),
+						3, pos0.get(),
+						4, pos7.get(),
+						6, pos6.get(),
+						7, pos4.get())
+				);
+				results.add(Map.of(
+						1, pos3.get(),
+						2, pos1.get(),
+						4, pos1.get(),
+						5, pos7.get(),
+						7, pos6.get(),
+						8, pos4.get())
+				);
 				return results;
 			}
 			else if (shapeWidth == 1)
 			{
+				// Normal
 				results.add(Map.of(
 					0, pos0.get(),
 					3, pos3.get(),
@@ -457,6 +489,22 @@ public class RecipeManager
 					5, pos3.get(),
 					8, pos6.get())
 				);
+				// Flip Horizontally
+				results.add(Map.of(
+						0, pos6.get(),
+						3, pos3.get(),
+						6, pos0.get())
+				);
+				results.add(Map.of(
+						1, pos6.get(),
+						4, pos3.get(),
+						7, pos0.get())
+				);
+				results.add(Map.of(
+						2, pos6.get(),
+						5, pos3.get(),
+						8, pos0.get())
+				);
 				return results;
 			}
 		}
@@ -466,6 +514,7 @@ public class RecipeManager
 		{
 			if (shapeWidth == 3)
 			{
+				// Normal
 				results.add(Map.of(
 					0, pos0.get(),
 					1, pos1.get(),
@@ -482,10 +531,28 @@ public class RecipeManager
 						7, pos4.get(),
 						8, pos5.get())
 				);
+				// Flip Horizontally
+				results.add(Map.of(
+						0, pos2.get(),
+						1, pos1.get(),
+						2, pos0.get(),
+						3, pos5.get(),
+						4, pos4.get(),
+						5, pos3.get())
+				);
+				results.add(Map.of(
+						3, pos2.get(),
+						4, pos1.get(),
+						5, pos0.get(),
+						6, pos5.get(),
+						7, pos4.get(),
+						8, pos3.get())
+				);
 				return results;
 			}
 			else if (shapeWidth == 2)
 			{
+				// Normal
 				results.add(Map.of(
 					0, pos0.get(),
 					1, pos1.get(),
@@ -509,6 +576,31 @@ public class RecipeManager
 					5, pos1.get(),
 					7, pos3.get(),
 					8, pos4.get())
+				);
+				// Flip Horizontally
+				results.add(Map.of(
+						0, pos1.get(),
+						1, pos0.get(),
+						3, pos4.get(),
+						4, pos3.get())
+				);
+				results.add(Map.of(
+						1, pos1.get(),
+						2, pos0.get(),
+						4, pos4.get(),
+						5, pos3.get())
+				);
+				results.add(Map.of(
+						3, pos1.get(),
+						4, pos0.get(),
+						6, pos4.get(),
+						7, pos3.get())
+				);
+				results.add(Map.of(
+						4, pos1.get(),
+						5, pos0.get(),
+						7, pos4.get(),
+						8, pos3.get())
 				);
 				return results;
 			}
@@ -547,6 +639,7 @@ public class RecipeManager
 		{
 			if (shapeWidth == 3)
 			{
+				// Normal
 				results.add(Map.of(
 					0, pos0.get(),
 					1, pos1.get(),
@@ -562,10 +655,27 @@ public class RecipeManager
 						7, pos1.get(),
 						8, pos2.get())
 				);
+				// Flip Horizontally
+				results.add(Map.of(
+						0, pos2.get(),
+						1, pos1.get(),
+						2, pos0.get())
+				);
+				results.add(Map.of(
+						3, pos2.get(),
+						4, pos1.get(),
+						5, pos0.get())
+				);
+				results.add(Map.of(
+						6, pos2.get(),
+						7, pos1.get(),
+						8, pos0.get())
+				);
 				return results;
 			}
 			else if (shapeWidth == 2)
 			{
+				// Normal
 				results.add(Map.of(
 					0, pos0.get(),
 					1, pos1.get())
@@ -589,6 +699,31 @@ public class RecipeManager
 				results.add(Map.of(
 					7, pos0.get(),
 					8, pos1.get())
+				);
+				// Flip Horizontally
+				results.add(Map.of(
+						0, pos1.get(),
+						1, pos0.get())
+				);
+				results.add(Map.of(
+						1, pos1.get(),
+						2, pos0.get())
+				);
+				results.add(Map.of(
+						3, pos1.get(),
+						4, pos0.get())
+				);
+				results.add(Map.of(
+						4, pos1.get(),
+						5, pos0.get())
+				);
+				results.add(Map.of(
+						6, pos1.get(),
+						7, pos0.get())
+				);
+				results.add(Map.of(
+						7, pos1.get(),
+						8, pos0.get())
 				);
 				return results;
 			}

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
@@ -437,37 +437,37 @@ public class RecipeManager
 			{
 				// Normal
 				results.add(Map.of(
-						0, pos0.get(),
-						1, pos1.get(),
-						3, pos3.get(),
-						4, pos4.get(),
-						6, pos6.get(),
-						7, pos7.get())
+					0, pos0.get(),
+					1, pos1.get(),
+					3, pos3.get(),
+					4, pos4.get(),
+					6, pos6.get(),
+					7, pos7.get())
 				);
 				results.add(Map.of(
-						1, pos0.get(),
-						2, pos1.get(),
-						4, pos3.get(),
-						5, pos4.get(),
-						7, pos6.get(),
-						8, pos7.get())
+					1, pos0.get(),
+					2, pos1.get(),
+					4, pos3.get(),
+					5, pos4.get(),
+					7, pos6.get(),
+					8, pos7.get())
 				);
 				// Flip Horizontally
 				results.add(Map.of(
-						0, pos3.get(),
-						1, pos1.get(),
-						3, pos0.get(),
-						4, pos7.get(),
-						6, pos6.get(),
-						7, pos4.get())
+					0, pos3.get(),
+					1, pos1.get(),
+					3, pos0.get(),
+					4, pos7.get(),
+					6, pos6.get(),
+					7, pos4.get())
 				);
 				results.add(Map.of(
-						1, pos3.get(),
-						2, pos1.get(),
-						4, pos1.get(),
-						5, pos7.get(),
-						7, pos6.get(),
-						8, pos4.get())
+					1, pos3.get(),
+					2, pos1.get(),
+					4, pos1.get(),
+					5, pos7.get(),
+					7, pos6.get(),
+					8, pos4.get())
 				);
 				return results;
 			}
@@ -491,19 +491,19 @@ public class RecipeManager
 				);
 				// Flip Horizontally
 				results.add(Map.of(
-						0, pos6.get(),
-						3, pos3.get(),
-						6, pos0.get())
+					0, pos6.get(),
+					3, pos3.get(),
+					6, pos0.get())
 				);
 				results.add(Map.of(
-						1, pos6.get(),
-						4, pos3.get(),
-						7, pos0.get())
+					1, pos6.get(),
+					4, pos3.get(),
+					7, pos0.get())
 				);
 				results.add(Map.of(
-						2, pos6.get(),
-						5, pos3.get(),
-						8, pos0.get())
+					2, pos6.get(),
+					5, pos3.get(),
+					8, pos0.get())
 				);
 				return results;
 			}
@@ -524,29 +524,29 @@ public class RecipeManager
 					5, pos5.get())
 				);
 				results.add(Map.of(
-						3, pos0.get(),
-						4, pos1.get(),
-						5, pos2.get(),
-						6, pos3.get(),
-						7, pos4.get(),
-						8, pos5.get())
+					3, pos0.get(),
+					4, pos1.get(),
+					5, pos2.get(),
+					6, pos3.get(),
+					7, pos4.get(),
+					8, pos5.get())
 				);
 				// Flip Horizontally
 				results.add(Map.of(
-						0, pos2.get(),
-						1, pos1.get(),
-						2, pos0.get(),
-						3, pos5.get(),
-						4, pos4.get(),
-						5, pos3.get())
+					0, pos2.get(),
+					1, pos1.get(),
+					2, pos0.get(),
+					3, pos5.get(),
+					4, pos4.get(),
+					5, pos3.get())
 				);
 				results.add(Map.of(
-						3, pos2.get(),
-						4, pos1.get(),
-						5, pos0.get(),
-						6, pos5.get(),
-						7, pos4.get(),
-						8, pos3.get())
+					3, pos2.get(),
+					4, pos1.get(),
+					5, pos0.get(),
+					6, pos5.get(),
+					7, pos4.get(),
+					8, pos3.get())
 				);
 				return results;
 			}
@@ -579,28 +579,28 @@ public class RecipeManager
 				);
 				// Flip Horizontally
 				results.add(Map.of(
-						0, pos1.get(),
-						1, pos0.get(),
-						3, pos4.get(),
-						4, pos3.get())
+					0, pos1.get(),
+					1, pos0.get(),
+					3, pos4.get(),
+					4, pos3.get())
 				);
 				results.add(Map.of(
-						1, pos1.get(),
-						2, pos0.get(),
-						4, pos4.get(),
-						5, pos3.get())
+					1, pos1.get(),
+					2, pos0.get(),
+					4, pos4.get(),
+					5, pos3.get())
 				);
 				results.add(Map.of(
-						3, pos1.get(),
-						4, pos0.get(),
-						6, pos4.get(),
-						7, pos3.get())
+					3, pos1.get(),
+					4, pos0.get(),
+					6, pos4.get(),
+					7, pos3.get())
 				);
 				results.add(Map.of(
-						4, pos1.get(),
-						5, pos0.get(),
-						7, pos4.get(),
-						8, pos3.get())
+					4, pos1.get(),
+					5, pos0.get(),
+					7, pos4.get(),
+					8, pos3.get())
 				);
 				return results;
 			}
@@ -646,30 +646,30 @@ public class RecipeManager
 					2, pos2.get())
 				);
 				results.add(Map.of(
-						3, pos0.get(),
-						4, pos1.get(),
-						5, pos2.get())
+					3, pos0.get(),
+					4, pos1.get(),
+					5, pos2.get())
 				);
 				results.add(Map.of(
-						6, pos0.get(),
-						7, pos1.get(),
-						8, pos2.get())
+					6, pos0.get(),
+					7, pos1.get(),
+					8, pos2.get())
 				);
 				// Flip Horizontally
 				results.add(Map.of(
-						0, pos2.get(),
-						1, pos1.get(),
-						2, pos0.get())
+					0, pos2.get(),
+					1, pos1.get(),
+					2, pos0.get())
 				);
 				results.add(Map.of(
-						3, pos2.get(),
-						4, pos1.get(),
-						5, pos0.get())
+					3, pos2.get(),
+					4, pos1.get(),
+					5, pos0.get())
 				);
 				results.add(Map.of(
-						6, pos2.get(),
-						7, pos1.get(),
-						8, pos0.get())
+					6, pos2.get(),
+					7, pos1.get(),
+					8, pos0.get())
 				);
 				return results;
 			}
@@ -702,28 +702,28 @@ public class RecipeManager
 				);
 				// Flip Horizontally
 				results.add(Map.of(
-						0, pos1.get(),
-						1, pos0.get())
+					0, pos1.get(),
+					1, pos0.get())
 				);
 				results.add(Map.of(
-						1, pos1.get(),
-						2, pos0.get())
+					1, pos1.get(),
+					2, pos0.get())
 				);
 				results.add(Map.of(
-						3, pos1.get(),
-						4, pos0.get())
+					3, pos1.get(),
+					4, pos0.get())
 				);
 				results.add(Map.of(
-						4, pos1.get(),
-						5, pos0.get())
+					4, pos1.get(),
+					5, pos0.get())
 				);
 				results.add(Map.of(
-						6, pos1.get(),
-						7, pos0.get())
+					6, pos1.get(),
+					7, pos0.get())
 				);
 				results.add(Map.of(
-						7, pos1.get(),
-						8, pos0.get())
+					7, pos1.get(),
+					8, pos0.get())
 				);
 				return results;
 			}
@@ -736,25 +736,25 @@ public class RecipeManager
 					1, pos0.get())
 				);
 				results.add(Map.of(
-						2, pos0.get())
+					2, pos0.get())
 				);
 				results.add(Map.of(
-						3, pos0.get())
+					3, pos0.get())
 				);
 				results.add(Map.of(
-						4, pos0.get())
+					4, pos0.get())
 				);
 				results.add(Map.of(
-						5, pos0.get())
+					5, pos0.get())
 				);
 				results.add(Map.of(
-						6, pos0.get())
+					6, pos0.get())
 				);
 				results.add(Map.of(
-						7, pos0.get())
+					7, pos0.get())
 				);
 				results.add(Map.of(
-						8, pos0.get())
+					8, pos0.get())
 				);
 				return results;
 			}

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/RecipeManager.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public class RecipeManager
@@ -299,9 +300,332 @@ public class RecipeManager
 		Preconditions.checkArgument(shapedRecipe != null, "The recipe cannot be null");
 		Preconditions.checkArgument(craftingMatrix != null, "The craftingMatrix cannot be null");
 
-		// TODO: Logic for shaped recipes
+		String[] shape = shapedRecipe.getShape();
+		Map<Character, RecipeChoice> ingredients = shapedRecipe.getChoiceMap();
+
+		validateShape(shape);
+
+		List<Map<Integer, Character>> possibleCombinations = getShapedRecipePossiblePositions(shape);
+		for (Map<Integer, Character> possibleCombination : possibleCombinations)
+		{
+			boolean found = true;
+			for (int index = 0 ; index < 9 ; index++)
+			{
+				ItemStack item = craftingMatrix[index];
+				Character character = possibleCombination.get(index);
+				if (character == null)
+				{
+					if (item.isEmpty())
+					{
+						continue;
+					}
+
+					found = false;
+					break;
+				}
+
+				RecipeChoice recipeChoice = ingredients.get(character);
+				if (recipeChoice == null)
+				{
+					// If the item does not exist, we can proceed
+					continue;
+				}
+
+				if (!recipeChoice.test(item))
+				{
+					found = false;
+					break;
+				}
+			}
+			if (found)
+			{
+				// We found the recipe!
+				return true;
+			}
+		}
 
 		return false;
+	}
+
+	public static Character getChoiceAt(String[] shape, int position)
+	{
+		Preconditions.checkArgument(shape != null, "Must provide a shape");
+		Preconditions.checkArgument(position >= 0 && position <= 8, "Position must be between 0 and 8");
+
+		validateShape(shape);
+
+		int rowIndex = position / 3;
+		int col = position % 3;
+
+		String row = shape[rowIndex];
+		if (row.length() <= col)
+		{
+			return null;
+		}
+
+		return row.charAt(col);
+	}
+
+	private static int validateShape(@NotNull String[] shape)
+	{
+		int lastLen = -1;
+		for (String row : shape)
+		{
+			Preconditions.checkArgument(row != null, "Shape cannot have null rows");
+			Preconditions.checkArgument(row.length() > 0 && row.length() < 4, "Crafting rows should be 1, 2, or 3 characters, not ", row.length());
+
+			Preconditions.checkArgument(lastLen == -1 || lastLen == row.length(), "Crafting recipes must be rectangular");
+			lastLen = row.length();
+		}
+
+		return lastLen;
+	}
+
+	public static List<Map<Integer, Character>> getShapedRecipePossiblePositions(String[] shape)
+	{
+		Preconditions.checkArgument(shape != null, "Must provide a shape");
+		Preconditions.checkArgument(shape.length > 0 && shape.length < 4, "Crafting recipes should be 1, 2 or 3 rows, not ", shape.length);
+
+		int shapeHeight = shape.length;
+		int shapeWidth = validateShape(shape);
+
+		List<Map<Integer, Character>> results = new ArrayList<>();
+
+		// Map values
+		Supplier<Character> pos0 = () -> getChoiceAt(shape, 0);
+		Supplier<Character> pos1 = () -> getChoiceAt(shape, 1);
+		Supplier<Character> pos2 = () -> getChoiceAt(shape, 2);
+		Supplier<Character> pos3 = () -> getChoiceAt(shape, 3);
+		Supplier<Character> pos4 = () -> getChoiceAt(shape, 4);
+		Supplier<Character> pos5 = () -> getChoiceAt(shape, 5);
+		Supplier<Character> pos6 = () -> getChoiceAt(shape, 6);
+		Supplier<Character> pos7 = () -> getChoiceAt(shape, 7);
+		Supplier<Character> pos8 = () -> getChoiceAt(shape, 8);
+
+		// Shaped with height 3
+		if (shapeHeight == 3)
+		{
+			if (shapeWidth == 3)
+			{
+				results.add(Map.of(
+					0, pos0.get(),
+					1, pos1.get(),
+					2, pos2.get(),
+					3, pos3.get(),
+					4, pos4.get(),
+					5, pos5.get(),
+					6, pos6.get(),
+					7, pos7.get(),
+					8, pos8.get())
+				);
+				return results;
+			}
+			else if (shapeWidth == 2)
+			{
+				results.add(Map.of(
+						0, pos0.get(),
+						1, pos1.get(),
+						3, pos3.get(),
+						4, pos4.get(),
+						6, pos6.get(),
+						7, pos7.get())
+				);
+				results.add(Map.of(
+						1, pos0.get(),
+						2, pos1.get(),
+						4, pos3.get(),
+						5, pos4.get(),
+						7, pos6.get(),
+						8, pos7.get())
+				);
+				return results;
+			}
+			else if (shapeWidth == 1)
+			{
+				results.add(Map.of(
+					0, pos0.get(),
+					3, pos3.get(),
+					6, pos6.get())
+				);
+				results.add(Map.of(
+					1, pos0.get(),
+					4, pos3.get(),
+					7, pos6.get())
+				);
+				results.add(Map.of(
+					2, pos0.get(),
+					5, pos3.get(),
+					8, pos6.get())
+				);
+				return results;
+			}
+		}
+
+		// Shaped with height 2
+		if (shapeHeight == 2)
+		{
+			if (shapeWidth == 3)
+			{
+				results.add(Map.of(
+					0, pos0.get(),
+					1, pos1.get(),
+					2, pos2.get(),
+					3, pos3.get(),
+					4, pos4.get(),
+					5, pos5.get())
+				);
+				results.add(Map.of(
+						3, pos0.get(),
+						4, pos1.get(),
+						5, pos2.get(),
+						6, pos3.get(),
+						7, pos4.get(),
+						8, pos5.get())
+				);
+				return results;
+			}
+			else if (shapeWidth == 2)
+			{
+				results.add(Map.of(
+					0, pos0.get(),
+					1, pos1.get(),
+					3, pos3.get(),
+					4, pos4.get())
+				);
+				results.add(Map.of(
+					1, pos0.get(),
+					2, pos1.get(),
+					4, pos3.get(),
+					5, pos4.get())
+				);
+				results.add(Map.of(
+					3, pos0.get(),
+					4, pos1.get(),
+					6, pos3.get(),
+					7, pos4.get())
+				);
+				results.add(Map.of(
+					4, pos0.get(),
+					5, pos1.get(),
+					7, pos3.get(),
+					8, pos4.get())
+				);
+				return results;
+			}
+			else if (shapeWidth == 1)
+			{
+				results.add(Map.of(
+					0, pos0.get(),
+					3, pos3.get())
+				);
+				results.add(Map.of(
+					1, pos0.get(),
+					4, pos3.get())
+				);
+				results.add(Map.of(
+					2, pos0.get(),
+					5, pos3.get())
+				);
+				results.add(Map.of(
+					3, pos0.get(),
+					6, pos3.get())
+				);
+				results.add(Map.of(
+					4, pos0.get(),
+					7, pos3.get())
+				);
+				results.add(Map.of(
+					5, pos0.get(),
+					8, pos3.get())
+				);
+				return results;
+			}
+		}
+
+		// Shaped with 1 height
+		if (shapeHeight == 1)
+		{
+			if (shapeWidth == 3)
+			{
+				results.add(Map.of(
+					0, pos0.get(),
+					1, pos1.get(),
+					2, pos2.get())
+				);
+				results.add(Map.of(
+						3, pos0.get(),
+						4, pos1.get(),
+						5, pos2.get())
+				);
+				results.add(Map.of(
+						6, pos0.get(),
+						7, pos1.get(),
+						8, pos2.get())
+				);
+				return results;
+			}
+			else if (shapeWidth == 2)
+			{
+				results.add(Map.of(
+					0, pos0.get(),
+					1, pos1.get())
+				);
+				results.add(Map.of(
+					1, pos0.get(),
+					2, pos1.get())
+				);
+				results.add(Map.of(
+					3, pos0.get(),
+					4, pos1.get())
+				);
+				results.add(Map.of(
+					4, pos0.get(),
+					5, pos1.get())
+				);
+				results.add(Map.of(
+					6, pos0.get(),
+					7, pos1.get())
+				);
+				results.add(Map.of(
+					7, pos0.get(),
+					8, pos1.get())
+				);
+				return results;
+			}
+			else if (shapeWidth == 1)
+			{
+				results.add(Map.of(
+					0, pos0.get())
+				);
+				results.add(Map.of(
+					1, pos0.get())
+				);
+				results.add(Map.of(
+						2, pos0.get())
+				);
+				results.add(Map.of(
+						3, pos0.get())
+				);
+				results.add(Map.of(
+						4, pos0.get())
+				);
+				results.add(Map.of(
+						5, pos0.get())
+				);
+				results.add(Map.of(
+						6, pos0.get())
+				);
+				results.add(Map.of(
+						7, pos0.get())
+				);
+				results.add(Map.of(
+						8, pos0.get())
+				);
+				return results;
+			}
+		}
+
+		throw new UnsupportedOperationException("Crafting recipes must be rectangular");
 	}
 
 	static boolean matches(@NotNull ComplexRecipe complexRecipe, @NotNull ItemStack @NotNull [] items)

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/RecipeManagerTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/RecipeManagerTest.java
@@ -1,5 +1,6 @@
 package org.mockbukkit.mockbukkit.inventory;
 
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -20,6 +21,7 @@ import org.mockbukkit.mockbukkit.MockBukkitExtension;
 
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -416,29 +418,115 @@ class RecipeManagerTest
 				assertEquals("The craftingMatrix cannot be null", e.getMessage());
 			}
 
-			@Test
-			@Disabled("This was not implemented yet")
-			void givenValidCraftMatrix()
+			@Nested
+			class GivenValidSamples
 			{
-				ItemStack[] matrix = new ItemStack[]{
-						ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
-						ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.OAK_PLANKS),
-						ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.OAK_PLANKS)
-				};
-				boolean result = RecipeManager.matches(recipe, matrix);
-				assertTrue(result);
+
+				@Test
+				void givenSticks()
+				{
+					ItemStack[] matrix = new ItemStack[]{
+							ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
+							ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.OAK_PLANKS),
+							ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.OAK_PLANKS)
+					};
+					boolean result = RecipeManager.matches(recipe, matrix);
+					assertTrue(result);
+				}
+
+				@Test
+				void givenSticksWithDifferentMaterials()
+				{
+					ItemStack[] matrix = createCrafting(
+							Material.BIRCH_PLANKS, 	null, 	null,
+							Material.OAK_PLANKS, 			null, 	null,
+							null, 							null, 	null
+					);
+					boolean result = RecipeManager.matches(recipe, matrix);
+					assertTrue(result);
+				}
+
+				@Test
+				void givenBoat()
+				{
+					ShapedRecipe boatRecipe = (ShapedRecipe) Bukkit.getRecipe(NamespacedKey.minecraft("oak_boat"));
+
+					ItemStack[] matrix = createCrafting(
+							null, 			null, 					null,
+							Material.OAK_PLANKS, 	null, 					Material.OAK_PLANKS,
+							Material.OAK_PLANKS, 	Material.OAK_PLANKS, 	Material.OAK_PLANKS
+					);
+					boolean result = RecipeManager.matches(boatRecipe, matrix);
+					assertTrue(result);
+				}
+
+				@Test
+				void givenDoor()
+				{
+					ShapedRecipe doorRecipe = (ShapedRecipe) Bukkit.getRecipe(NamespacedKey.minecraft("acacia_door"));
+
+					ItemStack[] matrix = createCrafting(
+							null,	Material.ACACIA_PLANKS, Material.ACACIA_PLANKS,
+							null, 			Material.ACACIA_PLANKS, Material.ACACIA_PLANKS,
+							null, 			Material.ACACIA_PLANKS, Material.ACACIA_PLANKS
+					);
+					boolean result = RecipeManager.matches(doorRecipe, matrix);
+					assertTrue(result);
+				}
+
+				@Test
+				void givenFence()
+				{
+					ShapedRecipe fenceRecipe = (ShapedRecipe) Bukkit.getRecipe(NamespacedKey.minecraft("acacia_fence"));
+
+					ItemStack[] matrix = createCrafting(
+							Material.ACACIA_PLANKS,	Material.STICK, Material.ACACIA_PLANKS,
+							Material.ACACIA_PLANKS, 		Material.STICK, Material.ACACIA_PLANKS,
+							null, 							null, 			null
+					);
+					boolean result = RecipeManager.matches(fenceRecipe, matrix);
+					assertTrue(result);
+				}
+
+				private static ItemStack[] createCrafting(Material... slots)
+				{
+					Preconditions.checkArgument(slots.length == 9, "The crafting table should have 9 items");
+
+					return Stream.of(slots)
+							.map(m -> (m == null ? ItemStack.empty() : ItemStack.of(m)))
+							.toArray(ItemStack[]::new);
+				}
+
 			}
 
-			@Test
-			void givenInvalidCraftMatrix()
+			@Nested
+			class GivenInvalidSamples
 			{
-				ItemStack[] matrix = new ItemStack[]{
-						ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
-						ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.BIRCH_PLANKS),
-						ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.BIRCH_PLANKS)
-				};
-				boolean result = RecipeManager.matches(recipe, matrix);
-				assertFalse(result);
+
+				@Test
+				void givenInvalidStick()
+				{
+					ItemStack[] matrix = new ItemStack[]{
+							ItemStack.empty(), ItemStack.empty(), ItemStack.empty(),
+							ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.STONE),
+							ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.BIRCH_PLANKS)
+					};
+					boolean result = RecipeManager.matches(recipe, matrix);
+					assertFalse(result);
+				}
+
+				@Test
+				void givenValidRecipeButWithExtraMaterial()
+				{
+					ItemStack[] matrix = new ItemStack[]{
+							ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.STONE),
+							ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.OAK_PLANKS),
+							ItemStack.empty(), ItemStack.empty(), ItemStack.of(Material.OAK_PLANKS)
+					};
+					boolean result = RecipeManager.matches(recipe, matrix);
+					assertFalse(result);
+				}
+
 			}
 
 		}
@@ -467,4 +555,34 @@ class RecipeManagerTest
 
 	}
 
+	@Nested
+	class GetChoiceAt
+	{
+
+		@ParameterizedTest
+		@CsvSource({
+			"0,a",
+			"1,b",
+			"2,c",
+			"3,d",
+			"4,e",
+			"5,f",
+			"6,g",
+			"7,h",
+			"8,i",
+		})
+		void givenSimpleExample(int index, Character expectedValue)
+		{
+			String[] shape = new String[]{
+					"abc",
+					"def",
+					"ghi",
+			};
+
+			Character actual = RecipeManager.getChoiceAt(shape, index);
+
+			assertEquals(expectedValue, actual);
+		}
+
+	}
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/RecipeManagerTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/RecipeManagerTest.java
@@ -488,6 +488,62 @@ class RecipeManagerTest
 					assertTrue(result);
 				}
 
+				@Test
+				void givenBow()
+				{
+					ShapedRecipe fenceRecipe = (ShapedRecipe) Bukkit.getRecipe(NamespacedKey.minecraft("bow"));
+
+					ItemStack[] matrix = createCrafting(
+							null,	Material.STICK, Material.STRING,
+							Material.STICK, null, 			Material.STRING,
+							null, 			Material.STICK, Material.STRING
+					);
+					boolean result = RecipeManager.matches(fenceRecipe, matrix);
+					assertTrue(result);
+				}
+
+				@Test
+				void givenBowFlipped()
+				{
+					ShapedRecipe fenceRecipe = (ShapedRecipe) Bukkit.getRecipe(NamespacedKey.minecraft("bow"));
+
+					ItemStack[] matrix = createCrafting(
+							Material.STRING,	Material.STICK, null,
+							Material.STRING, 		null, 			Material.STICK,
+							Material.STRING, 		Material.STICK, null
+					);
+					boolean result = RecipeManager.matches(fenceRecipe, matrix);
+					assertTrue(result);
+				}
+
+				@Test
+				void givenStairs()
+				{
+					ShapedRecipe fenceRecipe = (ShapedRecipe) Bukkit.getRecipe(NamespacedKey.minecraft("stone_stairs"));
+
+					ItemStack[] matrix = createCrafting(
+							Material.STONE,	null, 			null,
+							Material.STONE, 		Material.STONE, null,
+							Material.STONE, 		Material.STONE, Material.STONE
+					);
+					boolean result = RecipeManager.matches(fenceRecipe, matrix);
+					assertTrue(result);
+				}
+
+				@Test
+				void givenStairsFlipped()
+				{
+					ShapedRecipe fenceRecipe = (ShapedRecipe) Bukkit.getRecipe(NamespacedKey.minecraft("stone_stairs"));
+
+					ItemStack[] matrix = createCrafting(
+							null,		null, 				Material.STONE,
+							null,				Material.STONE, 	Material.STONE,
+							Material.STONE, 	Material.STONE, 	Material.STONE
+					);
+					boolean result = RecipeManager.matches(fenceRecipe, matrix);
+					assertTrue(result);
+				}
+
 				private static ItemStack[] createCrafting(Material... slots)
 				{
 					Preconditions.checkArgument(slots.length == 9, "The crafting table should have 9 items");


### PR DESCRIPTION
# Description

> (...) many recipes must have their ingredients placed in the correct relative positions on the crafting grid. These are commonly known as shaped recipes. Ingredients in shaped recipes can be ‘moved’ up, down, left, or right. They can also be flipped side-ways. For example, a 3×1 recipe, such as [bread](https://minecraft.fandom.com/wiki/Bread), can be made using the top, middle, or bottom row of the 3×3 grid, and a [bow](https://minecraft.fandom.com/wiki/Bow) may be made with the strings placed on the left instead of on the right.

Source: https://minecraft.fandom.com/wiki/Crafting

This PR emulates shaped recipe behavior so that players can use the other 674 recipes available in the crafting grid, making it a total of 969 recipes available.

Examples:

## Move behavior:
![Pos1](https://github.com/user-attachments/assets/7f01c09c-d160-4f85-8802-7b5b51d494a2)
![Pos2](https://github.com/user-attachments/assets/8b726d75-58fa-4429-942d-5aa3c919e57d)

## Flipping behavior:
![Normal](https://github.com/user-attachments/assets/f93e6110-2f13-422c-92e4-13198a03035e)
![Flipped](https://github.com/user-attachments/assets/d9009fb3-b345-45e4-8b86-a3739e64f2c1)



# Checklist

The following items should be checked before the pull request can be merged.

- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
