### PR TITLE
feat(blockdata): Add LadderDataMock with unit tests

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/LadderDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/LadderDataMock.java
@@ -1,0 +1,74 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.type.Ladder;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+import static org.mockbukkit.mockbukkit.block.data.BlockDataKey.FACING;
+
+public class LadderDataMock extends BlockDataMock implements Ladder
+
+{
+	/**
+	 * Constructs a new {@link LadderDataMock} for the provided {@link Material}.
+	 *
+	 * @param material The material this data is for.
+	 */
+	public LadderDataMock(@NotNull Material material)
+	{
+		super(material);
+	}
+
+	/**
+	 * Create a new {@link LadderDataMock} based on an existing {@link LadderDataMock}.
+	 *
+	 * @param other the other block data.
+	 */
+	public LadderDataMock(@NotNull BlockDataMock other)
+	{
+		super(other);
+	}
+
+	@Override
+	public @NotNull BlockFace getFacing()
+	{
+		return super.get(FACING);
+	}
+
+	@Override
+	public void setFacing(@NotNull BlockFace facing)
+	{
+		Preconditions.checkArgument(this.getFaces().contains(facing), "BlockFace %s is not a valid BlockFace.", facing);
+		super.set(FACING, facing);
+	}
+
+	@Override
+	public @NotNull Set<BlockFace> getFaces()
+	{
+		return this.getLimitationValue(BlockDataLimitation.Type.FACES);
+	}
+
+	@Override
+	public boolean isWaterlogged()
+	{
+		return super.get(BlockDataKey.WATERLOGGED);
+	}
+
+	@Override
+	public void setWaterlogged(boolean waterlogged)
+	{
+		super.set(BlockDataKey.WATERLOGGED, waterlogged);
+	}
+
+	@Override
+	@SuppressWarnings({"MethodDoesntCallSuperMethod", "java:S2975", "java:S1182"})
+	public @NotNull LadderDataMock clone()
+	{
+		return new LadderDataMock(this);
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/LadderDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/LadderDataMock.java
@@ -28,7 +28,7 @@ public class LadderDataMock extends BlockDataMock implements Ladder
 	 *
 	 * @param other the other block data.
 	 */
-	public LadderDataMock(@NotNull BlockDataMock other)
+	public LadderDataMock(@NotNull LadderDataMock other)
 	{
 		super(other);
 	}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/LadderDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/LadderDataMockTest.java
@@ -1,0 +1,92 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockBukkitExtension.class)
+public class LadderDataMockTest
+{
+
+	private LadderDataMock ladderData;
+
+	@BeforeEach
+	void setUp()
+	{
+		this.ladderData = new LadderDataMock(Material.LADDER);
+	}
+
+	@Nested
+	class SetFacing
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(BlockFace.NORTH, ladderData.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.INCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST"})
+		void givenValidValues(BlockFace face)
+		{
+			ladderData.setFacing(face);
+			assertEquals(face, ladderData.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.EXCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST", "UP", "DOWN" })
+		void givenInvalidValues(BlockFace face)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> ladderData.setFacing(face));
+			assertEquals(String.format("BlockFace %s is not a valid BlockFace.", face), e.getMessage());
+		}
+
+	}
+	@Test
+	void isWaterlogged_default()
+	{
+		assertFalse(ladderData.isWaterlogged());
+	}
+
+	@Test
+	void setWaterlogged()
+	{
+		ladderData.setWaterlogged(true);
+		assertTrue(ladderData.isWaterlogged());
+	}
+
+	@Test
+	void validateClone()
+	{
+		@NotNull LadderDataMock cloned = ladderData.clone();
+
+		assertEquals(ladderData, cloned);
+		assertEquals(ladderData.isWaterlogged(), cloned.isWaterlogged());
+
+		ladderData.setWaterlogged(true);
+
+		assertNotEquals(ladderData, cloned);
+		assertTrue(ladderData.isWaterlogged());
+		assertFalse(cloned.isWaterlogged());
+	}
+
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/LadderDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/LadderDataMockTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockBukkitExtension.class)
-public class LadderDataMockTest
+class LadderDataMockTest
 {
 
 	private LadderDataMock ladderData;

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/LadderDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/LadderDataMockTest.java
@@ -87,6 +87,4 @@ public class LadderDataMockTest
 		assertTrue(ladderData.isWaterlogged());
 		assertFalse(cloned.isWaterlogged());
 	}
-
-
 }


### PR DESCRIPTION
- Implemented `LadderDataMock` for `Ladder` block data.
- Created corresponding unit tests in `LadderDataMockTest`.
- Added support for `facing`, `waterlogged` properties and cloning functionality.

# Description

<!-- State the changes of the pull request below. -->

# Checklist

The following items should be checked before the pull request can be merged.

- [ ] Code follows existing style.
- [ ] Unit tests added (if applicable).
