### PR TITLE
BlockData for BrewingStand, Dispenser, Observer, Piston and Directional

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
@@ -31,6 +31,7 @@ import org.bukkit.block.data.type.Chest;
 import org.bukkit.block.data.type.CommandBlock;
 import org.bukkit.block.data.type.Crafter;
 import org.bukkit.block.data.type.DecoratedPot;
+import org.bukkit.block.data.type.Dispenser;
 import org.bukkit.block.data.type.Door;
 import org.bukkit.block.data.type.Farmland;
 import org.bukkit.block.data.type.Gate;
@@ -156,7 +157,7 @@ public enum BlockDataKey
 	CRACKED("cracked", Boolean::parseBoolean, DecoratedPot.class::isInstance),
 
 	CRAFTING("crafting", Boolean::parseBoolean, Crafter.class::isInstance),
-	TRIGGERED("triggered", Boolean::parseBoolean, Crafter.class::isInstance),
+	TRIGGERED("triggered", Boolean::parseBoolean, o -> o instanceof Crafter || o instanceof Dispenser),
 	ENABLED("enabled", Boolean::parseBoolean, Hopper.class::isInstance),
 	ORIENTATION("orientation", EnumDataDeserializer.of(Orientation.class), Crafter.class::isInstance),
 	HINGE("hinge", EnumDataDeserializer.of(Door.Hinge.class), Door.class::isInstance),

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
@@ -38,6 +38,7 @@ import org.bukkit.block.data.type.Gate;
 import org.bukkit.block.data.type.Hopper;
 import org.bukkit.block.data.type.Lectern;
 import org.bukkit.block.data.type.Piston;
+import org.bukkit.block.data.type.PistonHead;
 import org.bukkit.block.data.type.RedstoneWire;
 import org.bukkit.block.data.type.Repeater;
 import org.bukkit.block.data.type.Sapling;
@@ -192,6 +193,7 @@ public enum BlockDataKey
 	EGGS("eggs", Integer::parseInt, TurtleEgg.class::isInstance),
 
 	EXTENDED("extended", Boolean::parseBoolean, Piston.class::isInstance),
+	SHORT("short", Boolean::parseBoolean, PistonHead.class::isInstance),
 
 	HAS_BOTTLE_0("has_bottle_0", Boolean::parseBoolean, BrewingStand.class::isInstance),
 	HAS_BOTTLE_1("has_bottle_1", Boolean::parseBoolean, BrewingStand.class::isInstance),

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
@@ -44,6 +44,7 @@ import org.bukkit.block.data.type.Sapling;
 import org.bukkit.block.data.type.Slab;
 import org.bukkit.block.data.type.Stairs;
 import org.bukkit.block.data.type.TNT;
+import org.bukkit.block.data.type.TechnicalPiston;
 import org.bukkit.block.data.type.TestBlock;
 import org.bukkit.block.data.type.TrialSpawner;
 import org.bukkit.block.data.type.TurtleEgg;
@@ -122,6 +123,7 @@ public enum BlockDataKey
 	 */
 	TYPE("type", EnumDataDeserializer.of(Slab.Type.class), Slab.class::isInstance),
 	TYPE_CHEST("type", EnumDataDeserializer.of(Chest.Type.class), Chest.class::isInstance),
