### PR TITLE
feat: Enhance injection with broader Plugin support and entity types

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/MockBukkit.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/MockBukkit.java
@@ -101,7 +101,7 @@ public class MockBukkit
 	 *
 	 * @return The {@link ServerMock} instance.
 	 */
-	public static @Nullable ServerMock getOrCreateMock()
+	public static @NotNull ServerMock getOrCreateMock()
 	{
 		if (!isMocked())
 		{
@@ -160,7 +160,7 @@ public class MockBukkit
 	 * @param plugin The plugin to load for mocking.
 	 * @return An instance of the plugin's main class.
 	 */
-	public static <T extends JavaPlugin> @NotNull T load(@NotNull Class<T> plugin)
+	public static <T extends Plugin> @NotNull T load(@NotNull Class<T> plugin)
 	{
 		return load(plugin, new Object[0]);
 	}
@@ -173,11 +173,11 @@ public class MockBukkit
 	 * @param parameters Extra parameters to pass on to the plugin constructor.
 	 * @return An instance of the plugin's main class.
 	 */
-	public static <T extends JavaPlugin> @NotNull T load(@NotNull Class<T> plugin, Object @NotNull ... parameters)
+	public static <T extends Plugin> @NotNull T load(@NotNull Class<T> plugin, Object @NotNull ... parameters)
 	{
 		ensureMocking();
 		PluginManagerMock pluginManager = mock.getPluginManager();
-		JavaPlugin instance = pluginManager.loadPlugin(plugin, parameters);
+		Plugin instance = pluginManager.loadPlugin(plugin, parameters);
 		return processFinalLoad(plugin, instance, pluginManager);
 	}
 
@@ -191,10 +191,10 @@ public class MockBukkit
 	 * @param parameters      Extra parameters to pass on to the plugin constructor.
 	 * @return An instance of the plugin's main class.
 	 */
-	public static <T extends JavaPlugin> @NotNull T loadWith(@NotNull Class<T> plugin, @NotNull PluginDescriptionFile descriptionFile, Object @NotNull ... parameters)
+	public static <T extends Plugin> @NotNull T loadWith(@NotNull Class<T> plugin, @NotNull PluginDescriptionFile descriptionFile, Object @NotNull ... parameters)
 	{
 		ensureMocking();
-		JavaPlugin instance = mock.getPluginManager().loadPlugin(plugin, descriptionFile, parameters);
+		Plugin instance = mock.getPluginManager().loadPlugin(plugin, descriptionFile, parameters);
 		mock.getPluginManager().enablePlugin(instance);
 		return plugin.cast(instance);
 	}
@@ -209,7 +209,7 @@ public class MockBukkit
 	 * @param parameters       Extra parameters to pass on to the plugin constructor.
 	 * @return An instance of the plugin's main class.
 	 */
-	public static <T extends JavaPlugin> @NotNull T loadWith(@NotNull Class<T> plugin, @NotNull InputStream descriptionInput, Object... parameters)
+	public static <T extends Plugin> @NotNull T loadWith(@NotNull Class<T> plugin, @NotNull InputStream descriptionInput, Object... parameters)
 	{
 		try
 		{
@@ -231,7 +231,7 @@ public class MockBukkit
 	 * @param parameters      Extra parameters to pass on to the plugin constructor.
 	 * @return An instance of the plugin's main class.
 	 */
-	public static <T extends JavaPlugin> @NotNull T loadWith(@NotNull Class<T> plugin, @NotNull File descriptionFile, Object... parameters)
+	public static <T extends Plugin> @NotNull T loadWith(@NotNull Class<T> plugin, @NotNull File descriptionFile, Object... parameters)
 	{
 		try
 		{
@@ -253,7 +253,7 @@ public class MockBukkit
 	 * @param parameters          Extra parameters to pass on to the plugin constructor.
 	 * @return An instance of the plugin's main class.
 	 */
-	public static <T extends JavaPlugin> @NotNull T loadWith(@NotNull Class<T> plugin, String descriptionFileName, Object... parameters)
+	public static <T extends Plugin> @NotNull T loadWith(@NotNull Class<T> plugin, String descriptionFileName, Object... parameters)
 	{
 		return loadWith(plugin, ClassLoader.getSystemResourceAsStream(descriptionFileName), parameters);
 	}
@@ -269,7 +269,7 @@ public class MockBukkit
 	 * @return An instance of the plugin's main class.
 	 * @apiNote The File name can't be the same as the one the plugin loads by default
 	 */
-	public static <T extends JavaPlugin> @NotNull T loadWithConfig(
+	public static <T extends Plugin> @NotNull T loadWithConfig(
 			@NotNull Class<T> plugin,
 			InputStream configStream,
 			Object... parameters
@@ -299,7 +299,7 @@ public class MockBukkit
 	 * @return An instance of the plugin's main class.
 	 * @apiNote The File name can't be the same as the one the plugin loads by default
 	 */
-	public static <T extends JavaPlugin> @NotNull T loadWithConfig(
+	public static <T extends Plugin> @NotNull T loadWithConfig(
 			@NotNull Class<T> plugin,
 			File configFile,
 			Object... parameters
@@ -319,7 +319,7 @@ public class MockBukkit
 	 * @return An instance of the plugin's main class.
 	 * @apiNote The File name can't be the same as the one the plugin loads by default
 	 */
-	public static <T extends JavaPlugin> @NotNull T loadWithConfig(
+	public static <T extends Plugin> @NotNull T loadWithConfig(
 			@NotNull Class<T> plugin,
 			FileConfiguration fileConfiguration,
 			Object... parameters
@@ -327,7 +327,7 @@ public class MockBukkit
 	{
 		ensureMocking();
 		PluginManagerMock pluginManager = mock.getPluginManager();
-		JavaPlugin instance = pluginManager.loadPlugin(plugin, parameters);
+		Plugin instance = pluginManager.loadPlugin(plugin, parameters);
 
 		try
 		{
@@ -343,7 +343,7 @@ public class MockBukkit
 		return processFinalLoad(plugin, instance, pluginManager);
 	}
 
-	private static <T extends JavaPlugin> @NotNull T processFinalLoad(@NotNull Class<T> plugin, JavaPlugin instance, PluginManagerMock pluginManager)
+	private static <T extends Plugin> @NotNull T processFinalLoad(@NotNull Class<T> plugin, @NotNull Plugin instance, @NotNull PluginManagerMock pluginManager)
 	{
 		List<Permission> permissionList = instance.getDescription().getPermissions();
 		List<Permission> permissionsToLoad = new ArrayList<>();
@@ -355,25 +355,6 @@ public class MockBukkit
 		return plugin.cast(instance);
 	}
 
-	/*public static <T extends JavaPlugin> T loadWith(Class<T> plugin, File configFile, Object... parameters)
-	{
-		ensureMocking();
-		JavaPlugin instance = mock.getPluginManager().loadPlugin(plugin, parameters);
-		YamlConfiguration yamlConfig = new YamlConfiguration();
-
-		try
-		{
-			yamlConfig.load(configFile);
-		}
-		catch (IOException | InvalidConfigurationException e)
-		{
-			throw new PluginLoadException(e);
-		}
-		instance.getConfig().setDefaults(yamlConfig);
-		mock.getPluginManager().enablePlugin(instance);
-		return plugin.cast(instance);
-	}*/
-
 	/**
 	 * Loads and enables a plugin for mocking. It will not load the {@code plugin.yml} file, but rather it will use a
 	 * mock one. This can be useful in certain multi-project plugins where one cannot always access the
@@ -384,12 +365,12 @@ public class MockBukkit
 	 * @param parameters Extra parameters to pass on to the plugin constructor.
 	 * @return An instance of the plugin's main class.
 	 */
-	public static <T extends JavaPlugin> @NotNull T loadSimple(@NotNull Class<T> plugin, Object @NotNull ... parameters)
+	public static <T extends Plugin> @NotNull T loadSimple(@NotNull Class<T> plugin, Object @NotNull ... parameters)
 	{
 		ensureMocking();
 		PluginDescriptionFile description = new PluginDescriptionFile(plugin.getSimpleName(), "1.0.0",
 				plugin.getCanonicalName());
-		JavaPlugin instance = mock.getPluginManager().loadPlugin(plugin, description, parameters);
+		Plugin instance = mock.getPluginManager().loadPlugin(plugin, description, parameters);
 		mock.getPluginManager().enablePlugin(instance);
 		return plugin.cast(instance);
 	}
@@ -422,7 +403,7 @@ public class MockBukkit
 	}
 
 	/**
-	 * Creates a mock instance of a {@link JavaPlugin} implementation. This plugin offers no functionality, but it does
+	 * Creates a mock instance of a {@link Plugin} implementation. This plugin offers no functionality, but it does
 	 * allow a plugin that might enable and disable other plugins to be tested.
 	 *
 	 * @return An instance of a mock plugin.
@@ -433,7 +414,7 @@ public class MockBukkit
 	}
 
 	/**
-	 * Creates a mock instance of a {@link JavaPlugin} implementation and gives you a chance to name the plugin. This plugin offers no functionality, but it does
+	 * Creates a mock instance of a {@link Plugin} implementation and gives you a chance to name the plugin. This plugin offers no functionality, but it does
 	 * allow a plugin that might enable and disable other plugins to be tested.
 	 *
 	 * @param pluginName A name of a new plugin.
@@ -445,7 +426,7 @@ public class MockBukkit
 	}
 
 	/**
-	 * Creates a mock instance of a {@link JavaPlugin} implementation and gives you a chance to name the plugin. This plugin offers no functionality, but it does
+	 * Creates a mock instance of a {@link Plugin} implementation and gives you a chance to name the plugin. This plugin offers no functionality, but it does
 	 * allow a plugin that might enable and disable other plugins to be tested.
 	 *
 	 * @param pluginName    A name of a new plugin.
@@ -456,7 +437,7 @@ public class MockBukkit
 	{
 		ensureMocking();
 		PluginDescriptionFile description = new PluginDescriptionFile(pluginName, pluginVersion, PluginMock.class.getName());
-		JavaPlugin instance = mock.getPluginManager().loadPlugin(PluginMock.class, description, new Object[0]);
+		Plugin instance = mock.getPluginManager().loadPlugin(PluginMock.class, description, new Object[0]);
 		mock.getPluginManager().enablePlugin(instance);
 		return (PluginMock) instance;
 	}

--- a/src/main/java/org/mockbukkit/mockbukkit/MockBukkitExtension.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/MockBukkitExtension.java
@@ -312,8 +312,10 @@ public class MockBukkitExtension implements TestInstancePostProcessor, TestInsta
 		return paramHasCorrectAnnotation && (
 				paramType.isAssignableFrom(ServerMock.class) ||
 						paramType.isAssignableFrom(PlayerMock.class) ||
-						paramType.isAssignableFrom(PluginMock.class) ||
-						paramType.isAssignableFrom(WorldMock.class)
+						paramType.isAssignableFrom(Location.class) ||
+						paramType.isAssignableFrom(WorldMock.class) ||
+						Plugin.class.isAssignableFrom(paramType) ||
+						Entity.class.isAssignableFrom(paramType)
 		);
 	}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/MockBukkitExtension.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/MockBukkitExtension.java
@@ -197,6 +197,7 @@ public class MockBukkitExtension implements TestInstancePostProcessor, TestInsta
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	private @Nullable Object createMockForType(@NotNull Class<?> type, @NotNull MockBukkitInject annotation)
 	{
 		if (type.isAssignableFrom(ServerMock.class))

--- a/src/main/java/org/mockbukkit/mockbukkit/MockBukkitExtension.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/MockBukkitExtension.java
@@ -1,8 +1,10 @@
 package org.mockbukkit.mockbukkit;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
+import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.World;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
@@ -17,6 +19,7 @@ import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
 import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 import org.junit.jupiter.api.extension.TestInstancePreDestroyCallback;
 import org.junit.platform.commons.util.ExceptionUtils;
+import org.mockbukkit.mockbukkit.entity.EntityMock;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
 import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 import org.mockbukkit.mockbukkit.plugin.PluginMock;
@@ -198,27 +201,98 @@ public class MockBukkitExtension implements TestInstancePostProcessor, TestInsta
 	{
 		if (type.isAssignableFrom(ServerMock.class))
 		{
-			return MockBukkit.getOrCreateMock();
+			return getServerMock();
 		}
-		else if (type.isAssignableFrom(PlayerMock.class))
+
+		if (type.isAssignableFrom(Location.class))
 		{
-			final String playerName = annotation.name().isEmpty() ? "Player" + playerCounter++ : annotation.name();
-			return MockBukkit.getOrCreateMock().addPlayer(playerName);
+			return getLocation();
 		}
-		else if (type.isAssignableFrom(WorldMock.class))
+
+		if (type.isAssignableFrom(PlayerMock.class))
 		{
-			final String worldName = annotation.name().isEmpty() ? "World" + worldCounter++ : annotation.name();
-			return MockBukkit.getOrCreateMock().addSimpleWorld(worldName);
+			return getPlayerMock(annotation);
 		}
-		else if (type.isAssignableFrom(PluginMock.class))
+
+		if (type.isAssignableFrom(WorldMock.class))
 		{
-			final String pluginName = annotation.name().isEmpty() ? "Plugin" + pluginCounter++ : annotation.name();
-			return MockBukkit.createMockPlugin(pluginName);
+			return getWorldMock(annotation);
 		}
-		else
+
+		if (Plugin.class.isAssignableFrom(type))
 		{
-			return null;
+			return getPluginMock((Class<? extends Plugin>) type, annotation.name());
 		}
+
+		if (Entity.class.isAssignableFrom(type)) // is type a subclass of Entity?
+		{
+			return getEntityMock((Class<? extends Entity>) type);
+		}
+
+		return null;
+	}
+
+	private @NotNull <T extends Entity> EntityMock getEntityMock(Class<T> clazz)
+	{
+		return (EntityMock) getFirstWorld().spawn(getLocation(), clazz);
+	}
+
+	private @NotNull <T extends Plugin> Plugin getPluginMock(Class<T> clazz, @NotNull String name)
+	{
+		name = name.trim();
+		if (name.isEmpty())
+		{
+			name = "Plugin" + pluginCounter++;
+		}
+
+		if (clazz.isInterface() || PluginMock.class.isAssignableFrom(clazz))
+		{
+			return MockBukkit.createMockPlugin(name);
+		}
+
+		// real plugin here
+		return MockBukkit.load(clazz);
+	}
+
+	private @NotNull PlayerMock getPlayerMock(@NotNull MockBukkitInject annotation)
+	{
+		final String playerName = annotation.name().isEmpty() ? "Player" + playerCounter++ : annotation.name();
+		return getServerMock().addPlayer(playerName);
+	}
+
+	private @NotNull Location getLocation()
+	{
+		return new Location(getFirstWorld(), 0, 0, 0);
+	}
+
+	private @NotNull WorldMock getFirstWorld()
+	{
+		if (getServerMock().getWorlds().isEmpty())
+		{
+			return getWorldMock("");
+		}
+
+		return (WorldMock) getServerMock().getWorlds().getFirst();
+	}
+
+	private @NotNull WorldMock getWorldMock(@NotNull String name)
+	{
+		if (name.isEmpty())
+		{
+			name = "World" + worldCounter++;
+		}
+
+		return getServerMock().addSimpleWorld(name);
+	}
+
+	private @NotNull WorldMock getWorldMock(@NotNull MockBukkitInject annotation)
+	{
+		return getWorldMock(annotation.name());
+	}
+
+	private static @NotNull ServerMock getServerMock()
+	{
+		return MockBukkit.getOrCreateMock();
 	}
 
 	@Override
@@ -255,7 +329,7 @@ public class MockBukkitExtension implements TestInstancePostProcessor, TestInsta
 	@Override
 	public void beforeAll(ExtensionContext context)
 	{
-		MockBukkit.getOrCreateMock();
+		getServerMock();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
@@ -1630,7 +1630,7 @@ public class ServerMock extends Server.Spigot implements Server
 			@SuppressWarnings("unchecked")
 			Class<? extends JavaPlugin> originalClass = (Class<? extends JavaPlugin>) oldJavaPlugin.getClass().getSuperclass();
 			// Don't use MockBukkit#load here since we enable later.
-			JavaPlugin plugin = getPluginManager().loadPlugin(originalClass, oldJavaPlugin.getDescription(), new Object[0]);
+			Plugin plugin = getPluginManager().loadPlugin(originalClass, oldJavaPlugin.getDescription(), new Object[0]);
 			newPlugins.add(plugin);
 		}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/EntityTypesMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/EntityTypesMock.java
@@ -400,7 +400,12 @@ public final class EntityTypesMock
 		EntityData<? extends Entity, ? extends EntityMock> data = bukkitToMockData.get(bukkitClazz);
 		if (data == null)
 		{
-			throw new UnimplementedOperationException(String.format("Mock for entity %s was not implemented yet.", bukkitClazz.getName()));
+			// try a little harder
+			data = bukkitToMockData.values().stream().filter(entityData -> bukkitClazz.isAssignableFrom(entityData.mockClass)).findFirst().orElse(null);
+			if (data == null)
+			{
+				throw new UnimplementedOperationException(String.format("Mock for entity %s was not implemented yet.", bukkitClazz.getName()));
+			}
 		}
 
 		@Nullable EntityMock mockedEntity = data.mockFactory().apply(server, entityUUID);

--- a/src/main/java/org/mockbukkit/mockbukkit/plugin/MockBukkitConfiguredPluginClassLoader.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/plugin/MockBukkitConfiguredPluginClassLoader.java
@@ -9,6 +9,7 @@ import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.dynamic.scaffold.subclass.ConstructorStrategy;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
@@ -97,9 +98,9 @@ public class MockBukkitConfiguredPluginClassLoader extends URLClassLoader implem
 		}
 	}
 
-	public Class<? extends JavaPlugin> loadProxyClass(Class<? extends JavaPlugin> target)
+	public Class<? extends Plugin> loadProxyClass(Class<? extends Plugin> target)
 	{
-		DynamicType.Unloaded<? extends JavaPlugin> dynamicType = new ByteBuddy()
+		DynamicType.Unloaded<? extends Plugin> dynamicType = new ByteBuddy()
 				.subclass(target, ConstructorStrategy.Default.IMITATE_SUPER_CLASS)
 				.name(target.getSimpleName() + "Proxy")
 				.make();

--- a/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
@@ -312,7 +312,7 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	 * @throws NoSuchMethodException if no compatible constructor could be found.
 	 */
 	@SuppressWarnings("unchecked")
-	private @NotNull Constructor<? extends JavaPlugin> getCompatibleConstructor(@NotNull Class<? extends JavaPlugin> class1,
+	private @NotNull Constructor<? extends Plugin> getCompatibleConstructor(@NotNull Class<? extends Plugin> class1,
 																				@NotNull Class<?> @NotNull [] types) throws NoSuchMethodException
 	{
 		Preconditions.checkNotNull(class1, "Class cannot be null");
@@ -322,7 +322,7 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 			Class<?>[] parameters = constructor.getParameterTypes();
 			if (parameters.length == types.length && isConstructorCompatible(constructor, types))
 			{
-				return (Constructor<? extends JavaPlugin>) constructor;
+				return (Constructor<? extends Plugin>) constructor;
 			}
 		}
 
@@ -418,17 +418,9 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	 * @param class1 The plugin to load.
 	 * @return The loaded plugin.
 	 */
-	public @NotNull JavaPlugin loadPlugin(@NotNull Class<? extends JavaPlugin> class1)
+	public @NotNull Plugin loadPlugin(@NotNull Class<? extends Plugin> class1)
 	{
-		try
-		{
-			return loadPlugin(class1, new Object[0]);
-		}
-		catch (PluginLoadException ignored)
-		{
-			PluginDescriptionFile description = new PluginDescriptionFile(class1.getSimpleName(), "0.0.0", class1.getName());
-			return loadPlugin(class1, description, new Object[0]);
-		}
+		return loadPlugin(class1, new Object[0]);
 	}
 
 	/**
@@ -439,7 +431,7 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	 * @param parameters  Extra parameters to pass on to the plugin constructor. Must not be {@code null}.
 	 * @return The loaded plugin.
 	 */
-	public @NotNull JavaPlugin loadPlugin(@NotNull Class<? extends JavaPlugin> class1, @NotNull PluginDescriptionFile description,
+	public @NotNull Plugin loadPlugin(@NotNull Class<? extends Plugin> class1, @NotNull PluginDescriptionFile description,
 										  @NotNull Object @NotNull [] parameters)
 	{
 		Preconditions.checkNotNull(class1, "Class cannot be null");
@@ -456,10 +448,10 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 				types.add(parameter.getClass());
 			}
 
-			Constructor<? extends JavaPlugin> constructor = getCompatibleConstructor(class1, types.toArray(new Class<?>[0]));
+			Constructor<? extends Plugin> constructor = getCompatibleConstructor(class1, types.toArray(new Class<?>[0]));
 			constructor.setAccessible(true);
 
-			JavaPlugin plugin = constructor.newInstance(parameters);
+			Plugin plugin = constructor.newInstance(parameters);
 			registerLoadedPlugin(plugin);
 			return plugin;
 		}
@@ -507,17 +499,19 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	 * @param parameters Extra parameters to pass on to the plugin constructor.
 	 * @return The loaded plugin.
 	 */
-	public @NotNull JavaPlugin loadPlugin(@NotNull Class<? extends JavaPlugin> class1, Object @NotNull [] parameters)
+	public @NotNull Plugin loadPlugin(@NotNull Class<? extends Plugin> class1, Object @NotNull [] parameters)
 	{
+		PluginDescriptionFile description;
 		try
 		{
-			PluginDescriptionFile description = findPluginDescription(class1);
-			return loadPlugin(class1, description, parameters);
+			description = findPluginDescription(class1);
 		}
-		catch (IOException | InvalidDescriptionException e)
+		catch (IOException | InvalidDescriptionException ignored)
 		{
-			throw new PluginLoadException(e);
+			description = new PluginDescriptionFile(class1.getSimpleName(), "0.0.0", class1.getName());
 		}
+
+		return loadPlugin(class1, description, parameters);
 	}
 
 	/**
@@ -529,7 +523,7 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	 * @throws IOException                 Thrown when the file wan't be found or loaded.
 	 * @throws InvalidDescriptionException If the plugin description file is formatted incorrectly.
 	 */
-	private @NotNull PluginDescriptionFile findPluginDescription(@NotNull Class<? extends JavaPlugin> class1)
+	private @NotNull PluginDescriptionFile findPluginDescription(@NotNull Class<? extends Plugin> class1)
 			throws IOException, InvalidDescriptionException
 	{
 		Preconditions.checkNotNull(class1, "Class cannot be null");

--- a/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginMock.java
@@ -1,6 +1,7 @@
 package org.mockbukkit.mockbukkit.plugin;
 
 import com.google.common.base.Preconditions;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.java.JavaPluginLoader;
@@ -155,7 +156,7 @@ public class PluginMock extends JavaPlugin
 
 			PluginDescriptionFile description = new PluginDescriptionFile(pluginName, pluginVersion, InternalPluginMock.class.getName());
 			ServerMock mock = MockBukkit.getMock();
-			JavaPlugin instance = mock.getPluginManager().loadPlugin(InternalPluginMock.class, description, new Object[]{ onEnable, onDisable, onLoad });
+			Plugin instance = mock.getPluginManager().loadPlugin(InternalPluginMock.class, description, new Object[]{ onEnable, onDisable, onLoad });
 			mock.getPluginManager().enablePlugin(instance);
 			return (PluginMock) instance;
 		}

--- a/src/test/java/org/mockbukkit/mockbukkit/MockBukkitExtensionDifferentMocksTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/MockBukkitExtensionDifferentMocksTest.java
@@ -3,15 +3,18 @@ package org.mockbukkit.mockbukkit;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockbukkit.mockbukkit.entity.CowMock;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
 import org.mockbukkit.mockbukkit.plugin.PluginMock;
 import org.mockbukkit.mockbukkit.world.WorldMock;
@@ -27,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockBukkitExtension.class)
 class MockBukkitExtensionDifferentMocksTest
@@ -81,10 +85,16 @@ class MockBukkitExtensionDifferentMocksTest
 		PlayerMock playerMock;
 
 		@MockBukkitInject
+		CowMock cowMock;
+
+		@MockBukkitInject
 		WorldMock worldMock;
 
 		@MockBukkitInject
 		Plugin pluginMock;
+
+		@MockBukkitInject
+		Location location;
 
 		@Test
 		void serverMockIsNotNull()
@@ -99,6 +109,12 @@ class MockBukkitExtensionDifferentMocksTest
 		}
 
 		@Test
+		void cowMockIsNotNull()
+		{
+			assertNotNull(cowMock);
+		}
+
+		@Test
 		void worldMockIsNotNull()
 		{
 			assertNotNull(worldMock);
@@ -108,6 +124,18 @@ class MockBukkitExtensionDifferentMocksTest
 		void pluginMockIsNotNull()
 		{
 			assertNotNull(pluginMock);
+		}
+
+		@Test
+		void locationIsNotNull()
+		{
+			assertNotNull(location);
+			assertEquals(serverMock.getWorlds().getFirst(), location.getWorld());
+			assertEquals(0, location.getX());
+			assertEquals(0, location.getY());
+			assertEquals(0, location.getZ());
+			assertEquals(0, location.getPitch());
+			assertEquals(0, location.getYaw());
 		}
 
 	}
@@ -116,34 +144,34 @@ class MockBukkitExtensionDifferentMocksTest
 	class TestAllTypesWithNamesClass
 	{
 
-		@MockBukkitInject(name="Bumba")
+		@MockBukkitInject(name = "Bumba")
 		PlayerMock playerMock;
 
-		@MockBukkitInject(name="Studio100")
+		@MockBukkitInject(name = "Studio100")
 		WorldMock worldMock;
 
-		@MockBukkitInject(name="CodeMonkey")
+		@MockBukkitInject(name = "CodeMonkey")
 		Plugin pluginMock;
 
 		@Test
 		void playerMockIsNotNull()
 		{
 			assertNotNull(playerMock);
-			assertEquals( "Bumba", playerMock.getName() );
+			assertEquals("Bumba", playerMock.getName());
 		}
 
 		@Test
 		void worldMockIsNotNull()
 		{
 			assertNotNull(worldMock);
-			assertEquals( "Studio100", worldMock.getName() );
+			assertEquals("Studio100", worldMock.getName());
 		}
 
 		@Test
 		void pluginMockIsNotNull()
 		{
 			assertNotNull(pluginMock);
-			assertEquals( "CodeMonkey v1.0.0", pluginMock.getDescription().getFullName() );
+			assertEquals("CodeMonkey v1.0.0", pluginMock.getDescription().getFullName());
 		}
 
 	}
@@ -286,4 +314,34 @@ class MockBukkitExtensionDifferentMocksTest
 		assertNull(extension.resolveParameter(parameterContext, null));
 	}
 
+	public static class MyPlugin extends JavaPlugin
+	{
+
+		public int someInt = 42;
+
+		@Override
+		public void onEnable()
+		{
+			getLogger().info("Enabled!");
+		}
+
+	}
+
+	@Nested
+	class TestCustomPluginInjection
+	{
+
+		@MockBukkitInject
+		MyPlugin plugin;
+
+		@Test
+		void testIsProperlyInjected()
+		{
+			assertNotNull(plugin);
+			assertInstanceOf(MyPlugin.class, plugin);
+			assertTrue(plugin.isEnabled());
+			assertEquals(42, plugin.someInt);
+		}
+
+	}
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/MockBukkitExtensionDifferentMocksTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/MockBukkitExtensionDifferentMocksTest.java
@@ -344,4 +344,28 @@ class MockBukkitExtensionDifferentMocksTest
 		}
 
 	}
+
+	@Nested
+			// This test when a server/world hasn't been populated before.
+	class TestOnlyEntityMocking
+	{
+
+		@MockBukkitInject
+		CowMock cowMock;
+
+		@Test
+		void testIsProperlyInjected()
+		{
+			assertNotNull(cowMock);
+			var cowLocation = cowMock.getLocation();
+			assertEquals("World0", cowLocation.getWorld().getName());
+			assertEquals(0, cowLocation.getX());
+			assertEquals(0, cowLocation.getY());
+			assertEquals(0, cowLocation.getZ());
+			assertEquals(0, cowLocation.getPitch());
+			assertEquals(0, cowLocation.getYaw());
+		}
+
+	}
+
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/MockBukkitExtensionDifferentMocksTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/MockBukkitExtensionDifferentMocksTest.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.entity.Cow;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -257,7 +258,9 @@ class MockBukkitExtensionDifferentMocksTest
 			@MockBukkitInject ServerMock server,
 			@MockBukkitInject Player player,
 			@MockBukkitInject World world,
-			@MockBukkitInject Plugin plugin
+			@MockBukkitInject Plugin plugin,
+			@MockBukkitInject Location location,
+			@MockBukkitInject Cow cowMock
 	)
 	{
 		assertEquals("dummy", value);
@@ -270,6 +273,10 @@ class MockBukkitExtensionDifferentMocksTest
 		assertInstanceOf(WorldMock.class, world);
 		assertNotNull(plugin);
 		assertInstanceOf(Plugin.class, plugin);
+		assertNotNull(location);
+		assertInstanceOf(Location.class, location);
+		assertNotNull(cowMock);
+		assertInstanceOf(Cow.class, cowMock);
 	}
 
 	@SuppressWarnings({ "java:S1144", "java:S1172" })
@@ -346,19 +353,22 @@ class MockBukkitExtensionDifferentMocksTest
 	}
 
 	@Nested
-			// This test when a server/world hasn't been populated before.
 	class TestOnlyEntityMocking
 	{
-
-		@MockBukkitInject
-		CowMock cowMock;
+		// This test when a server/world hasn't been populated before.
 
 		@Test
-		void testIsProperlyInjected()
+		void noWorldsCreated()
+		{
+			assertTrue(MockBukkit.getOrCreateMock().getWorlds().isEmpty());
+		}
+
+		@Test
+		void testIsProperlyInjected(@MockBukkitInject CowMock cowMock)
 		{
 			assertNotNull(cowMock);
+			assertEquals(1, MockBukkit.getOrCreateMock().getWorlds().size());
 			var cowLocation = cowMock.getLocation();
-			assertEquals("World0", cowLocation.getWorld().getName());
 			assertEquals(0, cowLocation.getX());
 			assertEquals(0, cowLocation.getY());
 			assertEquals(0, cowLocation.getZ());

--- a/src/test/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMockTest.java
@@ -395,7 +395,7 @@ class PluginManagerMockTest
 	@Test
 	void loadPluginViaPureLoadPlugin_NormalFlow()
 	{
-		JavaPlugin loadedPlugin = pluginManager.loadPlugin(TestPlugin.class);
+		Plugin loadedPlugin = pluginManager.loadPlugin(TestPlugin.class);
 		assertInstanceOf(JavaPlugin.class, loadedPlugin);
 		assertEquals("MockBukkitTestPlugin", loadedPlugin.getName());
 		assertEquals("0.1.0", loadedPlugin.getDescription().getVersion());
@@ -406,7 +406,7 @@ class PluginManagerMockTest
 	{
 		// This works because JavaPlugin is a plugin where the `plugin.yml` file cannot be found.
 		//   So, it'll throw a `FileNotFound`
-		JavaPlugin loadedPlugin = pluginManager.loadPlugin(JavaPlugin.class);
+		Plugin loadedPlugin = pluginManager.loadPlugin(JavaPlugin.class);
 		assertInstanceOf(JavaPlugin.class, loadedPlugin);
 		assertEquals("JavaPlugin", loadedPlugin.getName());
 		assertEquals("0.0.0", loadedPlugin.getDescription().getVersion());


### PR DESCRIPTION
# Description

This PR expands MockBukkit's plugin injection capabilities to work with any Plugin implementation, not just JavaPlugin subclasses. Previously, the framework was limited to JavaPlugin types, but now developers can inject and test a broader range of plugin architectures through the MockBukkitExtension.

The extension has been enhanced with smarter injection logic that automatically determines the appropriate mock type based on the requested class. When you inject a concrete plugin class, it loads the actual plugin implementation, while interface types receive a standard PluginMock. We've also added support for injecting additional Bukkit types like Entity implementations and Location objects, making it easier to set up comprehensive test environments without manual mock creation.

The plugin loading process is now more resilient to missing or malformed plugin.yml files. Instead of failing with exceptions, the system gracefully creates default plugin descriptions when the standard configuration files aren't available. This makes testing much smoother when working with plugins that don't follow conventional packaging or when testing in isolation from full plugin structures.

# Checklist

The following items should be checked before the pull request can be merged.

- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
