### PR TITLE
feat: allow for more injections

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/MockBukkitExtension.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/MockBukkitExtension.java
@@ -25,7 +25,6 @@ import org.mockbukkit.mockbukkit.world.WorldMock;
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.logging.Logger;
 
 /**
@@ -147,10 +146,6 @@ public class MockBukkitExtension implements TestInstancePostProcessor, TestInsta
 	private static final String HORIZONTAL_DIVIDER = "------------------------------------------------------------------------------------";
 
 	private final Logger logger = Logger.getLogger("MockBukkitExtension");
-	private final Set<Class<?>> serverSupportedTypes = Set.of(Server.class, ServerMock.class);
-	private final Set<Class<?>> playerSupportedTypes = Set.of(Player.class, PlayerMock.class);
-	private final Set<Class<?>> worldSupportedTypes = Set.of(World.class, WorldMock.class);
-	private final Set<Class<?>> pluginSupportedTypes = Set.of(Plugin.class, PluginMock.class);
 
 	private int playerCounter = 0;
 	private int worldCounter = 0;
@@ -187,21 +182,21 @@ public class MockBukkitExtension implements TestInstancePostProcessor, TestInsta
 
 	private @Nullable Object createMockForType(Class<?> type)
 	{
-		if (serverSupportedTypes.contains(type))
+		if (type.isAssignableFrom(ServerMock.class))
 		{
 			return MockBukkit.getOrCreateMock();
 		}
-		else if (playerSupportedTypes.contains(type))
+		else if (type.isAssignableFrom(PlayerMock.class))
 		{
 			final String playerName = "Player" + playerCounter++;
 			return MockBukkit.getOrCreateMock().addPlayer(playerName);
 		}
-		else if (worldSupportedTypes.contains(type))
+		else if (type.isAssignableFrom(WorldMock.class))
 		{
 			final String worldName = "World" + worldCounter++;
 			return MockBukkit.getOrCreateMock().addSimpleWorld(worldName);
 		}
-		else if (pluginSupportedTypes.contains(type))
+		else if (type.isAssignableFrom(PluginMock.class))
 		{
 			final String pluginName = "Plugin" + pluginCounter++;
 			return MockBukkit.createMockPlugin(pluginName);
@@ -231,10 +226,10 @@ public class MockBukkitExtension implements TestInstancePostProcessor, TestInsta
 		final boolean paramHasCorrectAnnotation = parameterContext.isAnnotated(MockBukkitInject.class);
 
 		return paramHasCorrectAnnotation && (
-				serverSupportedTypes.contains(paramType) ||
-						playerSupportedTypes.contains(paramType) ||
-						worldSupportedTypes.contains(paramType) ||
-						pluginSupportedTypes.contains(paramType)
+				paramType.isAssignableFrom(ServerMock.class) ||
+						paramType.isAssignableFrom(PlayerMock.class) ||
+						paramType.isAssignableFrom(PluginMock.class) ||
+						paramType.isAssignableFrom(WorldMock.class)
 		);
 	}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/MockBukkitExtension.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/MockBukkitExtension.java
@@ -30,23 +30,43 @@ import java.util.logging.Logger;
 
 /**
  * Extension that mocks the Bukkit singleton before each test and subsequently unmocks it after each test. It will also
- * inject this instance of {@link ServerMock} to any field or parameter of that type in the extended test class that is
- * annotated with {@link MockBukkitInject}.
+ * inject instances of {@link ServerMock}, {@link PlayerMock}, {@link WorldMock}, and {@link Plugin} to any field or
+ * parameter of those types in the extended test class that is annotated with {@link MockBukkitInject}.
+ *
+ * <p>The extension supports injection of the following types:</p>
+ * <ul>
+ *   <li>{@link Server} or {@link ServerMock} - The main server mock instance</li>
+ *   <li>{@link Player} or {@link PlayerMock} - Auto-generated players with unique names (Player0, Player1, etc.)</li>
+ *   <li>{@link World} or {@link WorldMock} - Auto-generated worlds with unique names (World0, World1, etc.)</li>
+ *   <li>{@link Plugin} or {@link PluginMock} - Auto-generated plugins with unique names (Plugin0, Plugin1, etc.)</li>
+ * </ul>
  *
  * <p>Example field usage:</p>
  *
  * <pre class="code"><code class="java">
- * <b>&#064;ExtendWith(MockBukkitExtension.class)</b>
+ * <b>@ExtendWith(MockBukkitExtension.class)</b>
  * class FieldExampleTest
  * {
  *
- * 	<b>&#064;MockBukkitInject</b>
+ * 	<b>@MockBukkitInject</b>
  * 	private ServerMock serverMock;
  *
- * 	&#064;Test
- * 	void aUnitTest()
+ * 	<b>@MockBukkitInject</b>
+ * 	private PlayerMock player;
+ *
+ * 	<b>@MockBukkitInject</b>
+ * 	private World world;
+ *
+ * 	<b>@MockBukkitInject</b>
+ * 	private Plugin plugin;
+ *
+ *    @Test
+ *    void aUnitTest()
  *    {
  * 		assert serverMock != null;
+ * 		assert player != null;
+ * 		assert world != null;
+ * 		assert plugin != null;
  * 		// ...
  *    }
  *
@@ -56,19 +76,19 @@ import java.util.logging.Logger;
  * Example constructor parameter usage:
  *
  * <pre class="code"><code class="java">
- * <b>&#064;ExtendWith(MockBukkitExtension.class)</b>
+ * <b>@ExtendWith(MockBukkitExtension.class)</b>
  * class ConstructorExampleTest
  * {
  *
  * 	private ServerMock serverMock;
  *
- * 	public ConstructorExampleTest(<b>&#064;MockBukkitSever</b> ServerMock serverMock)
+ * 	public ConstructorExampleTest(<b>@MockBukkitInject</b> ServerMock serverMock)
  *    {
  * 		this.serverMock = serverMock;
  *    }
  *
- * 	&#064;Test
- * 	void aUnitTest()
+ *    @Test
+ *    void aUnitTest()
  *    {
  * 		assert serverMock != null;
  * 		// ...
@@ -80,14 +100,41 @@ import java.util.logging.Logger;
  * Example method parameter usage:
  *
  * <pre class="code"><code class="java">
- * <b>&#064;ExtendWith(MockBukkitExtension.class)</b>
+ * <b>@ExtendWith(MockBukkitExtension.class)</b>
  * class MethodExampleTest
  * {
  *
- * 	&#064;Test
- * 	void aUnitTest(<b>&#064;MockBukkitInject</b> ServerMock serverMock)
+ *    @Test
+ *    void aUnitTest(<b>@MockBukkitInject</b> ServerMock serverMock,
+ * 	               <b>@MockBukkitInject</b> Player player,
+ * 	               <b>@MockBukkitInject</b> World world)
  *    {
  * 		assert serverMock != null;
+ * 		assert player != null;
+ * 		assert world != null;
+ * 		// ...
+ *    }
+ *
+ * }
+ * </code></pre>
+ *
+ * <p>Example inheritance usage (fields in mixin classes are also supported):</p>
+ *
+ * <pre class="code"><code class="java">
+ * class BaseMixin
+ * {
+ * 	<b>@MockBukkitInject</b>
+ * 	protected ServerMock serverMock;
+ * }
+ *
+ * <b>@ExtendWith(MockBukkitExtension.class)</b>
+ * class InheritanceExampleTest extends BaseMixin
+ * {
+ *
+ *    @Test
+ *    void aUnitTest()
+ *    {
+ * 		assert serverMock != null; // Injected from parent class
  * 		// ...
  *    }
  *

--- a/src/main/java/org/mockbukkit/mockbukkit/MockBukkitExtension.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/MockBukkitExtension.java
@@ -2,6 +2,11 @@ package org.mockbukkit.mockbukkit;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.bukkit.Server;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -12,7 +17,10 @@ import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
 import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 import org.junit.jupiter.api.extension.TestInstancePreDestroyCallback;
 import org.junit.platform.commons.util.ExceptionUtils;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
+import org.mockbukkit.mockbukkit.plugin.PluginMock;
+import org.mockbukkit.mockbukkit.world.WorldMock;
 
 import java.lang.reflect.Field;
 import java.util.List;
@@ -93,15 +101,21 @@ public class MockBukkitExtension implements TestInstancePostProcessor, TestInsta
 
 	private final Logger logger = Logger.getLogger("MockBukkitExtension");
 	private final Set<Class<?>> serverSupportedTypes = Set.of(Server.class, ServerMock.class);
+	private final Set<Class<?>> playerSupportedTypes = Set.of(Player.class, PlayerMock.class);
+	private final Set<Class<?>> worldSupportedTypes = Set.of(World.class, WorldMock.class);
+	private final Set<Class<?>> pluginSupportedTypes = Set.of(Plugin.class, PluginMock.class);
+
+	private int playerCounter = 0;
+	private int worldCounter = 0;
+	private int pluginCounter = 0;
 
 	@Override
 	public void postProcessTestInstance(Object testInstance, ExtensionContext context) throws Exception
 	{
-		final ServerMock serverMock = MockBukkit.getOrCreateMock();
-		injectServerMockIntoFields(testInstance, context, serverMock);
+		injectMocksIntoFields(testInstance, context);
 	}
 
-	private void injectServerMockIntoFields(Object testInstance, ExtensionContext context, ServerMock serverMock) throws IllegalAccessException
+	private void injectMocksIntoFields(Object testInstance, @NotNull ExtensionContext context) throws IllegalAccessException
 	{
 		final Optional<Class<?>> classOptional = context.getTestClass();
 		if (classOptional.isEmpty())
@@ -109,17 +123,51 @@ public class MockBukkitExtension implements TestInstancePostProcessor, TestInsta
 			return;
 		}
 
-		final List<Field> serverMockFields = FieldUtils.getAllFieldsList(classOptional.get())
+		final List<Field> allFields = FieldUtils.getAllFieldsList(classOptional.get())
 				.stream()
-				.filter(field -> serverSupportedTypes.contains(field.getType()))
 				.filter(field -> field.getAnnotation(MockBukkitInject.class) != null)
 				.toList();
 
-		for (final Field field : serverMockFields)
+		for (final Field field : allFields)
 		{
-			final String name = field.getName();
-			FieldUtils.writeDeclaredField(testInstance, name, serverMock, true);
+			final Object mockObject = createMockForField(field);
+			if (mockObject != null)
+			{
+				FieldUtils.writeField(field, testInstance, mockObject, true);
+			}
 		}
+	}
+
+	private @Nullable Object createMockForType(Class<?> type)
+	{
+		if (serverSupportedTypes.contains(type))
+		{
+			return MockBukkit.getOrCreateMock();
+		}
+		else if (playerSupportedTypes.contains(type))
+		{
+			final String playerName = "Player" + playerCounter++;
+			return MockBukkit.getOrCreateMock().addPlayer(playerName);
+		}
+		else if (worldSupportedTypes.contains(type))
+		{
+			final String worldName = "World" + worldCounter++;
+			return MockBukkit.getOrCreateMock().addSimpleWorld(worldName);
+		}
+		else if (pluginSupportedTypes.contains(type))
+		{
+			final String pluginName = "Plugin" + pluginCounter++;
+			return MockBukkit.createMockPlugin(pluginName);
+		}
+		else
+		{
+			return null;
+		}
+	}
+
+	private Object createMockForField(@NotNull Field field)
+	{
+		return createMockForType(field.getType());
 	}
 
 	@Override
@@ -130,11 +178,17 @@ public class MockBukkitExtension implements TestInstancePostProcessor, TestInsta
 	}
 
 	@Override
-	public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException
+	public boolean supportsParameter(@NotNull ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException
 	{
-		final boolean paramIsCorrectType = parameterContext.getParameter().getType() == ServerMock.class;
+		final Class<?> paramType = parameterContext.getParameter().getType();
 		final boolean paramHasCorrectAnnotation = parameterContext.isAnnotated(MockBukkitInject.class);
-		return paramIsCorrectType && paramHasCorrectAnnotation;
+
+		return paramHasCorrectAnnotation && (
+				serverSupportedTypes.contains(paramType) ||
+						playerSupportedTypes.contains(paramType) ||
+						worldSupportedTypes.contains(paramType) ||
+						pluginSupportedTypes.contains(paramType)
+		);
 	}
 
 	@Override
@@ -142,7 +196,8 @@ public class MockBukkitExtension implements TestInstancePostProcessor, TestInsta
 	{
 		if (!supportsParameter(parameterContext, extensionContext))
 			return null;
-		return MockBukkit.getOrCreateMock();
+
+		return createMockForType(parameterContext.getParameter().getType());
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/MockBukkitExtension.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/MockBukkitExtension.java
@@ -172,7 +172,7 @@ public class MockBukkitExtension implements TestInstancePostProcessor, TestInsta
 
 		for (final Field field : allFields)
 		{
-			final Object mockObject = createMockForField(field);
+			final Object mockObject = createMockForType(field.getType());
 			if (mockObject != null)
 			{
 				FieldUtils.writeField(field, testInstance, mockObject, true);
@@ -180,7 +180,7 @@ public class MockBukkitExtension implements TestInstancePostProcessor, TestInsta
 		}
 	}
 
-	private @Nullable Object createMockForType(Class<?> type)
+	private @Nullable Object createMockForType(@NotNull Class<?> type)
 	{
 		if (type.isAssignableFrom(ServerMock.class))
 		{
@@ -205,11 +205,6 @@ public class MockBukkitExtension implements TestInstancePostProcessor, TestInsta
 		{
 			return null;
 		}
-	}
-
-	private Object createMockForField(@NotNull Field field)
-	{
-		return createMockForType(field.getType());
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/MockBukkitExtension.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/MockBukkitExtension.java
@@ -35,10 +35,18 @@ import java.util.logging.Logger;
  * <p>The extension supports injection of the following types:</p>
  * <ul>
  *   <li>{@link Server} or {@link ServerMock} - The main server mock instance</li>
- *   <li>{@link Player} or {@link PlayerMock} - Auto-generated players with unique names (Player0, Player1, etc.)</li>
- *   <li>{@link World} or {@link WorldMock} - Auto-generated worlds with unique names (World0, World1, etc.)</li>
- *   <li>{@link Plugin} or {@link PluginMock} - Auto-generated plugins with unique names (Plugin0, Plugin1, etc.)</li>
+ *   <li>{@link Player} or {@link PlayerMock} - Auto-generated players with unique names (Player0, Player1, etc.) or custom names</li>
+ *   <li>{@link World} or {@link WorldMock} - Auto-generated worlds with unique names (World0, World1, etc.) or custom names</li>
+ *   <li>{@link Plugin} or {@link PluginMock} - Auto-generated plugins with unique names (Plugin0, Plugin1, etc.) or custom names</li>
  * </ul>
+ *
+ * <p>Custom names can be specified using the {@code name} parameter of the {@link MockBukkitInject} annotation.
+ * When {@code name} is provided and not empty, it will be used as the exact name for the mock object.
+ * When {@code name} is not provided or is an empty string, auto-generated names with incrementing counters
+ * will be used (Player0, Player1, World0, World1, Plugin0, Plugin1, etc.).</p>
+ *
+ * <p>Note: The {@code name} parameter only affects {@link PlayerMock}, {@link WorldMock}, and {@link PluginMock} objects.
+ * {@link ServerMock} instances ignore the name parameter as there is only one server instance.</p>
  *
  * <p>Example field usage:</p>
  *
@@ -50,13 +58,13 @@ import java.util.logging.Logger;
  * 	<b>@MockBukkitInject</b>
  * 	private ServerMock serverMock;
  *
- * 	<b>@MockBukkitInject</b>
+ * 	<b>@MockBukkitInject(name = "testPlayer")</b>
  * 	private PlayerMock player;
  *
- * 	<b>@MockBukkitInject</b>
+ * 	<b>@MockBukkitInject</b>  // Will be auto-named "World0"
  * 	private World world;
  *
- * 	<b>@MockBukkitInject</b>
+ * 	<b>@MockBukkitInject(name = "myPlugin")</b>
  * 	private Plugin plugin;
  *
  *    @Test
@@ -64,8 +72,11 @@ import java.util.logging.Logger;
  *    {
  * 		assert serverMock != null;
  * 		assert player != null;
+ * 		assert player.getName().equals("testPlayer");
  * 		assert world != null;
+ * 		assert world.getName().equals("World0");  // Auto-generated name
  * 		assert plugin != null;
+ * 		assert plugin.getName().equals("myPlugin");
  * 		// ...
  *    }
  *
@@ -105,12 +116,14 @@ import java.util.logging.Logger;
  *
  *    @Test
  *    void aUnitTest(<b>@MockBukkitInject</b> ServerMock serverMock,
- * 	               <b>@MockBukkitInject</b> Player player,
- * 	               <b>@MockBukkitInject</b> World world)
+ * 	               <b>@MockBukkitInject(name = "admin")</b> Player player,
+ * 	               <b>@MockBukkitInject(name = "testWorld")</b> World world)
  *    {
  * 		assert serverMock != null;
  * 		assert player != null;
+ * 		assert player.getName().equals("admin");
  * 		assert world != null;
+ * 		assert world.getName().equals("testWorld");
  * 		// ...
  *    }
  *
@@ -172,7 +185,8 @@ public class MockBukkitExtension implements TestInstancePostProcessor, TestInsta
 
 		for (final Field field : allFields)
 		{
-			final Object mockObject = createMockForType(field.getType());
+			final MockBukkitInject annotation = field.getAnnotation(MockBukkitInject.class);
+			final Object mockObject = createMockForType(field.getType(), annotation);
 			if (mockObject != null)
 			{
 				FieldUtils.writeField(field, testInstance, mockObject, true);
@@ -180,7 +194,7 @@ public class MockBukkitExtension implements TestInstancePostProcessor, TestInsta
 		}
 	}
 
-	private @Nullable Object createMockForType(@NotNull Class<?> type)
+	private @Nullable Object createMockForType(@NotNull Class<?> type, @NotNull MockBukkitInject annotation)
 	{
 		if (type.isAssignableFrom(ServerMock.class))
 		{
@@ -188,17 +202,17 @@ public class MockBukkitExtension implements TestInstancePostProcessor, TestInsta
 		}
 		else if (type.isAssignableFrom(PlayerMock.class))
 		{
-			final String playerName = "Player" + playerCounter++;
+			final String playerName = annotation.name().isEmpty() ? "Player" + playerCounter++ : annotation.name();
 			return MockBukkit.getOrCreateMock().addPlayer(playerName);
 		}
 		else if (type.isAssignableFrom(WorldMock.class))
 		{
-			final String worldName = "World" + worldCounter++;
+			final String worldName = annotation.name().isEmpty() ? "World" + worldCounter++ : annotation.name();
 			return MockBukkit.getOrCreateMock().addSimpleWorld(worldName);
 		}
 		else if (type.isAssignableFrom(PluginMock.class))
 		{
-			final String pluginName = "Plugin" + pluginCounter++;
+			final String pluginName = annotation.name().isEmpty() ? "Plugin" + pluginCounter++ : annotation.name();
 			return MockBukkit.createMockPlugin(pluginName);
 		}
 		else
@@ -234,7 +248,8 @@ public class MockBukkitExtension implements TestInstancePostProcessor, TestInsta
 		if (!supportsParameter(parameterContext, extensionContext))
 			return null;
 
-		return createMockForType(parameterContext.getParameter().getType());
+		final MockBukkitInject annotation = parameterContext.getParameter().getAnnotation(MockBukkitInject.class);
+		return createMockForType(parameterContext.getParameter().getType(), annotation);
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/MockBukkitInject.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/MockBukkitInject.java
@@ -15,5 +15,5 @@ import java.lang.annotation.Target;
 @Documented
 public @interface MockBukkitInject
 {
-
+	String name() default "";
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/MockBukkitExtensionDifferentMocksTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/MockBukkitExtensionDifferentMocksTest.java
@@ -113,6 +113,42 @@ class MockBukkitExtensionDifferentMocksTest
 	}
 
 	@Nested
+	class TestAllTypesWithNamesClass
+	{
+
+		@MockBukkitInject(name="Bumba")
+		PlayerMock playerMock;
+
+		@MockBukkitInject(name="Studio100")
+		WorldMock worldMock;
+
+		@MockBukkitInject(name="CodeMonkey")
+		Plugin pluginMock;
+
+		@Test
+		void playerMockIsNotNull()
+		{
+			assertNotNull(playerMock);
+			assertEquals( "Bumba", playerMock.getName() );
+		}
+
+		@Test
+		void worldMockIsNotNull()
+		{
+			assertNotNull(worldMock);
+			assertEquals( "Studio100", worldMock.getName() );
+		}
+
+		@Test
+		void pluginMockIsNotNull()
+		{
+			assertNotNull(pluginMock);
+			assertEquals( "CodeMonkey v1.0.0", pluginMock.getDescription().getFullName() );
+		}
+
+	}
+
+	@Nested
 	class TestMultiplesClass
 	{
 

--- a/src/test/java/org/mockbukkit/mockbukkit/MockBukkitExtensionDifferentMocksTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/MockBukkitExtensionDifferentMocksTest.java
@@ -1,0 +1,175 @@
+package org.mockbukkit.mockbukkit;
+
+import lombok.Getter;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.plugin.PluginMock;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@ExtendWith(MockBukkitExtension.class)
+class MockBukkitExtensionDifferentMocksTest
+{
+
+	// Test classes
+	@Getter
+	@Nested
+	class MixinClassTest
+	{
+
+		@MockBukkitInject
+		private ServerMock serverMock;
+
+		@Test
+		void serverMockIsNotNull()
+		{
+			assertNotNull(serverMock);
+		}
+
+	}
+
+	@Nested
+	class TestChildClass extends MixinClassTest
+	{
+		// Inherits the tests from TestMixinClass
+	}
+
+	@Nested
+	class TestDirectClass
+	{
+
+		@MockBukkitInject
+		ServerMock serverMock;
+
+		@Test
+		void serverMockIsNotNull()
+		{
+			assertNotNull(serverMock);
+		}
+
+	}
+
+	@Nested
+	class TestAllTypesClass
+	{
+
+		@MockBukkitInject
+		ServerMock serverMock;
+
+		@MockBukkitInject
+		PlayerMock playerMock;
+
+		@MockBukkitInject
+		WorldMock worldMock;
+
+		@MockBukkitInject
+		Plugin pluginMock;
+
+		@Test
+		void serverMockIsNotNull()
+		{
+			assertNotNull(serverMock);
+		}
+
+		@Test
+		void playerMockIsNotNull()
+		{
+			assertNotNull(playerMock);
+		}
+
+		@Test
+		void worldMockIsNotNull()
+		{
+			assertNotNull(worldMock);
+		}
+
+		@Test
+		void pluginMockIsNotNull()
+		{
+			assertNotNull(pluginMock);
+		}
+
+	}
+
+	@Nested
+	class TestMultiplesClass
+	{
+
+		@MockBukkitInject
+		Player player1;
+
+		@MockBukkitInject
+		PlayerMock player2;
+
+		@MockBukkitInject
+		World world1;
+
+		@MockBukkitInject
+		WorldMock world2;
+
+		@MockBukkitInject
+		Plugin plugin1;
+
+		@MockBukkitInject
+		PluginMock plugin2;
+
+		@Test
+		void playerMocksNotNull()
+		{
+			assertNotNull(player1);
+			assertNotNull(player2);
+
+			assertNotSame(player1, player2);
+
+			assertNotEquals(player1.getUniqueId(), player2.getUniqueId());
+			assertNotEquals(player1.getName(), player2.getName());
+		}
+
+		@Test
+		void worldMocksNotNull()
+		{
+			assertNotNull(world1);
+			assertNotNull(world2);
+
+			assertNotSame(world1, world2);
+
+			assertNotEquals(world1.getUID(), world2.getUID());
+			assertNotEquals(world1.getName(), world2.getName());
+		}
+
+		@Test
+		void pluginMocksNotNull()
+		{
+			assertNotNull(plugin1);
+			assertNotNull(plugin2);
+
+			assertNotSame(plugin1, plugin2);
+
+			assertNotEquals(plugin1.getDescription().getFullName(), plugin2.getDescription().getFullName());
+		}
+
+	}
+
+	@Nested
+	class TestInvalidThingie
+	{
+		@MockBukkitInject
+		private Integer someInteger;
+
+		@Test
+		void testInteger() {
+			assertNull(someInteger);
+		}
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/MockBukkitExtensionDifferentMocksTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/MockBukkitExtensionDifferentMocksTest.java
@@ -208,8 +208,10 @@ class MockBukkitExtensionDifferentMocksTest
 		assertInstanceOf(Plugin.class, plugin);
 	}
 
+	@SuppressWarnings({ "java:S1144", "java:S1172" })
 	private void testMethodWithInteger(@MockBukkitInject Integer param)
 	{
+		// I just need the methods signature. It doesn't have to do anything.
 	}
 
 	@RequiredArgsConstructor

--- a/src/test/java/org/mockbukkit/mockbukkit/MockBukkitExtensionDifferentMocksTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/MockBukkitExtensionDifferentMocksTest.java
@@ -1,17 +1,28 @@
 package org.mockbukkit.mockbukkit;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
 import org.mockbukkit.mockbukkit.plugin.PluginMock;
 import org.mockbukkit.mockbukkit.world.WorldMock;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -163,13 +174,78 @@ class MockBukkitExtensionDifferentMocksTest
 	@Nested
 	class TestInvalidThingie
 	{
+
 		@MockBukkitInject
 		private Integer someInteger;
 
 		@Test
-		void testInteger() {
+		void testInteger()
+		{
 			assertNull(someInteger);
 		}
+
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "dummy" })
+	void shouldInjectMocksViaMethodParameters(
+			String value,
+			@MockBukkitInject ServerMock server,
+			@MockBukkitInject Player player,
+			@MockBukkitInject World world,
+			@MockBukkitInject Plugin plugin
+	)
+	{
+		assertEquals("dummy", value);
+
+		assertNotNull(server);
+		assertInstanceOf(ServerMock.class, server);
+		assertNotNull(player);
+		assertInstanceOf(PlayerMock.class, player);
+		assertNotNull(world);
+		assertInstanceOf(WorldMock.class, world);
+		assertNotNull(plugin);
+		assertInstanceOf(Plugin.class, plugin);
+	}
+
+	private void testMethodWithInteger(@MockBukkitInject Integer param)
+	{
+	}
+
+	@RequiredArgsConstructor
+	private static class TestParameterContext implements ParameterContext
+	{
+
+		@Getter
+		private final Parameter parameter;
+
+		@Override
+		public int getIndex()
+		{
+			return 0;
+		}
+
+		@Override
+		public Optional<Object> getTarget()
+		{
+			return Optional.empty();
+		}
+
+	}
+
+	@Test
+	@SneakyThrows
+	void checkForInvalidSupportedAnnotation()
+	{
+		// I can't do this via a normal way, because it will crash before I reach the correct point inside the code.
+		var extension = new MockBukkitExtension();
+		Method testMethod = getClass().getDeclaredMethod("testMethodWithInteger", Integer.class);
+		Parameter parameter = testMethod.getParameters()[0];
+
+		ParameterContext parameterContext = new TestParameterContext(parameter);
+
+		assertFalse(extension.supportsParameter(parameterContext, null));
+		assertNull(extension.resolveParameter(parameterContext, null));
 	}
 
 }


### PR DESCRIPTION
# Description

right now you can only inject the server, but what about player, world or plugins? Quite often used as well.
I extended the code to add this behaviour.

# Checklist

The following items should be checked before the pull request can be merged.

- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
