### PR TITLE
Fixed serialization of ItemStackMirrorMock

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMirror.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMirror.java
@@ -11,6 +11,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
 import org.bukkit.Material;
 import org.bukkit.UndefinedNullability;
+import org.bukkit.configuration.serialization.DelegateDeserialization;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -41,6 +42,7 @@ import java.util.function.UnaryOperator;
  * @see ItemStack
  */
 @ApiStatus.Internal
+@DelegateDeserialization(ItemStack.class)
 public final class ItemStackMirror extends ItemStack
 {
 

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/ItemStackMirrorTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/ItemStackMirrorTest.java
@@ -1,13 +1,22 @@
 package org.mockbukkit.mockbukkit.inventory;
 
 import org.bukkit.Material;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.configuration.serialization.DelegateDeserialization;
 import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockbukkit.mockbukkit.MockBukkitExtension;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 @ExtendWith(MockBukkitExtension.class)
@@ -58,6 +67,42 @@ class ItemStackMirrorTest
 			assertNotSame(originalItem, mirror);
 		}
 
+	}
+
+	@Test
+	void classHasDelegateSerializationAnnotation()
+	{
+		DelegateDeserialization delegateDeserialization = ItemStackMirror.class.getAnnotation(DelegateDeserialization.class);
+		assertNotNull(delegateDeserialization, "The class should be annotated with @DelegateDeserialization(ItemStack.class)");
+		assertEquals(ItemStack.class, delegateDeserialization.value());
+	}
+
+	/*
+	 * See: https://github.com/MockBukkit/MockBukkit/issues/1449
+	 */
+	@Test
+	void fileSerializationAndDeserializationShouldSucceed(@TempDir Path tempDir) throws IOException
+	{
+		// Create an instance of ItemStackMirror
+		ItemStack item = ItemStackMirror.create(new ItemStack(Material.STONE_BRICKS));
+		item.setAmount(5);
+
+		// Serialize to YAML
+		YamlConfiguration config = new YamlConfiguration();
+		config.set("item", item);
+
+		File file = tempDir.resolve("test.yml").toFile();
+		config.save(file);
+
+		// Load and deserialize
+		YamlConfiguration loadedConfig = YamlConfiguration.loadConfiguration(file);
+		Object deserialized = loadedConfig.get("item");
+
+		assertNotNull(deserialized, "Deserialized object should not be null");
+		ItemStack loadedItem = assertInstanceOf(ItemStack.class, deserialized, "Deserialized object should be of type ItemStack");
+
+		assertEquals(5, loadedItem.getAmount());
+		assertEquals(Material.STONE_BRICKS, loadedItem.getType());
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/ItemStackMirrorTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/ItemStackMirrorTest.java
@@ -2,7 +2,6 @@ package org.mockbukkit.mockbukkit.inventory;
 
 import org.bukkit.Material;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.configuration.serialization.DelegateDeserialization;
 import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -67,14 +66,6 @@ class ItemStackMirrorTest
 			assertNotSame(originalItem, mirror);
 		}
 
-	}
-
-	@Test
-	void classHasDelegateSerializationAnnotation()
-	{
-		DelegateDeserialization delegateDeserialization = ItemStackMirror.class.getAnnotation(DelegateDeserialization.class);
-		assertNotNull(delegateDeserialization, "The class should be annotated with @DelegateDeserialization(ItemStack.class)");
-		assertEquals(ItemStack.class, delegateDeserialization.value());
 	}
 
 	/*


### PR DESCRIPTION
# Description

Fixes serialization of ItemStackMirrorMock so that it emulates the real serialization.
Fixes https://github.com/MockBukkit/MockBukkit/issues/1449.

# Checklist

The following items should be checked before the pull request can be merged.

- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
