### PR TITLE
Enforce maxPlayers limit when adding players (PlayerListMock#addPlayer)

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/PlayerListMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/PlayerListMock.java
@@ -47,13 +47,11 @@ public class PlayerListMock
 
 	/**
 	 * Sets the maximum number of online players.
-	 * <b>This is not currently enforced.</b>
 	 *
 	 * @param maxPlayers The maximum amount of players.
 	 */
 	public void setMaxPlayers(int maxPlayers)
 	{
-		// TODO: The maxPlayers setting is currently not enforced.
 		this.maxPlayers = maxPlayers;
 	}
 
@@ -91,6 +89,10 @@ public class PlayerListMock
 	@ApiStatus.Internal
 	public synchronized void addPlayer(@NotNull PlayerMock player)
 	{
+		if (this.onlinePlayers.size() >= this.maxPlayers)
+		{
+			return;
+		}
 		long currentTime = System.currentTimeMillis();
 		this.firstPlayed.putIfAbsent(player.getUniqueId(), currentTime);
 		this.lastLogins.put(player.getUniqueId(), currentTime);

--- a/src/main/java/org/mockbukkit/mockbukkit/PlayerListMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/PlayerListMock.java
@@ -85,13 +85,14 @@ public class PlayerListMock
 	 * Marks a player as on the server, and sets related data like hasPlayedBefore and lastLogin.
 	 *
 	 * @param player The player to add.
+	 * @return Whether the player was added.
 	 */
 	@ApiStatus.Internal
-	public synchronized void addPlayer(@NotNull PlayerMock player)
+	public synchronized boolean addPlayer(@NotNull PlayerMock player)
 	{
 		if (this.onlinePlayers.size() >= this.maxPlayers)
 		{
-			return;
+			return false;
 		}
 		long currentTime = System.currentTimeMillis();
 		this.firstPlayed.putIfAbsent(player.getUniqueId(), currentTime);
@@ -99,6 +100,8 @@ public class PlayerListMock
 		this.onlinePlayers.add(player);
 		this.offlinePlayers.add(player);
 		this.hasPlayedBefore.put(player.getUniqueId(), this.hasPlayedBefore.containsKey(player.getUniqueId()));
+
+		return true;
 	}
 
 	/**

--- a/src/test/java/org/mockbukkit/mockbukkit/PlayerListMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/PlayerListMockTest.java
@@ -70,6 +70,21 @@ class PlayerListMockTest
 	}
 
 	@Test
+	void addPlayer_MaxPlayersEnforced()
+	{
+		playerList.setMaxPlayers(1);
+		PlayerMock player1 = new PlayerMock(server, "player1", UUID.randomUUID());
+		playerList.addPlayer(player1); // This should add player1
+
+		PlayerMock player2 = new PlayerMock(server, "player2", UUID.randomUUID());
+		playerList.addPlayer(player2); // This should _NOT_ add player2
+
+		assertEquals(1, playerList.getOnlinePlayers().size());
+		assertTrue(playerList.getOnlinePlayers().contains(player1));
+		assertFalse(playerList.getOnlinePlayers().contains(player2));
+	}
+
+	@Test
 	void disconnect_RemovesFromOnline()
 	{
 		PlayerMock player = server.addPlayer();


### PR DESCRIPTION
# Description

This pull request enforces the `maxPlayers` limit in `PlayerListMock`, as it wasn't being enforced, allowing more players to be added than the specified maximum.

The changes include:
- Adding a check to the `addPlayer` method to stop more players being added once the maximum has been reached.
- Introducing a new unit test, to verify the `maxPlayera` limit is being enforced correctly.
- Consequently, removing outdated comments (and respective Javadoc line) indicating that the `maxPlayers` limit was not enforced.

# Checklist

The following items should be checked before the pull request can be merged.

- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