+	TYPE_TECHNICAL_PISTON("type", EnumDataDeserializer.of(TechnicalPiston.Type.class), TechnicalPiston.class::isInstance),
 
 	/**
 	 * Stores whether a {@link Waterlogged} block is waterlogged.

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
@@ -24,6 +24,7 @@ import org.bukkit.block.data.Snowable;
 import org.bukkit.block.data.Waterlogged;
 import org.bukkit.block.data.type.Bamboo;
 import org.bukkit.block.data.type.Bed;
+import org.bukkit.block.data.type.BrewingStand;
 import org.bukkit.block.data.type.Campfire;
 import org.bukkit.block.data.type.Candle;
 import org.bukkit.block.data.type.Chest;
@@ -184,7 +185,11 @@ public enum BlockDataKey
 	CONDITIONAL("conditional", Boolean::parseBoolean, CommandBlock.class::isInstance),
 	MOISTURE("moisture", Integer::parseInt, Farmland.class::isInstance),
 	HATCH("hatch", Integer::parseInt, Hatchable.class::isInstance),
-	EGGS("eggs", Integer::parseInt, TurtleEgg.class::isInstance);
+	EGGS("eggs", Integer::parseInt, TurtleEgg.class::isInstance),
+
+	HAS_BOTTLE_0("has_bottle_0", Boolean::parseBoolean, BrewingStand.class::isInstance),
+	HAS_BOTTLE_1("has_bottle_1", Boolean::parseBoolean, BrewingStand.class::isInstance),
+	HAS_BOTTLE_2("has_bottle_2", Boolean::parseBoolean, BrewingStand.class::isInstance);
 
 
 	private static final Set<String> KEYS = compileKeys();

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
@@ -37,6 +37,7 @@ import org.bukkit.block.data.type.Farmland;
 import org.bukkit.block.data.type.Gate;
 import org.bukkit.block.data.type.Hopper;
 import org.bukkit.block.data.type.Lectern;
+import org.bukkit.block.data.type.Piston;
 import org.bukkit.block.data.type.RedstoneWire;
 import org.bukkit.block.data.type.Repeater;
 import org.bukkit.block.data.type.Sapling;
@@ -187,6 +188,8 @@ public enum BlockDataKey
 	MOISTURE("moisture", Integer::parseInt, Farmland.class::isInstance),
 	HATCH("hatch", Integer::parseInt, Hatchable.class::isInstance),
 	EGGS("eggs", Integer::parseInt, TurtleEgg.class::isInstance),
+
+	EXTENDED("extended", Boolean::parseBoolean, Piston.class::isInstance),
 
 	HAS_BOTTLE_0("has_bottle_0", Boolean::parseBoolean, BrewingStand.class::isInstance),
 	HAS_BOTTLE_1("has_bottle_1", Boolean::parseBoolean, BrewingStand.class::isInstance),

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
@@ -32,6 +32,7 @@ import org.bukkit.block.data.type.Furnace;
 import org.bukkit.block.data.type.Hopper;
 import org.bukkit.block.data.type.Lectern;
 import org.bukkit.block.data.type.Light;
+import org.bukkit.block.data.type.Observer;
 import org.bukkit.block.data.type.RedstoneRail;
 import org.bukkit.block.data.type.RedstoneWallTorch;
 import org.bukkit.block.data.type.RedstoneWire;
@@ -44,6 +45,7 @@ import org.bukkit.block.data.type.TrialSpawner;
 import org.bukkit.block.data.type.TurtleEgg;
 import org.bukkit.block.data.type.Vault;
 import org.jetbrains.annotations.NotNull;
+import org.mockbukkit.mockbukkit.block.ObserverDataMock;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -94,6 +96,7 @@ public final class BlockDataMockFactory
 			.put(Levelled.class, LevelledDataMock::new)
 			.put(Light.class, LightDataMock::new)
 			.put(Lightable.class, LightableDataMock::new)
+			.put(Observer.class, ObserverDataMock::new)
 			.put(Orientable.class, OrientableMock::new)
 			.put(Switch.class, SwitchDataMock::new)
 			.put(TestBlock.class, TestBlockDataMock::new)

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
@@ -20,6 +20,7 @@ import org.bukkit.block.data.Waterlogged;
 import org.bukkit.block.data.type.AmethystCluster;
 import org.bukkit.block.data.type.Bamboo;
 import org.bukkit.block.data.type.Barrel;
+import org.bukkit.block.data.type.BrewingStand;
 import org.bukkit.block.data.type.Chest;
 import org.bukkit.block.data.type.CommandBlock;
 import org.bukkit.block.data.type.Crafter;
@@ -76,6 +77,7 @@ public final class BlockDataMockFactory
 	private static final Map<Class<? extends BlockData>, Function<Material, BlockDataMock>> FACTORIES_BY_BLOCK_DATA = ImmutableMap.<Class<? extends BlockData>, Function<Material, BlockDataMock>>builder()
 			.put(AmethystCluster.class, AmethystClusterDataMock::new)
 			.put(Bamboo.class, m -> new BambooDataMock())
+			.put(BrewingStand.class, BrewingStandDataMock::new)
 			.put(Brushable.class, BrushableDataMock::new)
 			.put(Chest.class, ChestDataMock::new)
 			.put(CommandBlock.class, CommandBlockDataMock::new)

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
@@ -41,6 +41,7 @@ import org.bukkit.block.data.type.Repeater;
 import org.bukkit.block.data.type.Sapling;
 import org.bukkit.block.data.type.Switch;
 import org.bukkit.block.data.type.TNT;
+import org.bukkit.block.data.type.TechnicalPiston;
 import org.bukkit.block.data.type.TestBlock;
 import org.bukkit.block.data.type.TrialSpawner;
 import org.bukkit.block.data.type.TurtleEgg;
@@ -101,6 +102,7 @@ public final class BlockDataMockFactory
 			.put(Orientable.class, OrientableMock::new)
 			.put(Piston.class, PistonDataMock::new)
 			.put(Switch.class, SwitchDataMock::new)
+			.put(TechnicalPiston.class, TechnicalPistonDataMock::new)
 			.put(TestBlock.class, TestBlockDataMock::new)
 			.put(TNT.class, TNTDataMock::new)
 			.put(TrialSpawner.class, TrialSpawnerDataMock::new)

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
@@ -25,6 +25,7 @@ import org.bukkit.block.data.type.Chest;
 import org.bukkit.block.data.type.CommandBlock;
 import org.bukkit.block.data.type.Crafter;
 import org.bukkit.block.data.type.DecoratedPot;
+import org.bukkit.block.data.type.Dispenser;
 import org.bukkit.block.data.type.EnderChest;
 import org.bukkit.block.data.type.Farmland;
 import org.bukkit.block.data.type.Furnace;
@@ -83,6 +84,7 @@ public final class BlockDataMockFactory
 			.put(CommandBlock.class, CommandBlockDataMock::new)
 			.put(Crafter.class, CrafterDataMock::new)
 			.put(DecoratedPot.class, m -> new DecoratedPotDataMock())
+			.put(Dispenser.class, DispenserDataMock::new)
 			.put(EnderChest.class, EnderChestDataMock::new)
 			.put(Farmland.class, FarmlandDataMock::new)
 			.put(Furnace.class, FurnaceDataMock::new)

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
@@ -33,6 +33,7 @@ import org.bukkit.block.data.type.Hopper;
 import org.bukkit.block.data.type.Lectern;
 import org.bukkit.block.data.type.Light;
 import org.bukkit.block.data.type.Observer;
+import org.bukkit.block.data.type.Piston;
 import org.bukkit.block.data.type.RedstoneRail;
 import org.bukkit.block.data.type.RedstoneWallTorch;
 import org.bukkit.block.data.type.RedstoneWire;
@@ -98,6 +99,7 @@ public final class BlockDataMockFactory
 			.put(Lightable.class, LightableDataMock::new)
 			.put(Observer.class, ObserverDataMock::new)
 			.put(Orientable.class, OrientableMock::new)
+			.put(Piston.class, PistonDataMock::new)
 			.put(Switch.class, SwitchDataMock::new)
 			.put(TestBlock.class, TestBlockDataMock::new)
 			.put(TNT.class, TNTDataMock::new)

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
@@ -9,6 +9,7 @@ import org.bukkit.block.data.AnaloguePowerable;
 import org.bukkit.block.data.Bisected;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Brushable;
+import org.bukkit.block.data.Directional;
 import org.bukkit.block.data.Hatchable;
 import org.bukkit.block.data.Levelled;
 import org.bukkit.block.data.Lightable;
@@ -90,6 +91,7 @@ public final class BlockDataMockFactory
 			.put(Crafter.class, CrafterDataMock::new)
 			.put(DecoratedPot.class, m -> new DecoratedPotDataMock())
 			.put(Dispenser.class, DispenserDataMock::new)
+			.put(Directional.class, DirectionalDataMock::new)
 			.put(EnderChest.class, EnderChestDataMock::new)
 			.put(Farmland.class, FarmlandDataMock::new)
 			.put(Furnace.class, FurnaceDataMock::new)

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
@@ -49,7 +49,6 @@ import org.bukkit.block.data.type.TrialSpawner;
 import org.bukkit.block.data.type.TurtleEgg;
 import org.bukkit.block.data.type.Vault;
 import org.jetbrains.annotations.NotNull;
-import org.mockbukkit.mockbukkit.block.ObserverDataMock;
 
 import java.util.Map;
 import java.util.function.Function;

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
@@ -34,6 +34,7 @@ import org.bukkit.block.data.type.Lectern;
 import org.bukkit.block.data.type.Light;
 import org.bukkit.block.data.type.Observer;
 import org.bukkit.block.data.type.Piston;
+import org.bukkit.block.data.type.PistonHead;
 import org.bukkit.block.data.type.RedstoneRail;
 import org.bukkit.block.data.type.RedstoneWallTorch;
 import org.bukkit.block.data.type.RedstoneWire;
@@ -101,6 +102,7 @@ public final class BlockDataMockFactory
 			.put(Observer.class, ObserverDataMock::new)
 			.put(Orientable.class, OrientableMock::new)
 			.put(Piston.class, PistonDataMock::new)
+			.put(PistonHead.class, PistonHeadDataMock::new)
 			.put(Switch.class, SwitchDataMock::new)
 			.put(TechnicalPiston.class, TechnicalPistonDataMock::new)
 			.put(TestBlock.class, TestBlockDataMock::new)

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BrewingStandDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BrewingStandDataMock.java
@@ -1,0 +1,59 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import com.google.common.collect.ImmutableSet;
+import org.bukkit.Material;
+import org.bukkit.block.data.type.BrewingStand;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+public class BrewingStandDataMock extends BlockDataMock implements BrewingStand
+{
+
+	private final BlockDataKey[] bottleSlots = new BlockDataKey[] {
+			BlockDataKey.HAS_BOTTLE_0, BlockDataKey.HAS_BOTTLE_1, BlockDataKey.HAS_BOTTLE_2
+	};
+
+	public BrewingStandDataMock(@NotNull Material material)
+	{
+		super(material);
+	}
+
+	protected BrewingStandDataMock(@NotNull BlockDataMock other)
+	{
+		super(other);
+	}
+
+	@Override
+	public boolean hasBottle(int index)
+	{
+		return this.get(bottleSlots[index]);
+	}
+
+	@Override
+	public void setBottle(int index, boolean has)
+	{
+		this.set(bottleSlots[index], has);
+	}
+
+	@Override
+	public @NotNull Set<Integer> getBottles()
+	{
+		ImmutableSet.Builder<Integer> bottles = ImmutableSet.builder();
+		for (int index = 0, len = bottleSlots.length; index < len; index++)
+		{
+			if (this.get(bottleSlots[index]))
+			{
+				bottles.add(index);
+			}
+		}
+		return bottles.build();
+	}
+
+	@Override
+	public int getMaximumBottles()
+	{
+		return bottleSlots.length;
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BrewingStandDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BrewingStandDataMock.java
@@ -7,6 +7,11 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
 
+/**
+ * Mock implementation of {@link BrewingStand}.
+ *
+ * @see BlockDataMock
+ */
 public class BrewingStandDataMock extends BlockDataMock implements BrewingStand
 {
 

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BrewingStandDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BrewingStandDataMock.java
@@ -56,4 +56,11 @@ public class BrewingStandDataMock extends BlockDataMock implements BrewingStand
 		return bottleSlots.length;
 	}
 
