### PR TITLE
fix: concurrent modification error on modification of effects inside the effects handler.

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -719,51 +719,44 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		for (PotionEffectType type : effectTypes)
 		{
 			var queue = activeEffects.get(type);
-			if (queue == null)
+			long expiredCount = queue == null ? 0 : queue.stream().filter(ActivePotionEffect::hasExpired).count();
+			if (expiredCount == 0)
 			{
 				continue;
 			}
 
-			var expiredEffects = queue.stream().filter(ActivePotionEffect::hasExpired).toList();
-			if (expiredEffects.isEmpty())
-			{
-				continue;
-			}
+			boolean allExpired = queue.size() == expiredCount;
 
-			if (queue.size() == expiredEffects.size())
+			if (allExpired)
 			{
-				// All removed -> Send change event
 				var event = new EntityPotionEffectEvent(this, mapToPotionEffect(queue.peek()), null,
 						EntityPotionEffectEvent.Cause.EXPIRATION, EntityPotionEffectEvent.Action.REMOVED, true);
 				Bukkit.getPluginManager().callEvent(event);
+
 				if (!event.isCancelled())
 				{
-					// Re-fetch the queue as it might have been modified during the event
-					queue = activeEffects.get(type);
-					if (queue != null)
-					{
-						expiredEffects = queue.stream().filter(ActivePotionEffect::hasExpired).toList();
-						if (!expiredEffects.isEmpty())
-						{
-							if (queue.size() == expiredEffects.size())
-							{
-								// Still all expired: remove the entry
-								activeEffects.remove(type);
-							}
-							else
-							{
-								// Remove only the expired ones
-								queue.removeIf(ActivePotionEffect::hasExpired);
-							}
-						}
-					}
+					removeExpiredFromQueue(type);
 				}
 			}
 			else
 			{
-				// Not the last to be removed: don't send the event!
 				queue.removeIf(ActivePotionEffect::hasExpired);
 			}
+		}
+	}
+
+	private void removeExpiredFromQueue(PotionEffectType type)
+	{
+		var queue = activeEffects.get(type);
+		if (queue == null)
+		{
+			return;
+		}
+
+		queue.removeIf(ActivePotionEffect::hasExpired);
+		if (queue.isEmpty())
+		{
+			activeEffects.remove(type);
 		}
 	}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -715,11 +715,14 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 
 	private void removeExpiredEffects()
 	{
-		var it = activeEffects.entrySet().iterator();
-		while (it.hasNext())
+		List<PotionEffectType> effectTypes = new ArrayList<>(activeEffects.keySet());
+		for (PotionEffectType type : effectTypes)
 		{
-			var entry = it.next();
-			var queue = entry.getValue();
+			var queue = activeEffects.get(type);
+			if (queue == null)
+			{
+				continue;
+			}
 
 			var expiredEffects = queue.stream().filter(ActivePotionEffect::hasExpired).toList();
 			if (expiredEffects.isEmpty())
@@ -735,12 +738,30 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 				Bukkit.getPluginManager().callEvent(event);
 				if (!event.isCancelled())
 				{
-					it.remove();
+					// Re-fetch the queue as it might have been modified during the event
+					queue = activeEffects.get(type);
+					if (queue != null)
+					{
+						expiredEffects = queue.stream().filter(ActivePotionEffect::hasExpired).toList();
+						if (!expiredEffects.isEmpty())
+						{
+							if (queue.size() == expiredEffects.size())
+							{
+								// Still all expired: remove the entry
+								activeEffects.remove(type);
+							}
+							else
+							{
+								// Remove only the expired ones
+								queue.removeIf(ActivePotionEffect::hasExpired);
+							}
+						}
+					}
 				}
 			}
 			else
 			{
-				// Not the last event to be removed: don't send the event!
+				// Not the last to be removed: don't send the event!
 				queue.removeIf(ActivePotionEffect::hasExpired);
 			}
 		}

--- a/src/test/java/org/mockbukkit/mockbukkit/potion/PotionEffectPriorityQueueTests.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/potion/PotionEffectPriorityQueueTests.java
@@ -576,4 +576,88 @@ class PotionEffectPriorityQueueTests
 		server.getScheduler().performTicks(DEFAULT_DURATION * 2); // Shouldn't error & should keep the effect running
 		assertTrue(player.hasPotionEffect(PotionEffectType.STRENGTH));
 	}
