### PR TITLE
format: nicer debug presentation for effects

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/potion/PotionEffectTypeMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/potion/PotionEffectTypeMock.java
@@ -231,4 +231,10 @@ public class PotionEffectTypeMock extends PotionEffectType
 		return this.translationKey;
 	}
 
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/potion/PotionEffectTypeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/potion/PotionEffectTypeMockTest.java
@@ -154,4 +154,10 @@ class PotionEffectTypeMockTest
 		return Arrays.stream(PotionEffectType.values());
 	}
 
+	@Test
+	void testPotionEffectStringifiedRepresentation()
+	{
+		assertEquals("INCREASE_DAMAGE", PotionEffectType.STRENGTH.toString());
+	}
+
 }


### PR DESCRIPTION
**Before:**
![image](https://github.com/user-attachments/assets/84553f7a-4716-48c8-b679-2dd609a8cbef)

**After:**
![image](https://github.com/user-attachments/assets/c2558d8f-3107-46f0-8c07-b0ce0e240fed)

Especially in combination this is useful:

**Before:**
```
PotionEffect{amplifier=0, duration=600, type={PotionEffectTypeMock@5411}, ambient=true, particles=true, icon=true, hiddenEffect=null}
```
**After:**
```
PotionEffect{amplifier=0, duration=600, type=INCREASE_DAMAGE, ambient=true, particles=true, icon=true, hiddenEffect=null}
```
