### PR TITLE
fix: having a mixin with an injection didn't work.

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/MockBukkitExtension.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/MockBukkitExtension.java
@@ -118,7 +118,7 @@ public class MockBukkitExtension implements TestInstancePostProcessor, TestInsta
 		for (final Field field : serverMockFields)
 		{
 			final String name = field.getName();
-			FieldUtils.writeDeclaredField(testInstance, name, serverMock, true);
+			FieldUtils.writeField(testInstance, name, serverMock, true);
 		}
 	}
 

--- a/src/test/java/org/mockbukkit/mockbukkit/MockBukkitExtensionTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/MockBukkitExtensionTest.java
@@ -76,7 +76,7 @@ class MockBukkitExtensionTest
 	{
 
 		@MockBukkitInject
-		private ServerMock nestedClassAnnotation;
+		protected ServerMock nestedClassAnnotation;
 
 		@Test
 		void isFieldInjectedCorrectly()
@@ -104,7 +104,7 @@ class MockBukkitExtensionTest
 	{
 
 		@MockBukkitInject
-		private ServerMock nestedClassAnnotation;
+		protected ServerMock nestedClassAnnotation;
 
 		@Test
 		void isFieldInjectedCorrectly()
@@ -142,4 +142,8 @@ class MockBukkitExtensionTest
 
 	}
 
+	@Nested
+	class SubclassWithoutAnnotation extends WithNestedClassWithAnnotation
+	{
+	}
 }


### PR DESCRIPTION
# Description

```
@ExtendWith(MockBukkitExtension.class)
public class CommonMixinTest {
    @MockBukkitInject
    protected ServerMock server;
}

public class MyTest extends CommonMixinTest {
// here it fails to locate "server" to do the proper injection.
}
```

# Checklist

The following items should be checked before the pull request can be merged.

- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
