### PR TITLE
feat: easily load plugin via its class

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
@@ -408,6 +408,18 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	}
 
 	/**
+	 * Load a plugin from a class. The description will be guessed as best as possible.
+	 *
+	 * @param class1      The plugin to load.
+	 * @return The loaded plugin.
+	 */
+	public @NotNull JavaPlugin loadPlugin(@NotNull Class<? extends JavaPlugin> class1)
+	{
+		PluginDescriptionFile description = new PluginDescriptionFile(class1.getName(), "0.0.0", class1.getName());
+		return loadPlugin(class1, description, new Object[0]);
+	}
+
+	/**
 	 * Load a plugin from a class. It will use the system resource {@code plugin.yml} as the resource file.
 	 *
 	 * @param description The {@link PluginDescriptionFile} that contains information about the plugin.

--- a/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
@@ -421,7 +421,7 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 		}
 		catch (PluginLoadException ignored)
 		{
-			PluginDescriptionFile description = new PluginDescriptionFile(class1.getName(), "0.0.0", class1.getName());
+			PluginDescriptionFile description = new PluginDescriptionFile(class1.getSimpleName(), "0.0.0", class1.getSimpleName());
 			return loadPlugin(class1, description, new Object[0]);
 		}
 	}

--- a/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
@@ -410,7 +410,7 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	/**
 	 * Load a plugin from a class. The description will be guessed as best as possible.
 	 *
-	 * @param class1      The plugin to load.
+	 * @param class1 The plugin to load.
 	 * @return The loaded plugin.
 	 */
 	public @NotNull JavaPlugin loadPlugin(@NotNull Class<? extends JavaPlugin> class1)

