### PR TITLE
fix: Support Multiple Potion Effects of the Same Type

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -43,6 +43,7 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
@@ -652,15 +653,8 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		if (!event.isCancelled())
 		{
 			activeEffects.computeIfAbsent(type, k -> new PriorityQueue<>()).add(new ActivePotionEffect(effect));
-
-			// Only fire additional CHANGED event if the active effect actually changed
-			PotionEffect newActiveEffect = getPotionEffect(type);
-			if (oldEffect != null && !oldEffect.equals(newActiveEffect) && action == EntityPotionEffectEvent.Action.CHANGED)
-			{
-				// The active effect changed due to priority, but we already fired the CHANGED event above
-				// No need to fire another event
-			}
 		}
+
 		return event;
 	}
 
@@ -687,17 +681,12 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	@Override
 	public boolean hasPotionEffect(@NotNull PotionEffectType type)
 	{
-		var queue = activeEffects.get(type);
-		return queue != null && !queue.isEmpty();
+		return activeEffects.containsKey(type);
 	}
 
-	private @Nullable PotionEffect mapToPotionEffect(@Nullable ActivePotionEffect activeEffect)
+	@Contract(value = "_ -> new", pure = true)
+	private @NotNull PotionEffect mapToPotionEffect(@NotNull ActivePotionEffect activeEffect)
 	{
-		if (activeEffect == null)
-		{
-			return null;
-		}
-
 		var effect = activeEffect.getPotionEffect();
 		return new PotionEffect(effect.getType(), activeEffect.getDuration(), effect.getAmplifier(), effect.isAmbient(), effect.hasParticles(), effect.hasIcon());
 	}
@@ -706,11 +695,13 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	public @Nullable PotionEffect getPotionEffect(@NotNull PotionEffectType type)
 	{
 		Preconditions.checkNotNull(type, "Potion type cannot be null");
+
 		var queue = activeEffects.get(type);
-		if (queue == null || queue.isEmpty())
+		if (queue == null)
 		{
 			return null;
 		}
+
 		return mapToPotionEffect(queue.peek());
 	}
 
@@ -722,7 +713,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 			var entry = it.next();
 			var queue = entry.getValue();
 
-			PotionEffect oldActiveEffect = queue.isEmpty() ? null : mapToPotionEffect(queue.peek());
+			PotionEffect oldActiveEffect = mapToPotionEffect(queue.peek());
 
 			// Remove ALL expired effects from the queue, not just the top one
 			var queueIt = queue.iterator();
@@ -739,31 +730,20 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 			}
 
 			// Check if the active effect changed after removing expired effects
-			PotionEffect newActiveEffect = queue.isEmpty() ? null : mapToPotionEffect(queue.peek());
-			if (oldActiveEffect != null && newActiveEffect != null)
-			{
-				// Only fire CHANGED event if the effective properties changed
-				if (oldActiveEffect.getAmplifier() != newActiveEffect.getAmplifier() ||
-						oldActiveEffect.getType() != newActiveEffect.getType())
-				{
-					var changeEvent = new EntityPotionEffectEvent(this, oldActiveEffect, newActiveEffect,
-							EntityPotionEffectEvent.Cause.EXPIRATION, EntityPotionEffectEvent.Action.CHANGED, true);
-					Bukkit.getPluginManager().callEvent(changeEvent);
-				}
-			}
-			else if (oldActiveEffect != null && newActiveEffect == null)
-			{
-				// Effect completely removed - but we already fired the REMOVED event above
-			}
-			else if (oldActiveEffect == null && newActiveEffect != null)
-			{
-				// This shouldn't happen in expiration context
-			}
-
-			// Remove empty queues
 			if (queue.isEmpty())
 			{
 				it.remove();
+				return;
+			}
+
+			PotionEffect newActiveEffect = mapToPotionEffect(queue.peek());
+
+			// Only fire CHANGED event if the effective properties changed
+			if (oldActiveEffect.getAmplifier() != newActiveEffect.getAmplifier())
+			{
+				var changeEvent = new EntityPotionEffectEvent(this, oldActiveEffect, newActiveEffect,
+						EntityPotionEffectEvent.Cause.EXPIRATION, EntityPotionEffectEvent.Action.CHANGED, true);
+				Bukkit.getPluginManager().callEvent(changeEvent);
 			}
 		}
 	}
@@ -773,39 +753,25 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	{
 		Preconditions.checkNotNull(type, "Potion type cannot be null");
 		var queue = activeEffects.get(type);
-		if (queue != null && !queue.isEmpty())
+		if (queue == null)
 		{
-			PotionEffect oldActiveEffect = mapToPotionEffect(queue.peek());
-			var removedEffect = queue.poll(); // Only remove the top effect
-
-			var event = new EntityPotionEffectEvent(this, removedEffect.getPotionEffect(), null,
-					EntityPotionEffectEvent.Cause.PLUGIN, EntityPotionEffectEvent.Action.REMOVED, true);
-			Bukkit.getPluginManager().callEvent(event);
-
-			// Check if a different effect became active
-			if (!queue.isEmpty())
-			{
-				PotionEffect newActiveEffect = mapToPotionEffect(queue.peek());
-				if (!oldActiveEffect.equals(newActiveEffect))
-				{
-					var changeEvent = new EntityPotionEffectEvent(this, oldActiveEffect, newActiveEffect,
-							EntityPotionEffectEvent.Cause.PLUGIN, EntityPotionEffectEvent.Action.CHANGED, true);
-					Bukkit.getPluginManager().callEvent(changeEvent);
-				}
-			}
-
-			if (queue.isEmpty())
-			{
-				activeEffects.remove(type);
-			}
+			return;
 		}
+
+		for (var activeEffect : queue)
+		{
+			var changeEvent = new EntityPotionEffectEvent(this, mapToPotionEffect(activeEffect), null,
+					EntityPotionEffectEvent.Cause.PLUGIN, EntityPotionEffectEvent.Action.REMOVED, true);
+			Bukkit.getPluginManager().callEvent(changeEvent);
+		}
+
+		activeEffects.remove(type);
 	}
 
 	@Override
 	public @NotNull Collection<PotionEffect> getActivePotionEffects()
 	{
 		return activeEffects.values().stream()
-				.filter(queue -> !queue.isEmpty())
 				.map(queue -> mapToPotionEffect(queue.peek()))
 				.toList();
 	}
@@ -813,7 +779,10 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	@Override
 	public boolean clearActivePotionEffects()
 	{
-		final boolean res = !activeEffects.isEmpty();
+		if (activeEffects.isEmpty())
+		{
+			return false;
+		}
 
 		// Fire removal events for all active effects
 		activeEffects.forEach((type, queue) ->
@@ -827,7 +796,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		});
 
 		activeEffects.clear();
-		return res;
+		return true;
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -63,6 +63,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -129,7 +131,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	@Setter
 	private @Nullable Player killer;
 
-	private final Map<PotionEffectType, ActivePotionEffect> activeEffects = new HashMap<>();
+	private final Map<PotionEffectType, PriorityQueue<ActivePotionEffect>> activeEffects = new HashMap<>();
 	private TriState frictionState = TriState.NOT_SET;
 	private Entity leashHolder;
 
@@ -635,32 +637,29 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	 * @param cause  The cause.
 	 * @return The event containing details about adding the potion effect.
 	 */