+
+	@Test
+	void testQueueBecomesNullAfterEvent(@MockBukkitInject PlayerMock player)
+	{
+		int DEFAULT_DURATION = 10;
+
+		// Listener that removes the entire effect type during expiration event
+		server.getPluginManager().registerEvent(EntityPotionEffectEvent.class,
+				new org.bukkit.event.Listener()
+				{
+				},
+				org.bukkit.event.EventPriority.NORMAL,
+				(listener, event) ->
+				{
+					if (event instanceof EntityPotionEffectEvent _event && _event.getEntity() instanceof Player pl && _event.getCause() == EntityPotionEffectEvent.Cause.EXPIRATION)
+					{
+						pl.addPotionEffect(_event.getOldEffect().withDuration(DEFAULT_DURATION));
+					}
+				},
+				plugin, false);
+
+		player.addPotionEffect(PotionEffectType.STRENGTH.createEffect(DEFAULT_DURATION, 0), EntityPotionEffectEvent.Cause.COMMAND);
+		server.getScheduler().performTicks(DEFAULT_DURATION + 1); // Expire the effect
+		assertFalse(player.hasPotionEffect(PotionEffectType.STRENGTH)); // Effect should be fully removed
+	}
+
+	@Test
+	void testSecondSizeCheckFalse(@MockBukkitInject PlayerMock player)
+	{
+		int DEFAULT_DURATION = 10;
+
+		// Removes another effect during effect handling
+		server.getPluginManager().registerEvent(EntityPotionEffectEvent.class,
+				new org.bukkit.event.Listener()
+				{
+				},
+				org.bukkit.event.EventPriority.NORMAL,
+				(listener, event) ->
+				{
+					if (event instanceof EntityPotionEffectEvent _event && _event.getEntity() instanceof Player pl && _event.getCause() == EntityPotionEffectEvent.Cause.EXPIRATION)
+					{
+						var effect = _event.getOldEffect().getType() == PotionEffectType.STRENGTH ? PotionEffectType.SPEED : PotionEffectType.STRENGTH;
+						pl.removePotionEffect(effect);
+					}
+				},
+				plugin, false);
+
+		player.addPotionEffect(PotionEffectType.STRENGTH.createEffect(DEFAULT_DURATION, 0), EntityPotionEffectEvent.Cause.COMMAND);
+		player.addPotionEffect(PotionEffectType.SPEED.createEffect(DEFAULT_DURATION, 0), EntityPotionEffectEvent.Cause.COMMAND);
+
+		server.getScheduler().performTicks(DEFAULT_DURATION + 1); // Expire the original
+
+		assertFalse(player.hasPotionEffect(PotionEffectType.STRENGTH));
+		assertFalse(player.hasPotionEffect(PotionEffectType.SPEED));
+	}
+
+
+	@Test
+	void testRemoveYourOwnEffectDuringHandling(@MockBukkitInject PlayerMock player)
+	{
+		int DEFAULT_DURATION = 10;
+
+		// Removes another effect during effect handling
+		server.getPluginManager().registerEvent(EntityPotionEffectEvent.class,
+				new org.bukkit.event.Listener()
+				{
+				},
+				org.bukkit.event.EventPriority.NORMAL,
+				(listener, event) ->
+				{
+					if (event instanceof EntityPotionEffectEvent _event && _event.getEntity() instanceof Player pl && _event.getCause() == EntityPotionEffectEvent.Cause.EXPIRATION)
+					{
+						pl.removePotionEffect(_event.getOldEffect().getType());
+					}
+				},
+				plugin, false);
+
+		player.addPotionEffect(PotionEffectType.STRENGTH.createEffect(DEFAULT_DURATION, 0), EntityPotionEffectEvent.Cause.COMMAND);
+
+		server.getScheduler().performTicks(DEFAULT_DURATION + 1); // Expire the original
+
+		assertFalse(player.hasPotionEffect(PotionEffectType.STRENGTH));
+	}
+
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/potion/PotionEffectPriorityQueueTests.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/potion/PotionEffectPriorityQueueTests.java
@@ -555,7 +555,8 @@ class PotionEffectPriorityQueueTests
 	@Test
 	void testConcurrentModificationError(@MockBukkitInject PlayerMock player)
 	{
-		int DEFAULT_DURATION = 10;
+		int effectDuration = 10;
+
 		// Keep the potion effects coming! once expired: restart again
 		server.getPluginManager().registerEvent(EntityPotionEffectEvent.class,
 				new org.bukkit.event.Listener()
@@ -567,22 +568,22 @@ class PotionEffectPriorityQueueTests
 					if (event instanceof EntityPotionEffectEvent _event && _event.getEntity() instanceof Player pl && _event.getCause() == EntityPotionEffectEvent.Cause.EXPIRATION)
 					{
 						pl.removePotionEffect(_event.getOldEffect().getType());
-						pl.addPotionEffect(_event.getOldEffect().withDuration(DEFAULT_DURATION));
+						pl.addPotionEffect(_event.getOldEffect().withDuration(effectDuration));
 					}
 				},
 				plugin, false);
 