--- a/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
@@ -415,8 +415,15 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	 */
 	public @NotNull JavaPlugin loadPlugin(@NotNull Class<? extends JavaPlugin> class1)
 	{
-		PluginDescriptionFile description = new PluginDescriptionFile(class1.getName(), "0.0.0", class1.getName());
-		return loadPlugin(class1, description, new Object[0]);
+		try
+		{
+			return loadPlugin(class1, new Object[0]);
+		}
+		catch (PluginLoadException ignored)
+		{
+			PluginDescriptionFile description = new PluginDescriptionFile(class1.getName(), "0.0.0", class1.getName());
+			return loadPlugin(class1, description, new Object[0]);
+		}
 	}
 
 	/**

--- a/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
@@ -421,7 +421,7 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 		}
 		catch (PluginLoadException ignored)
 		{
-			PluginDescriptionFile description = new PluginDescriptionFile(class1.getSimpleName(), "0.0.0", class1.getSimpleName());
+			PluginDescriptionFile description = new PluginDescriptionFile(class1.getSimpleName(), "0.0.0", class1.getName());
 			return loadPlugin(class1, description, new Object[0]);
 		}
 	}

--- a/src/test/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMockTest.java
@@ -393,16 +393,20 @@ class PluginManagerMockTest
 	}
 
 	@Test
-	void loadPluginViaPureLoadPlugin()
+	void loadPluginViaPureLoadPlugin_NormalFlow()
 	{
-		// Normal flow
 		JavaPlugin loadedPlugin = pluginManager.loadPlugin(TestPlugin.class);
 		assertInstanceOf(JavaPlugin.class, loadedPlugin);
 		assertEquals("MockBukkitTestPlugin", loadedPlugin.getName());
 		assertEquals("0.1.0", loadedPlugin.getDescription().getVersion());
+	}
 
-		// FileNotFound flow
-		loadedPlugin = pluginManager.loadPlugin(JavaPlugin.class); // Internal plugin, can't find plugin.yml file
+	@Test
+	void loadPluginViaPureLoadPlugin_InvalidPluginYml()
+	{
+		// This works because JavaPlugin is a plugin where the `plugin.yml` file cannot be found.
+		//   So, it'll throw a `FileNotFound`
+		JavaPlugin loadedPlugin = pluginManager.loadPlugin(JavaPlugin.class);
 		assertInstanceOf(JavaPlugin.class, loadedPlugin);
 		assertEquals("JavaPlugin", loadedPlugin.getName());
 		assertEquals("0.0.0", loadedPlugin.getDescription().getVersion());

--- a/src/test/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMockTest.java
@@ -392,10 +392,23 @@ class PluginManagerMockTest
 		assertThrows(PluginLoadException.class, () -> pluginManager.loadPlugin(TestPlugin.class, sillyName, new Object[0]));
 	}
 
+	public static class MyPlugin extends JavaPlugin {
+	}
+
 	@Test
 	void loadPluginViaPureLoadPlugin()
 	{
-		assertInstanceOf(JavaPlugin.class, pluginManager.loadPlugin(TestPlugin.class));
+		// Normal flow
+		JavaPlugin loadedPlugin = pluginManager.loadPlugin(TestPlugin.class);
+		assertInstanceOf(JavaPlugin.class, loadedPlugin);
+		assertEquals("MockBukkitTestPlugin", loadedPlugin.getName());
+		assertEquals("0.1.0", loadedPlugin.getDescription().getVersion());
+
+		// FileNotFound flow
+		loadedPlugin = pluginManager.loadPlugin(MyPlugin.class); // Internal plugin, can't find plugin.yml file
+		assertInstanceOf(JavaPlugin.class, loadedPlugin);
+		assertEquals("MyPlugin", loadedPlugin.getName());
+		assertEquals("0.0.0", loadedPlugin.getDescription().getVersion());
 	}
 
 	@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMockTest.java
@@ -392,11 +392,6 @@ class PluginManagerMockTest
 		assertThrows(PluginLoadException.class, () -> pluginManager.loadPlugin(TestPlugin.class, sillyName, new Object[0]));
 	}
 
-	public static class MyPlugin extends JavaPlugin
-	{
-
-	}
-
 	@Test
 	void loadPluginViaPureLoadPlugin()
 	{
@@ -407,9 +402,9 @@ class PluginManagerMockTest
 		assertEquals("0.1.0", loadedPlugin.getDescription().getVersion());
 
 		// FileNotFound flow
-		loadedPlugin = pluginManager.loadPlugin(MyPlugin.class); // Internal plugin, can't find plugin.yml file
+		loadedPlugin = pluginManager.loadPlugin(JavaPlugin.class); // Internal plugin, can't find plugin.yml file
 		assertInstanceOf(JavaPlugin.class, loadedPlugin);
-		assertEquals("MyPlugin", loadedPlugin.getName());
+		assertEquals("JavaPlugin", loadedPlugin.getName());
 		assertEquals("0.0.0", loadedPlugin.getDescription().getVersion());
 	}
 

--- a/src/test/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMockTest.java
@@ -13,6 +13,7 @@ import org.bukkit.permissions.PermissionDefault;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.ServicePriority;
+import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.java.JavaPluginUtils;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.junit.jupiter.api.AfterEach;
@@ -33,6 +34,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -388,6 +390,12 @@ class PluginManagerMockTest
 		nameField.set(sillyName, name);
 
 		assertThrows(PluginLoadException.class, () -> pluginManager.loadPlugin(TestPlugin.class, sillyName, new Object[0]));
+	}
+
+	@Test
+	void loadPluginViaPureLoadPlugin()
+	{
+		assertInstanceOf(JavaPlugin.class, pluginManager.loadPlugin(TestPlugin.class));
 	}
 
 	@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMockTest.java
@@ -392,7 +392,9 @@ class PluginManagerMockTest
 		assertThrows(PluginLoadException.class, () -> pluginManager.loadPlugin(TestPlugin.class, sillyName, new Object[0]));
 	}
 
-	public static class MyPlugin extends JavaPlugin {
+	public static class MyPlugin extends JavaPlugin
+	{
+
 	}
 
 	@Test


### PR DESCRIPTION
# Description

I know there is already a `loadPlugin(<class>, <params>)` method, but that one needs a descriptor file.
This method adds the benefit of transparency: if the file is not there, a simple dummy descriptor is created and used.
So people don't need to really bother if they don't care about names and versions and so on in their tests, but just about the functionality.

# Checklist

The following items should be checked before the pull request can be merged.

- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
