### PR TITLE
Add support for Dialog Registry

### DIFF
--- a/metaminer/build.gradle.kts
+++ b/metaminer/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
 	id("java")
-	id("io.papermc.paperweight.userdev") version "2.0.0-beta.17"
+	id("io.papermc.paperweight.userdev") version "2.0.0-beta.18"
 	id("xyz.jpenilla.run-paper") version "2.3.1"
 }
 

--- a/src/main/java/org/mockbukkit/mockbukkit/dialog/DialogMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/dialog/DialogMock.java
@@ -28,7 +28,7 @@ public class DialogMock implements Dialog
 
 	private final NamespacedKey key;
 
-	public DialogMock(@NotNull NamespacedKey key)
+	private DialogMock(@NotNull NamespacedKey key)
 	{
 		this.key = Objects.requireNonNull(key, "The key cannot be null");
 	}

--- a/src/main/java/org/mockbukkit/mockbukkit/dialog/DialogMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/dialog/DialogMock.java
@@ -1,0 +1,42 @@
+package org.mockbukkit.mockbukkit.dialog;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.JsonObject;
+import io.papermc.paper.dialog.Dialog;
+import org.bukkit.NamespacedKey;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+@SuppressWarnings("NonExtendableApiUsage")
+public class DialogMock implements Dialog
+{
+
+	@NotNull
+	@ApiStatus.Internal
+	public static DialogMock from(@NotNull JsonObject data)
+	{
+		Preconditions.checkNotNull(data);
+		Preconditions.checkArgument(data.has("key"), "Missing json key");
+
+		NamespacedKey key = NamespacedKey.fromString(data.get("key").getAsString());
+		Preconditions.checkNotNull(key, "Missing key");
+
+		return new DialogMock(key);
+	}
+
+	private final NamespacedKey key;
+
+	public DialogMock(@NotNull NamespacedKey key)
+	{
+		this.key = Objects.requireNonNull(key, "The key cannot be null");
+	}
+
+	@Override
+	public @NotNull NamespacedKey getKey()
+	{
+		return this.key;
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/registry/RegistryAccessMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/registry/RegistryAccessMock.java
@@ -95,6 +95,7 @@ public class RegistryAccessMock implements RegistryAccess
 	private static List<RegistryKey<? extends Keyed>> getOutlierKeyedRegistryKeys()
 	{
 		return List.of(
+				RegistryKey.DIALOG,
 				RegistryKey.STRUCTURE,
 				RegistryKey.STRUCTURE_TYPE,
 				RegistryKey.TRIM_MATERIAL,

--- a/src/main/java/org/mockbukkit/mockbukkit/registry/RegistryMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/registry/RegistryMock.java
@@ -19,6 +19,7 @@ import org.mockbukkit.mockbukkit.block.BlockTypeMock;
 import org.mockbukkit.mockbukkit.block.banner.PatternTypeMock;
 import org.mockbukkit.mockbukkit.damage.DamageTypeMock;
 import org.mockbukkit.mockbukkit.datacomponent.DataComponentTypeMock;
+import org.mockbukkit.mockbukkit.dialog.DialogMock;
 import org.mockbukkit.mockbukkit.enchantments.EnchantmentMock;
 import org.mockbukkit.mockbukkit.entity.memory.MemoryModuleMock;
 import org.mockbukkit.mockbukkit.entity.variant.CatVariantMock;
@@ -87,6 +88,7 @@ public class RegistryMock<T extends Keyed> implements Registry<T>
 	private Function<JsonObject, ? extends Keyed> getConstructorFunction(RegistryKey<T> key)
 	{
 		Map<RegistryKey<?>, Function<JsonObject, ? extends Keyed>> factoryMap = new HashMap<>();
+		factoryMap.put(RegistryKey.DIALOG, DialogMock::from);
 		factoryMap.put(RegistryKey.STRUCTURE, StructureMock::from);
 		factoryMap.put(RegistryKey.STRUCTURE_TYPE, StructureTypeMock::from);
 		factoryMap.put(RegistryKey.TRIM_MATERIAL, TrimMaterialMock::from);

--- a/src/main/resources-autogenerated/keyed/dialog.json
+++ b/src/main/resources-autogenerated/keyed/dialog.json
@@ -1,0 +1,13 @@
+{
+	"values": [
+		{
+			"key": "minecraft:custom_options"
+		},
+		{
+			"key": "minecraft:quick_actions"
+		},
+		{
+			"key": "minecraft:server_links"
+		}
+	]
+}

--- a/src/main/resources-autogenerated/registries/registry_key_class_relation.json
+++ b/src/main/resources-autogenerated/registries/registry_key_class_relation.json
@@ -7,6 +7,7 @@
 	"minecraft:cow_variant": "org.bukkit.entity.Cow$Variant",
 	"minecraft:damage_type": "org.bukkit.damage.DamageType",
 	"minecraft:data_component_type": "io.papermc.paper.datacomponent.DataComponentType",
+	"minecraft:dialog": "io.papermc.paper.dialog.Dialog",
 	"minecraft:enchantment": "org.bukkit.enchantments.Enchantment",
 	"minecraft:entity_type": "org.bukkit.entity.EntityType",
 	"minecraft:fluid": "org.bukkit.Fluid",

--- a/src/test/java/org/mockbukkit/mockbukkit/dialog/DialogMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/dialog/DialogMockTest.java
@@ -1,0 +1,31 @@
+package org.mockbukkit.mockbukkit.dialog;
+
+import io.papermc.paper.dialog.Dialog;
+import io.papermc.paper.registry.RegistryAccess;
+import io.papermc.paper.registry.RegistryKey;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockBukkitExtension.class)
+class DialogMockTest
+{
+
+	@Test
+	void getKey()
+	{
+		Registry<@NotNull Dialog> registry = RegistryAccess.registryAccess().getRegistry(RegistryKey.DIALOG);
+
+		Dialog serverLinks = registry.get(NamespacedKey.minecraft("server_links"));
+
+		assertNotNull(serverLinks);
+		assertEquals("minecraft:server_links", serverLinks.getKey().asString());
+	}
+
+}

--- a/src/test/resources-autogenerated/blocks/block_states.csv
+++ b/src/test/resources-autogenerated/blocks/block_states.csv
@@ -348,6 +348,7 @@ DISPENSER, org.bukkit.block.Dispenser
 DRAGON_EGG, org.bukkit.block.BlockState
 DRAGON_HEAD, org.bukkit.block.Skull
 DRAGON_WALL_HEAD, org.bukkit.block.Skull
+DRIED_GHAST, org.bukkit.block.BlockState
 DRIED_KELP_BLOCK, org.bukkit.block.BlockState
 DRIPSTONE_BLOCK, org.bukkit.block.BlockState
 DROPPER, org.bukkit.block.Dropper


### PR DESCRIPTION
# Description

Implemented registry for Dialog added in https://github.com/PaperMC/Paper/commit/b4466ec981d104c4756d1a3b90c2ee0d6ce4e6bd.

# Checklist

The following items should be checked before the pull request can be merged.

- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