-		player.addPotionEffect(PotionEffectType.STRENGTH.createEffect(DEFAULT_DURATION, 0), EntityPotionEffectEvent.Cause.COMMAND);
-		server.getScheduler().performTicks(DEFAULT_DURATION * 2); // Shouldn't error & should keep the effect running
+		player.addPotionEffect(PotionEffectType.STRENGTH.createEffect(effectDuration, 0), EntityPotionEffectEvent.Cause.COMMAND);
+		server.getScheduler().performTicks(effectDuration * 2); // Shouldn't error & should keep the effect running
 		assertTrue(player.hasPotionEffect(PotionEffectType.STRENGTH));
 	}
 
 	@Test
 	void testQueueBecomesNullAfterEvent(@MockBukkitInject PlayerMock player)
 	{
-		int DEFAULT_DURATION = 10;
+		int effectDuration = 10;
 
-		// Listener that removes the entire effect type during expiration event
+		// Listener that adds a new (non-expired) effect type during expiration event
 		server.getPluginManager().registerEvent(EntityPotionEffectEvent.class,
 				new org.bukkit.event.Listener()
 				{
@@ -592,20 +593,20 @@ class PotionEffectPriorityQueueTests
 				{
 					if (event instanceof EntityPotionEffectEvent _event && _event.getEntity() instanceof Player pl && _event.getCause() == EntityPotionEffectEvent.Cause.EXPIRATION)
 					{
-						pl.addPotionEffect(_event.getOldEffect().withDuration(DEFAULT_DURATION));
+						pl.addPotionEffect(_event.getOldEffect().withDuration(effectDuration));
 					}
 				},
 				plugin, false);
 
-		player.addPotionEffect(PotionEffectType.STRENGTH.createEffect(DEFAULT_DURATION, 0), EntityPotionEffectEvent.Cause.COMMAND);
-		server.getScheduler().performTicks(DEFAULT_DURATION + 1); // Expire the effect
-		assertFalse(player.hasPotionEffect(PotionEffectType.STRENGTH)); // Effect should be fully removed
+		player.addPotionEffect(PotionEffectType.STRENGTH.createEffect(effectDuration, 0), EntityPotionEffectEvent.Cause.COMMAND);
+		server.getScheduler().performTicks(effectDuration + 1); // Expire the effect
+		assertTrue(player.hasPotionEffect(PotionEffectType.STRENGTH)); // Effect should be fully removed
 	}
 
 	@Test
 	void testSecondSizeCheckFalse(@MockBukkitInject PlayerMock player)
 	{
-		int DEFAULT_DURATION = 10;
+		int effectDuration = 10;
 
 		// Removes another effect during effect handling
 		server.getPluginManager().registerEvent(EntityPotionEffectEvent.class,
@@ -623,10 +624,10 @@ class PotionEffectPriorityQueueTests
 				},
 				plugin, false);
 
-		player.addPotionEffect(PotionEffectType.STRENGTH.createEffect(DEFAULT_DURATION, 0), EntityPotionEffectEvent.Cause.COMMAND);
-		player.addPotionEffect(PotionEffectType.SPEED.createEffect(DEFAULT_DURATION, 0), EntityPotionEffectEvent.Cause.COMMAND);
+		player.addPotionEffect(PotionEffectType.STRENGTH.createEffect(effectDuration, 0), EntityPotionEffectEvent.Cause.COMMAND);
+		player.addPotionEffect(PotionEffectType.SPEED.createEffect(effectDuration, 0), EntityPotionEffectEvent.Cause.COMMAND);
 
-		server.getScheduler().performTicks(DEFAULT_DURATION + 1); // Expire the original
+		server.getScheduler().performTicks(effectDuration + 1); // Expire the original
 
 		assertFalse(player.hasPotionEffect(PotionEffectType.STRENGTH));
 		assertFalse(player.hasPotionEffect(PotionEffectType.SPEED));
@@ -636,7 +637,7 @@ class PotionEffectPriorityQueueTests
 	@Test
 	void testRemoveYourOwnEffectDuringHandling(@MockBukkitInject PlayerMock player)
 	{
-		int DEFAULT_DURATION = 10;
+		int effectDuration = 10;
 
 		// Removes another effect during effect handling
 		server.getPluginManager().registerEvent(EntityPotionEffectEvent.class,
@@ -653,9 +654,9 @@ class PotionEffectPriorityQueueTests
 				},
 				plugin, false);
 
-		player.addPotionEffect(PotionEffectType.STRENGTH.createEffect(DEFAULT_DURATION, 0), EntityPotionEffectEvent.Cause.COMMAND);
+		player.addPotionEffect(PotionEffectType.STRENGTH.createEffect(effectDuration, 0), EntityPotionEffectEvent.Cause.COMMAND);
 
-		server.getScheduler().performTicks(DEFAULT_DURATION + 1); // Expire the original
+		server.getScheduler().performTicks(effectDuration + 1); // Expire the original
 
 		assertFalse(player.hasPotionEffect(PotionEffectType.STRENGTH));
 	}

