### PR TITLE
Implement initial support for Paper API

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
@@ -552,6 +552,25 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 			throws IOException, InvalidDescriptionException
 	{
 		Preconditions.checkNotNull(class1, "Class cannot be null");
+		try
+		{
+			Enumeration<URL> resources = class1.getClassLoader().getResources("paper-plugin.yml");
+			while (resources.hasMoreElements())
+			{
+				URL url = resources.nextElement();
+				PluginDescriptionFile description = new PluginDescriptionFile(url.openStream());
+				String mainClass = description.getMain();
+				if (class1.getName().equals(mainClass))
+				{
+					return description;
+				}
+			}
+		}
+		catch (IOException e)
+		{
+			// Ignore, we'll try plugin.yml next
+		}
+
 		Enumeration<URL> resources = class1.getClassLoader().getResources("plugin.yml");
 		while (resources.hasMoreElements())
 		{
@@ -564,7 +583,7 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 			}
 		}
 		throw new FileNotFoundException(
-				"Could not find file plugin.yml. Maybe forgot to add the 'main' property?");
+				"Could not find file plugin.yml or paper-plugin.yml. Maybe forgot to add the 'main' property?");
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
@@ -583,7 +583,7 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 			}
 		}
 		throw new FileNotFoundException(
-				"Could not find file plugin.yml or paper-plugin.yml. Maybe forgot to add the 'main' property?");
+   			"Could not find file paper-plugin.yml or plugin.yml. Maybe forgot to add the 'main' property?");
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMockTest.java
@@ -431,7 +431,7 @@ class PluginManagerMockTest
 	void loadPlugin_WithPaperPluginYml_PluginLoaded()
 	{
 		Plugin loadedPlugin = pluginManager.loadPlugin(PaperTestPlugin.class);
-		assertInstanceOf(JavaPlugin.class, loadedPlugin);
+		assertInstanceOf(PaperTestPlugin.class, loadedPlugin);
 		assertEquals("MockBukkitTestPaperPlugin", loadedPlugin.getName());
 		assertEquals("0.1.0", loadedPlugin.getDescription().getVersion());
 	}

--- a/src/test/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMockTest.java
@@ -427,4 +427,17 @@ class PluginManagerMockTest
 		assertEquals("No publicly available constructor for PrivateConstructorPluginProxy without parameters", exception.getCause().getMessage());
 	}
 
+	@Test
+	void loadPlugin_WithPaperPluginYml_PluginLoaded()
+	{
+		Plugin loadedPlugin = pluginManager.loadPlugin(PaperTestPlugin.class);
+		assertInstanceOf(JavaPlugin.class, loadedPlugin);
+		assertEquals("MockBukkitTestPaperPlugin", loadedPlugin.getName());
+		assertEquals("0.1.0", loadedPlugin.getDescription().getVersion());
+	}
+
+	public static class PaperTestPlugin extends JavaPlugin
+	{
+	}
+
 }

--- a/src/test/resources/paper-plugin.yml
+++ b/src/test/resources/paper-plugin.yml
@@ -1,0 +1,3 @@
+name: MockBukkitTestPaperPlugin
+main: org.mockbukkit.mockbukkit.plugin.PluginManagerMockTest$PaperTestPlugin
+version: 0.1.0


### PR DESCRIPTION
# Description

This pull request adds an initial check to `PluginManagerMock.java` to load the `paper-plugin.yml` file before checking if `plugin.yml` exists.

# Checklist

The following items should be checked before the pull request can be merged.

- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
