### PR TITLE
chore(build): Simplify run function and mitigate deprecations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -232,10 +232,9 @@ fun getFullVersion(): String {
 }
 
 fun run(vararg cmd: String): String {
-	val process = ProcessBuilder()
-		.command(*cmd)
-		.directory(rootProject.projectDir)
-		.start()
-	process.waitFor(5, TimeUnit.SECONDS)
-	return process.inputStream.bufferedReader().readText().trim()
+	return providers.exec {
+		commandLine(*cmd)
+	}.standardOutput.asText.get().trim()
 }
+
+

--- a/metaminer/build.gradle.kts
+++ b/metaminer/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
 	id("java")
-	id("io.papermc.paperweight.userdev") version "2.0.0-beta.18"
+	id("io.papermc.paperweight.userdev") version "2.0.0-beta.19"
 	id("xyz.jpenilla.run-paper") version "3.0.1"
 }
 
@@ -34,5 +34,9 @@ tasks {
 	test {
 		dependsOn(project(":extra:TestPlugin").tasks.jar)
 		useJUnitPlatform()
+		maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
+		systemProperty("junit.jupiter.execution.parallel.enabled", "true")
+		systemProperty("junit.jupiter.execution.parallel.mode.default", "concurrent")
+		systemProperty("junit.jupiter.execution.parallel.mode.classes.default", "concurrent")
 	}
 }


### PR DESCRIPTION
- Bump `io.papermc.paperweight.userdev` plugin to version 2.0.0-beta.19.
- Replace `ProcessBuilder` with `providers.exec` for improved process execution.
- Enhance JUnit test configuration with parallel execution support.

# Description

<!-- State the changes of the pull request below. -->

# Checklist

The following items should be checked before the pull request can be merged.

- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
