### PR TITLE
fix: Provide a better error message when failing to load a plugin

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
@@ -46,6 +46,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -63,6 +64,7 @@ import java.util.function.Predicate;
 import java.util.jar.JarFile;
 import java.util.logging.Level;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.fail;
@@ -324,12 +326,16 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 			}
 		}
 
-		StringBuilder parameters = new StringBuilder("[");
-		for (Class<?> type : types)
-			parameters.append(type.getName()).append(", ");
-		String str = parameters.substring(0, parameters.length() - 2) + "]";
+		String parameters = " without parameters";
+		if (types.length > 0)
+		{
+			parameters = " with parameters [" + Arrays.stream(types)
+					.map(Class::getName)
+					.collect(Collectors.joining(", ")) + "]";
+		}
+
 		throw new NoSuchMethodException(
-				"No compatible constructor for " + class1.getName() + " with parameters " + str);
+				"No publicly available constructor for " + class1.getName() + parameters);
 	}
 
 	/**

--- a/src/test/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMockTest.java
@@ -419,4 +419,16 @@ class PluginManagerMockTest
 		assertTrue(plugin.classLoadSucceed);
 	}
 
+	@Test
+	void test_privateConstructorPlugin()
+	{
+		PluginLoadException exception = assertThrows(
+				PluginLoadException.class,
+				() -> pluginManager.loadPlugin(PrivateConstructorPlugin.class)
+		);
+
+		assertInstanceOf(NoSuchMethodException.class, exception.getCause());
+		assertEquals("No publicly available constructor for PrivateConstructorPluginProxy without parameters", exception.getCause().getMessage());
+	}
+
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/plugin/PrivateConstructorPlugin.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/plugin/PrivateConstructorPlugin.java
@@ -1,0 +1,12 @@
+package org.mockbukkit.mockbukkit.plugin;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class PrivateConstructorPlugin extends JavaPlugin
+{
+
+	private PrivateConstructorPlugin()
+	{
+	}
+
+}


### PR DESCRIPTION
# Description

I had a very cryptic message about a plugin that I try to load. Finally I figured out it was a package-private constructor.
The error was :
```
Range [0, -1) out of bounds for length 1
```
(no types passed, so it failed)

I fixed that error and improved the error message.

# Checklist

The following items should be checked before the pull request can be merged.

- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