-	public EntityPotionEffectEvent addPotionEffect(@NotNull PotionEffect effect, EntityPotionEffectEvent.Cause cause)
-	{
+	public EntityPotionEffectEvent addPotionEffect(@NotNull PotionEffect effect, EntityPotionEffectEvent.Cause cause) {
 		AsyncCatcher.catchOp("effect add");
 		Preconditions.checkNotNull(effect, "PotionEffect cannot be null");
-
-		/*
-		Applying completely new effect -> old: null, new: new effect, action: add, override: false
-		A single effects runs out (on time) (not possible via this method because @NotNull) -> old: effect that ran out, new: null, action: remove, override: true
-		Applying a new effect but effect type already active -> old: existing effect, new: new effect, action: changed, override: true
-		Clearing all effects (not possible via this method) -> old: effect that was cleared, new: null, action: clear, override: true
-
-		 Notes:
-		 If multiple effects are cleared, then for each one an EntityPotionEffectEvent is called.
-		 */
 
 		PotionEffectType type = effect.getType();
 		PotionEffect oldEffect = getPotionEffect(type);
 		EntityPotionEffectEvent.Action action = oldEffect == null ? EntityPotionEffectEvent.Action.ADDED : EntityPotionEffectEvent.Action.CHANGED;
 		boolean override = oldEffect != null;
 
-
 		EntityPotionEffectEvent event = new EntityPotionEffectEvent(this, oldEffect, effect, cause, action, override);
 		Bukkit.getPluginManager().callEvent(event);
-		if (!event.isCancelled())
-		{
-			activeEffects.put(type, new ActivePotionEffect(effect));
+
+		if (!event.isCancelled()) {
+			activeEffects.computeIfAbsent(type, k -> new PriorityQueue<>()).add(new ActivePotionEffect(effect));
+
+			// Check if the active effect changed due to priority
+			PotionEffect newActiveEffect = getPotionEffect(type);
+			if (oldEffect != null && !oldEffect.equals(newActiveEffect)) {
+				// The active effect changed, fire another event
+				var changeEvent = new EntityPotionEffectEvent(this, oldEffect, newActiveEffect, cause,
+						EntityPotionEffectEvent.Action.CHANGED, true);
+				Bukkit.getPluginManager().callEvent(changeEvent);
+			}
 		}
 		return event;
 	}
@@ -686,9 +685,9 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	}
 
 	@Override
-	public boolean hasPotionEffect(@NotNull PotionEffectType type)
-	{
-		return activeEffects.containsKey(type);
+	public boolean hasPotionEffect(@NotNull PotionEffectType type) {
+		var queue = activeEffects.get(type);
+		return queue != null && !queue.isEmpty();
 	}
 
 	private @Nullable PotionEffect mapToPotionEffect(@Nullable ActivePotionEffect activeEffect)
@@ -703,29 +702,99 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	}
 
 	@Override
-	public @Nullable PotionEffect getPotionEffect(@NotNull PotionEffectType type)
-	{
+	public @Nullable PotionEffect getPotionEffect(@NotNull PotionEffectType type) {
 		Preconditions.checkNotNull(type, "Potion type cannot be null");
-		return mapToPotionEffect(activeEffects.get(type));
+		var queue = activeEffects.get(type);
+		if (queue == null || queue.isEmpty()) {
+			return null;
+		}
+		return mapToPotionEffect(queue.peek());
+	}
+
+	private void removeExpiredEffects() {
+		var it = activeEffects.entrySet().iterator();
+		while (it.hasNext()) {
+			var entry = it.next();
+			var queue = entry.getValue();
+			var effectType = entry.getKey();
+
+			PotionEffect oldActiveEffect = queue.isEmpty() ? null : mapToPotionEffect(queue.peek());
+
+			// Remove expired effects and fire events
+			while (!queue.isEmpty() && queue.peek().hasExpired()) {
+				var expiredEffect = queue.poll();
+				var event = new EntityPotionEffectEvent(this, expiredEffect.getPotionEffect(), null,
+						EntityPotionEffectEvent.Cause.EXPIRATION, EntityPotionEffectEvent.Action.REMOVED, true);
+				Bukkit.getPluginManager().callEvent(event);
+			}
+
+			// Check if the active effect changed after removing expired effects
+			PotionEffect newActiveEffect = queue.isEmpty() ? null : mapToPotionEffect(queue.peek());
+			if (oldActiveEffect != null && !Objects.equals(oldActiveEffect, newActiveEffect)) {
+				if (newActiveEffect != null) {
+					// A different effect became active
+					var changeEvent = new EntityPotionEffectEvent(this, oldActiveEffect, newActiveEffect,
+							EntityPotionEffectEvent.Cause.EXPIRATION, EntityPotionEffectEvent.Action.CHANGED, true);
+					Bukkit.getPluginManager().callEvent(changeEvent);
+				}
+			}
+
+			// Remove empty queues
+			if (queue.isEmpty()) {
+				it.remove();
+			}
+		}
 	}
 
 	@Override
-	public void removePotionEffect(@NotNull PotionEffectType type)
-	{
+	public void removePotionEffect(@NotNull PotionEffectType type) {
 		Preconditions.checkNotNull(type, "Potion type cannot be null");
-		activeEffects.remove(type);
+		var queue = activeEffects.get(type);
+		if (queue != null && !queue.isEmpty()) {
+			PotionEffect oldActiveEffect = mapToPotionEffect(queue.peek());
+			var removedEffect = queue.poll();
+
+			var event = new EntityPotionEffectEvent(this, removedEffect.getPotionEffect(), null,
+					EntityPotionEffectEvent.Cause.PLUGIN, EntityPotionEffectEvent.Action.REMOVED, true);
+			Bukkit.getPluginManager().callEvent(event);
+
+			// Check if a different effect became active
+			if (!queue.isEmpty()) {
+				PotionEffect newActiveEffect = mapToPotionEffect(queue.peek());
+				if (!oldActiveEffect.equals(newActiveEffect)) {
+					var changeEvent = new EntityPotionEffectEvent(this, oldActiveEffect, newActiveEffect,
+							EntityPotionEffectEvent.Cause.PLUGIN, EntityPotionEffectEvent.Action.CHANGED, true);
+					Bukkit.getPluginManager().callEvent(changeEvent);
+				}
+			}
+
+			if (queue.isEmpty()) {
+				activeEffects.remove(type);
+			}
+		}
 	}
 
 	@Override
-	public @NotNull Collection<PotionEffect> getActivePotionEffects()
-	{
-		return activeEffects.values().stream().map(this::mapToPotionEffect).toList();
+	public @NotNull Collection<PotionEffect> getActivePotionEffects() {
+		return activeEffects.values().stream()
+				.filter(queue -> !queue.isEmpty())
+				.map(queue -> mapToPotionEffect(queue.peek()))
+				.toList();
 	}
 
 	@Override
-	public boolean clearActivePotionEffects()
-	{
+	public boolean clearActivePotionEffects() {
 		final boolean res = !activeEffects.isEmpty();
+
+		// Fire removal events for all active effects
+		activeEffects.forEach((type, queue) -> {
+			queue.forEach(activeEffect -> {
+				var event = new EntityPotionEffectEvent(this, activeEffect.getPotionEffect(), null,
+						EntityPotionEffectEvent.Cause.PLUGIN, EntityPotionEffectEvent.Action.CLEARED, true);
+				Bukkit.getPluginManager().callEvent(event);
+			});
+		});
+
 		activeEffects.clear();
 		return res;
 	}
@@ -1303,7 +1372,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	public void tick()
 	{
 		super.tick();
-		activeEffects.entrySet().removeIf(entry -> entry.getValue().hasExpired());
+		removeExpiredEffects();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -63,7 +63,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.UUID;
@@ -722,7 +721,6 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		{
 			var entry = it.next();
 			var queue = entry.getValue();
-			var effectType = entry.getKey();
 
 			PotionEffect oldActiveEffect = queue.isEmpty() ? null : mapToPotionEffect(queue.peek());
 
@@ -742,15 +740,24 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 
 			// Check if the active effect changed after removing expired effects
 			PotionEffect newActiveEffect = queue.isEmpty() ? null : mapToPotionEffect(queue.peek());
-			if (oldActiveEffect != null && !Objects.equals(oldActiveEffect, newActiveEffect))
+			if (oldActiveEffect != null && newActiveEffect != null)
 			{
-				if (newActiveEffect != null)
+				// Only fire CHANGED event if the effective properties changed
+				if (oldActiveEffect.getAmplifier() != newActiveEffect.getAmplifier() ||
+						oldActiveEffect.getType() != newActiveEffect.getType())
 				{
-					// A different effect became active
 					var changeEvent = new EntityPotionEffectEvent(this, oldActiveEffect, newActiveEffect,
 							EntityPotionEffectEvent.Cause.EXPIRATION, EntityPotionEffectEvent.Action.CHANGED, true);
 					Bukkit.getPluginManager().callEvent(changeEvent);
 				}
+			}
+			else if (oldActiveEffect != null && newActiveEffect == null)
+			{
+				// Effect completely removed - but we already fired the REMOVED event above
+			}
+			else if (oldActiveEffect == null && newActiveEffect != null)
+			{
+				// This shouldn't happen in expiration context
 			}
 
 			// Remove empty queues

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -637,7 +637,8 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	 * @param cause  The cause.
 	 * @return The event containing details about adding the potion effect.
 	 */
-	public EntityPotionEffectEvent addPotionEffect(@NotNull PotionEffect effect, EntityPotionEffectEvent.Cause cause) {
+	public EntityPotionEffectEvent addPotionEffect(@NotNull PotionEffect effect, EntityPotionEffectEvent.Cause cause)
+	{
 		AsyncCatcher.catchOp("effect add");
 		Preconditions.checkNotNull(effect, "PotionEffect cannot be null");
 
@@ -649,16 +650,16 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		EntityPotionEffectEvent event = new EntityPotionEffectEvent(this, oldEffect, effect, cause, action, override);
 		Bukkit.getPluginManager().callEvent(event);
 
-		if (!event.isCancelled()) {
+		if (!event.isCancelled())
+		{
 			activeEffects.computeIfAbsent(type, k -> new PriorityQueue<>()).add(new ActivePotionEffect(effect));
 
-			// Check if the active effect changed due to priority
+			// Only fire additional CHANGED event if the active effect actually changed
 			PotionEffect newActiveEffect = getPotionEffect(type);
-			if (oldEffect != null && !oldEffect.equals(newActiveEffect)) {
-				// The active effect changed, fire another event
-				var changeEvent = new EntityPotionEffectEvent(this, oldEffect, newActiveEffect, cause,
-						EntityPotionEffectEvent.Action.CHANGED, true);
-				Bukkit.getPluginManager().callEvent(changeEvent);
+			if (oldEffect != null && !oldEffect.equals(newActiveEffect) && action == EntityPotionEffectEvent.Action.CHANGED)
+			{
+				// The active effect changed due to priority, but we already fired the CHANGED event above
+				// No need to fire another event
 			}
 		}
 		return event;
@@ -685,7 +686,8 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	}
 
 	@Override
-	public boolean hasPotionEffect(@NotNull PotionEffectType type) {
+	public boolean hasPotionEffect(@NotNull PotionEffectType type)
+	{
 		var queue = activeEffects.get(type);
 		return queue != null && !queue.isEmpty();
 	}
@@ -702,36 +704,48 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	}
 
 	@Override
-	public @Nullable PotionEffect getPotionEffect(@NotNull PotionEffectType type) {
+	public @Nullable PotionEffect getPotionEffect(@NotNull PotionEffectType type)
+	{
 		Preconditions.checkNotNull(type, "Potion type cannot be null");
 		var queue = activeEffects.get(type);
-		if (queue == null || queue.isEmpty()) {
+		if (queue == null || queue.isEmpty())
+		{
 			return null;
 		}
 		return mapToPotionEffect(queue.peek());
 	}
 
-	private void removeExpiredEffects() {
+	private void removeExpiredEffects()
+	{
 		var it = activeEffects.entrySet().iterator();
-		while (it.hasNext()) {
+		while (it.hasNext())
+		{
 			var entry = it.next();
 			var queue = entry.getValue();
 			var effectType = entry.getKey();
 
 			PotionEffect oldActiveEffect = queue.isEmpty() ? null : mapToPotionEffect(queue.peek());
 
-			// Remove expired effects and fire events
-			while (!queue.isEmpty() && queue.peek().hasExpired()) {
-				var expiredEffect = queue.poll();
-				var event = new EntityPotionEffectEvent(this, expiredEffect.getPotionEffect(), null,
-						EntityPotionEffectEvent.Cause.EXPIRATION, EntityPotionEffectEvent.Action.REMOVED, true);
-				Bukkit.getPluginManager().callEvent(event);
+			// Remove ALL expired effects from the queue, not just the top one
+			var queueIt = queue.iterator();
+			while (queueIt.hasNext())
+			{
+				var activeEffect = queueIt.next();
+				if (activeEffect.hasExpired())
+				{
+					queueIt.remove();
+					var event = new EntityPotionEffectEvent(this, activeEffect.getPotionEffect(), null,
+							EntityPotionEffectEvent.Cause.EXPIRATION, EntityPotionEffectEvent.Action.REMOVED, true);
+					Bukkit.getPluginManager().callEvent(event);
+				}
 			}
 
 			// Check if the active effect changed after removing expired effects
 			PotionEffect newActiveEffect = queue.isEmpty() ? null : mapToPotionEffect(queue.peek());
-			if (oldActiveEffect != null && !Objects.equals(oldActiveEffect, newActiveEffect)) {
-				if (newActiveEffect != null) {
+			if (oldActiveEffect != null && !Objects.equals(oldActiveEffect, newActiveEffect))
+			{
+				if (newActiveEffect != null)
+				{
 					// A different effect became active
 					var changeEvent = new EntityPotionEffectEvent(this, oldActiveEffect, newActiveEffect,
 							EntityPotionEffectEvent.Cause.EXPIRATION, EntityPotionEffectEvent.Action.CHANGED, true);
@@ -740,42 +754,49 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 			}
 
 			// Remove empty queues
-			if (queue.isEmpty()) {
+			if (queue.isEmpty())
+			{
 				it.remove();
 			}
 		}
 	}
 
 	@Override
-	public void removePotionEffect(@NotNull PotionEffectType type) {
+	public void removePotionEffect(@NotNull PotionEffectType type)
+	{
 		Preconditions.checkNotNull(type, "Potion type cannot be null");
 		var queue = activeEffects.get(type);
-		if (queue != null && !queue.isEmpty()) {
+		if (queue != null && !queue.isEmpty())
+		{
 			PotionEffect oldActiveEffect = mapToPotionEffect(queue.peek());
-			var removedEffect = queue.poll();
+			var removedEffect = queue.poll(); // Only remove the top effect
 
 			var event = new EntityPotionEffectEvent(this, removedEffect.getPotionEffect(), null,
 					EntityPotionEffectEvent.Cause.PLUGIN, EntityPotionEffectEvent.Action.REMOVED, true);
 			Bukkit.getPluginManager().callEvent(event);
 
 			// Check if a different effect became active
-			if (!queue.isEmpty()) {
+			if (!queue.isEmpty())
+			{
 				PotionEffect newActiveEffect = mapToPotionEffect(queue.peek());
-				if (!oldActiveEffect.equals(newActiveEffect)) {
+				if (!oldActiveEffect.equals(newActiveEffect))
+				{
 					var changeEvent = new EntityPotionEffectEvent(this, oldActiveEffect, newActiveEffect,
 							EntityPotionEffectEvent.Cause.PLUGIN, EntityPotionEffectEvent.Action.CHANGED, true);
 					Bukkit.getPluginManager().callEvent(changeEvent);
 				}
 			}
 
-			if (queue.isEmpty()) {
+			if (queue.isEmpty())
+			{
 				activeEffects.remove(type);
 			}
 		}
 	}
 
 	@Override
-	public @NotNull Collection<PotionEffect> getActivePotionEffects() {
+	public @NotNull Collection<PotionEffect> getActivePotionEffects()
+	{
 		return activeEffects.values().stream()
 				.filter(queue -> !queue.isEmpty())
 				.map(queue -> mapToPotionEffect(queue.peek()))
@@ -783,12 +804,15 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	}
 
 	@Override
-	public boolean clearActivePotionEffects() {
+	public boolean clearActivePotionEffects()
+	{
 		final boolean res = !activeEffects.isEmpty();
 
 		// Fire removal events for all active effects
-		activeEffects.forEach((type, queue) -> {
-			queue.forEach(activeEffect -> {
+		activeEffects.forEach((type, queue) ->
+		{
+			queue.forEach(activeEffect ->
+			{
 				var event = new EntityPotionEffectEvent(this, activeEffect.getPotionEffect(), null,
 						EntityPotionEffectEvent.Cause.PLUGIN, EntityPotionEffectEvent.Action.CLEARED, true);
 				Bukkit.getPluginManager().callEvent(event);

--- a/src/main/java/org/mockbukkit/mockbukkit/potion/ActivePotionEffect.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/potion/ActivePotionEffect.java
@@ -1,63 +1,43 @@
 package org.mockbukkit.mockbukkit.potion;
 
 import org.bukkit.Bukkit;
-import org.bukkit.entity.LivingEntity;
 import org.bukkit.potion.PotionEffect;
 import org.jetbrains.annotations.NotNull;
-import org.mockbukkit.mockbukkit.entity.LivingEntityMock;
 
-/**
- * This class represents an active {@link PotionEffect} which was applied to a {@link LivingEntity}.
- *
- * @author TheBusyBiscuit
- * @see LivingEntityMock#addPotionEffect(PotionEffect)
- */
-public final class ActivePotionEffect
-{
-
+public final class ActivePotionEffect implements Comparable<ActivePotionEffect> {
 	private final @NotNull PotionEffect effect;
 	private final int startTick;
 
-	/**
-	 * Constructs a new {@link ActivePotionEffect} with the provided {@link PotionEffect}.
-	 *
-	 * @param effect The effect that's been applied.
-	 */
-	public ActivePotionEffect(@NotNull PotionEffect effect)
-	{
+	public ActivePotionEffect(@NotNull PotionEffect effect) {
 		this.effect = effect;
 		this.startTick = Bukkit.getCurrentTick();
 	}
 
-	/**
-	 * This returns whether this {@link PotionEffect} has expired.
-	 *
-	 * @return Whether the effect wore off.
-	 */
-	public boolean hasExpired()
-	{
+	public boolean hasExpired() {
 		return getDuration() == 0;
 	}
 
-	/**
-	 * This method returns the underlying {@link PotionEffect}
-	 *
-	 * @return The actual {@link PotionEffect}.
-	 */
 	@NotNull
-	public PotionEffect getPotionEffect()
-	{
+	public PotionEffect getPotionEffect() {
 		return effect;
 	}
 
-	public int getDuration()
-	{
-		if (effect.isInfinite())
-		{
+	public int getDuration() {
+		if (effect.isInfinite()) {
 			return -1;
 		}
-
 		return Math.max(0, effect.getDuration() - Bukkit.getCurrentTick() + startTick);
 	}
 
+	@Override
+	public int compareTo(@NotNull ActivePotionEffect other) {
+		// Higher amplifier wins
+		int amplifierCompare = Integer.compare(other.effect.getAmplifier(), this.effect.getAmplifier());
+		if (amplifierCompare != 0) {
+			return amplifierCompare;
+		}
+
+		// If amplifiers are equal, higher remaining duration wins
+		return Integer.compare(other.getDuration(), this.getDuration());
+	}
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/potion/ActivePotionEffect.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/potion/ActivePotionEffect.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
  * @author TheBusyBiscuit
  * @see LivingEntityMock#addPotionEffect(PotionEffect)
  */
-public final class ActivePotionEffect
+public final class ActivePotionEffect implements Comparable<ActivePotionEffect>
 {
 
 	private final @NotNull PotionEffect effect;

--- a/src/main/java/org/mockbukkit/mockbukkit/potion/ActivePotionEffect.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/potion/ActivePotionEffect.java
@@ -4,40 +4,50 @@ import org.bukkit.Bukkit;
 import org.bukkit.potion.PotionEffect;
 import org.jetbrains.annotations.NotNull;
 
-public final class ActivePotionEffect implements Comparable<ActivePotionEffect> {
+public final class ActivePotionEffect implements Comparable<ActivePotionEffect>
+{
+
 	private final @NotNull PotionEffect effect;
 	private final int startTick;
 
-	public ActivePotionEffect(@NotNull PotionEffect effect) {
+	public ActivePotionEffect(@NotNull PotionEffect effect)
+	{
 		this.effect = effect;
 		this.startTick = Bukkit.getCurrentTick();
 	}
 
-	public boolean hasExpired() {
+	public boolean hasExpired()
+	{
 		return getDuration() == 0;
 	}
 
 	@NotNull
-	public PotionEffect getPotionEffect() {
+	public PotionEffect getPotionEffect()
+	{
 		return effect;
 	}
 
-	public int getDuration() {
-		if (effect.isInfinite()) {
+	public int getDuration()
+	{
+		if (effect.isInfinite())
+		{
 			return -1;
 		}
 		return Math.max(0, effect.getDuration() - Bukkit.getCurrentTick() + startTick);
 	}
 
 	@Override
-	public int compareTo(@NotNull ActivePotionEffect other) {
+	public int compareTo(@NotNull ActivePotionEffect other)
+	{
 		// Higher amplifier wins
 		int amplifierCompare = Integer.compare(other.effect.getAmplifier(), this.effect.getAmplifier());
-		if (amplifierCompare != 0) {
+		if (amplifierCompare != 0)
+		{
 			return amplifierCompare;
 		}
 
 		// If amplifiers are equal, higher remaining duration wins
 		return Integer.compare(other.getDuration(), this.getDuration());
 	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/potion/ActivePotionEffect.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/potion/ActivePotionEffect.java
@@ -4,23 +4,44 @@ import org.bukkit.Bukkit;
 import org.bukkit.potion.PotionEffect;
 import org.jetbrains.annotations.NotNull;
 
-public final class ActivePotionEffect implements Comparable<ActivePotionEffect>
+/**
+ * This class represents an active {@link PotionEffect} which was applied to a {@link LivingEntity}.
+ *
+ * @author TheBusyBiscuit
+ * @see LivingEntityMock#addPotionEffect(PotionEffect)
+ */
+public final class ActivePotionEffect
 {
 
 	private final @NotNull PotionEffect effect;
 	private final int startTick;
 
+	/**
+	 * Constructs a new {@link ActivePotionEffect} with the provided {@link PotionEffect}.
+	 *
+	 * @param effect The effect that's been applied.
+	 */
 	public ActivePotionEffect(@NotNull PotionEffect effect)
 	{
 		this.effect = effect;
 		this.startTick = Bukkit.getCurrentTick();
 	}
 
+	/**
+	 * This returns whether this {@link PotionEffect} has expired.
+	 *
+	 * @return Whether the effect wore off.
+	 */
 	public boolean hasExpired()
 	{
 		return getDuration() == 0;
 	}
 
+	/**
+	 * This method returns the underlying {@link PotionEffect}
+	 *
+	 * @return The actual {@link PotionEffect}.
+	 */
 	@NotNull
 	public PotionEffect getPotionEffect()
 	{
@@ -33,6 +54,7 @@ public final class ActivePotionEffect implements Comparable<ActivePotionEffect>
 		{
 			return -1;
 		}
+
 		return Math.max(0, effect.getDuration() - Bukkit.getCurrentTick() + startTick);
 	}
 

--- a/src/test/java/org/mockbukkit/mockbukkit/potion/PotionEffectPriorityQueueTests.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/potion/PotionEffectPriorityQueueTests.java
@@ -3,139 +3,206 @@ package org.mockbukkit.mockbukkit.potion;
 import org.bukkit.event.entity.EntityPotionEffectEvent;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockbukkit.mockbukkit.MockBukkitExtension;
 import org.mockbukkit.mockbukkit.MockBukkitInject;
 import org.mockbukkit.mockbukkit.ServerMock;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.plugin.PluginMock;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockBukkitExtension.class)
-class PotionEffectPriorityQueueTests
-{
+class PotionEffectPriorityQueueTests {
 
 	@MockBukkitInject
 	private ServerMock server;
 	@MockBukkitInject
 	private PlayerMock livingEntity;
+	@MockBukkitInject
+	private PluginMock plugin;
 
-	@Test
-	void testStrongerEffectOverridesWeaker()
-	{
-		PotionEffect weakEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
-		PotionEffect strongEffect = new PotionEffect(PotionEffectType.REGENERATION, 50, 3);
+	// Standard test effects
+	private PotionEffect weakEffect;
+	private PotionEffect strongEffect;
+	private PotionEffect shortEffect;
+	private PotionEffect longEffect;
 
-		// Add weak effect first
-		EntityPotionEffectEvent event1 = livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
-		assertEntityPotionEffectEvent(event1, null, weakEffect, EntityPotionEffectEvent.Cause.PLUGIN, EntityPotionEffectEvent.Action.ADDED, false);
-		assertEquals(weakEffect, livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
+	@BeforeEach
+	void setUp() {
+		weakEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
+		strongEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 3);
+		shortEffect = new PotionEffect(PotionEffectType.REGENERATION, 2, 3);
+		longEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
+	}
 
-		// Add stronger effect - should change active effect
-		EntityPotionEffectEvent event2 = livingEntity.addPotionEffect(strongEffect, EntityPotionEffectEvent.Cause.PLUGIN);
-
-		// Should fire events for adding and changing active effect
-		var firedEvents = server.getPluginManager().getFiredEvents()
-				.filter(event -> event instanceof EntityPotionEffectEvent)
-				.map(event -> (EntityPotionEffectEvent) event)
-				.filter(event -> event.getAction() == EntityPotionEffectEvent.Action.CHANGED &&
-						event.getOldEffect().equals(weakEffect) &&
-						event.getNewEffect().equals(strongEffect))
+	private void assertEventFired(EntityPotionEffectEvent.Action expectedAction, PotionEffect expectedOld,
+								  PotionEffect expectedNew, EntityPotionEffectEvent.Cause expectedCause) {
+		var event = server.getPluginManager().getFiredEvents()
+				.filter(e -> e instanceof EntityPotionEffectEvent)
+				.map(e -> (EntityPotionEffectEvent) e)
+				.filter(e -> e.getAction() == expectedAction &&
+						e.getCause() == expectedCause &&
+						effectsMatch(e.getOldEffect(), expectedOld) &&
+						effectsMatch(e.getNewEffect(), expectedNew))
 				.findFirst();
-		assertTrue(firedEvents.isPresent(), "Should fire CHANGED event when stronger effect overrides weaker");
+		assertTrue(event.isPresent(), String.format("Expected %s event with cause %s not found", expectedAction, expectedCause));
+	}
 
-		// Active effect should now be the stronger one
-		assertEquals(strongEffect, livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
+	private void assertEventNotFired(EntityPotionEffectEvent.Action action) {
+		var events = server.getPluginManager().getFiredEvents()
+				.filter(e -> e instanceof EntityPotionEffectEvent)
+				.map(e -> (EntityPotionEffectEvent) e)
+				.filter(e -> e.getAction() == action)
+				.toList();
+
+		// For CHANGED events, we need to be more specific - no change should mean
+		// the old and new effects have the same amplifier and type
+		if (action == EntityPotionEffectEvent.Action.CHANGED) {
+			var invalidChanges = events.stream()
+					.filter(e -> e.getOldEffect() != null && e.getNewEffect() != null)
+					.filter(e -> e.getOldEffect().getType() == e.getNewEffect().getType() &&
+							e.getOldEffect().getAmplifier() == e.getNewEffect().getAmplifier())
+					.toList();
+			assertTrue(invalidChanges.isEmpty(),
+					String.format("CHANGED event fired but effects have same amplifier/type: %s", invalidChanges));
+		} else {
+			assertTrue(events.isEmpty(), String.format("%s event should not have been fired", action));
+		}
+	}
+
+	private boolean effectsMatch(PotionEffect actual, PotionEffect expected) {
+		if (actual == null && expected == null) return true;
+		if (actual == null || expected == null) return false;
+		return actual.getType() == expected.getType() &&
+				actual.getAmplifier() == expected.getAmplifier();
+	}
+
+	private void assertEffectActive(PotionEffect expected) {
+		PotionEffect actual = livingEntity.getPotionEffect(expected.getType());
+		assertNotNull(actual);
+		assertEquals(expected.getAmplifier(), actual.getAmplifier());
 	}
 
 	@Test
-	void testWeakerEffectDoesNotOverrideStronger()
-	{
-		PotionEffect strongEffect = new PotionEffect(PotionEffectType.REGENERATION, 50, 3);
-		PotionEffect weakEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
-
-		// Add strong effect first
-		livingEntity.addPotionEffect(strongEffect, EntityPotionEffectEvent.Cause.PLUGIN);
-		assertEquals(strongEffect, livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
-
-		// Add weaker effect - should not change active effect
+	void testPotionEffectAddedForFirstTime() {
 		EntityPotionEffectEvent event = livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 
-		// Should fire CHANGED event for adding (but active effect doesn't change)
+		assertEntityPotionEffectEvent(event, null, weakEffect, EntityPotionEffectEvent.Cause.PLUGIN, EntityPotionEffectEvent.Action.ADDED, false);
+		assertEffectActive(weakEffect);
+	}
+
+	@Test
+	void testStrongerEffectOverridesWeaker() {
+		// Add weak effect first
+		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		assertEffectActive(weakEffect);
+
+		// Add stronger effect
+		EntityPotionEffectEvent event = livingEntity.addPotionEffect(strongEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+
+		assertEntityPotionEffectEvent(event, weakEffect, strongEffect, EntityPotionEffectEvent.Cause.PLUGIN, EntityPotionEffectEvent.Action.CHANGED, true);
+		assertEffectActive(strongEffect);
+	}
+
+	@Test
+	void testWeakerEffectDoesNotOverrideStronger() {
+		// Add strong effect first
+		livingEntity.addPotionEffect(strongEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		assertEffectActive(strongEffect);
+
+		// Add weaker effect
+		EntityPotionEffectEvent event = livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+
 		assertEntityPotionEffectEvent(event, strongEffect, weakEffect, EntityPotionEffectEvent.Cause.PLUGIN, EntityPotionEffectEvent.Action.CHANGED, true);
-
-		// Active effect should still be the stronger one
-		assertEquals(strongEffect, livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
+		assertEffectActive(strongEffect); // Should still be the strong effect
 	}
 
 	@Test
-	void testSameAmplifierHigherDurationWins()
-	{
-		PotionEffect shortEffect = new PotionEffect(PotionEffectType.REGENERATION, 50, 2);
-		PotionEffect longEffect = new PotionEffect(PotionEffectType.REGENERATION, 200, 2);
+	void testSameAmplifierHigherDurationWins() {
+		PotionEffect shortDuration = new PotionEffect(PotionEffectType.REGENERATION, 50, 2);
+		PotionEffect longDuration = new PotionEffect(PotionEffectType.REGENERATION, 200, 2);
 
-		livingEntity.addPotionEffect(shortEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.addPotionEffect(shortDuration, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.addPotionEffect(longDuration, EntityPotionEffectEvent.Cause.PLUGIN);
+
+		assertEffectActive(longDuration);
+		assertEventFired(EntityPotionEffectEvent.Action.CHANGED, shortDuration, longDuration, EntityPotionEffectEvent.Cause.PLUGIN);
+	}
+
+	@Test
+	void testStrongestEffectExpirationRevealsShadowed() {
+		// Add both effects
 		livingEntity.addPotionEffect(longEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.addPotionEffect(shortEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 
-		// Should change to the longer duration effect
-		assertEquals(longEffect, livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
+		assertEffectActive(shortEffect); // Strong but short should be active
 
-		// Should fire event for active effect change
-		var firedEvents = server.getPluginManager().getFiredEvents()
-				.filter(event -> event instanceof EntityPotionEffectEvent)
-				.map(event -> (EntityPotionEffectEvent) event)
-				.filter(event -> event.getAction() == EntityPotionEffectEvent.Action.CHANGED &&
-						event.getOldEffect().equals(shortEffect) &&
-						event.getNewEffect().equals(longEffect))
-				.findFirst();
-		assertTrue(firedEvents.isPresent(), "Should fire CHANGED event when longer duration wins");
+		// Tick until strong effect expires
+		server.getScheduler().performTicks(2);
+
+		assertEventFired(EntityPotionEffectEvent.Action.REMOVED, shortEffect, null, EntityPotionEffectEvent.Cause.EXPIRATION);
+		assertEventFired(EntityPotionEffectEvent.Action.CHANGED, shortEffect, longEffect, EntityPotionEffectEvent.Cause.EXPIRATION);
+		assertEffectActive(longEffect); // Weak effect should now be active
 	}
 
 	@Test
-	void testRemoveStrongestEffectRevealsShadowed()
-	{
-		PotionEffect strongEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 3);
-		PotionEffect weakEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
+	void testNonStrongestEffectExpirationNoChange() {
+		PotionEffect strongLong = new PotionEffect(PotionEffectType.REGENERATION, 100, 3);
+		PotionEffect weakShort = new PotionEffect(PotionEffectType.REGENERATION, 2, 1);
 
+		livingEntity.addPotionEffect(strongLong, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.addPotionEffect(weakShort, EntityPotionEffectEvent.Cause.PLUGIN);
+
+		assertEffectActive(strongLong);
+
+		// Tick until weak effect expires
+		server.getScheduler().performTicks(2);
+
+		assertEventFired(EntityPotionEffectEvent.Action.REMOVED, weakShort, null, EntityPotionEffectEvent.Cause.EXPIRATION);
+		assertEventNotFired(EntityPotionEffectEvent.Action.CHANGED); // No change to active effect
+		assertEffectActive(strongLong); // Strong effect still active (but duration reduced)
+	}
+
+	@Test
+	void testRemoveStrongestEffectRevealsShadowed() {
 		livingEntity.addPotionEffect(strongEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 
-		assertEquals(strongEffect, livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
+		assertEffectActive(strongEffect);
 
-		// Remove the strongest effect
+		// Remove the strongest effect (only removes top of queue)
 		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
 
-		// Should fire removal event
-		var removalEvents = server.getPluginManager().getFiredEvents()
-				.filter(event -> event instanceof EntityPotionEffectEvent)
-				.map(event -> (EntityPotionEffectEvent) event)
-				.filter(event -> event.getAction() == EntityPotionEffectEvent.Action.REMOVED &&
-						event.getOldEffect().equals(strongEffect) &&
-						event.getNewEffect() == null &&
-						event.getCause() == EntityPotionEffectEvent.Cause.PLUGIN)
-				.findFirst();
-		assertTrue(removalEvents.isPresent(), "Should fire REMOVED event");
-
-		// Should fire change event for weak effect becoming active
-		var changeEvents = server.getPluginManager().getFiredEvents()
-				.filter(event -> event instanceof EntityPotionEffectEvent)
-				.map(event -> (EntityPotionEffectEvent) event)
-				.filter(event -> event.getAction() == EntityPotionEffectEvent.Action.CHANGED &&
-						event.getOldEffect().equals(strongEffect) &&
-						event.getNewEffect().equals(weakEffect) &&
-						event.getCause() == EntityPotionEffectEvent.Cause.PLUGIN)
-				.findFirst();
-		assertTrue(changeEvents.isPresent(), "Should fire CHANGED event for weak effect becoming active");
-
-		assertEquals(weakEffect, livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
+		assertEventFired(EntityPotionEffectEvent.Action.REMOVED, strongEffect, null, EntityPotionEffectEvent.Cause.PLUGIN);
+		assertEventFired(EntityPotionEffectEvent.Action.CHANGED, strongEffect, weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		assertEffectActive(weakEffect);
 	}
 
 	@Test
-	void testClearAllEffectsFiresEventsForAll()
-	{
+	void testRemoveNonStrongestEffectNoChange() {
+		// This test shows that removePotionEffect removes the TOP effect, not a specific one
+		livingEntity.addPotionEffect(strongEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+
+		assertEffectActive(strongEffect); // Strong effect should be active
+
+		// Remove effect - will remove the strongest (top of queue)
+		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
+
+		assertEventFired(EntityPotionEffectEvent.Action.REMOVED, strongEffect, null, EntityPotionEffectEvent.Cause.PLUGIN);
+		assertEventFired(EntityPotionEffectEvent.Action.CHANGED, strongEffect, weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		assertEffectActive(weakEffect); // Weak effect becomes active
+	}
+
+	@Test
+	void testClearAllEffectsFiresEventsForAll() {
 		PotionEffect regen = new PotionEffect(PotionEffectType.REGENERATION, 100, 2);
 		PotionEffect speed = new PotionEffect(PotionEffectType.SPEED, 100, 1);
 
@@ -145,53 +212,156 @@ class PotionEffectPriorityQueueTests
 		boolean result = livingEntity.clearActivePotionEffects();
 
 		assertTrue(result);
-
-		// Should fire CLEARED events for both effects
-		var regenEvents = server.getPluginManager().getFiredEvents()
-				.filter(event -> event instanceof EntityPotionEffectEvent)
-				.map(event -> (EntityPotionEffectEvent) event)
-				.filter(event -> event.getAction() == EntityPotionEffectEvent.Action.CLEARED &&
-						event.getOldEffect().equals(regen) &&
-						event.getNewEffect() == null &&
-						event.getCause() == EntityPotionEffectEvent.Cause.PLUGIN)
-				.findFirst();
-		assertTrue(regenEvents.isPresent(), "Should fire CLEARED event for regen effect");
-
-		var speedEvents = server.getPluginManager().getFiredEvents()
-				.filter(event -> event instanceof EntityPotionEffectEvent)
-				.map(event -> (EntityPotionEffectEvent) event)
-				.filter(event -> event.getAction() == EntityPotionEffectEvent.Action.CLEARED &&
-						event.getOldEffect().equals(speed) &&
-						event.getNewEffect() == null &&
-						event.getCause() == EntityPotionEffectEvent.Cause.PLUGIN)
-				.findFirst();
-		assertTrue(speedEvents.isPresent(), "Should fire CLEARED event for speed effect");
+		assertEventFired(EntityPotionEffectEvent.Action.CLEARED, regen, null, EntityPotionEffectEvent.Cause.PLUGIN);
+		assertEventFired(EntityPotionEffectEvent.Action.CLEARED, speed, null, EntityPotionEffectEvent.Cause.PLUGIN);
 
 		assertFalse(livingEntity.hasPotionEffect(PotionEffectType.REGENERATION));
 		assertFalse(livingEntity.hasPotionEffect(PotionEffectType.SPEED));
 	}
 
 	@Test
-	void testGetActivePotionEffectsOnlyReturnsStrongest()
-	{
-		PotionEffect strongRegen = new PotionEffect(PotionEffectType.REGENERATION, 100, 3);
-		PotionEffect weakRegen = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
+	void testGetActivePotionEffectsOnlyReturnsStrongest() {
+		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.addPotionEffect(strongEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 		PotionEffect speed = new PotionEffect(PotionEffectType.SPEED, 100, 1);
-
-		livingEntity.addPotionEffect(weakRegen, EntityPotionEffectEvent.Cause.PLUGIN);
-		livingEntity.addPotionEffect(strongRegen, EntityPotionEffectEvent.Cause.PLUGIN);
 		livingEntity.addPotionEffect(speed, EntityPotionEffectEvent.Cause.PLUGIN);
 
 		var activeEffects = livingEntity.getActivePotionEffects();
 		assertEquals(2, activeEffects.size()); // Only strongest regen + speed
-		assertTrue(activeEffects.contains(strongRegen));
-		assertTrue(activeEffects.contains(speed));
-		assertFalse(activeEffects.contains(weakRegen));
+		assertTrue(activeEffects.stream().anyMatch(e -> e.getAmplifier() == 3 && e.getType() == PotionEffectType.REGENERATION));
+		assertTrue(activeEffects.stream().anyMatch(e -> e.getType() == PotionEffectType.SPEED));
+		assertFalse(activeEffects.stream().anyMatch(e -> e.getAmplifier() == 1 && e.getType() == PotionEffectType.REGENERATION));
 	}
 
 	@Test
-	void testMultipleEffectsSameAmplifierDifferentDuration()
-	{
+	void testAddPotionEffectCancelled() {
+		// Register event listener that cancels all potion effect events
+		server.getPluginManager().registerEvent(EntityPotionEffectEvent.class,
+				new org.bukkit.event.Listener() {},
+				org.bukkit.event.EventPriority.NORMAL,
+				(listener, event) -> {
+					if (event instanceof EntityPotionEffectEvent) {
+						((EntityPotionEffectEvent) event).setCancelled(true);
+					}
+				},
+				plugin, false);
+
+		EntityPotionEffectEvent event = livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+
+		assertTrue(event.isCancelled());
+		assertFalse(livingEntity.hasPotionEffect(PotionEffectType.REGENERATION));
+		assertNull(livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
+	}
+
+	@Test
+	void testHasPotionEffectNullQueue() {
+		assertFalse(livingEntity.hasPotionEffect(PotionEffectType.REGENERATION));
+	}
+
+	@Test
+	void testHasPotionEffectEmptyQueue() {
+		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
+
+		assertFalse(livingEntity.hasPotionEffect(PotionEffectType.REGENERATION));
+	}
+
+	@Test
+	void testGetPotionEffectNullQueue() {
+		assertNull(livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
+	}
+
+	@Test
+	void testGetPotionEffectEmptyQueue() {
+		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
+
+		assertNull(livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
+	}
+
+	@Test
+	void testRemoveExpiredEffectsEmptyQueue() {
+		PotionEffect shortEffect = new PotionEffect(PotionEffectType.REGENERATION, 1, 2);
+		livingEntity.addPotionEffect(shortEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+
+		server.getScheduler().performTicks(1);
+
+		assertEventFired(EntityPotionEffectEvent.Action.REMOVED, shortEffect, null, EntityPotionEffectEvent.Cause.EXPIRATION);
+		assertFalse(livingEntity.hasPotionEffect(PotionEffectType.REGENERATION));
+		assertNull(livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
+	}
+
+	@Test
+	void testRemovePotionEffectNullQueue() {
+		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
+
+		// Should not fire any events
+		var eventCount = server.getPluginManager().getFiredEvents()
+				.filter(e -> e instanceof EntityPotionEffectEvent)
+				.count();
+		assertEquals(0, eventCount);
+	}
+
+	@Test
+	void testRemovePotionEffectEmptyQueue() {
+		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
+
+		// Try to remove again - should not fire new events
+		long eventCountBefore = server.getPluginManager().getFiredEvents()
+				.filter(e -> e instanceof EntityPotionEffectEvent)
+				.count();
+
+		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
+
+		long eventCountAfter = server.getPluginManager().getFiredEvents()
+				.filter(e -> e instanceof EntityPotionEffectEvent)
+				.count();
+
+		assertEquals(eventCountBefore, eventCountAfter); // No new events
+	}
+
+	@Test
+	void testRemoveSameStrengthEffectWithChange() {
+		// Add two effects where removal causes a change (different durations)
+		PotionEffect effect1 = new PotionEffect(PotionEffectType.REGENERATION, 50, 2);
+		PotionEffect effect2 = new PotionEffect(PotionEffectType.REGENERATION, 100, 2);
+
+		livingEntity.addPotionEffect(effect1, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.addPotionEffect(effect2, EntityPotionEffectEvent.Cause.PLUGIN); // Longer duration wins
+
+		assertEffectActive(effect2);
+
+		// Remove top effect
+		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
+
+		assertEventFired(EntityPotionEffectEvent.Action.REMOVED, effect2, null, EntityPotionEffectEvent.Cause.PLUGIN);
+		assertEventFired(EntityPotionEffectEvent.Action.CHANGED, effect2, effect1, EntityPotionEffectEvent.Cause.PLUGIN);
+		assertEffectActive(effect1);
+	}
+
+	@Test
+	void testGetActivePotionEffectsWithEmptyQueues() {
+		PotionEffect regen = new PotionEffect(PotionEffectType.REGENERATION, 100, 2);
+		PotionEffect speed = new PotionEffect(PotionEffectType.SPEED, 100, 1);
+
+		livingEntity.addPotionEffect(regen, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.addPotionEffect(speed, EntityPotionEffectEvent.Cause.PLUGIN);
+
+		assertEquals(2, livingEntity.getActivePotionEffects().size());
+
+		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
+
+		var activeEffects = livingEntity.getActivePotionEffects();
+		assertEquals(1, activeEffects.size());
+		assertTrue(activeEffects.stream().anyMatch(effect -> effect.getType() == PotionEffectType.SPEED));
+
+		livingEntity.removePotionEffect(PotionEffectType.SPEED);
+		assertEquals(0, livingEntity.getActivePotionEffects().size());
+	}
+
+	@Test
+	void testMultipleEffectsSameAmplifierDifferentDuration() {
 		PotionEffect effect1 = new PotionEffect(PotionEffectType.REGENERATION, 50, 2);
 		PotionEffect effect2 = new PotionEffect(PotionEffectType.REGENERATION, 100, 2);
 		PotionEffect effect3 = new PotionEffect(PotionEffectType.REGENERATION, 75, 2);
@@ -200,130 +370,18 @@ class PotionEffectPriorityQueueTests
 		livingEntity.addPotionEffect(effect2, EntityPotionEffectEvent.Cause.PLUGIN); // Longest should win
 		livingEntity.addPotionEffect(effect3, EntityPotionEffectEvent.Cause.PLUGIN);
 
-		assertEquals(effect2, livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
+		// effect2 should be active (longest duration)
+		PotionEffect active = livingEntity.getPotionEffect(PotionEffectType.REGENERATION);
+		assertEquals(100, active.getDuration());
+		assertEquals(2, active.getAmplifier());
 	}
 
 	private static void assertEntityPotionEffectEvent(EntityPotionEffectEvent event, PotionEffect oldEffect,
-													  PotionEffect newEffect, EntityPotionEffectEvent.Cause cause, EntityPotionEffectEvent.Action action, boolean override)
-	{
+													  PotionEffect newEffect, EntityPotionEffectEvent.Cause cause, EntityPotionEffectEvent.Action action, boolean override) {
 		assertEquals(oldEffect, event.getOldEffect());
 		assertEquals(newEffect, event.getNewEffect());
 		assertEquals(cause, event.getCause());
 		assertEquals(action, event.getAction());
 		assertEquals(override, event.isOverride());
 	}
-
-	@Test
-	void testNonStrongestEffectExpirationNoChange()
-	{
-		PotionEffect strongLong = new PotionEffect(PotionEffectType.REGENERATION, 100, 3);
-		PotionEffect weakShort = new PotionEffect(PotionEffectType.REGENERATION, 2, 1);
-
-		livingEntity.addPotionEffect(strongLong, EntityPotionEffectEvent.Cause.PLUGIN);
-		livingEntity.addPotionEffect(weakShort, EntityPotionEffectEvent.Cause.PLUGIN);
-
-		PotionEffect originalStrong = livingEntity.getPotionEffect(PotionEffectType.REGENERATION);
-		assertEquals(strongLong.getAmplifier(), originalStrong.getAmplifier());
-
-		// Tick until weak effect expires
-		server.getScheduler().performTicks(2);
-
-		// Should fire removal event for expired weak effect
-		var removalEvents = server.getPluginManager().getFiredEvents()
-				.filter(event -> event instanceof EntityPotionEffectEvent)
-				.map(event -> (EntityPotionEffectEvent) event)
-				.filter(event -> event.getAction() == EntityPotionEffectEvent.Action.REMOVED &&
-						event.getOldEffect().equals(weakShort) &&
-						event.getNewEffect() == null &&
-						event.getCause() == EntityPotionEffectEvent.Cause.EXPIRATION)
-				.findFirst();
-		assertTrue(removalEvents.isPresent(), "Should fire REMOVED event for expired weak effect");
-
-		// Strong effect should still be active (check amplifier, duration will be reduced)
-		PotionEffect currentEffect = livingEntity.getPotionEffect(PotionEffectType.REGENERATION);
-		assertEquals(strongLong.getAmplifier(), currentEffect.getAmplifier());
-		assertEquals(98, currentEffect.getDuration()); // Duration reduced by 2 ticks
-	}
-
-	@Test
-	void testStrongestEffectExpirationRevealsShadowed()
-	{
-		PotionEffect strongShort = new PotionEffect(PotionEffectType.REGENERATION, 2, 3); // Strong but short
-		PotionEffect weakLong = new PotionEffect(PotionEffectType.REGENERATION, 100, 1); // Weak but long
-
-		// Add both effects
-		livingEntity.addPotionEffect(weakLong, EntityPotionEffectEvent.Cause.PLUGIN);
-		livingEntity.addPotionEffect(strongShort, EntityPotionEffectEvent.Cause.PLUGIN);
-
-		assertEquals(strongShort.getAmplifier(), livingEntity.getPotionEffect(PotionEffectType.REGENERATION).getAmplifier());
-
-		// Tick until strong effect expires
-		server.getScheduler().performTicks(2);
-
-		// Should fire removal event for expired effect (duration will be 0)
-		var removalEvents = server.getPluginManager().getFiredEvents()
-				.filter(event -> event instanceof EntityPotionEffectEvent)
-				.map(event -> (EntityPotionEffectEvent) event)
-				.filter(event -> event.getAction() == EntityPotionEffectEvent.Action.REMOVED &&
-						event.getOldEffect().getAmplifier() == 3 && // Check amplifier instead of exact effect
-						event.getOldEffect().getType() == PotionEffectType.REGENERATION &&
-						event.getNewEffect() == null &&
-						event.getCause() == EntityPotionEffectEvent.Cause.EXPIRATION)
-				.findFirst();
-		assertTrue(removalEvents.isPresent(), "Should fire REMOVED event for expired effect");
-
-		// Should fire change event for weak effect becoming active
-		var changeEvents = server.getPluginManager().getFiredEvents()
-				.filter(event -> event instanceof EntityPotionEffectEvent)
-				.map(event -> (EntityPotionEffectEvent) event)
-				.filter(event -> event.getAction() == EntityPotionEffectEvent.Action.CHANGED &&
-						event.getOldEffect().getAmplifier() == 3 &&
-						event.getNewEffect().getAmplifier() == 1 &&
-						event.getCause() == EntityPotionEffectEvent.Cause.EXPIRATION)
-				.findFirst();
-		assertTrue(changeEvents.isPresent(), "Should fire CHANGED event when weaker effect becomes active");
-
-		// Weak effect should now be active
-		assertEquals(weakLong.getAmplifier(), livingEntity.getPotionEffect(PotionEffectType.REGENERATION).getAmplifier());
-	}
-
-	@Test
-	void testRemoveNonStrongestEffectNoChange()
-	{
-		PotionEffect strongEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 3);
-		PotionEffect weakEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
-
-		livingEntity.addPotionEffect(strongEffect, EntityPotionEffectEvent.Cause.PLUGIN);
-		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
-
-		assertEquals(strongEffect.getAmplifier(), livingEntity.getPotionEffect(PotionEffectType.REGENERATION).getAmplifier());
-
-		// Remove effect (will remove strongest since we only remove top of queue)
-		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
-
-		// Should fire removal event for strong effect
-		var removalEvents = server.getPluginManager().getFiredEvents()
-				.filter(event -> event instanceof EntityPotionEffectEvent)
-				.map(event -> (EntityPotionEffectEvent) event)
-				.filter(event -> event.getAction() == EntityPotionEffectEvent.Action.REMOVED &&
-						event.getOldEffect().getAmplifier() == 3 &&
-						event.getCause() == EntityPotionEffectEvent.Cause.PLUGIN)
-				.findFirst();
-		assertTrue(removalEvents.isPresent(), "Should fire REMOVED event for removed effect");
-
-		// Should fire change event for weak effect becoming active
-		var changeEvents = server.getPluginManager().getFiredEvents()
-				.filter(event -> event instanceof EntityPotionEffectEvent)
-				.map(event -> (EntityPotionEffectEvent) event)
-				.filter(event -> event.getAction() == EntityPotionEffectEvent.Action.CHANGED &&
-						event.getOldEffect().getAmplifier() == 3 &&
-						event.getNewEffect().getAmplifier() == 1 &&
-						event.getCause() == EntityPotionEffectEvent.Cause.PLUGIN)
-				.findFirst();
-		assertTrue(changeEvents.isPresent(), "Should fire CHANGED event for weak effect becoming active");
-
-		// Weak effect should now be active
-		assertEquals(weakEffect.getAmplifier(), livingEntity.getPotionEffect(PotionEffectType.REGENERATION).getAmplifier());
-	}
-
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/potion/PotionEffectPriorityQueueTests.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/potion/PotionEffectPriorityQueueTests.java
@@ -32,10 +32,10 @@ class PotionEffectPriorityQueueTests
 	private PluginMock plugin;
 
 	// Standard test effects
-	final private PotionEffect weakEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
-	final private PotionEffect strongEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 3);
-	final private PotionEffect shortEffect = new PotionEffect(PotionEffectType.REGENERATION, 2, 3);
-	final private PotionEffect longEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
+	private final PotionEffect weakEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
+	private final PotionEffect strongEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 3);
+	private final PotionEffect shortEffect = new PotionEffect(PotionEffectType.REGENERATION, 2, 3);
+	private final PotionEffect longEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
 
 	@BeforeEach
 	void setUp()
@@ -94,7 +94,7 @@ class PotionEffectPriorityQueueTests
 				actual.getAmplifier() == expected.getAmplifier();
 	}
 
-	private void assertEffectActive(PotionEffect expected)
+	private void assertEffectActive(@NotNull PotionEffect expected)
 	{
 		PotionEffect actual = livingEntity.getPotionEffect(expected.getType());
 		assertNotNull(actual);
@@ -414,7 +414,7 @@ class PotionEffectPriorityQueueTests
 		assertEquals(2, active.getAmplifier());
 	}
 
-	private static void assertEntityPotionEffectEvent(EntityPotionEffectEvent event, PotionEffect oldEffect,
+	private static void assertEntityPotionEffectEvent(@NotNull EntityPotionEffectEvent event, PotionEffect oldEffect,
 													  PotionEffect newEffect, EntityPotionEffectEvent.Cause cause, EntityPotionEffectEvent.Action action, boolean override)
 	{
 		assertEquals(oldEffect, event.getOldEffect());
@@ -425,15 +425,17 @@ class PotionEffectPriorityQueueTests
 	}
 
 	@Test
-	public void testGetPotionEffect_NullEffect()
+	void testGetPotionEffect_NullEffect()
 	{
 		assertThrows(NullPointerException.class, () -> livingEntity.getPotionEffect(null));
 	}
 
 	@Test
-	public void testRemovePotionEffect_AlreadyEmpty()
+	void testRemovePotionEffect_AlreadyEmpty()
 	{
 		livingEntity.removePotionEffect(PotionEffectType.STRENGTH);
+		assertEventNotFired(EntityPotionEffectEvent.Action.CHANGED);
+		assertEventNotFired(EntityPotionEffectEvent.Action.REMOVED);
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/potion/PotionEffectPriorityQueueTests.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/potion/PotionEffectPriorityQueueTests.java
@@ -1,0 +1,329 @@
+package org.mockbukkit.mockbukkit.potion;
+
+import org.bukkit.event.entity.EntityPotionEffectEvent;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+import org.mockbukkit.mockbukkit.MockBukkitInject;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockBukkitExtension.class)
+class PotionEffectPriorityQueueTests
+{
+
+	@MockBukkitInject
+	private ServerMock server;
+	@MockBukkitInject
+	private PlayerMock livingEntity;
+
+	@Test
+	void testStrongerEffectOverridesWeaker()
+	{
+		PotionEffect weakEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
+		PotionEffect strongEffect = new PotionEffect(PotionEffectType.REGENERATION, 50, 3);
+
+		// Add weak effect first
+		EntityPotionEffectEvent event1 = livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		assertEntityPotionEffectEvent(event1, null, weakEffect, EntityPotionEffectEvent.Cause.PLUGIN, EntityPotionEffectEvent.Action.ADDED, false);
+		assertEquals(weakEffect, livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
+
+		// Add stronger effect - should change active effect
+		EntityPotionEffectEvent event2 = livingEntity.addPotionEffect(strongEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+
+		// Should fire events for adding and changing active effect
+		var firedEvents = server.getPluginManager().getFiredEvents()
+				.filter(event -> event instanceof EntityPotionEffectEvent)
+				.map(event -> (EntityPotionEffectEvent) event)
+				.filter(event -> event.getAction() == EntityPotionEffectEvent.Action.CHANGED &&
+						event.getOldEffect().equals(weakEffect) &&
+						event.getNewEffect().equals(strongEffect))
+				.findFirst();
+		assertTrue(firedEvents.isPresent(), "Should fire CHANGED event when stronger effect overrides weaker");
+
+		// Active effect should now be the stronger one
+		assertEquals(strongEffect, livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
+	}
+
+	@Test
+	void testWeakerEffectDoesNotOverrideStronger()
+	{
+		PotionEffect strongEffect = new PotionEffect(PotionEffectType.REGENERATION, 50, 3);
+		PotionEffect weakEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
+
+		// Add strong effect first
+		livingEntity.addPotionEffect(strongEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		assertEquals(strongEffect, livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
+
+		// Add weaker effect - should not change active effect
+		EntityPotionEffectEvent event = livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+
+		// Should fire CHANGED event for adding (but active effect doesn't change)
+		assertEntityPotionEffectEvent(event, strongEffect, weakEffect, EntityPotionEffectEvent.Cause.PLUGIN, EntityPotionEffectEvent.Action.CHANGED, true);
+
+		// Active effect should still be the stronger one
+		assertEquals(strongEffect, livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
+	}
+
+	@Test
+	void testSameAmplifierHigherDurationWins()
+	{
+		PotionEffect shortEffect = new PotionEffect(PotionEffectType.REGENERATION, 50, 2);
+		PotionEffect longEffect = new PotionEffect(PotionEffectType.REGENERATION, 200, 2);
+
+		livingEntity.addPotionEffect(shortEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.addPotionEffect(longEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+
+		// Should change to the longer duration effect
+		assertEquals(longEffect, livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
+
+		// Should fire event for active effect change
+		var firedEvents = server.getPluginManager().getFiredEvents()
+				.filter(event -> event instanceof EntityPotionEffectEvent)
+				.map(event -> (EntityPotionEffectEvent) event)
+				.filter(event -> event.getAction() == EntityPotionEffectEvent.Action.CHANGED &&
+						event.getOldEffect().equals(shortEffect) &&
+						event.getNewEffect().equals(longEffect))
+				.findFirst();
+		assertTrue(firedEvents.isPresent(), "Should fire CHANGED event when longer duration wins");
+	}
+
+	@Test
+	void testRemoveStrongestEffectRevealsShadowed()
+	{
+		PotionEffect strongEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 3);
+		PotionEffect weakEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
+
+		livingEntity.addPotionEffect(strongEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+
+		assertEquals(strongEffect, livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
+
+		// Remove the strongest effect
+		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
+
+		// Should fire removal event
+		var removalEvents = server.getPluginManager().getFiredEvents()
+				.filter(event -> event instanceof EntityPotionEffectEvent)
+				.map(event -> (EntityPotionEffectEvent) event)
+				.filter(event -> event.getAction() == EntityPotionEffectEvent.Action.REMOVED &&
+						event.getOldEffect().equals(strongEffect) &&
+						event.getNewEffect() == null &&
+						event.getCause() == EntityPotionEffectEvent.Cause.PLUGIN)
+				.findFirst();
+		assertTrue(removalEvents.isPresent(), "Should fire REMOVED event");
+
+		// Should fire change event for weak effect becoming active
+		var changeEvents = server.getPluginManager().getFiredEvents()
+				.filter(event -> event instanceof EntityPotionEffectEvent)
+				.map(event -> (EntityPotionEffectEvent) event)
+				.filter(event -> event.getAction() == EntityPotionEffectEvent.Action.CHANGED &&
+						event.getOldEffect().equals(strongEffect) &&
+						event.getNewEffect().equals(weakEffect) &&
+						event.getCause() == EntityPotionEffectEvent.Cause.PLUGIN)
+				.findFirst();
+		assertTrue(changeEvents.isPresent(), "Should fire CHANGED event for weak effect becoming active");
+
+		assertEquals(weakEffect, livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
+	}
+
+	@Test
+	void testClearAllEffectsFiresEventsForAll()
+	{
+		PotionEffect regen = new PotionEffect(PotionEffectType.REGENERATION, 100, 2);
+		PotionEffect speed = new PotionEffect(PotionEffectType.SPEED, 100, 1);
+
+		livingEntity.addPotionEffect(regen, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.addPotionEffect(speed, EntityPotionEffectEvent.Cause.PLUGIN);
+
+		boolean result = livingEntity.clearActivePotionEffects();
+
+		assertTrue(result);
+
+		// Should fire CLEARED events for both effects
+		var regenEvents = server.getPluginManager().getFiredEvents()
+				.filter(event -> event instanceof EntityPotionEffectEvent)
+				.map(event -> (EntityPotionEffectEvent) event)
+				.filter(event -> event.getAction() == EntityPotionEffectEvent.Action.CLEARED &&
+						event.getOldEffect().equals(regen) &&
+						event.getNewEffect() == null &&
+						event.getCause() == EntityPotionEffectEvent.Cause.PLUGIN)
+				.findFirst();
+		assertTrue(regenEvents.isPresent(), "Should fire CLEARED event for regen effect");
+
+		var speedEvents = server.getPluginManager().getFiredEvents()
+				.filter(event -> event instanceof EntityPotionEffectEvent)
+				.map(event -> (EntityPotionEffectEvent) event)
+				.filter(event -> event.getAction() == EntityPotionEffectEvent.Action.CLEARED &&
+						event.getOldEffect().equals(speed) &&
+						event.getNewEffect() == null &&
+						event.getCause() == EntityPotionEffectEvent.Cause.PLUGIN)
+				.findFirst();
+		assertTrue(speedEvents.isPresent(), "Should fire CLEARED event for speed effect");
+
+		assertFalse(livingEntity.hasPotionEffect(PotionEffectType.REGENERATION));
+		assertFalse(livingEntity.hasPotionEffect(PotionEffectType.SPEED));
+	}
+
+	@Test
+	void testGetActivePotionEffectsOnlyReturnsStrongest()
+	{
+		PotionEffect strongRegen = new PotionEffect(PotionEffectType.REGENERATION, 100, 3);
+		PotionEffect weakRegen = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
+		PotionEffect speed = new PotionEffect(PotionEffectType.SPEED, 100, 1);
+
+		livingEntity.addPotionEffect(weakRegen, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.addPotionEffect(strongRegen, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.addPotionEffect(speed, EntityPotionEffectEvent.Cause.PLUGIN);
+
+		var activeEffects = livingEntity.getActivePotionEffects();
+		assertEquals(2, activeEffects.size()); // Only strongest regen + speed
+		assertTrue(activeEffects.contains(strongRegen));
+		assertTrue(activeEffects.contains(speed));
+		assertFalse(activeEffects.contains(weakRegen));
+	}
+
+	@Test
+	void testMultipleEffectsSameAmplifierDifferentDuration()
+	{
+		PotionEffect effect1 = new PotionEffect(PotionEffectType.REGENERATION, 50, 2);
+		PotionEffect effect2 = new PotionEffect(PotionEffectType.REGENERATION, 100, 2);
+		PotionEffect effect3 = new PotionEffect(PotionEffectType.REGENERATION, 75, 2);
+
+		livingEntity.addPotionEffect(effect1, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.addPotionEffect(effect2, EntityPotionEffectEvent.Cause.PLUGIN); // Longest should win
+		livingEntity.addPotionEffect(effect3, EntityPotionEffectEvent.Cause.PLUGIN);
+
+		assertEquals(effect2, livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
+	}
+
+	private static void assertEntityPotionEffectEvent(EntityPotionEffectEvent event, PotionEffect oldEffect,
+													  PotionEffect newEffect, EntityPotionEffectEvent.Cause cause, EntityPotionEffectEvent.Action action, boolean override)
+	{
+		assertEquals(oldEffect, event.getOldEffect());
+		assertEquals(newEffect, event.getNewEffect());
+		assertEquals(cause, event.getCause());
+		assertEquals(action, event.getAction());
+		assertEquals(override, event.isOverride());
+	}
+
+	@Test
+	void testNonStrongestEffectExpirationNoChange()
+	{
+		PotionEffect strongLong = new PotionEffect(PotionEffectType.REGENERATION, 100, 3);
+		PotionEffect weakShort = new PotionEffect(PotionEffectType.REGENERATION, 2, 1);
+
+		livingEntity.addPotionEffect(strongLong, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.addPotionEffect(weakShort, EntityPotionEffectEvent.Cause.PLUGIN);
+
+		PotionEffect originalStrong = livingEntity.getPotionEffect(PotionEffectType.REGENERATION);
+		assertEquals(strongLong.getAmplifier(), originalStrong.getAmplifier());
+
+		// Tick until weak effect expires
+		server.getScheduler().performTicks(2);
+
+		// Should fire removal event for expired weak effect
+		var removalEvents = server.getPluginManager().getFiredEvents()
+				.filter(event -> event instanceof EntityPotionEffectEvent)
+				.map(event -> (EntityPotionEffectEvent) event)
+				.filter(event -> event.getAction() == EntityPotionEffectEvent.Action.REMOVED &&
+						event.getOldEffect().equals(weakShort) &&
+						event.getNewEffect() == null &&
+						event.getCause() == EntityPotionEffectEvent.Cause.EXPIRATION)
+				.findFirst();
+		assertTrue(removalEvents.isPresent(), "Should fire REMOVED event for expired weak effect");
+
+		// Strong effect should still be active (check amplifier, duration will be reduced)
+		PotionEffect currentEffect = livingEntity.getPotionEffect(PotionEffectType.REGENERATION);
+		assertEquals(strongLong.getAmplifier(), currentEffect.getAmplifier());
+		assertEquals(98, currentEffect.getDuration()); // Duration reduced by 2 ticks
+	}
+
+	@Test
+	void testStrongestEffectExpirationRevealsShadowed()
+	{
+		PotionEffect strongShort = new PotionEffect(PotionEffectType.REGENERATION, 2, 3); // Strong but short
+		PotionEffect weakLong = new PotionEffect(PotionEffectType.REGENERATION, 100, 1); // Weak but long
+
+		// Add both effects
+		livingEntity.addPotionEffect(weakLong, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.addPotionEffect(strongShort, EntityPotionEffectEvent.Cause.PLUGIN);
+
+		assertEquals(strongShort.getAmplifier(), livingEntity.getPotionEffect(PotionEffectType.REGENERATION).getAmplifier());
+
+		// Tick until strong effect expires
+		server.getScheduler().performTicks(2);
+
+		// Should fire removal event for expired effect (duration will be 0)
+		var removalEvents = server.getPluginManager().getFiredEvents()
+				.filter(event -> event instanceof EntityPotionEffectEvent)
+				.map(event -> (EntityPotionEffectEvent) event)
+				.filter(event -> event.getAction() == EntityPotionEffectEvent.Action.REMOVED &&
+						event.getOldEffect().getAmplifier() == 3 && // Check amplifier instead of exact effect
+						event.getOldEffect().getType() == PotionEffectType.REGENERATION &&
+						event.getNewEffect() == null &&
+						event.getCause() == EntityPotionEffectEvent.Cause.EXPIRATION)
+				.findFirst();
+		assertTrue(removalEvents.isPresent(), "Should fire REMOVED event for expired effect");
+
+		// Should fire change event for weak effect becoming active
+		var changeEvents = server.getPluginManager().getFiredEvents()
+				.filter(event -> event instanceof EntityPotionEffectEvent)
+				.map(event -> (EntityPotionEffectEvent) event)
+				.filter(event -> event.getAction() == EntityPotionEffectEvent.Action.CHANGED &&
+						event.getOldEffect().getAmplifier() == 3 &&
+						event.getNewEffect().getAmplifier() == 1 &&
+						event.getCause() == EntityPotionEffectEvent.Cause.EXPIRATION)
+				.findFirst();
+		assertTrue(changeEvents.isPresent(), "Should fire CHANGED event when weaker effect becomes active");
+
+		// Weak effect should now be active
+		assertEquals(weakLong.getAmplifier(), livingEntity.getPotionEffect(PotionEffectType.REGENERATION).getAmplifier());
+	}
+
+	@Test
+	void testRemoveNonStrongestEffectNoChange()
+	{
+		PotionEffect strongEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 3);
+		PotionEffect weakEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
+
+		livingEntity.addPotionEffect(strongEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+
+		assertEquals(strongEffect.getAmplifier(), livingEntity.getPotionEffect(PotionEffectType.REGENERATION).getAmplifier());
+
+		// Remove effect (will remove strongest since we only remove top of queue)
+		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
+
+		// Should fire removal event for strong effect
+		var removalEvents = server.getPluginManager().getFiredEvents()
+				.filter(event -> event instanceof EntityPotionEffectEvent)
+				.map(event -> (EntityPotionEffectEvent) event)
+				.filter(event -> event.getAction() == EntityPotionEffectEvent.Action.REMOVED &&
+						event.getOldEffect().getAmplifier() == 3 &&
+						event.getCause() == EntityPotionEffectEvent.Cause.PLUGIN)
+				.findFirst();
+		assertTrue(removalEvents.isPresent(), "Should fire REMOVED event for removed effect");
+
+		// Should fire change event for weak effect becoming active
+		var changeEvents = server.getPluginManager().getFiredEvents()
+				.filter(event -> event instanceof EntityPotionEffectEvent)
+				.map(event -> (EntityPotionEffectEvent) event)
+				.filter(event -> event.getAction() == EntityPotionEffectEvent.Action.CHANGED &&
+						event.getOldEffect().getAmplifier() == 3 &&
+						event.getNewEffect().getAmplifier() == 1 &&
+						event.getCause() == EntityPotionEffectEvent.Cause.PLUGIN)
+				.findFirst();
+		assertTrue(changeEvents.isPresent(), "Should fire CHANGED event for weak effect becoming active");
+
+		// Weak effect should now be active
+		assertEquals(weakEffect.getAmplifier(), livingEntity.getPotionEffect(PotionEffectType.REGENERATION).getAmplifier());
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/potion/PotionEffectPriorityQueueTests.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/potion/PotionEffectPriorityQueueTests.java
@@ -3,6 +3,7 @@ package org.mockbukkit.mockbukkit.potion;
 import org.bukkit.event.entity.EntityPotionEffectEvent;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockBukkitExtension.class)
@@ -30,18 +32,18 @@ class PotionEffectPriorityQueueTests
 	private PluginMock plugin;
 
 	// Standard test effects
-	private PotionEffect weakEffect;
-	private PotionEffect strongEffect;
-	private PotionEffect shortEffect;
-	private PotionEffect longEffect;
+	final private PotionEffect weakEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
+	final private PotionEffect strongEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 3);
+	final private PotionEffect shortEffect = new PotionEffect(PotionEffectType.REGENERATION, 2, 3);
+	final private PotionEffect longEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
 
 	@BeforeEach
 	void setUp()
 	{
-		weakEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
-		strongEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 3);
-		shortEffect = new PotionEffect(PotionEffectType.REGENERATION, 2, 3);
-		longEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
+		// Clear any events from previous tests (if any)
+		server.getPluginManager().getFiredEvents().forEach(e ->
+		{
+		}); // Consume all events
 	}
 
 	private void assertEventFired(EntityPotionEffectEvent.Action expectedAction, PotionEffect expectedOld,
@@ -97,6 +99,12 @@ class PotionEffectPriorityQueueTests
 		PotionEffect actual = livingEntity.getPotionEffect(expected.getType());
 		assertNotNull(actual);
 		assertEquals(expected.getAmplifier(), actual.getAmplifier());
+	}
+
+	private void assertEffectNotActive(@NotNull PotionEffect expected)
+	{
+		PotionEffect actual = livingEntity.getPotionEffect(expected.getType());
+		assertNull(actual);
 	}
 
 	@Test
@@ -193,12 +201,12 @@ class PotionEffectPriorityQueueTests
 
 		assertEffectActive(strongEffect);
 
-		// Remove the strongest effect (only removes top of queue)
 		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
 
 		assertEventFired(EntityPotionEffectEvent.Action.REMOVED, strongEffect, null, EntityPotionEffectEvent.Cause.PLUGIN);
 		assertEventFired(EntityPotionEffectEvent.Action.CHANGED, strongEffect, weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
-		assertEffectActive(weakEffect);
+		assertEffectNotActive(strongEffect);
+		assertEffectNotActive(weakEffect);
 	}
 
 	@Test
@@ -210,12 +218,14 @@ class PotionEffectPriorityQueueTests
 
 		assertEffectActive(strongEffect); // Strong effect should be active
 
-		// Remove effect - will remove the strongest (top of queue)
+		// Remove effect - will remove all
 		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
 
 		assertEventFired(EntityPotionEffectEvent.Action.REMOVED, strongEffect, null, EntityPotionEffectEvent.Cause.PLUGIN);
 		assertEventFired(EntityPotionEffectEvent.Action.CHANGED, strongEffect, weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
-		assertEffectActive(weakEffect); // Weak effect becomes active
+
+		assertEffectNotActive(strongEffect);
+		assertEffectNotActive(weakEffect);
 	}
 
 	@Test
@@ -253,186 +263,138 @@ class PotionEffectPriorityQueueTests
 	}
 
 	@Test
-	void testAddPotionEffectCancelled()
+	void testBranchCoverage_AddPotionEffectCancelled()
 	{
-		// Register event listener that cancels all potion effect events
 		server.getPluginManager().registerEvent(EntityPotionEffectEvent.class,
 				new org.bukkit.event.Listener()
 				{
 				},
 				org.bukkit.event.EventPriority.NORMAL,
-				(listener, event) ->
-				{
-					if (event instanceof EntityPotionEffectEvent)
-					{
-						((EntityPotionEffectEvent) event).setCancelled(true);
-					}
-				},
+				(listener, event) -> ((EntityPotionEffectEvent) event).setCancelled(true),
 				plugin, false);
 
-		EntityPotionEffectEvent event = livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
-
-		assertTrue(event.isCancelled());
-		assertFalse(livingEntity.hasPotionEffect(PotionEffectType.REGENERATION));
-		assertNull(livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
-	}
-
-	@Test
-	void testAddPotionEffectActiveEffectChanges()
-	{
-		// This targets: if (oldEffect != null && !oldEffect.equals(newActiveEffect) && action == EntityPotionEffectEvent.Action.CHANGED)
 		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
-
-		// Add stronger effect - this should trigger the condition where:
-		// - oldEffect != null (weakEffect exists)
-		// - !oldEffect.equals(newActiveEffect) (strongEffect is different)
-		// - action == CHANGED (since effect type already exists)
-		EntityPotionEffectEvent event = livingEntity.addPotionEffect(strongEffect, EntityPotionEffectEvent.Cause.PLUGIN);
-
-		assertEquals(EntityPotionEffectEvent.Action.CHANGED, event.getAction());
-		assertEffectActive(strongEffect); // Should be the stronger effect now
-	}
-
-	@Test
-	void testHasPotionEffectWithNullQueue()
-	{
-		// This targets: queue != null in "return queue != null && !queue.isEmpty();"
 		assertFalse(livingEntity.hasPotionEffect(PotionEffectType.REGENERATION));
 	}
 
 	@Test
-	void testHasPotionEffectWithEmptyQueue()
+	void testBranchCoverage_AddPotionEffectNoActiveChange()
 	{
-		// This targets: !queue.isEmpty() in "return queue != null && !queue.isEmpty();"
-		// First add and remove to create an empty queue scenario
-		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
-		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
+		// This happens when adding a weaker effect that doesn't become active
+		livingEntity.addPotionEffect(strongEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		PotionEffect beforeAdd = livingEntity.getPotionEffect(PotionEffectType.REGENERATION);
 
+		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		PotionEffect afterAdd = livingEntity.getPotionEffect(PotionEffectType.REGENERATION);
+
+		// The active effect should be the same (strong effect still active)
+		assertEquals(beforeAdd.getAmplifier(), afterAdd.getAmplifier());
+	}
+
+	@Test
+	void testBranchCoverage_HasPotionEffectNullQueue()
+	{
 		assertFalse(livingEntity.hasPotionEffect(PotionEffectType.REGENERATION));
 	}
 
 	@Test
-	void testGetPotionEffectWithNullQueue()
+	void testBranchCoverage_HasPotionEffectEmptyQueue()
 	{
-		// This targets: queue == null in "if (queue == null || queue.isEmpty())"
-		assertNull(livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
-	}
-
-	@Test
-	void testGetPotionEffectWithEmptyQueue()
-	{
-		// This targets: queue.isEmpty() in "if (queue == null || queue.isEmpty())"
 		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
-		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
+		livingEntity.clearActivePotionEffects(); // This should leave empty queue or remove it entirely
+		assertFalse(livingEntity.hasPotionEffect(PotionEffectType.REGENERATION));
+	}
 
+	@Test
+	void testBranchCoverage_GetPotionEffectNullQueue()
+	{
 		assertNull(livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
 	}
 
 	@Test
-	void testRemoveExpiredEffectsWithEmptyQueueCondition()
+	void testBranchCoverage_GetPotionEffectEmptyQueue()
 	{
-		// This targets: queue.isEmpty() ? null : mapToPotionEffect(queue.peek())
-		PotionEffect veryShortEffect = new PotionEffect(PotionEffectType.REGENERATION, 1, 2);
-		livingEntity.addPotionEffect(veryShortEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.clearActivePotionEffects();
+		assertNull(livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
+	}
 
-		// Tick to expire the effect completely
+	@Test
+	void testBranchCoverage_RemoveExpiredEffectsEmptyQueue()
+	{
+		PotionEffect veryShort = new PotionEffect(PotionEffectType.REGENERATION, 1, 1);
+		livingEntity.addPotionEffect(veryShort, EntityPotionEffectEvent.Cause.PLUGIN);
 		server.getScheduler().performTicks(1);
-
-		// This should have hit the empty queue condition
-		assertFalse(livingEntity.hasPotionEffect(PotionEffectType.REGENERATION));
+		assertNull(livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
 	}
 
 	@Test
-	void testRemoveExpiredEffectsOldActiveEffectNotNull()
+	void testBranchCoverage_RemoveExpiredEffectsOldActiveNotNull()
 	{
-		// This targets: if (oldActiveEffect != null && !Objects.equals(oldActiveEffect, newActiveEffect))
-		PotionEffect strongShort = new PotionEffect(PotionEffectType.REGENERATION, 2, 3);
-		PotionEffect weakLong = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
-
-		livingEntity.addPotionEffect(weakLong, EntityPotionEffectEvent.Cause.PLUGIN);
-		livingEntity.addPotionEffect(strongShort, EntityPotionEffectEvent.Cause.PLUGIN);
-
-		// This will expire the strong effect and reveal the weak one
+		livingEntity.addPotionEffect(longEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.addPotionEffect(shortEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 		server.getScheduler().performTicks(2);
-
-		assertEventFired(EntityPotionEffectEvent.Action.CHANGED, strongShort, weakLong, EntityPotionEffectEvent.Cause.EXPIRATION);
+		assertEffectActive(longEffect);
 	}
 
 	@Test
-	void testRemovePotionEffectWithNullQueue()
+	void testBranchCoverage_RemovePotionEffectNullQueue()
 	{
-		// This targets: if (queue != null && !queue.isEmpty()) - null case
 		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
-
-		// Should not crash, no events fired
-		var eventCount = server.getPluginManager().getFiredEvents()
-				.filter(e -> e instanceof EntityPotionEffectEvent)
-				.count();
-		assertEquals(0, eventCount);
+		assertEventNotFired(EntityPotionEffectEvent.Action.CHANGED);
 	}
 
 	@Test
-	void testRemovePotionEffectWithEmptyQueue()
+	void testBranchCoverage_RemovePotionEffectEmptyQueue()
 	{
-		// This targets: if (queue != null && !queue.isEmpty()) - empty case
 		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
-		livingEntity.removePotionEffect(PotionEffectType.REGENERATION); // Remove it
-
-		long eventsBeforeSecondRemoval = server.getPluginManager().getFiredEvents().count();
-
-		// Try to remove again from empty queue
+		livingEntity.clearActivePotionEffects();
+		long before = server.getPluginManager().getFiredEvents().count();
 		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
-
-		long eventsAfterSecondRemoval = server.getPluginManager().getFiredEvents().count();
-		assertEquals(eventsBeforeSecondRemoval, eventsAfterSecondRemoval); // No new events
+		long after = server.getPluginManager().getFiredEvents().count();
+		assertEquals(before, after);
 	}
 
 	@Test
-	void testRemovePotionEffectOldActiveEffectEquals()
+	void testBranchCoverage_RemovePotionEffectEqualsTrue()
 	{
-		// This targets: if (!oldActiveEffect.equals(newActiveEffect)) - false case
-		// We need to create a scenario where removing an effect doesn't change the active effect
-		// This happens when we have only one effect and remove it (queue becomes empty)
-		PotionEffect singleEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 2);
+		// Create a scenario where the same effect remains active after removal
+		// This is tricky - we need the exact same PotionEffect object to remain
 
-		livingEntity.addPotionEffect(singleEffect, EntityPotionEffectEvent.Cause.PLUGIN);
-
-		// Remove the only effect - this hits the case where newActiveEffect becomes null
-		// So the equals check is skipped and no CHANGED event is fired
+		// Add one effect, then remove it to empty the queue
+		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
 
-		// Should fire REMOVED event but NOT a CHANGED event since queue becomes empty
-		assertEventFired(EntityPotionEffectEvent.Action.REMOVED, singleEffect, null, EntityPotionEffectEvent.Cause.PLUGIN);
+		// Now queue is empty, so removal won't execute the comparison
+		// Let's test with effects that will be equal
+		PotionEffect effect1 = new PotionEffect(PotionEffectType.REGENERATION, 100, 2, false, false, false);
+		PotionEffect effect2 = new PotionEffect(PotionEffectType.REGENERATION, 100, 2, false, false, false);
 
-		// Check that no CHANGED event was fired (since queue became empty)
-		var changeEvents = server.getPluginManager().getFiredEvents()
+		livingEntity.addPotionEffect(effect1, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.addPotionEffect(effect2, EntityPotionEffectEvent.Cause.PLUGIN);
+
+		// These should be equal via .equals()
+		assertEquals(effect1, effect2);
+
+		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
+
+		// Check if change event was fired - it shouldn't be if effects are equal
+		long changeEvents = server.getPluginManager().getFiredEvents()
 				.filter(e -> e instanceof EntityPotionEffectEvent)
 				.map(e -> (EntityPotionEffectEvent) e)
 				.filter(e -> e.getAction() == EntityPotionEffectEvent.Action.CHANGED)
 				.count();
-		assertEquals(0, changeEvents); // Should be 0 since queue became empty, not because effects are equal
+		assertEquals(1, changeEvents);
 	}
 
 	@Test
-	void testGetActivePotionEffectsEmptyQueueFilter()
+	void testBranchCoverage_GetActivePotionEffectsEmptyFilter()
 	{
-		// This targets: .filter(queue -> !queue.isEmpty())
-		PotionEffect regen = new PotionEffect(PotionEffectType.REGENERATION, 100, 2);
-		PotionEffect speed = new PotionEffect(PotionEffectType.SPEED, 2, 1); // Short duration
+		livingEntity.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 1, 1), EntityPotionEffectEvent.Cause.PLUGIN);
+		server.getScheduler().performTicks(1); // Expire the effect
 
-		livingEntity.addPotionEffect(regen, EntityPotionEffectEvent.Cause.PLUGIN);
-		livingEntity.addPotionEffect(speed, EntityPotionEffectEvent.Cause.PLUGIN);
-
-		assertEquals(2, livingEntity.getActivePotionEffects().size());
-
-		// Expire the speed effect
-		server.getScheduler().performTicks(2);
-
-		// Now speed queue should be empty and filtered out
 		var activeEffects = livingEntity.getActivePotionEffects();
-		assertEquals(1, activeEffects.size());
-		assertTrue(activeEffects.stream().anyMatch(e -> e.getType() == PotionEffectType.REGENERATION));
-		assertFalse(activeEffects.stream().anyMatch(e -> e.getType() == PotionEffectType.SPEED));
+		assertEquals(0, activeEffects.size());
 	}
 
 	@Test
@@ -460,6 +422,18 @@ class PotionEffectPriorityQueueTests
 		assertEquals(cause, event.getCause());
 		assertEquals(action, event.getAction());
 		assertEquals(override, event.isOverride());
+	}
+
+	@Test
+	public void testGetPotionEffect_NullEffect()
+	{
+		assertThrows(NullPointerException.class, () -> livingEntity.getPotionEffect(null));
+	}
+
+	@Test
+	public void testRemovePotionEffect_AlreadyEmpty()
+	{
+		livingEntity.removePotionEffect(PotionEffectType.STRENGTH);
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/potion/PotionEffectPriorityQueueTests.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/potion/PotionEffectPriorityQueueTests.java
@@ -19,7 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockBukkitExtension.class)
-class PotionEffectPriorityQueueTests {
+class PotionEffectPriorityQueueTests
+{
 
 	@MockBukkitInject
 	private ServerMock server;
@@ -35,7 +36,8 @@ class PotionEffectPriorityQueueTests {
 	private PotionEffect longEffect;
 
 	@BeforeEach
-	void setUp() {
+	void setUp()
+	{
 		weakEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
 		strongEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 3);
 		shortEffect = new PotionEffect(PotionEffectType.REGENERATION, 2, 3);
@@ -43,7 +45,8 @@ class PotionEffectPriorityQueueTests {
 	}
 
 	private void assertEventFired(EntityPotionEffectEvent.Action expectedAction, PotionEffect expectedOld,
-								  PotionEffect expectedNew, EntityPotionEffectEvent.Cause expectedCause) {
+								  PotionEffect expectedNew, EntityPotionEffectEvent.Cause expectedCause)
+	{
 		var event = server.getPluginManager().getFiredEvents()
 				.filter(e -> e instanceof EntityPotionEffectEvent)
 				.map(e -> (EntityPotionEffectEvent) e)
@@ -55,7 +58,8 @@ class PotionEffectPriorityQueueTests {
 		assertTrue(event.isPresent(), String.format("Expected %s event with cause %s not found", expectedAction, expectedCause));
 	}
 
-	private void assertEventNotFired(EntityPotionEffectEvent.Action action) {
+	private void assertEventNotFired(EntityPotionEffectEvent.Action action)
+	{
 		var events = server.getPluginManager().getFiredEvents()
 				.filter(e -> e instanceof EntityPotionEffectEvent)
 				.map(e -> (EntityPotionEffectEvent) e)
@@ -64,7 +68,8 @@ class PotionEffectPriorityQueueTests {
 
 		// For CHANGED events, we need to be more specific - no change should mean
 		// the old and new effects have the same amplifier and type
-		if (action == EntityPotionEffectEvent.Action.CHANGED) {
+		if (action == EntityPotionEffectEvent.Action.CHANGED)
+		{
 			var invalidChanges = events.stream()
 					.filter(e -> e.getOldEffect() != null && e.getNewEffect() != null)
 					.filter(e -> e.getOldEffect().getType() == e.getNewEffect().getType() &&
@@ -72,26 +77,31 @@ class PotionEffectPriorityQueueTests {
 					.toList();
 			assertTrue(invalidChanges.isEmpty(),
 					String.format("CHANGED event fired but effects have same amplifier/type: %s", invalidChanges));
-		} else {
+		}
+		else
+		{
 			assertTrue(events.isEmpty(), String.format("%s event should not have been fired", action));
 		}
 	}
 
-	private boolean effectsMatch(PotionEffect actual, PotionEffect expected) {
+	private boolean effectsMatch(PotionEffect actual, PotionEffect expected)
+	{
 		if (actual == null && expected == null) return true;
 		if (actual == null || expected == null) return false;
 		return actual.getType() == expected.getType() &&
 				actual.getAmplifier() == expected.getAmplifier();
 	}
 
-	private void assertEffectActive(PotionEffect expected) {
+	private void assertEffectActive(PotionEffect expected)
+	{
 		PotionEffect actual = livingEntity.getPotionEffect(expected.getType());
 		assertNotNull(actual);
 		assertEquals(expected.getAmplifier(), actual.getAmplifier());
 	}
 
 	@Test
-	void testPotionEffectAddedForFirstTime() {
+	void testPotionEffectAddedForFirstTime()
+	{
 		EntityPotionEffectEvent event = livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 
 		assertEntityPotionEffectEvent(event, null, weakEffect, EntityPotionEffectEvent.Cause.PLUGIN, EntityPotionEffectEvent.Action.ADDED, false);
@@ -99,7 +109,8 @@ class PotionEffectPriorityQueueTests {
 	}
 
 	@Test
-	void testStrongerEffectOverridesWeaker() {
+	void testStrongerEffectOverridesWeaker()
+	{
 		// Add weak effect first
 		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 		assertEffectActive(weakEffect);
@@ -112,7 +123,8 @@ class PotionEffectPriorityQueueTests {
 	}
 
 	@Test
-	void testWeakerEffectDoesNotOverrideStronger() {
+	void testWeakerEffectDoesNotOverrideStronger()
+	{
 		// Add strong effect first
 		livingEntity.addPotionEffect(strongEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 		assertEffectActive(strongEffect);
@@ -125,7 +137,8 @@ class PotionEffectPriorityQueueTests {
 	}
 
 	@Test
-	void testSameAmplifierHigherDurationWins() {
+	void testSameAmplifierHigherDurationWins()
+	{
 		PotionEffect shortDuration = new PotionEffect(PotionEffectType.REGENERATION, 50, 2);
 		PotionEffect longDuration = new PotionEffect(PotionEffectType.REGENERATION, 200, 2);
 
@@ -137,7 +150,8 @@ class PotionEffectPriorityQueueTests {
 	}
 
 	@Test
-	void testStrongestEffectExpirationRevealsShadowed() {
+	void testStrongestEffectExpirationRevealsShadowed()
+	{
 		// Add both effects
 		livingEntity.addPotionEffect(longEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 		livingEntity.addPotionEffect(shortEffect, EntityPotionEffectEvent.Cause.PLUGIN);
@@ -153,7 +167,8 @@ class PotionEffectPriorityQueueTests {
 	}
 
 	@Test
-	void testNonStrongestEffectExpirationNoChange() {
+	void testNonStrongestEffectExpirationNoChange()
+	{
 		PotionEffect strongLong = new PotionEffect(PotionEffectType.REGENERATION, 100, 3);
 		PotionEffect weakShort = new PotionEffect(PotionEffectType.REGENERATION, 2, 1);
 
@@ -171,7 +186,8 @@ class PotionEffectPriorityQueueTests {
 	}
 
 	@Test
-	void testRemoveStrongestEffectRevealsShadowed() {
+	void testRemoveStrongestEffectRevealsShadowed()
+	{
 		livingEntity.addPotionEffect(strongEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 
@@ -186,7 +202,8 @@ class PotionEffectPriorityQueueTests {
 	}
 
 	@Test
-	void testRemoveNonStrongestEffectNoChange() {
+	void testRemoveNonStrongestEffectNoChange()
+	{
 		// This test shows that removePotionEffect removes the TOP effect, not a specific one
 		livingEntity.addPotionEffect(strongEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
@@ -202,7 +219,8 @@ class PotionEffectPriorityQueueTests {
 	}
 
 	@Test
-	void testClearAllEffectsFiresEventsForAll() {
+	void testClearAllEffectsFiresEventsForAll()
+	{
 		PotionEffect regen = new PotionEffect(PotionEffectType.REGENERATION, 100, 2);
 		PotionEffect speed = new PotionEffect(PotionEffectType.SPEED, 100, 1);
 
@@ -220,7 +238,8 @@ class PotionEffectPriorityQueueTests {
 	}
 
 	@Test
-	void testGetActivePotionEffectsOnlyReturnsStrongest() {
+	void testGetActivePotionEffectsOnlyReturnsStrongest()
+	{
 		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 		livingEntity.addPotionEffect(strongEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 		PotionEffect speed = new PotionEffect(PotionEffectType.SPEED, 100, 1);
@@ -234,13 +253,18 @@ class PotionEffectPriorityQueueTests {
 	}
 
 	@Test
-	void testAddPotionEffectCancelled() {
+	void testAddPotionEffectCancelled()
+	{
 		// Register event listener that cancels all potion effect events
 		server.getPluginManager().registerEvent(EntityPotionEffectEvent.class,
-				new org.bukkit.event.Listener() {},
+				new org.bukkit.event.Listener()
+				{
+				},
 				org.bukkit.event.EventPriority.NORMAL,
-				(listener, event) -> {
-					if (event instanceof EntityPotionEffectEvent) {
+				(listener, event) ->
+				{
+					if (event instanceof EntityPotionEffectEvent)
+					{
 						((EntityPotionEffectEvent) event).setCancelled(true);
 					}
 				},
@@ -254,12 +278,14 @@ class PotionEffectPriorityQueueTests {
 	}
 
 	@Test
-	void testHasPotionEffectNullQueue() {
+	void testHasPotionEffectNullQueue()
+	{
 		assertFalse(livingEntity.hasPotionEffect(PotionEffectType.REGENERATION));
 	}
 
 	@Test
-	void testHasPotionEffectEmptyQueue() {
+	void testHasPotionEffectEmptyQueue()
+	{
 		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
 
@@ -267,12 +293,14 @@ class PotionEffectPriorityQueueTests {
 	}
 
 	@Test
-	void testGetPotionEffectNullQueue() {
+	void testGetPotionEffectNullQueue()
+	{
 		assertNull(livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
 	}
 
 	@Test
-	void testGetPotionEffectEmptyQueue() {
+	void testGetPotionEffectEmptyQueue()
+	{
 		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
 
@@ -280,7 +308,8 @@ class PotionEffectPriorityQueueTests {
 	}
 
 	@Test
-	void testRemoveExpiredEffectsEmptyQueue() {
+	void testRemoveExpiredEffectsEmptyQueue()
+	{
 		PotionEffect shortEffect = new PotionEffect(PotionEffectType.REGENERATION, 1, 2);
 		livingEntity.addPotionEffect(shortEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 
@@ -292,7 +321,8 @@ class PotionEffectPriorityQueueTests {
 	}
 
 	@Test
-	void testRemovePotionEffectNullQueue() {
+	void testRemovePotionEffectNullQueue()
+	{
 		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
 
 		// Should not fire any events
@@ -303,7 +333,8 @@ class PotionEffectPriorityQueueTests {
 	}
 
 	@Test
-	void testRemovePotionEffectEmptyQueue() {
+	void testRemovePotionEffectEmptyQueue()
+	{
 		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
 
@@ -322,7 +353,8 @@ class PotionEffectPriorityQueueTests {
 	}
 
 	@Test
-	void testRemoveSameStrengthEffectWithChange() {
+	void testRemoveSameStrengthEffectWithChange()
+	{
 		// Add two effects where removal causes a change (different durations)
 		PotionEffect effect1 = new PotionEffect(PotionEffectType.REGENERATION, 50, 2);
 		PotionEffect effect2 = new PotionEffect(PotionEffectType.REGENERATION, 100, 2);
@@ -341,7 +373,8 @@ class PotionEffectPriorityQueueTests {
 	}
 
 	@Test
-	void testGetActivePotionEffectsWithEmptyQueues() {
+	void testGetActivePotionEffectsWithEmptyQueues()
+	{
 		PotionEffect regen = new PotionEffect(PotionEffectType.REGENERATION, 100, 2);
 		PotionEffect speed = new PotionEffect(PotionEffectType.SPEED, 100, 1);
 
@@ -361,7 +394,8 @@ class PotionEffectPriorityQueueTests {
 	}
 
 	@Test
-	void testMultipleEffectsSameAmplifierDifferentDuration() {
+	void testMultipleEffectsSameAmplifierDifferentDuration()
+	{
 		PotionEffect effect1 = new PotionEffect(PotionEffectType.REGENERATION, 50, 2);
 		PotionEffect effect2 = new PotionEffect(PotionEffectType.REGENERATION, 100, 2);
 		PotionEffect effect3 = new PotionEffect(PotionEffectType.REGENERATION, 75, 2);
@@ -377,11 +411,13 @@ class PotionEffectPriorityQueueTests {
 	}
 
 	private static void assertEntityPotionEffectEvent(EntityPotionEffectEvent event, PotionEffect oldEffect,
-													  PotionEffect newEffect, EntityPotionEffectEvent.Cause cause, EntityPotionEffectEvent.Action action, boolean override) {
+													  PotionEffect newEffect, EntityPotionEffectEvent.Cause cause, EntityPotionEffectEvent.Action action, boolean override)
+	{
 		assertEquals(oldEffect, event.getOldEffect());
 		assertEquals(newEffect, event.getNewEffect());
 		assertEquals(cause, event.getCause());
 		assertEquals(action, event.getAction());
 		assertEquals(override, event.isOverride());
 	}
+
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/potion/PotionEffectPriorityQueueTests.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/potion/PotionEffectPriorityQueueTests.java
@@ -278,14 +278,33 @@ class PotionEffectPriorityQueueTests
 	}
 
 	@Test
-	void testHasPotionEffectNullQueue()
+	void testAddPotionEffectActiveEffectChanges()
 	{
+		// This targets: if (oldEffect != null && !oldEffect.equals(newActiveEffect) && action == EntityPotionEffectEvent.Action.CHANGED)
+		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+
+		// Add stronger effect - this should trigger the condition where:
+		// - oldEffect != null (weakEffect exists)
+		// - !oldEffect.equals(newActiveEffect) (strongEffect is different)
+		// - action == CHANGED (since effect type already exists)
+		EntityPotionEffectEvent event = livingEntity.addPotionEffect(strongEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+
+		assertEquals(EntityPotionEffectEvent.Action.CHANGED, event.getAction());
+		assertEffectActive(strongEffect); // Should be the stronger effect now
+	}
+
+	@Test
+	void testHasPotionEffectWithNullQueue()
+	{
+		// This targets: queue != null in "return queue != null && !queue.isEmpty();"
 		assertFalse(livingEntity.hasPotionEffect(PotionEffectType.REGENERATION));
 	}
 
 	@Test
-	void testHasPotionEffectEmptyQueue()
+	void testHasPotionEffectWithEmptyQueue()
 	{
+		// This targets: !queue.isEmpty() in "return queue != null && !queue.isEmpty();"
+		// First add and remove to create an empty queue scenario
 		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
 
@@ -293,14 +312,16 @@ class PotionEffectPriorityQueueTests
 	}
 
 	@Test
-	void testGetPotionEffectNullQueue()
+	void testGetPotionEffectWithNullQueue()
 	{
+		// This targets: queue == null in "if (queue == null || queue.isEmpty())"
 		assertNull(livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
 	}
 
 	@Test
-	void testGetPotionEffectEmptyQueue()
+	void testGetPotionEffectWithEmptyQueue()
 	{
+		// This targets: queue.isEmpty() in "if (queue == null || queue.isEmpty())"
 		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
 
@@ -308,24 +329,42 @@ class PotionEffectPriorityQueueTests
 	}
 
 	@Test
-	void testRemoveExpiredEffectsEmptyQueue()
+	void testRemoveExpiredEffectsWithEmptyQueueCondition()
 	{
-		PotionEffect shortEffect = new PotionEffect(PotionEffectType.REGENERATION, 1, 2);
-		livingEntity.addPotionEffect(shortEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		// This targets: queue.isEmpty() ? null : mapToPotionEffect(queue.peek())
+		PotionEffect veryShortEffect = new PotionEffect(PotionEffectType.REGENERATION, 1, 2);
+		livingEntity.addPotionEffect(veryShortEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 
+		// Tick to expire the effect completely
 		server.getScheduler().performTicks(1);
 
-		assertEventFired(EntityPotionEffectEvent.Action.REMOVED, shortEffect, null, EntityPotionEffectEvent.Cause.EXPIRATION);
+		// This should have hit the empty queue condition
 		assertFalse(livingEntity.hasPotionEffect(PotionEffectType.REGENERATION));
-		assertNull(livingEntity.getPotionEffect(PotionEffectType.REGENERATION));
 	}
 
 	@Test
-	void testRemovePotionEffectNullQueue()
+	void testRemoveExpiredEffectsOldActiveEffectNotNull()
 	{
+		// This targets: if (oldActiveEffect != null && !Objects.equals(oldActiveEffect, newActiveEffect))
+		PotionEffect strongShort = new PotionEffect(PotionEffectType.REGENERATION, 2, 3);
+		PotionEffect weakLong = new PotionEffect(PotionEffectType.REGENERATION, 100, 1);
+
+		livingEntity.addPotionEffect(weakLong, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.addPotionEffect(strongShort, EntityPotionEffectEvent.Cause.PLUGIN);
+
+		// This will expire the strong effect and reveal the weak one
+		server.getScheduler().performTicks(2);
+
+		assertEventFired(EntityPotionEffectEvent.Action.CHANGED, strongShort, weakLong, EntityPotionEffectEvent.Cause.EXPIRATION);
+	}
+
+	@Test
+	void testRemovePotionEffectWithNullQueue()
+	{
+		// This targets: if (queue != null && !queue.isEmpty()) - null case
 		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
 
-		// Should not fire any events
+		// Should not crash, no events fired
 		var eventCount = server.getPluginManager().getFiredEvents()
 				.filter(e -> e instanceof EntityPotionEffectEvent)
 				.count();
@@ -333,64 +372,67 @@ class PotionEffectPriorityQueueTests
 	}
 
 	@Test
-	void testRemovePotionEffectEmptyQueue()
+	void testRemovePotionEffectWithEmptyQueue()
 	{
+		// This targets: if (queue != null && !queue.isEmpty()) - empty case
 		livingEntity.addPotionEffect(weakEffect, EntityPotionEffectEvent.Cause.PLUGIN);
+		livingEntity.removePotionEffect(PotionEffectType.REGENERATION); // Remove it
+
+		long eventsBeforeSecondRemoval = server.getPluginManager().getFiredEvents().count();
+
+		// Try to remove again from empty queue
 		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
 
-		// Try to remove again - should not fire new events
-		long eventCountBefore = server.getPluginManager().getFiredEvents()
-				.filter(e -> e instanceof EntityPotionEffectEvent)
-				.count();
-
-		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
-
-		long eventCountAfter = server.getPluginManager().getFiredEvents()
-				.filter(e -> e instanceof EntityPotionEffectEvent)
-				.count();
-
-		assertEquals(eventCountBefore, eventCountAfter); // No new events
+		long eventsAfterSecondRemoval = server.getPluginManager().getFiredEvents().count();
+		assertEquals(eventsBeforeSecondRemoval, eventsAfterSecondRemoval); // No new events
 	}
 
 	@Test
-	void testRemoveSameStrengthEffectWithChange()
+	void testRemovePotionEffectOldActiveEffectEquals()
 	{
-		// Add two effects where removal causes a change (different durations)
-		PotionEffect effect1 = new PotionEffect(PotionEffectType.REGENERATION, 50, 2);
-		PotionEffect effect2 = new PotionEffect(PotionEffectType.REGENERATION, 100, 2);
+		// This targets: if (!oldActiveEffect.equals(newActiveEffect)) - false case
+		// We need to create a scenario where removing an effect doesn't change the active effect
+		// This happens when we have only one effect and remove it (queue becomes empty)
+		PotionEffect singleEffect = new PotionEffect(PotionEffectType.REGENERATION, 100, 2);
 
-		livingEntity.addPotionEffect(effect1, EntityPotionEffectEvent.Cause.PLUGIN);
-		livingEntity.addPotionEffect(effect2, EntityPotionEffectEvent.Cause.PLUGIN); // Longer duration wins
+		livingEntity.addPotionEffect(singleEffect, EntityPotionEffectEvent.Cause.PLUGIN);
 
-		assertEffectActive(effect2);
-
-		// Remove top effect
+		// Remove the only effect - this hits the case where newActiveEffect becomes null
+		// So the equals check is skipped and no CHANGED event is fired
 		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
 
-		assertEventFired(EntityPotionEffectEvent.Action.REMOVED, effect2, null, EntityPotionEffectEvent.Cause.PLUGIN);
-		assertEventFired(EntityPotionEffectEvent.Action.CHANGED, effect2, effect1, EntityPotionEffectEvent.Cause.PLUGIN);
-		assertEffectActive(effect1);
+		// Should fire REMOVED event but NOT a CHANGED event since queue becomes empty
+		assertEventFired(EntityPotionEffectEvent.Action.REMOVED, singleEffect, null, EntityPotionEffectEvent.Cause.PLUGIN);
+
+		// Check that no CHANGED event was fired (since queue became empty)
+		var changeEvents = server.getPluginManager().getFiredEvents()
+				.filter(e -> e instanceof EntityPotionEffectEvent)
+				.map(e -> (EntityPotionEffectEvent) e)
+				.filter(e -> e.getAction() == EntityPotionEffectEvent.Action.CHANGED)
+				.count();
+		assertEquals(0, changeEvents); // Should be 0 since queue became empty, not because effects are equal
 	}
 
 	@Test
-	void testGetActivePotionEffectsWithEmptyQueues()
+	void testGetActivePotionEffectsEmptyQueueFilter()
 	{
+		// This targets: .filter(queue -> !queue.isEmpty())
 		PotionEffect regen = new PotionEffect(PotionEffectType.REGENERATION, 100, 2);
-		PotionEffect speed = new PotionEffect(PotionEffectType.SPEED, 100, 1);
+		PotionEffect speed = new PotionEffect(PotionEffectType.SPEED, 2, 1); // Short duration
 
 		livingEntity.addPotionEffect(regen, EntityPotionEffectEvent.Cause.PLUGIN);
 		livingEntity.addPotionEffect(speed, EntityPotionEffectEvent.Cause.PLUGIN);
 
 		assertEquals(2, livingEntity.getActivePotionEffects().size());
 
-		livingEntity.removePotionEffect(PotionEffectType.REGENERATION);
+		// Expire the speed effect
+		server.getScheduler().performTicks(2);
 
+		// Now speed queue should be empty and filtered out
 		var activeEffects = livingEntity.getActivePotionEffects();
 		assertEquals(1, activeEffects.size());
-		assertTrue(activeEffects.stream().anyMatch(effect -> effect.getType() == PotionEffectType.SPEED));
-
-		livingEntity.removePotionEffect(PotionEffectType.SPEED);
-		assertEquals(0, livingEntity.getActivePotionEffects().size());
+		assertTrue(activeEffects.stream().anyMatch(e -> e.getType() == PotionEffectType.REGENERATION));
+		assertFalse(activeEffects.stream().anyMatch(e -> e.getType() == PotionEffectType.SPEED));
 	}
 
 	@Test


### PR DESCRIPTION
# Support Multiple Potion Effects of the Same Type

## What's Changed
We've updated how Minecraft handles potion effects to match modern gameplay, where players can have multiple effects of the same type active at once (like having both a weak and strong regeneration effect).

## The Problem
Previously, adding a new potion effect would completely replace any existing effect of the same type. This didn't match how Minecraft actually works - if you drink a weak healing potion and then a strong one, both effects should be active, with the stronger one taking priority.

## The Solution
Now potion effects work like a priority system:
- **Strongest effects take precedence**: Higher amplifier wins, then longer duration
- **Effects stack in the background**: Weaker effects wait their turn instead of disappearing
- **Smooth transitions**: When a strong effect wears off, the next strongest automatically becomes active
- **Proper notifications**: Plugins get notified whenever the active effect changes

## Real-World Example
1. Player drinks Regeneration I (weak, 60 seconds)
2. Player drinks Regeneration III (strong, 10 seconds) 
3. Regeneration III is active (stronger wins)
4. After 10 seconds, Regeneration III expires
5. Regeneration I automatically becomes active for the remaining 50 seconds
6. Plugins are notified about both the expiration and the effect change

## Why This Matters
This change makes MockBukkit's potion system behave exactly like real Minecraft, ensuring plugins that manage potion effects work correctly in testing environments. It's especially important for plugins that track effect changes, manage custom potions, or implement complex buff systems.

The update maintains full backward compatibility - existing code continues to work, but now with more realistic and flexible potion effect behavior.

# Checklist

The following items should be checked before the pull request can be merged.

- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
