### PR TITLE
Fix initialization in Windows system

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/tags/TagsMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/tags/TagsMock.java
@@ -103,7 +103,7 @@ public final class TagsMock
 			{
 				Path relativePath = directory.relativize(path);
 				// Splitting will strip away the .json
-				String name = filePattern.split(relativePath.toString())[0];
+				String name = filePattern.split(relativePath.toString())[0].replace('\\', '/');
 				NamespacedKey key = NamespacedKey.minecraft(name);
 				Tag<?> tag = TagFactory.createTag(registry, key);
 				registry.getTags().put(key, tag);


### PR DESCRIPTION
# Description

Fix for Windows system when initializing:
```
Non [a-z0-9_-./] character in key 'mineable\axe' at index 8 ('\', bytes: [92])
java.lang.IllegalArgumentException: Non [a-z0-9_-./] character in key 'mineable\axe' at index 8 ('\', bytes: [92])
	at org.bukkit.NamespacedKey.lambda$checkError$0(NamespacedKey.java:91)
	at java.base/java.util.OptionalInt.ifPresent(OptionalInt.java:165)
	at org.bukkit.NamespacedKey.checkError(NamespacedKey.java:89)
	at org.bukkit.NamespacedKey.validate(NamespacedKey.java:85)
	at org.bukkit.NamespacedKey.<init>(NamespacedKey.java:57)
	at org.bukkit.NamespacedKey.minecraft(NamespacedKey.java:150)
	at org.mockbukkit.mockbukkit.tags.TagsMock.lambda$loadRegistry$1(TagsMock.java:107)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.stream.SliceOps$1$1.accept(SliceOps.java:200)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at org.mockbukkit.mockbukkit.tags.TagsMock.loadRegistry(TagsMock.java:102)
	at org.mockbukkit.mockbukkit.tags.TagsMock.loadDefaultTags(TagsMock.java:52)
	at org.mockbukkit.mockbukkit.ServerMock.<init>(ServerMock.java:235)
	at org.mockbukkit.mockbukkit.MockBukkit.mock(MockBukkit.java:69)
	at org.mockbukkit.mockbukkit.MockBukkit.getOrCreateMock(MockBukkit.java:108)
	at org.mockbukkit.mockbukkit.MockBukkitExtension.getServerMock(MockBukkitExtension.java:311)
	at org.mockbukkit.mockbukkit.MockBukkitExtension.beforeAll(MockBukkitExtension.java:350)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```

# Checklist

The following items should be checked before the pull request can be merged.

- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
