### PR TITLE
Implement teamDisplayName and small code cleanup

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/EntityMock.java
@@ -476,10 +476,13 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	 * Gets the scoreboard entry for this entity.
 	 *
 	 * @return The scoreboard entry.
+	 *
+	 * @deprecated Replaced by {@link #getScoreboardEntryName()}
 	 */
+	@Deprecated(forRemoval = true)
 	public @NotNull String getScoreboardEntry()
 	{
-		return uuid.toString();
+		return this.getScoreboardEntryName();
 	}
 
 	/**
@@ -1544,8 +1547,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	@Override
 	public @NotNull String getScoreboardEntryName()
 	{
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException();
+		return this.getUniqueId().toString();
 	}
 
 	@ApiStatus.Internal

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/EntityMock.java
@@ -9,6 +9,7 @@ import io.papermc.paper.entity.TeleportFlag;
 import io.papermc.paper.threadedregions.scheduler.EntityScheduler;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.util.TriState;
 import org.bukkit.Bukkit;
@@ -44,6 +45,7 @@ import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.permissions.PermissionAttachmentInfo;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.scoreboard.Team;
 import org.bukkit.util.BoundingBox;
 import org.bukkit.util.NumberConversions;
 import org.bukkit.util.Vector;
@@ -61,6 +63,7 @@ import org.mockbukkit.mockbukkit.event.EventFactoryMock;
 import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 import org.mockbukkit.mockbukkit.metadata.MetadataTable;
 import org.mockbukkit.mockbukkit.persistence.PersistentDataContainerMock;
+import org.mockbukkit.mockbukkit.scoreboard.TeamMock;
 import org.mockbukkit.mockbukkit.world.WorldMock;
 
 import java.util.ArrayList;
@@ -1342,8 +1345,11 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	@Override
 	public @NotNull Component teamDisplayName()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Team team = this.getServer().getScoreboardManager().getMainScoreboard().getEntryTeam(this.getScoreboardEntryName());
+		return TeamMock.formatNameForTeam(team, this.name()).style(Style.style()
+				.hoverEvent(HoverEvent.showEntity(this.getType(), this.getUniqueId(), this.name()))
+				.insertion(this.getUniqueId().toString())
+				.build());
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
@@ -827,9 +827,9 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	}
 
 	@Override
-	public @NotNull String getScoreboardEntry()
+	public @NotNull String getScoreboardEntryName()
 	{
-		return getName();
+		return this.getName();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/scoreboard/ObjectiveMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scoreboard/ObjectiveMock.java
@@ -13,7 +13,6 @@ import org.bukkit.scoreboard.RenderType;
 import org.bukkit.scoreboard.Score;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.mockbukkit.mockbukkit.entity.EntityMock;
 import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 
 import java.util.HashMap;
@@ -201,7 +200,7 @@ public class ObjectiveMock implements Objective
 	public @NotNull Score getScoreFor(@NotNull Entity entity) throws IllegalArgumentException, IllegalStateException
 	{
 		Preconditions.checkNotNull(entity, "Entity cannot be null");
-		return getScore(((EntityMock) entity).getScoreboardEntry());
+		return getScore(entity.getScoreboardEntryName());
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/scoreboard/ScoreboardMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scoreboard/ScoreboardMock.java
@@ -176,14 +176,14 @@ public class ScoreboardMock implements Scoreboard
 	}
 
 	@Override
-	public Team getPlayerTeam(@NotNull OfflinePlayer player) throws IllegalArgumentException
+	public Team getPlayerTeam(@NotNull OfflinePlayer player)
 	{
 		Preconditions.checkNotNull(player, OFFLINE_PLAYER_CANNOT_BE_NULL);
 		return getEntryTeam(player.getName());
 	}
 
 	@Override
-	public Team getEntryTeam(@NotNull String entry) throws IllegalArgumentException
+	public Team getEntryTeam(@NotNull String entry)
 	{
 		for (Team t : teams.values())
 		{

--- a/src/main/java/org/mockbukkit/mockbukkit/scoreboard/ScoreboardMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scoreboard/ScoreboardMock.java
@@ -13,7 +13,6 @@ import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.Team;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.mockbukkit.mockbukkit.entity.EntityMock;
 
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -260,21 +259,21 @@ public class ScoreboardMock implements Scoreboard
 	public @NotNull Set<Score> getScoresFor(@NotNull Entity entity) throws IllegalArgumentException
 	{
 		Preconditions.checkNotNull(entity, ENTITY_CANNOT_BE_NULL);
-		return getScores(((EntityMock) entity).getScoreboardEntry());
+		return getScores(entity.getScoreboardEntryName());
 	}
 
 	@Override
 	public void resetScoresFor(@NotNull Entity entity) throws IllegalArgumentException
 	{
 		Preconditions.checkNotNull(entity, ENTITY_CANNOT_BE_NULL);
-		resetScores(((EntityMock) entity).getScoreboardEntry());
+		resetScores(entity.getScoreboardEntryName());
 	}
 
 	@Override
 	public @Nullable Team getEntityTeam(@NotNull Entity entity) throws IllegalArgumentException
 	{
 		Preconditions.checkNotNull(entity, ENTITY_CANNOT_BE_NULL);
-		return getEntryTeam(((EntityMock) entity).getScoreboardEntry());
+		return getEntryTeam(entity.getScoreboardEntryName());
 	}
 
 	/**

--- a/src/main/java/org/mockbukkit/mockbukkit/scoreboard/TeamMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scoreboard/TeamMock.java
@@ -17,7 +17,6 @@ import org.bukkit.scoreboard.Team;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mockbukkit.mockbukkit.MockBukkit;
-import org.mockbukkit.mockbukkit.entity.EntityMock;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -329,7 +328,7 @@ public class TeamMock implements Team
 	public void addEntities(@NotNull Collection<Entity> entities) throws IllegalStateException, IllegalArgumentException
 	{
 		Preconditions.checkNotNull(entities, "Entities cannot be null");
-		addEntries(entities.stream().map(entity -> ((EntityMock) entity).getScoreboardEntry()).toList());
+		addEntries(entities.stream().map(Entity::getScoreboardEntryName).toList());
 	}
 
 	@Override
@@ -364,7 +363,7 @@ public class TeamMock implements Team
 	public boolean removeEntities(@NotNull Collection<Entity> entities) throws IllegalStateException, IllegalArgumentException
 	{
 		Preconditions.checkNotNull(entities, "Entities cannot be null");
-		return removeEntries(entities.stream().map(entity -> ((EntityMock) entity).getScoreboardEntry()).toList());
+		return removeEntries(entities.stream().map(Entity::getScoreboardEntryName).toList());
 	}
 
 	@Override
@@ -424,14 +423,14 @@ public class TeamMock implements Team
 	public void addEntity(@NotNull Entity entity) throws IllegalStateException, IllegalArgumentException
 	{
 		Preconditions.checkNotNull(entity, ENTITY_CANNOT_BE_NULL);
-		addEntry(((EntityMock) entity).getScoreboardEntry());
+		addEntry(entity.getScoreboardEntryName());
 	}
 
 	@Override
 	public boolean removeEntity(@NotNull Entity entity) throws IllegalStateException, IllegalArgumentException
 	{
 		Preconditions.checkNotNull(entity, ENTITY_CANNOT_BE_NULL);
-		return removeEntry(((EntityMock) entity).getScoreboardEntry());
+		return removeEntry(entity.getScoreboardEntryName());
 	}
 
 	@Override
@@ -439,7 +438,7 @@ public class TeamMock implements Team
 	{
 		Preconditions.checkNotNull(entity, ENTITY_CANNOT_BE_NULL);
 		checkRegistered();
-		return this.entries.contains(((EntityMock) entity).getScoreboardEntry());
+		return this.entries.contains(entity.getScoreboardEntryName());
 	}
 
 	/**

--- a/src/main/java/org/mockbukkit/mockbukkit/scoreboard/TeamMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scoreboard/TeamMock.java
@@ -472,4 +472,26 @@ public class TeamMock implements Team
 		return audiences;
 	}
 
+	public Component getFormattedName(Component formattedName)
+	{
+		Component mutableComponent = Component.empty().append(this.prefix()).append(formattedName).append(this.suffix());
+		TextColor color = this.color();
+		if (color != null)
+		{
+			mutableComponent.color(color);
+		}
+
+		return mutableComponent;
+	}
+
+	public static Component formatNameForTeam(@Nullable Team playerTeam, Component playerName)
+	{
+		Component formattedName = null;
+		if (playerTeam instanceof TeamMock teamMock)
+		{
+			formattedName = teamMock.getFormattedName(playerName);
+		}
+
+		return formattedName == null ? playerName : formattedName;
+	}
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/CowMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/CowMockTest.java
@@ -2,8 +2,13 @@ package org.mockbukkit.mockbukkit.entity;
 
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.entity.Cow;
 import org.bukkit.entity.EntityType;
+import org.bukkit.scoreboard.Team;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +21,7 @@ import org.mockbukkit.mockbukkit.MockBukkitInject;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockBukkitExtension.class)
@@ -77,6 +83,52 @@ class CowMockTest
 					.map(Arguments::of);
 		}
 
+	}
+
+	@Nested
+	class TeamDisplayName
+	{
+		@Test
+		void withoutName()
+		{
+			Component name = cow.teamDisplayName();
+
+			assertNotNull(name);
+			assertEquals("entity", asString(name));
+		}
+
+		@Test
+		void withoutTeamInformation()
+		{
+			cow.setName("My Cow");
+
+			Component name = cow.teamDisplayName();
+
+			assertNotNull(name);
+			assertEquals("My Cow", asString(name));
+		}
+
+		@Test
+		void withTeamInformation()
+		{
+			@NotNull Team team = cow.getServer().getScoreboardManager().getMainScoreboard().registerNewTeam("test");
+			team.color(NamedTextColor.GREEN);
+			team.prefix(Component.text("["));
+			team.suffix(Component.text("]"));
+			team.addEntity(cow);
+
+			cow.setName("My Cow");
+
+			Component name = cow.teamDisplayName();
+
+			assertNotNull(name);
+			assertEquals("[My Cow]", asString(name));
+		}
+
+		public static String asString(@NotNull Component component)
+		{
+			return LegacyComponentSerializer.legacyAmpersand().serialize(component);
+		}
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/EntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/EntityMockTest.java
@@ -1561,4 +1561,11 @@ class EntityMockTest
 		assertNotEquals(entity, new SimpleEntityMock(server));
 	}
 
+	@Test
+	void getScoreboardEntryName()
+	{
+		String actual = entity.getScoreboardEntryName();
+		assertEquals(entity.getUniqueId().toString(), actual);
+	}
+
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
@@ -2740,6 +2740,13 @@ class PlayerMockTest
 		assertEquals(player.nextActionBar(), textComponent3);
 	}
 
+	@Test
+	void getScoreboardEntryName()
+	{
+		String actual = player.getScoreboardEntryName();
+		assertEquals(player.getName(), actual);
+	}
+
 	@Nested
 	class DeathScreenScore
 	{

--- a/src/test/java/org/mockbukkit/mockbukkit/scoreboard/ScoreboardMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/scoreboard/ScoreboardMockTest.java
@@ -146,7 +146,7 @@ class ScoreboardMockTest
 		team.addEntry("player");
 		team.addEntity(entity);
 		this.scoreboard.registerNewTeam("cyan").addEntry("player");
-		assertEquals(Set.of("player", entity.getScoreboardEntry()), this.scoreboard.getEntries());
+		assertEquals(Set.of("player", entity.getScoreboardEntryName()), this.scoreboard.getEntries());
 	}
 
 	@Test
@@ -154,14 +154,14 @@ class ScoreboardMockTest
 	{
 		EntityMock entity = new SimpleEntityMock(this.server);
 		Objective objectiveA = this.scoreboard.registerNewObjective("test", Criteria.DUMMY, empty());
-		Score scoreA = objectiveA.getScore(entity.getScoreboardEntry());
+		Score scoreA = objectiveA.getScore(entity.getScoreboardEntryName());
 		scoreA.setScore(78);
 		Objective objectiveB = this.scoreboard.registerNewObjective("test2", Criteria.DEATH_COUNT, empty());
 		Score scoreB = objectiveB.getScoreFor(entity);
 
 		Set<Score> excepted = Set.of(scoreA, scoreB);
 		assertEquals(excepted, this.scoreboard.getScoresFor(entity));
-		assertEquals(excepted, this.scoreboard.getScores(entity.getScoreboardEntry()));
+		assertEquals(excepted, this.scoreboard.getScores(entity.getScoreboardEntryName()));
 	}
 
 	@Test
@@ -195,7 +195,7 @@ class ScoreboardMockTest
 		Team team = this.scoreboard.registerNewTeam("green");
 		team.addEntity(entity);
 		this.scoreboard.registerNewTeam("cyan").addEntity(entity);
-		assertSame(team, this.scoreboard.getEntryTeam(entity.getScoreboardEntry()));
+		assertSame(team, this.scoreboard.getEntryTeam(entity.getScoreboardEntryName()));
 		assertSame(team, this.scoreboard.getEntityTeam(entity));
 	}
 


### PR DESCRIPTION
# Description

This PR implements the teamDisplayName in EntityMock.

# Checklist

The following items should be checked before the pull request can be merged.

- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
