### PR TITLE
Make paper api compile only

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ MockBukkit can easily be included in your project using either Maven or gradle.
 >
 > [![ALTERNATE-TEXT](https://img.shields.io/maven-central/v/org.mockbukkit.mockbukkit/mockbukkit-v1.21?color=1bcc94&logo=apache-maven)](https://central.sonatype.com/artifact/org.mockbukkit.mockbukkit/mockbukkit-v1.21)
 
-
 > Note: The Breaking Changes intended for 3.0 were already made in 2.145.1. Due to an Error it didn't get properly
 > tagged
 
@@ -71,6 +70,7 @@ repositories {
 
 dependencies {
     testImplementation 'org.mockbukkit.mockbukkit:mockbukkit-v1.21:[version]'
+    testImplementation 'io.papermc.paper:paper-api:[version]'
 }
 ```
 
@@ -85,6 +85,7 @@ repositories {
 
 dependencies {
     testImplementation 'com.github.MockBukkit:MockBukkit:v1.21-SNAPSHOT'
+    testImplementation 'io.papermc.paper:paper-api:[version]'
 }
 ```
 
@@ -112,12 +113,18 @@ MockBukkit can easily be included in Maven using the default Maven Central and P
 </repositories>
 
 <dependencies>
-  <dependency>
-    <groupId>org.mockbukkit.mockbukkit</groupId>
-    <artifactId>mockbukkit-v1.21</artifactId>
-    <version>[version]</version>
-    <scope>test</scope>
-  </dependency>
+    <dependency>
+        <groupId>org.mockbukkit.mockbukkit</groupId>
+        <artifactId>mockbukkit-v1.21</artifactId>
+        <version>[version]</version>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>io.papermc.paper</groupId>
+        <artifactId>paper-api</artifactId>
+        <version>[version]</version>
+        <version>test</version>
+    </dependency>
 </dependencies>
 ```
 
@@ -140,12 +147,18 @@ use [JitPack](https://jitpack.io/#MockBukkit/MockBukkit) as your maven repositor
 </repositories>
 
 <dependencies>
-  <dependency>
-    <groupId>com.github.MockBukkit</groupId>
-    <artifactId>MockBukkit</artifactId>
-    <version>v1.21-SNAPSHOT</version>
-    <scope>test</scope>
-  </dependency>
+    <dependency>
+        <groupId>com.github.MockBukkit</groupId>
+        <artifactId>MockBukkit</artifactId>
+        <version>v1.21-SNAPSHOT</version>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>io.papermc.paper</groupId>
+        <artifactId>paper-api</artifactId>
+        <version>[version]</version>
+        <version>test</version>
+    </dependency>
 </dependencies>
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ repositories {
 
 dependencies {
 	compileOnly("io.papermc.paper:paper-api:${property("paper.api.full-version")}")
+	testImplementation("io.papermc.paper:paper-api:${property("paper.api.full-version")}")
 	api("org.jetbrains:annotations:26.0.2")
 	api("org.hamcrest:hamcrest:3.0")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,8 +17,7 @@ repositories {
 }
 
 dependencies {
-	// Paper API
-	api("io.papermc.paper:paper-api:${property("paper.api.full-version")}")
+	compileOnly("io.papermc.paper:paper-api:${property("paper.api.full-version")}")
 	api("org.jetbrains:annotations:26.0.2")
 	api("org.hamcrest:hamcrest:3.0")
 


### PR DESCRIPTION
# Description

We currently have publishing issues to maven central because they just recently banned snapshot dependencies

# Checklist

The following items should be checked before the pull request can be merged.

- [ ] Code follows existing style.
- [ ] Unit tests added (if applicable).