+	@Override
+	@SuppressWarnings({"MethodDoesntCallSuperMethod", "java:S2975", "java:S1182"})
+	public @NotNull BrewingStandDataMock clone()
+	{
+		return new BrewingStandDataMock(this);
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/DirectionalDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/DirectionalDataMock.java
@@ -1,0 +1,51 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.Directional;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+public class DirectionalDataMock extends BlockDataMock implements Directional
+{
+
+	public DirectionalDataMock(@NotNull Material material)
+	{
+		super(material);
+	}
+
+	protected DirectionalDataMock(@NotNull BlockDataMock other)
+	{
+		super(other);
+	}
+
+	@Override
+	public @NotNull BlockFace getFacing()
+	{
+		return this.get(BlockDataKey.FACING);
+	}
+
+	@Override
+	public void setFacing(@NotNull BlockFace blockFace)
+	{
+		Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
+		Preconditions.checkArgument(this.getFaces().contains(blockFace), "Invalid face: %s. Possible values are: %s", blockFace, this.getFaces());
+		this.set(BlockDataKey.FACING, blockFace);
+	}
+
+	@Override
+	public @NotNull Set<BlockFace> getFaces()
+	{
+		return this.getLimitationValue(BlockDataLimitation.Type.FACES);
+	}
+
+	@Override
+	@SuppressWarnings({"MethodDoesntCallSuperMethod", "java:S2975", "java:S1182"})
+	public @NotNull DirectionalDataMock clone()
+	{
+		return new DirectionalDataMock(this);
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/DirectionalDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/DirectionalDataMock.java
@@ -8,6 +8,11 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
 
+/**
+ * Mock implementation of {@link Directional}.
+ *
+ * @see BlockDataMock
+ */
 public class DirectionalDataMock extends BlockDataMock implements Directional
 {
 

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/DispenserDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/DispenserDataMock.java
@@ -1,0 +1,56 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.type.Dispenser;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+public class DispenserDataMock extends BlockDataMock implements Dispenser
+{
+
+	public DispenserDataMock(@NotNull Material material)
+	{
+		super(material);
+	}
+
+	protected DispenserDataMock(@NotNull BlockDataMock other)
+	{
+		super(other);
+	}
+
+	@Override
+	public boolean isTriggered()
+	{
+		return this.get(BlockDataKey.TRIGGERED);
+	}
+
+	@Override
+	public void setTriggered(boolean triggered)
+	{
+		this.set(BlockDataKey.TRIGGERED, triggered);
+	}
+
+	@Override
+	public @NotNull BlockFace getFacing()
+	{
+		return this.get(BlockDataKey.FACING);
+	}
+
+	@Override
+	public void setFacing(@NotNull BlockFace blockFace)
+	{
+		Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
+		Preconditions.checkArgument(blockFace.isCartesian(), "Invalid face, only cartesian face are allowed for this property!");
+		this.set(BlockDataKey.FACING, blockFace);
+	}
+
+	@Override
+	public @NotNull Set<BlockFace> getFaces()
+	{
+		return this.getLimitationValue(BlockDataLimitation.Type.FACES);
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/DispenserDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/DispenserDataMock.java
@@ -8,6 +8,11 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
 
+/**
+ * Mock implementation of {@link Dispenser}.
+ *
+ * @see BlockDataMock
+ */
 public class DispenserDataMock extends BlockDataMock implements Dispenser
 {
 

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/DispenserDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/DispenserDataMock.java
@@ -53,4 +53,11 @@ public class DispenserDataMock extends BlockDataMock implements Dispenser
 		return this.getLimitationValue(BlockDataLimitation.Type.FACES);
 	}
 
+	@Override
+	@SuppressWarnings({"MethodDoesntCallSuperMethod", "java:S2975", "java:S1182"})
+	public @NotNull DispenserDataMock clone()
+	{
+		return new DispenserDataMock(this);
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/ObserverDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/ObserverDataMock.java
@@ -1,16 +1,18 @@
-package org.mockbukkit.mockbukkit.block;
+package org.mockbukkit.mockbukkit.block.data;
 
 import com.google.common.base.Preconditions;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.type.Observer;
 import org.jetbrains.annotations.NotNull;
-import org.mockbukkit.mockbukkit.block.data.BlockDataKey;
-import org.mockbukkit.mockbukkit.block.data.BlockDataLimitation;
-import org.mockbukkit.mockbukkit.block.data.BlockDataMock;
 
 import java.util.Set;
 
+/**
+ * Mock implementation of {@link Observer}.
+ *
+ * @see BlockDataMock
+ */
 public class ObserverDataMock extends BlockDataMock implements Observer
 {
 

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/ObserverDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/ObserverDataMock.java
@@ -56,4 +56,11 @@ public class ObserverDataMock extends BlockDataMock implements Observer
 		this.set(BlockDataKey.POWERED, powered);
 	}
 
+	@Override
+	@SuppressWarnings({"MethodDoesntCallSuperMethod", "java:S2975", "java:S1182"})
+	public @NotNull ObserverDataMock clone()
+	{
+		return new ObserverDataMock(this);
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/ObserverDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/ObserverDataMock.java
@@ -1,0 +1,59 @@
+package org.mockbukkit.mockbukkit.block;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.type.Observer;
+import org.jetbrains.annotations.NotNull;
+import org.mockbukkit.mockbukkit.block.data.BlockDataKey;
+import org.mockbukkit.mockbukkit.block.data.BlockDataLimitation;
+import org.mockbukkit.mockbukkit.block.data.BlockDataMock;
+
+import java.util.Set;
+
+public class ObserverDataMock extends BlockDataMock implements Observer
+{
+
+	public ObserverDataMock(@NotNull Material material)
+	{
+		super(material);
+	}
+
+	protected ObserverDataMock(@NotNull BlockDataMock other)
+	{
+		super(other);
+	}
+
+	@Override
+	public @NotNull BlockFace getFacing()
+	{
+		return this.get(BlockDataKey.FACING);
+	}
+
+	@Override
+	public void setFacing(@NotNull BlockFace blockFace)
+	{
+		Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
+		Preconditions.checkArgument(blockFace.isCartesian(), "Invalid face, only cartesian face are allowed for this property!");
+		this.set(BlockDataKey.FACING, blockFace);
+	}
+
+	@Override
+	public @NotNull Set<BlockFace> getFaces()
+	{
+		return this.getLimitationValue(BlockDataLimitation.Type.FACES);
+	}
+
+	@Override
+	public boolean isPowered()
+	{
+		return this.get(BlockDataKey.POWERED);
+	}
+
+	@Override
+	public void setPowered(boolean powered)
+	{
+		this.set(BlockDataKey.POWERED, powered);
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/PistonDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/PistonDataMock.java
@@ -53,4 +53,11 @@ public class PistonDataMock extends BlockDataMock implements Piston
 		return this.getLimitationValue(BlockDataLimitation.Type.FACES);
 	}
 
+	@Override
+	@SuppressWarnings({"MethodDoesntCallSuperMethod", "java:S2975", "java:S1182"})
+	public @NotNull PistonDataMock clone()
+	{
+		return new PistonDataMock(this);
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/PistonDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/PistonDataMock.java
@@ -1,0 +1,56 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.type.Piston;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+public class PistonDataMock extends BlockDataMock implements Piston
+{
+
+	public PistonDataMock(@NotNull Material material)
+	{
+		super(material);
+	}
+
+	protected PistonDataMock(@NotNull BlockDataMock other)
+	{
+		super(other);
+	}
+
+	@Override
+	public boolean isExtended()
+	{
+		return this.get(BlockDataKey.EXTENDED);
+	}
+
+	@Override
+	public void setExtended(boolean extended)
+	{
+		this.set(BlockDataKey.EXTENDED, extended);
+	}
+
+	@Override
+	public @NotNull BlockFace getFacing()
+	{
+		return this.get(BlockDataKey.FACING);
+	}
+
+	@Override
+	public void setFacing(@NotNull BlockFace blockFace)
+	{
+		Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
+		Preconditions.checkArgument(blockFace.isCartesian(), "Invalid face, only cartesian face are allowed for this property!");
+		this.set(BlockDataKey.FACING, blockFace);
+	}
+
+	@Override
+	public @NotNull Set<BlockFace> getFaces()
+	{
+		return this.getLimitationValue(BlockDataLimitation.Type.FACES);
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/PistonDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/PistonDataMock.java
@@ -8,6 +8,11 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
 
+/**
+ * Mock implementation of {@link Piston}.
+ *
+ * @see BlockDataMock
+ */
 public class PistonDataMock extends BlockDataMock implements Piston
 {
 

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/PistonHeadDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/PistonHeadDataMock.java
@@ -1,0 +1,70 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.type.PistonHead;
+import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Set;
+
+public class PistonHeadDataMock extends BlockDataMock implements PistonHead
+{
+
+	public PistonHeadDataMock(@NotNull Material material)
+	{
+		super(material);
+	}
+
+	protected PistonHeadDataMock(@NotNull BlockDataMock other)
+	{
+		super(other);
+	}
+
+	@Override
+	public @NotNull Type getType()
+	{
+		return this.get(BlockDataKey.TYPE_TECHNICAL_PISTON);
+	}
+
+	@Override
+	public void setType(@NotNull Type type)
+	{
+		Preconditions.checkArgument(type != null, "type cannot be null!");
+		this.set(BlockDataKey.TYPE_TECHNICAL_PISTON, type);
+	}
+
+	@Override
+	public @NonNull BlockFace getFacing()
+	{
+		return this.get(BlockDataKey.FACING);
+	}
+
+	@Override
+	public void setFacing(final BlockFace blockFace)
+	{
+		Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
+		Preconditions.checkArgument(blockFace.isCartesian(), "Invalid face, only cartesian face are allowed for this property!");
+		this.set(BlockDataKey.FACING, blockFace);
+	}
+
+	@Override
+	public @NonNull Set<BlockFace> getFaces()
+	{
+		return this.getLimitationValue(BlockDataLimitation.Type.FACES);
+	}
+
+	@Override
+	public boolean isShort()
+	{
+		return this.get(BlockDataKey.SHORT);
+	}
+
+	@Override
+	public void setShort(boolean _short)
+	{
+		this.set(BlockDataKey.SHORT, _short);
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/PistonHeadDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/PistonHeadDataMock.java
@@ -67,4 +67,11 @@ public class PistonHeadDataMock extends BlockDataMock implements PistonHead
 		this.set(BlockDataKey.SHORT, _short);
 	}
 
+	@Override
+	@SuppressWarnings({"MethodDoesntCallSuperMethod", "java:S2975", "java:S1182"})
+	public @NotNull PistonHeadDataMock clone()
+	{
+		return new PistonHeadDataMock(this);
+	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/PistonHeadDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/PistonHeadDataMock.java
@@ -9,6 +9,11 @@ import org.jspecify.annotations.NonNull;
 
 import java.util.Set;
 
+/**
+ * Mock implementation of {@link PistonHead}.
+ *
+ * @see BlockDataMock
+ */
 public class PistonHeadDataMock extends BlockDataMock implements PistonHead
 {
 

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/TechnicalPistonDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/TechnicalPistonDataMock.java
@@ -9,6 +9,11 @@ import org.jspecify.annotations.NonNull;
 
 import java.util.Set;
 
+/**
+ * Mock implementation of {@link TechnicalPiston}.
+ *
+ * @see BlockDataMock
+ */
 public class TechnicalPistonDataMock extends BlockDataMock implements TechnicalPiston
 {
 

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/TechnicalPistonDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/TechnicalPistonDataMock.java
@@ -1,0 +1,58 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.type.TechnicalPiston;
+import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Set;
+
+public class TechnicalPistonDataMock extends BlockDataMock implements TechnicalPiston
+{
+
+	public TechnicalPistonDataMock(@NotNull Material material)
+	{
+		super(material);
+	}
+
+	protected TechnicalPistonDataMock(@NotNull TechnicalPistonDataMock other)
+	{
+		super(other);
+	}
+
+	@Override
+	public @NotNull Type getType()
+	{
+		return this.get(BlockDataKey.TYPE_TECHNICAL_PISTON);
+	}
+
+	@Override
+	public void setType(@NotNull Type type)
+	{
+		Preconditions.checkArgument(type != null, "type cannot be null!");
+		this.set(BlockDataKey.TYPE_TECHNICAL_PISTON, type);
+	}
+
+	@Override
+	public @NonNull BlockFace getFacing()
+	{
+		return this.get(BlockDataKey.FACING);
+	}
+
+	@Override
+	public void setFacing(final BlockFace blockFace)
+	{
+		Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
+		Preconditions.checkArgument(blockFace.isCartesian(), "Invalid face, only cartesian face are allowed for this property!");
+		this.set(BlockDataKey.FACING, blockFace);
+	}
+
+	@Override
+	public @NonNull Set<BlockFace> getFaces()
+	{
+		return this.getLimitationValue(BlockDataLimitation.Type.FACES);
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/TechnicalPistonDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/TechnicalPistonDataMock.java
@@ -55,4 +55,11 @@ public class TechnicalPistonDataMock extends BlockDataMock implements TechnicalP
 		return this.getLimitationValue(BlockDataLimitation.Type.FACES);
 	}
 
+	@Override
+	@SuppressWarnings({"MethodDoesntCallSuperMethod", "java:S2975", "java:S1182"})
+	public @NotNull TechnicalPistonDataMock clone()
+	{
+		return new TechnicalPistonDataMock(this);
+	}
+
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
@@ -758,7 +758,6 @@ class BlockTypeMockTest
 		}
 
 		@Test
-		@Disabled("Not implemented yet #1088")
 		void givenDirectional()
 		{
 			Directional data = BlockType.WALL_TORCH.createBlockData();

--- a/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
@@ -717,7 +717,6 @@ class BlockTypeMockTest
 		}
 
 		@Test
-		@Disabled("Not implemented yet #1088")
 		void givenPistonHead()
 		{
 			PistonHead data = BlockType.PISTON_HEAD.createBlockData();

--- a/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
@@ -74,6 +74,7 @@ import org.bukkit.block.data.type.LightningRod;
 import org.bukkit.block.data.type.MangrovePropagule;
 import org.bukkit.block.data.type.MossyCarpet;
 import org.bukkit.block.data.type.NoteBlock;
+import org.bukkit.block.data.type.Observer;
 import org.bukkit.block.data.type.Piston;
 import org.bukkit.block.data.type.PistonHead;
 import org.bukkit.block.data.type.PointedDripstone;
@@ -679,6 +680,14 @@ class BlockTypeMockTest
 			BlockData data = BlockType.DROPPER.createBlockData();
 			assertNotNull(data);
 			assertInstanceOf(Dispenser.class, data);
+		}
+
+		@Test
+		void givenObserver()
+		{
+			BlockData data = BlockType.OBSERVER.createBlockData();
+			assertNotNull(data);
+			assertInstanceOf(Observer.class, data);
 		}
 
 		@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
@@ -709,7 +709,6 @@ class BlockTypeMockTest
 		}
 
 		@Test
-		@Disabled("Not implemented yet #1088")
 		void givenPiston()
 		{
 			Piston data = BlockType.PISTON.createBlockData();

--- a/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
@@ -958,7 +958,6 @@ class BlockTypeMockTest
 		}
 
 		@Test
-		@Disabled("Not implemented yet #1088")
 		void givenBrewingStand()
 		{
 			BrewingStand data = BlockType.BREWING_STAND.createBlockData();

--- a/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
@@ -726,7 +726,6 @@ class BlockTypeMockTest
 		}
 
 		@Test
-		@Disabled("Not implemented yet #1088")
 		void givenMovingPiston()
 		{
 			TechnicalPiston data = BlockType.MOVING_PISTON.createBlockData();

--- a/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
@@ -666,10 +666,17 @@ class BlockTypeMockTest
 		}
 
 		@Test
-		@Disabled("Not implemented yet #1088")
 		void givenDispenser()
 		{
 			Dispenser data = BlockType.DISPENSER.createBlockData();
+			assertNotNull(data);
+			assertInstanceOf(Dispenser.class, data);
+		}
+
+		@Test
+		void givenDropper()
+		{
+			BlockData data = BlockType.DROPPER.createBlockData();
 			assertNotNull(data);
 			assertInstanceOf(Dispenser.class, data);
 		}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/BrewingStandDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/BrewingStandDataMockTest.java
@@ -1,0 +1,96 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@ExtendWith(MockBukkitExtension.class)
+class BrewingStandDataMockTest
+{
+
+	private BrewingStandDataMock brewingStand;
+
+	@BeforeEach
+	void setUp()
+	{
+		this.brewingStand = new BrewingStandDataMock(Material.BREWING_STAND);
+	}
+
+	@Nested
+	class HasBottle
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertFalse(brewingStand.hasBottle(0));
+			assertFalse(brewingStand.hasBottle(1));
+			assertFalse(brewingStand.hasBottle(2));
+		}
+
+		@ParameterizedTest
+		@CsvSource({
+			"false, false,	false",
+			"true, 	false,	false",
+			"false, true, 	false",
+			"false, false, 	true",
+			"true, 	false, 	true",
+			"true, 	true, 	true",
+			"false,	true, 	true",
+		})
+		void givenIndexCombination(boolean expected0, boolean expected1, boolean expected2)
+		{
+			brewingStand.setBottle(0, expected0);
+			brewingStand.setBottle(1, expected1);
+			brewingStand.setBottle(2, expected2);
+
+			assertEquals(expected0, brewingStand.hasBottle(0));
+			assertEquals(expected1, brewingStand.hasBottle(1));
+			assertEquals(expected2, brewingStand.hasBottle(2));
+		}
+
+	}
+
+	@Nested
+	class GetBottle
+	{
+
+		@Test
+		void givenDefault()
+		{
+			Set<Integer> indexes = brewingStand.getBottles();
+			assertEquals(Collections.emptySet(), indexes);
+		}
+
+		@Test
+		void givenIndexCombination()
+		{
+			brewingStand.setBottle(0, true);
+			brewingStand.setBottle(1, false);
+			brewingStand.setBottle(2, true);
+
+			Set<Integer> indexes = brewingStand.getBottles();
+
+			assertEquals(Set.of(0, 2), indexes);
+		}
+
+	}
+
+	@Test
+	void getMaximumBottles()
+	{
+		assertEquals(3, brewingStand.getMaximumBottles());
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/DirectionalDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/DirectionalDataMockTest.java
@@ -1,0 +1,51 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DirectionalDataMockTest
+{
+
+	private final DirectionalDataMock torch = new DirectionalDataMock(Material.WALL_TORCH);
+
+	@Nested
+	class SetFacing
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(BlockFace.NORTH, torch.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.INCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST" })
+		void givenValidValues(BlockFace face)
+		{
+			torch.setFacing(face);
+			assertEquals(face, torch.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.EXCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST" })
+		void givenInvalidValues(BlockFace face)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> torch.setFacing(face));
+			String expectedString = String.format("Invalid face: %s. Possible values are: %s", face, torch.getFaces());
+			assertEquals(expectedString, e.getMessage());
+		}
+
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/DispenserDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/DispenserDataMockTest.java
@@ -1,0 +1,80 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockBukkitExtension.class)
+class DispenserDataMockTest
+{
+	private DispenserDataMock dispenser;
+
+	@BeforeEach
+	void setUp()
+	{
+		this.dispenser = new DispenserDataMock(Material.DISPENSER);
+	}
+
+	@Nested
+	class SetFacing
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(BlockFace.NORTH, dispenser.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.INCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST", "UP", "DOWN" })
+		void givenValidValues(BlockFace face)
+		{
+			dispenser.setFacing(face);
+			assertEquals(face, dispenser.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.EXCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST", "UP", "DOWN" })
+		void givenInvalidValues(BlockFace face)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> dispenser.setFacing(face));
+			assertEquals("Invalid face, only cartesian face are allowed for this property!", e.getMessage());
+		}
+
+	}
+
+	@Nested
+	class SetTriggered
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertFalse(dispenser.isTriggered());
+		}
+
+		@ParameterizedTest
+		@ValueSource(booleans = { true, false })
+		void givenPossibleValues(boolean isTriggered)
+		{
+			dispenser.setTriggered(isTriggered);
+			assertEquals(isTriggered, dispenser.isTriggered());
+		}
+
+	}
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/ObserverDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/ObserverDataMockTest.java
@@ -1,0 +1,83 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+import org.mockbukkit.mockbukkit.block.ObserverDataMock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockBukkitExtension.class)
+class ObserverDataMockTest
+{
+
+	private ObserverDataMock observer;
+
+	@BeforeEach
+	void setUp()
+	{
+		this.observer = new ObserverDataMock(Material.OBSERVER);
+	}
+
+	@Nested
+	class SetFacing
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(BlockFace.SOUTH, observer.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.INCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST", "UP", "DOWN" })
+		void givenValidValues(BlockFace face)
+		{
+			observer.setFacing(face);
+			assertEquals(face, observer.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.EXCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST", "UP", "DOWN" })
+		void givenInvalidValues(BlockFace face)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> observer.setFacing(face));
+			assertEquals("Invalid face, only cartesian face are allowed for this property!", e.getMessage());
+		}
+
+	}
+
+	@Nested
+	class SetPowered
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertFalse(observer.isPowered());
+		}
+
+		@ParameterizedTest
+		@ValueSource(booleans = { true, false })
+		void givenPossibleValues(boolean powered)
+		{
+			observer.setPowered(powered);
+			assertEquals(powered, observer.isPowered());
+		}
+
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/ObserverDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/ObserverDataMockTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockbukkit.mockbukkit.MockBukkitExtension;
-import org.mockbukkit.mockbukkit.block.ObserverDataMock;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/PistonDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/PistonDataMockTest.java
@@ -1,0 +1,82 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockBukkitExtension.class)
+class PistonDataMockTest
+{
+
+	private PistonDataMock piston;
+
+	@BeforeEach
+	void setUp()
+	{
+		this.piston = new PistonDataMock(Material.PISTON);
+	}
+
+	@Nested
+	class SetExtended
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertFalse(piston.isExtended());
+		}
+
+		@ParameterizedTest
+		@ValueSource(booleans = { true, false })
+		void givenPossibleValues(boolean powered)
+		{
+			piston.setExtended(powered);
+			assertEquals(powered, piston.isExtended());
+		}
+
+	}
+
+	@Nested
+	class SetFacing
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(BlockFace.NORTH, piston.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.INCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST", "UP", "DOWN" })
+		void givenValidValues(BlockFace face)
+		{
+			piston.setFacing(face);
+			assertEquals(face, piston.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.EXCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST", "UP", "DOWN" })
+		void givenInvalidValues(BlockFace face)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> piston.setFacing(face));
+			assertEquals("Invalid face, only cartesian face are allowed for this property!", e.getMessage());
+		}
+
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/PistonHeadDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/PistonHeadDataMockTest.java
@@ -1,0 +1,103 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.type.TechnicalPiston;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockBukkitExtension.class)
+class PistonHeadDataMockTest
+{
+
+	private PistonHeadDataMock pistonHead;
+
+	@BeforeEach
+	void setUp()
+	{
+		this.pistonHead = new PistonHeadDataMock(Material.PISTON_HEAD);
+	}
+
+	@Nested
+	class SetType
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(TechnicalPiston.Type.NORMAL, pistonHead.getType());
+		}
+
+		@ParameterizedTest
+		@EnumSource(TechnicalPiston.Type.class)
+		void givenValidValues(TechnicalPiston.Type type)
+		{
+			pistonHead.setType(type);
+			assertEquals(type, pistonHead.getType());
+		}
+
+	}
+
+	@Nested
+	class SetFacing
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(BlockFace.NORTH, pistonHead.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.INCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST", "UP", "DOWN" })
+		void givenValidValues(BlockFace face)
+		{
+			pistonHead.setFacing(face);
+			assertEquals(face, pistonHead.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.EXCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST", "UP", "DOWN" })
+		void givenInvalidValues(BlockFace face)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> pistonHead.setFacing(face));
+			assertEquals("Invalid face, only cartesian face are allowed for this property!", e.getMessage());
+		}
+
+	}
+
+	@Nested
+	class IsShort
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertFalse(pistonHead.isShort());
+		}
+
+		@ParameterizedTest
+		@ValueSource(booleans = { true, false })
+		void givenPossibleValues(boolean isShort)
+		{
+			pistonHead.setShort(isShort);
+			assertEquals(isShort, pistonHead.isShort());
+		}
+
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/TechnicalPistonDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/TechnicalPistonDataMockTest.java
@@ -1,0 +1,80 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.type.TechnicalPiston;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockBukkitExtension.class)
+class TechnicalPistonDataMockTest
+{
+	private TechnicalPistonDataMock piston;
+
+	@BeforeEach
+	void setUp()
+	{
+		this.piston = new TechnicalPistonDataMock(Material.MOVING_PISTON);
+	}
+
+	@Nested
+	class SetType
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(TechnicalPiston.Type.NORMAL, piston.getType());
+		}
+
+		@ParameterizedTest
+		@EnumSource(TechnicalPiston.Type.class)
+		void givenValidValues(TechnicalPiston.Type type)
+		{
+			piston.setType(type);
+			assertEquals(type, piston.getType());
+		}
+
+	}
+
+	@Nested
+	class SetFacing
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(BlockFace.NORTH, piston.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.INCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST", "UP", "DOWN" })
+		void givenValidValues(BlockFace face)
+		{
+			piston.setFacing(face);
+			assertEquals(face, piston.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.EXCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST", "UP", "DOWN" })
+		void givenInvalidValues(BlockFace face)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> piston.setFacing(face));
+			assertEquals("Invalid face, only cartesian face are allowed for this property!", e.getMessage());
+		}
+
+	}
+
+}


### PR DESCRIPTION
# Description
This is a PR related with issue #1088 and implements the following block data:
- BrewingStand
- Dispenser
- Observer
- Piston
- PistonHead
- MovingPiston (TechnicalPiston)
- Directional

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