--- a/src/test/java/org/mockbukkit/mockbukkit/potion/PotionEffectPriorityQueueTests.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/potion/PotionEffectPriorityQueueTests.java
@@ -1,5 +1,6 @@
 package org.mockbukkit.mockbukkit.potion;
 
+import org.bukkit.entity.Player;
 import org.bukkit.event.entity.EntityPotionEffectEvent;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -551,4 +552,28 @@ class PotionEffectPriorityQueueTests
 		assertEventCountAndClear(EntityPotionEffectEvent.Action.REMOVED, PotionEffectType.STRENGTH.createEffect(0, 0), null, EntityPotionEffectEvent.Cause.EXPIRATION, 1);
 	}
 
+	@Test
+	void testConcurrentModificationError(@MockBukkitInject PlayerMock player)
+	{
+		int DEFAULT_DURATION = 10;
+		// Keep the potion effects coming! once expired: restart again
+		server.getPluginManager().registerEvent(EntityPotionEffectEvent.class,
+				new org.bukkit.event.Listener()
+				{
+				},
+				org.bukkit.event.EventPriority.NORMAL,
+				(listener, event) ->
+				{
+					if (event instanceof EntityPotionEffectEvent _event && _event.getEntity() instanceof Player pl && _event.getCause() == EntityPotionEffectEvent.Cause.EXPIRATION)
+					{
+						pl.removePotionEffect(_event.getOldEffect().getType());
+						pl.addPotionEffect(_event.getOldEffect().withDuration(DEFAULT_DURATION));
+					}
+				},
+				plugin, false);
+
+		player.addPotionEffect(PotionEffectType.STRENGTH.createEffect(DEFAULT_DURATION, 0), EntityPotionEffectEvent.Cause.COMMAND);
+		server.getScheduler().performTicks(DEFAULT_DURATION * 2); // Shouldn't error & should keep the effect running
+		assertTrue(player.hasPotionEffect(PotionEffectType.STRENGTH));
+	}
 }


### PR DESCRIPTION
# Description

When modifying effects during effects handling, a concurrenthashmap was raised.

# Checklist

The following items should be checked before the pull request can be merged.

- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
