### PR TITLE
Implement WorldMock.isDayTime() method

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
@@ -1180,7 +1180,25 @@ public class WorldMock implements World
 	@Override
 	public boolean isDayTime()
 	{
-		return false;
+		long time = getTime();
+
+		// Tick times from Minecraft Wiki (https://minecraft.wiki/w/Bed#Sleeping)
+		long clearNightStartTick = 12542;
+		long clearNightEndTick = 23459;
+		long rainNightStartTick = 12010;
+		long rainNightEndTick = 23991;
+
+		if (isThundering())
+		{
+			return false;
+		}
+
+		if (hasStorm())
+		{
+			return time < rainNightStartTick || rainNightEndTick < time;
+		}
+
+		return time < clearNightStartTick || clearNightEndTick < time;
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
@@ -652,6 +652,20 @@ class WorldMockTest
 	}
 
 	@Test
+	void isDayTime()
+	{
+		WorldMock world = new WorldMock();
+
+		// Noon
+		world.setTime(6000L);
+		assertTrue(world.isDayTime());
+
+		// Midnight
+		world.setTime(18000L);
+		assertFalse(world.isDayTime());
+	}
+
+	@Test
 	void setTime_Event_Triggered()
 	{
 		WorldMock world = new WorldMock();


### PR DESCRIPTION
# Description

This pull request aims to resolve issue #853 by implementing `WorldMock.isDayTime()`. Unintuitively, Bukkit's `World.isDayTime()` method corresponds to the players ability to sleep, not the actual game day/night times. For example, calling `isDayTime()` during a thunderstorm will return `false` even if the time is noon (6000t). My implementation logic makes use of the sleep tick-times found on the Minecraft Wiki (https://minecraft.wiki/w/Bed#Sleeping). I manually verified the accuracy of this solution by writing a small plugin which asserts every tick that my mock implementation matches the result of Bukkit's `World.isDayTime()` method.

# Checklist

The following items should be checked before the pull request can be merged.

- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
