### PR TITLE
Implement World.getCoordinateScale() method

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
@@ -2220,8 +2220,7 @@ public class WorldMock implements World
 	@Override
 	public double getCoordinateScale()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return environment == Environment.NETHER ? 8.0 : 1.0;
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
@@ -2385,6 +2385,19 @@ class WorldMockTest
 	}
 
 	@Test
+	void testCoordinateScale()
+	{
+		WorldMock world = new WorldMock(Material.DIRT, 3);
+		assertEquals(1, world.getCoordinateScale());
+
+		world.setEnvironment(World.Environment.NETHER);
+		assertEquals(8, world.getCoordinateScale());
+
+		world.setEnvironment(World.Environment.THE_END);
+		assertEquals(1, world.getCoordinateScale());
+	}
+
+	@Test
 	void testIsFixedTime()
 	{
 		WorldMock world = new WorldMock(Material.DIRT, 3);


### PR DESCRIPTION
# Description
Add World.getCoordinateScale() method, nether scale is 8, and the rest is 1.

# Checklist

The following items should be checked before the pull request can be merged.

- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
