### PR TITLE
Implemented Data Components Bridges

### DIFF
--- a/src/main/java/io/papermc/paper/datacomponent/item/BannerPatternLayersMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/BannerPatternLayersMock.java
@@ -1,0 +1,44 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.block.banner.Pattern;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record BannerPatternLayersMock(@Unmodifiable List<Pattern> patterns) implements BannerPatternLayers
+{
+
+	static class BuilderMock implements Builder
+	{
+
+		List<Pattern> patterns = new ArrayList<>();
+
+		@Override
+		public Builder add(Pattern pattern)
+		{
+			Preconditions.checkNotNull(pattern);
+			patterns.add(pattern);
+			return this;
+		}
+
+		@Override
+		public Builder addAll(List<Pattern> patterns)
+		{
+			patterns.forEach(this::add);
+			return this;
+		}
+
+		@Override
+		public BannerPatternLayers build()
+		{
+			return new BannerPatternLayersMock(List.copyOf(patterns));
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/BlockItemDataPropertiesMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/BlockItemDataPropertiesMock.java
@@ -1,0 +1,35 @@
+package io.papermc.paper.datacomponent.item;
+
+import org.bukkit.block.BlockType;
+import org.bukkit.block.data.BlockData;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record BlockItemDataPropertiesMock() implements BlockItemDataProperties
+{
+
+	@Override
+	public BlockData createBlockData(BlockType blockType)
+	{
+		return blockType.createBlockData();
+	}
+
+	@Override
+	public BlockData applyTo(BlockData blockData)
+	{
+		return blockData.clone();
+	}
+
+	static class BuilderMock implements BlockItemDataProperties.Builder
+	{
+
+		@Override
+		public BlockItemDataProperties build()
+		{
+			return new BlockItemDataPropertiesMock();
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/BlocksAttacksMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/BlocksAttacksMock.java
@@ -1,0 +1,159 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import io.papermc.paper.datacomponent.item.blocksattacks.DamageReduction;
+import io.papermc.paper.datacomponent.item.blocksattacks.ItemDamageFunction;
+import io.papermc.paper.registry.tag.TagKey;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.kyori.adventure.key.Key;
+import org.bukkit.damage.DamageType;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public class BlocksAttacksMock implements BlocksAttacks
+{
+	private final float blockDelaySeconds;
+	private final float disableCooldownScale;
+	private final List<DamageReduction> damageReductions;
+	private final ItemDamageFunction itemDamage;
+	private final @Nullable TagKey<DamageType> bypassedBy;
+	private final @Nullable Key blockSound;
+	private final @Nullable Key disableSound;
+
+	private BlocksAttacksMock(BuilderMock builder)
+	{
+		this.blockDelaySeconds = builder.blockDelaySeconds;
+		this.disableCooldownScale = builder.disableCooldownScale;
+		this.damageReductions = builder.damageReductions;
+		this.itemDamage = builder.itemDamage;
+		this.bypassedBy = builder.bypassedBy;
+		this.blockSound = builder.blockSound;
+		this.disableSound = builder.disableSound;
+	}
+
+	@Override
+	public float blockDelaySeconds()
+	{
+		return this.blockDelaySeconds;
+	}
+
+	@Override
+	public float disableCooldownScale()
+	{
+		return this.disableCooldownScale;
+	}
+
+	@Override
+	public List<DamageReduction> damageReductions()
+	{
+		return Collections.unmodifiableList(this.damageReductions);
+	}
+
+	@Override
+	public ItemDamageFunction itemDamage()
+	{
+		return this.itemDamage;
+	}
+
+	@Override
+	public @Nullable TagKey<DamageType> bypassedBy()
+	{
+		return this.bypassedBy;
+	}
+
+	@Override
+	public @Nullable Key blockSound()
+	{
+		return this.blockSound;
+	}
+
+	@Override
+	public @Nullable Key disableSound()
+	{
+		return this.disableSound;
+	}
+
+	static class BuilderMock implements Builder
+	{
+
+		private float blockDelaySeconds;
+		private float disableCooldownScale = 1.0F;
+		private List<DamageReduction> damageReductions = new ObjectArrayList<>();
+		private ItemDamageFunction itemDamage = ItemDamageFunction.itemDamageFunction()
+				.threshold(1.0F).base(0.0F).factor(1.0F).build();
+		private @Nullable TagKey<DamageType> bypassedBy;
+		private @Nullable Key blockSound;
+		private @Nullable Key disableSound;
+
+		@Override
+		public Builder blockDelaySeconds(float delay)
+		{
+			Preconditions.checkArgument(delay >= 0.0F, "delay must be non-negative, was %s", delay);
+			this.blockDelaySeconds = delay;
+			return this;
+		}
+
+		@Override
+		public Builder disableCooldownScale(float scale)
+		{
+			Preconditions.checkArgument(scale >= 0.0F, "scale must be non-negative, was %s", scale);
+			this.disableCooldownScale = scale;
+			return this;
+		}
+
+		@Override
+		public Builder addDamageReduction(DamageReduction reduction)
+		{
+			this.damageReductions.add(reduction);
+			return this;
+		}
+
+		@Override
+		public Builder damageReductions(List<DamageReduction> reductions)
+		{
+			this.damageReductions = new ObjectArrayList<>(reductions);
+			return this;
+		}
+
+		@Override
+		public Builder itemDamage(ItemDamageFunction function)
+		{
+			this.itemDamage = function;
+			return this;
+		}
+
+		@Override
+		public Builder bypassedBy(@Nullable TagKey<DamageType> bypassedBy)
+		{
+			this.bypassedBy = bypassedBy;
+			return this;
+		}
+
+		@Override
+		public Builder blockSound(@Nullable Key sound)
+		{
+			this.blockSound = sound;
+			return this;
+		}
+
+		@Override
+		public Builder disableSound(@Nullable Key sound)
+		{
+			this.disableSound = sound;
+			return this;
+		}
+
+		@Override
+		public BlocksAttacks build()
+		{
+			return new BlocksAttacksMock(this);
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/BundleContentsMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/BundleContentsMock.java
@@ -1,0 +1,58 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public class BundleContentsMock implements BundleContents
+{
+
+	private final List<ItemStack> items;
+
+	private BundleContentsMock(List<ItemStack> items)
+	{
+		this.items = items;
+	}
+
+	@Override
+	public @Unmodifiable List<ItemStack> contents()
+	{
+		return items.stream().map(ItemStack::clone).toList();
+	}
+
+	static class BuilderMock implements Builder
+	{
+
+		List<ItemStack> items = new ArrayList<>();
+
+		@Override
+		public Builder add(ItemStack stack)
+		{
+			Preconditions.checkArgument(stack != null, "stack cannot be null");
+			Preconditions.checkArgument(!stack.isEmpty(), "stack cannot be empty");
+			items.add(stack.clone());
+			return this;
+		}
+
+		@Override
+		public Builder addAll(List<ItemStack> stacks)
+		{
+			stacks.forEach(this::add);
+			return this;
+		}
+
+		@Override
+		public BundleContents build()
+		{
+			return new BundleContentsMock(items);
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/ChargedProjectilesMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/ChargedProjectilesMock.java
@@ -1,0 +1,58 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public class ChargedProjectilesMock implements ChargedProjectiles
+{
+
+	private final List<ItemStack> items;
+
+	private ChargedProjectilesMock(List<ItemStack> items)
+	{
+		this.items = items;
+	}
+
+	@Override
+	public @Unmodifiable List<ItemStack> projectiles()
+	{
+		return items.stream().map(ItemStack::clone).toList();
+	}
+
+	static class BuilderMock implements Builder
+	{
+
+		private final List<ItemStack> items = new ArrayList<>();
+
+		@Override
+		public Builder add(ItemStack stack)
+		{
+			Preconditions.checkArgument(stack != null, "stack cannot be null");
+			Preconditions.checkArgument(!stack.isEmpty(), "stack cannot be empty");
+			items.add(stack.clone());
+			return this;
+		}
+
+		@Override
+		public Builder addAll(List<ItemStack> stacks)
+		{
+			stacks.forEach(this::add);
+			return this;
+		}
+
+		@Override
+		public ChargedProjectiles build()
+		{
+			return new ChargedProjectilesMock(items);
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/ConsumableMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/ConsumableMock.java
@@ -1,0 +1,101 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import io.papermc.paper.datacomponent.item.consumable.ConsumeEffect;
+import io.papermc.paper.datacomponent.item.consumable.ItemUseAnimation;
+import io.papermc.paper.registry.keys.SoundEventKeys;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.kyori.adventure.key.Key;
+import org.checkerframework.checker.index.qual.NonNegative;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.List;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record ConsumableMock(@NonNegative float consumeSeconds, ItemUseAnimation animation,
+							 Key sound, boolean hasConsumeParticles,
+							 @Unmodifiable List<ConsumeEffect> consumeEffects) implements Consumable
+{
+
+	@Override
+	public Builder toBuilder()
+	{
+		return new BuilderMock()
+				.consumeSeconds(consumeSeconds)
+				.animation(animation)
+				.sound(sound)
+				.hasConsumeParticles(hasConsumeParticles)
+				.addEffects(consumeEffects);
+	}
+
+	static class BuilderMock implements Builder
+	{
+
+		private float consumeSeconds = 1.6F;
+		private ItemUseAnimation consumeAnimation = ItemUseAnimation.EAT;
+		private Key eatSound = SoundEventKeys.ENTITY_GENERIC_EAT;
+		private boolean hasConsumeParticles = true;
+		private final List<ConsumeEffect> effects = new ObjectArrayList<>();
+
+		@Override
+		public Builder consumeSeconds(@NonNegative float consumeSeconds)
+		{
+			Preconditions.checkArgument(consumeSeconds >= 0, "consumeSeconds must be non-negative, was %s", consumeSeconds);
+			this.consumeSeconds = consumeSeconds;
+			return this;
+		}
+
+		@Override
+		public Builder animation(ItemUseAnimation animation)
+		{
+			this.consumeAnimation = animation;
+			return this;
+		}
+
+		@Override
+		public Builder sound(Key sound)
+		{
+			this.eatSound = sound;
+			return this;
+		}
+
+		@Override
+		public Builder hasConsumeParticles(boolean hasConsumeParticles)
+		{
+			this.hasConsumeParticles = hasConsumeParticles;
+			return this;
+		}
+
+		@Override
+		public Builder effects(List<ConsumeEffect> effects)
+		{
+			this.effects.clear();
+			return this.addEffects(effects);
+		}
+
+		@Override
+		public Builder addEffect(ConsumeEffect effect)
+		{
+			Preconditions.checkNotNull(effect);
+			this.effects.add(effect);
+			return this;
+		}
+
+		@Override
+		public Builder addEffects(List<ConsumeEffect> effects)
+		{
+			this.effects.addAll(effects);
+			return this;
+		}
+
+		@Override
+		public Consumable build()
+		{
+			return new ConsumableMock(consumeSeconds, consumeAnimation, eatSound, hasConsumeParticles, new ObjectArrayList<>(effects));
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/CustomModelDataMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/CustomModelDataMock.java
@@ -1,0 +1,113 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.booleans.BooleanArrayList;
+import it.unimi.dsi.fastutil.booleans.BooleanList;
+import it.unimi.dsi.fastutil.floats.FloatArrayList;
+import it.unimi.dsi.fastutil.floats.FloatList;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.bukkit.Color;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.List;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record CustomModelDataMock(@Unmodifiable List<Float> floats, @Unmodifiable List<Boolean> flags,
+								  @Unmodifiable List<String> strings,
+								  @Unmodifiable @ApiStatus.Internal List<Integer> internalColors) implements CustomModelData
+{
+
+	@Override
+	public @Unmodifiable List<Color> colors()
+	{
+		return internalColors.stream().map(Color::fromRGB).toList();
+	}
+
+	static class BuilderMock implements Builder
+	{
+
+		private final FloatList floats = new FloatArrayList();
+		private final BooleanList flags = new BooleanArrayList();
+		private final List<String> strings = new ObjectArrayList<>();
+		private final IntList colors = new IntArrayList();
+
+		@Override
+		public Builder addFloat(float f)
+		{
+			floats.add(f);
+			return this;
+		}
+
+		@Override
+		public Builder addFloats(List<Float> floats)
+		{
+			for (Float f : floats)
+			{
+				Preconditions.checkArgument(f != null, "Float cannot be null");
+			}
+			this.floats.addAll(floats);
+			return this;
+		}
+
+		@Override
+		public Builder addFlag(boolean flag)
+		{
+			this.flags.add(flag);
+			return this;
+		}
+
+		@Override
+		public Builder addFlags(List<Boolean> flags)
+		{
+			for (Boolean flag : flags)
+			{
+				Preconditions.checkArgument(flag != null, "Flag cannot be null");
+			}
+			this.flags.addAll(flags);
+			return this;
+		}
+
+		@Override
+		public Builder addString(String string)
+		{
+			Preconditions.checkArgument(string != null, "String cannot be null");
+			this.strings.add(string);
+			return this;
+		}
+
+		@Override
+		public Builder addStrings(List<String> strings)
+		{
+			strings.forEach(this::addString);
+			return this;
+		}
+
+		@Override
+		public Builder addColor(Color color)
+		{
+			Preconditions.checkArgument(color != null, "Color cannot be null");
+			this.colors.add(color.asRGB());
+			return this;
+		}
+
+		@Override
+		public Builder addColors(List<Color> colors)
+		{
+			colors.forEach(this::addColor);
+			return this;
+		}
+
+		@Override
+		public CustomModelData build()
+		{
+			return new CustomModelDataMock(List.copyOf(floats), List.copyOf(flags), List.copyOf(strings), List.copyOf(colors));
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/DamageResistantMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/DamageResistantMock.java
@@ -1,0 +1,12 @@
+package io.papermc.paper.datacomponent.item;
+
+import io.papermc.paper.registry.tag.TagKey;
+import org.bukkit.damage.DamageType;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record DamageResistantMock(TagKey<DamageType> types) implements DamageResistant
+{
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/DeathProtectionMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/DeathProtectionMock.java
@@ -1,0 +1,45 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import io.papermc.paper.datacomponent.item.consumable.ConsumeEffect;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.List;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record DeathProtectionMock(@Unmodifiable List<ConsumeEffect> deathEffects) implements DeathProtection
+{
+
+
+	static class BuilderMock implements Builder
+	{
+
+		ImmutableList.Builder<ConsumeEffect> effectBuilder = new ImmutableList.Builder<>();
+
+		@Override
+		public Builder addEffect(ConsumeEffect effect)
+		{
+			Preconditions.checkArgument(effect != null, "effect is null");
+			effectBuilder.add(effect);
+			return this;
+		}
+
+		@Override
+		public Builder addEffects(List<ConsumeEffect> effects)
+		{
+			effects.forEach(this::addEffect);
+			return this;
+		}
+
+		@Override
+		public DeathProtection build()
+		{
+			return new DeathProtectionMock(effectBuilder.build());
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/DyedItemColorMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/DyedItemColorMock.java
@@ -1,0 +1,31 @@
+package io.papermc.paper.datacomponent.item;
+
+import org.bukkit.Color;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record DyedItemColorMock(Color color) implements DyedItemColor
+{
+
+	static class BuilderMock implements Builder
+	{
+
+		private Color color = Color.WHITE;
+
+		@Override
+		public Builder color(Color color)
+		{
+			this.color = Color.fromRGB(color.asRGB());
+			return this;
+		}
+
+		@Override
+		public DyedItemColor build()
+		{
+			return new DyedItemColorMock(color);
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/EnchantableMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/EnchantableMock.java
@@ -1,0 +1,12 @@
+package io.papermc.paper.datacomponent.item;
+
+
+import org.checkerframework.checker.index.qual.Positive;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record EnchantableMock(@Positive int value) implements Enchantable
+{
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/EquipableMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/EquipableMock.java
@@ -1,0 +1,136 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import io.papermc.paper.registry.keys.SoundEventKeys;
+import io.papermc.paper.registry.set.RegistryKeySet;
+import net.kyori.adventure.key.Key;
+import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.EquipmentSlot;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record EquipableMock(EquipmentSlot slot, Key equipSound, @Nullable Key assetId,
+							@Nullable Key cameraOverlay, @Nullable RegistryKeySet<EntityType> allowedEntities,
+							boolean dispensable, boolean swappable, boolean damageOnHurt,
+							boolean equipOnInteract, boolean canBeSheared, Key shearSound
+) implements Equippable
+{
+
+	@Override
+	public Builder toBuilder()
+	{
+		return new BuilderMock(slot)
+				.equipSound(equipSound)
+				.assetId(assetId)
+				.cameraOverlay(this.cameraOverlay)
+				.allowedEntities(this.allowedEntities)
+				.dispensable(dispensable)
+				.swappable(swappable)
+				.damageOnHurt(damageOnHurt)
+				.equipOnInteract(equipOnInteract)
+				.shearSound(shearSound)
+				.canBeSheared(canBeSheared);
+	}
+
+	static class BuilderMock implements Builder
+	{
+
+		private final EquipmentSlot slot;
+		private Key equipSound = SoundEventKeys.ITEM_ARMOR_EQUIP_GENERIC;
+		private @Nullable Key assetId;
+		private @Nullable Key cameraOverlay;
+		private @Nullable RegistryKeySet<EntityType> allowedEntities;
+		private boolean dispensable = true;
+		private boolean swappable = true;
+		private boolean damageOnHurt = true;
+		private boolean equipOnInteract;
+		private boolean canBeSheared = false;
+		private Key shearSound = SoundEventKeys.ITEM_SHEARS_SNIP;
+
+		BuilderMock(EquipmentSlot slot)
+		{
+			this.slot = slot;
+		}
+
+		@Override
+		public Builder equipSound(Key sound)
+		{
+			this.equipSound = Preconditions.checkNotNull(sound);
+			return this;
+		}
+
+		@Override
+		public Builder assetId(@Nullable Key assetId)
+		{
+			this.assetId = assetId;
+			return this;
+		}
+
+		@Override
+		public Builder cameraOverlay(@Nullable Key cameraOverlay)
+		{
+			this.cameraOverlay = cameraOverlay;
+			return this;
+		}
+
+		@Override
+		public Builder allowedEntities(@Nullable RegistryKeySet<EntityType> allowedEntities)
+		{
+			this.allowedEntities = allowedEntities;
+			return this;
+		}
+
+		@Override
+		public Builder dispensable(boolean dispensable)
+		{
+			this.dispensable = dispensable;
+			return this;
+		}
+
+		@Override
+		public Builder swappable(boolean swappable)
+		{
+			this.swappable = swappable;
+			return this;
+		}
+
+		@Override
+		public Builder damageOnHurt(boolean damageOnHurt)
+		{
+			this.damageOnHurt = damageOnHurt;
+			return this;
+		}
+
+		@Override
+		public Builder equipOnInteract(boolean equipOnInteract)
+		{
+			this.equipOnInteract = equipOnInteract;
+			return this;
+		}
+
+		@Override
+		public Builder canBeSheared(boolean canBeSheared)
+		{
+			this.canBeSheared = canBeSheared;
+			return this;
+		}
+
+		@Override
+		public Builder shearSound(Key shearSound)
+		{
+			this.shearSound = Preconditions.checkNotNull(shearSound);
+			return this;
+		}
+
+		@Override
+		public Equippable build()
+		{
+			return new EquipableMock(slot, equipSound, assetId, cameraOverlay, allowedEntities, dispensable, swappable,
+					damageOnHurt, equipOnInteract, canBeSheared, shearSound);
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/FireworksMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/FireworksMock.java
@@ -1,0 +1,65 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.bukkit.FireworkEffect;
+import org.checkerframework.common.value.qual.IntRange;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.List;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record FireworksMock(int flightDuration, List<FireworkEffect> effects) implements Fireworks
+{
+
+	static class BuilderMock implements Builder
+	{
+
+		private int duration = 0;
+		private static final int MAX_EXPLOSIONS = 256;
+		private final List<FireworkEffect> effects = new ObjectArrayList<>();
+
+		@Override
+		public Builder flightDuration(@IntRange(from = 0L, to = 255L) int duration)
+		{
+			Preconditions.checkArgument(duration >= 0 && duration <= 255, "duration must be an unsigned byte ([%s, %s]), was %s", 0, 255, duration);
+			this.duration = duration;
+			return this;
+		}
+
+		@Override
+		public Builder addEffect(FireworkEffect effect)
+		{
+			Preconditions.checkArgument(
+					this.effects.size() + 1 <= MAX_EXPLOSIONS,
+					"Cannot have more than %s effects, had %s",
+					MAX_EXPLOSIONS,
+					this.effects.size() + 1
+			);
+			this.effects.add(effect);
+			return this;
+		}
+
+		@Override
+		public Builder addEffects(List<FireworkEffect> effects)
+		{
+			Preconditions.checkArgument(
+					this.effects.size() + effects.size() <= MAX_EXPLOSIONS,
+					"Cannot have more than %s effects, had %s",
+					MAX_EXPLOSIONS,
+					this.effects.size() + effects.size()
+			);
+			this.effects.addAll(effects);
+			return this;
+		}
+
+		@Override
+		public Fireworks build()
+		{
+			return new FireworksMock(duration, List.copyOf(effects));
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/FoodPropertiesMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/FoodPropertiesMock.java
@@ -1,0 +1,58 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import org.checkerframework.checker.index.qual.NonNegative;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record FoodPropertiesMock(int nutrition, float saturation, boolean canAlwaysEat) implements FoodProperties
+{
+
+	@Override
+	public Builder toBuilder()
+	{
+		return new BuilderMock()
+				.canAlwaysEat(canAlwaysEat)
+				.nutrition(nutrition)
+				.saturation(saturation);
+	}
+
+	static class BuilderMock implements Builder
+	{
+
+		private boolean canAlwaysEat = false;
+		private float saturation = 0.0F;
+		private int nutrition = 0;
+
+		@Override
+		public Builder canAlwaysEat(boolean canAlwaysEat)
+		{
+			this.canAlwaysEat = canAlwaysEat;
+			return this;
+		}
+
+		@Override
+		public Builder saturation(float saturation)
+		{
+			this.saturation = saturation;
+			return this;
+		}
+
+		@Override
+		public Builder nutrition(@NonNegative int nutrition)
+		{
+			Preconditions.checkArgument(nutrition >= 0, "nutrition must be non-negative, was %s", nutrition);
+			this.nutrition = nutrition;
+			return this;
+		}
+
+		@Override
+		public FoodProperties build()
+		{
+			return new FoodPropertiesMock(nutrition, saturation, canAlwaysEat);
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/ItemAdventurePredicateMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/ItemAdventurePredicateMock.java
@@ -1,0 +1,43 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import io.papermc.paper.block.BlockPredicate;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.List;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record ItemAdventurePredicateMock(List<BlockPredicate> predicates) implements ItemAdventurePredicate
+{
+
+	static class BuilderMock implements Builder
+	{
+
+		private final List<BlockPredicate> predicates = new ObjectArrayList<>();
+
+		@Override
+		public Builder addPredicate(BlockPredicate predicate)
+		{
+			Preconditions.checkArgument(predicate != null, "predicate is null");
+			predicates.add(predicate);
+			return this;
+		}
+
+		@Override
+		public Builder addPredicates(List<BlockPredicate> predicates)
+		{
+			predicates.forEach(this::addPredicate);
+			return this;
+		}
+
+		@Override
+		public ItemAdventurePredicate build()
+		{
+			return new ItemAdventurePredicateMock(new ObjectArrayList<>(predicates));
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/ItemArmorTrimMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/ItemArmorTrimMock.java
@@ -1,0 +1,35 @@
+package io.papermc.paper.datacomponent.item;
+
+import org.bukkit.inventory.meta.trim.ArmorTrim;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record ItemArmorTrimMock(ArmorTrim armorTrim) implements ItemArmorTrim
+{
+
+	static class BuilderMock implements Builder
+	{
+		private ArmorTrim armorTrim;
+
+		BuilderMock(ArmorTrim armorTrim)
+		{
+			this.armorTrim = armorTrim;
+		}
+
+		@Override
+		public Builder armorTrim(ArmorTrim armorTrim)
+		{
+			this.armorTrim = armorTrim;
+			return this;
+		}
+
+		@Override
+		public ItemArmorTrim build()
+		{
+			return new ItemArmorTrimMock(armorTrim);
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/ItemAttributeModifiersMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/ItemAttributeModifiersMock.java
@@ -1,0 +1,50 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import io.papermc.paper.datacomponent.item.attribute.AttributeModifierDisplay;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.inventory.EquipmentSlotGroup;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.List;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record ItemAttributeModifiersMock(List<Entry> modifiers) implements ItemAttributeModifiers
+{
+
+	record EntryMock(Attribute attribute, AttributeModifier modifier, AttributeModifierDisplay display) implements Entry
+	{
+	}
+
+	static class BuilderMock implements Builder
+	{
+
+		private final List<Entry> entries = new ObjectArrayList<>();
+
+		@Override
+		public Builder addModifier(Attribute attribute, AttributeModifier modifier, EquipmentSlotGroup equipmentSlotGroup, AttributeModifierDisplay display)
+		{
+			Preconditions.checkArgument(
+					this.entries.stream().noneMatch(e ->
+							e.modifier().getKey().equals(modifier.getKey()) && e.attribute().getKey().equals(attribute.getKey())
+					),
+					"Cannot add 2 modifiers with identical keys on the same attribute (modifier %s for attribute %s)",
+					modifier.getKey(), attribute.getKey()
+			);
+			AttributeModifier newModifier = new AttributeModifier(modifier.getKey(), modifier.getAmount(), modifier.getOperation(), equipmentSlotGroup);
+			entries.add(new EntryMock(attribute, newModifier, display));
+			return this;
+		}
+
+		@Override
+		public ItemAttributeModifiers build()
+		{
+			return new ItemAttributeModifiersMock(List.copyOf(entries));
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/ItemComponentTypesBridgeMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/ItemComponentTypesBridgeMock.java
@@ -1,0 +1,291 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.destroystokyo.paper.profile.PlayerProfile;
+import com.google.common.base.Preconditions;
+import io.papermc.paper.registry.set.RegistryKeySet;
+import io.papermc.paper.registry.tag.TagKey;
+import io.papermc.paper.text.Filtered;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.util.TriState;
+import org.bukkit.JukeboxSong;
+import org.bukkit.block.BlockType;
+import org.bukkit.damage.DamageType;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.ItemType;
+import org.bukkit.inventory.meta.trim.ArmorTrim;
+import org.bukkit.map.MapCursor;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.stream.Collectors;
+
+@NullMarked
+@ApiStatus.Internal
+@SuppressWarnings({ "UnstableApiUsage" })
+public class ItemComponentTypesBridgeMock implements ItemComponentTypesBridge
+{
+
+	@Override
+	public ChargedProjectiles.Builder chargedProjectiles()
+	{
+		return new ChargedProjectilesMock.BuilderMock();
+	}
+
+	@Override
+	public PotDecorations.Builder potDecorations()
+	{
+		return new PotDecorationsMock.BuilderMock();
+	}
+
+	@Override
+	public ItemLore.Builder lore()
+	{
+		return new ItemLoreMock.BuilderMock();
+	}
+
+	@Override
+	public ItemEnchantments.Builder enchantments()
+	{
+		return new ItemEnchantmentsMock.BuilderMock();
+	}
+
+	@Override
+	public ItemAttributeModifiers.Builder modifiers()
+	{
+		return new ItemAttributeModifiersMock.BuilderMock();
+	}
+
+	@Override
+	public FoodProperties.Builder food()
+	{
+		return new FoodPropertiesMock.BuilderMock();
+	}
+
+	@Override
+	public DyedItemColor.Builder dyedItemColor()
+	{
+		return new DyedItemColorMock.BuilderMock();
+	}
+
+	@Override
+	public PotionContents.Builder potionContents()
+	{
+		return new PotionContentsMock.BuilderMock();
+	}
+
+	@Override
+	public BundleContents.Builder bundleContents()
+	{
+		return new BundleContentsMock.BuilderMock();
+	}
+
+	@Override
+	public SuspiciousStewEffects.Builder suspiciousStewEffects()
+	{
+		return new SuspiciousStewEffectsMock.BuilderMock();
+	}
+
+	@Override
+	public MapItemColor.Builder mapItemColor()
+	{
+		return new MapItemColorMock.BuilderMock();
+	}
+
+	@Override
+	public MapDecorations.Builder mapDecorations()
+	{
+		return new MapDecorationsMock.BuilderMock();
+	}
+
+	@Override
+	public MapDecorations.DecorationEntry decorationEntry(MapCursor.Type type, double x, double z, float rotation)
+	{
+		return new MapDecorationsMock.DecorationEntryMock(type, x, z, rotation);
+	}
+
+	@Override
+	public SeededContainerLoot.Builder seededContainerLoot(Key lootTableKey)
+	{
+		return new SeededContainerLootMock.BuilderMock(lootTableKey);
+	}
+
+	@Override
+	public WrittenBookContent.Builder writtenBookContent(Filtered<String> title, String author)
+	{
+		return new WrittenBookContentMock.BuilderMock(title, author);
+	}
+
+	@Override
+	public WritableBookContent.Builder writeableBookContent()
+	{
+		return new WritableBookContentMock.BuilderMock();
+	}
+
+	@Override
+	public ItemArmorTrim.Builder itemArmorTrim(ArmorTrim armorTrim)
+	{
+		return new ItemArmorTrimMock.BuilderMock(armorTrim);
+	}
+
+	@Override
+	public LodestoneTrackerMock.Builder lodestoneTracker()
+	{
+		return new LodestoneTrackerMock.BuilderMock();
+	}
+
+	@Override
+	public Fireworks.Builder fireworks()
+	{
+		return new FireworksMock.BuilderMock();
+	}
+
+	@Override
+	public ResolvableProfile.Builder resolvableProfile()
+	{
+		return new ResolvableProfileMock.BuilderMock();
+	}
+
+	@Override
+	public ResolvableProfile resolvableProfile(PlayerProfile profile)
+	{
+		return new ResolvableProfileMock(profile.getId(), profile.getName(), profile.getProperties().stream().collect(Collectors.toUnmodifiableSet()));
+	}
+
+	@Override
+	public BannerPatternLayers.Builder bannerPatternLayers()
+	{
+		return new BannerPatternLayersMock.BuilderMock();
+	}
+
+	@Override
+	public BlockItemDataProperties.Builder blockItemStateProperties()
+	{
+		return new BlockItemDataPropertiesMock.BuilderMock();
+	}
+
+	@Override
+	public ItemContainerContents.Builder itemContainerContents()
+	{
+		return new ItemContainerContentsMock.BuilderMock();
+	}
+
+	@Override
+	public JukeboxPlayable.Builder jukeboxPlayable(JukeboxSong song)
+	{
+		return new JukeboxPlayableMock.BuilderMock(song);
+	}
+
+	@Override
+	public Tool.Builder tool()
+	{
+		return new ToolMock.BuilderMock();
+	}
+
+	@Override
+	public Tool.Rule rule(RegistryKeySet<BlockType> blocks, @Nullable Float speed, TriState correctForDrops)
+	{
+		return new ToolMock.RuleMock(blocks, speed, correctForDrops);
+	}
+
+	@Override
+	public ItemAdventurePredicate.Builder itemAdventurePredicate()
+	{
+		return new ItemAdventurePredicateMock.BuilderMock();
+	}
+
+	@Override
+	public CustomModelData.Builder customModelData()
+	{
+		return new CustomModelDataMock.BuilderMock();
+	}
+
+	@Override
+	public MapId mapId(int id)
+	{
+		return new MapIdMock(id);
+	}
+
+	@Override
+	public UseRemainder useRemainder(ItemStack itemStack)
+	{
+		Preconditions.checkArgument(itemStack != null, "Item cannot be null");
+		Preconditions.checkArgument(!itemStack.isEmpty(), "Remaining item cannot be empty!");
+		return new UseRemainderMock(itemStack);
+	}
+
+	@Override
+	public Consumable.Builder consumable()
+	{
+		return new ConsumableMock.BuilderMock();
+	}
+
+	@Override
+	public UseCooldown.Builder useCooldown(float seconds)
+	{
+		Preconditions.checkArgument(seconds > 0, "seconds must be positive, was %s", seconds);
+		return new UseCooldownMock.BuilderMock(seconds);
+	}
+
+	@Override
+	public DamageResistant damageResistant(TagKey<DamageType> types)
+	{
+		Preconditions.checkNotNull(types);
+		return new DamageResistantMock(types);
+	}
+
+	@Override
+	public Enchantable enchantable(int level)
+	{
+		Preconditions.checkArgument(level > 0, "Level has to be larger than 0");
+		return new EnchantableMock(level);
+	}
+
+	@Override
+	public Repairable repairable(RegistryKeySet<ItemType> types)
+	{
+		Preconditions.checkNotNull(types);
+		return new RepairableMock(types);
+	}
+
+	@Override
+	public Equippable.Builder equippable(EquipmentSlot slot)
+	{
+		return new EquipableMock.BuilderMock(slot);
+	}
+
+	@Override
+	public DeathProtection.Builder deathProtection()
+	{
+		return new DeathProtectionMock.BuilderMock();
+	}
+
+	@Override
+	public OminousBottleAmplifier ominousBottleAmplifier(int amplifier)
+	{
+		Preconditions.checkArgument(0 <= amplifier && amplifier <= 4,
+				"amplifier must be between %s-%s, was %s", 0, 4, amplifier
+		);
+		return new OminousBottleAmplifierMock(amplifier);
+	}
+
+	@Override
+	public BlocksAttacks.Builder blocksAttacks()
+	{
+		return new BlocksAttacksMock.BuilderMock();
+	}
+
+	@Override
+	public TooltipDisplay.Builder tooltipDisplay()
+	{
+		return new TooltipDisplayMock.BuilderMock();
+	}
+
+	@Override
+	public Weapon.Builder weapon()
+	{
+		return new WeaponMock.BuilderMock();
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/ItemContainerContentsMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/ItemContainerContentsMock.java
@@ -1,0 +1,60 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record ItemContainerContentsMock(List<ItemStack> contents) implements ItemContainerContents
+{
+	@Override
+	public @Unmodifiable List<ItemStack> contents()
+	{
+		return contents.stream()
+				.map(ItemStack::clone)
+				.toList();
+	}
+
+	static class BuilderMock implements Builder
+	{
+
+		private final List<ItemStack> items = new ArrayList<>();
+
+		@Override
+		public Builder add(ItemStack stack)
+		{
+			Preconditions.checkArgument(stack != null, "Item cannot be null");
+			checkSize(1);
+			items.add(stack);
+			return this;
+		}
+
+		@Override
+		public Builder addAll(List<ItemStack> stacks)
+		{
+			Preconditions.checkNotNull(stacks);
+			checkSize(stacks.size());
+			stacks.forEach(stack -> Preconditions.checkArgument(stack != null, "Cannot pass null item!"));
+			items.addAll(stacks);
+			return this;
+		}
+
+		@Override
+		public ItemContainerContents build()
+		{
+			return new ItemContainerContentsMock(items);
+		}
+
+		private void checkSize(int extra)
+		{
+			Preconditions.checkArgument(items.size() + extra <= 256, "Cannot have more than %s items, had %s", 256, items.size() + extra);
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/ItemEnchantmentsMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/ItemEnchantmentsMock.java
@@ -1,0 +1,52 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import org.bukkit.enchantments.Enchantment;
+import org.checkerframework.common.value.qual.IntRange;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record ItemEnchantmentsMock(Map<Enchantment, Integer> enchantments) implements ItemEnchantments
+{
+
+	static class BuilderMock implements Builder
+	{
+
+		private static final int MAX_LEVEL = 255;
+
+		Map<Enchantment, Integer> enchantments = new HashMap<>();
+
+		@Override
+		public Builder add(Enchantment enchantment, @IntRange(from = 1L, to = 255L) int level)
+		{
+			Preconditions.checkArgument(
+					level >= 1 && level <= MAX_LEVEL,
+					"level must be between %s and %s, was %s",
+					1, MAX_LEVEL,
+					level
+			);
+			this.enchantments.put(enchantment, level);
+			return this;
+		}
+
+		@Override
+		public Builder addAll(Map<Enchantment, @IntRange(from = 1L, to = 255L) Integer> enchantments)
+		{
+			enchantments.forEach(this::add);
+			return this;
+		}
+
+		@Override
+		public ItemEnchantments build()
+		{
+			return new ItemEnchantmentsMock(ImmutableMap.copyOf(enchantments));
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/ItemLoreMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/ItemLoreMock.java
@@ -1,0 +1,86 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentLike;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public class ItemLoreMock implements ItemLore
+{
+
+	private final List<Component> lines;
+
+	private ItemLoreMock(List<Component> lines)
+	{
+		this.lines = List.copyOf(lines);
+	}
+
+	@Override
+	public @Unmodifiable List<Component> lines()
+	{
+		return lines;
+	}
+
+	@Override
+	public @Unmodifiable List<Component> styledLines()
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	static class BuilderMock implements Builder
+	{
+
+		private static final int MAX_LINES = 256;
+
+		List<Component> lines = new ArrayList<>();
+
+		private static void validateLineCount(final int current, final int add)
+		{
+			final int newSize = current + add;
+			Preconditions.checkArgument(
+					newSize <= MAX_LINES,
+					"Cannot have more than %s lines, had %s",
+					MAX_LINES,
+					newSize
+			);
+		}
+
+		@Override
+		public Builder lines(List<? extends ComponentLike> lines)
+		{
+			validateLineCount(0, lines.size());
+			this.lines = new ArrayList<>(ComponentLike.asComponents(lines));
+			return this;
+		}
+
+		@Override
+		public Builder addLine(ComponentLike line)
+		{
+			validateLineCount(this.lines.size(), 1);
+			this.lines.add(line.asComponent());
+			return this;
+		}
+
+		@Override
+		public Builder addLines(List<? extends ComponentLike> lines)
+		{
+			validateLineCount(this.lines.size(), lines.size());
+			this.lines.addAll(ComponentLike.asComponents(lines));
+			return this;
+		}
+
+		@Override
+		public ItemLore build()
+		{
+			return new ItemLoreMock(lines);
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/JukeboxPlayableMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/JukeboxPlayableMock.java
@@ -1,0 +1,52 @@
+package io.papermc.paper.datacomponent.item;
+
+import org.bukkit.JukeboxSong;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Optional;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public class JukeboxPlayableMock implements JukeboxPlayable
+{
+
+	private final @Nullable JukeboxSong song;
+
+	private JukeboxPlayableMock(@Nullable JukeboxSong song)
+	{
+		this.song = song;
+	}
+
+	@Override
+	public JukeboxSong jukeboxSong()
+	{
+		return Optional.ofNullable(song).orElseThrow();
+	}
+
+	static class BuilderMock implements Builder
+	{
+
+		private @Nullable JukeboxSong song = null;
+
+		public BuilderMock(JukeboxSong song)
+		{
+			this.song = song;
+		}
+
+		@Override
+		public Builder jukeboxSong(JukeboxSong song)
+		{
+			this.song = song;
+			return this;
+		}
+
+		@Override
+		public JukeboxPlayable build()
+		{
+			return new JukeboxPlayableMock(song);
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/LodestoneTrackerMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/LodestoneTrackerMock.java
@@ -1,0 +1,61 @@
+package io.papermc.paper.datacomponent.item;
+
+import org.bukkit.Location;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public class LodestoneTrackerMock implements LodestoneTracker
+{
+
+	private final Location location;
+	private final boolean tracked;
+
+	private LodestoneTrackerMock(Location location, boolean tracked)
+	{
+		this.location = location;
+		this.tracked = tracked;
+	}
+
+	@Override
+	public @Nullable Location location()
+	{
+		return location == null ? null : location.clone();
+	}
+
+	@Override
+	public boolean tracked()
+	{
+		return tracked;
+	}
+
+	static class BuilderMock implements Builder
+	{
+
+		private Location location;
+		private boolean tracked;
+
+		@Override
+		public Builder location(@Nullable Location location)
+		{
+			this.location = location == null ? null : location.clone();
+			return this;
+		}
+
+		@Override
+		public Builder tracked(boolean tracked)
+		{
+			this.tracked = tracked;
+			return this;
+		}
+
+		@Override
+		public LodestoneTracker build()
+		{
+			return new LodestoneTrackerMock(location, tracked);
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/MapDecorationsMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/MapDecorationsMock.java
@@ -1,0 +1,54 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.collect.ImmutableMap;
+import org.bukkit.map.MapCursor;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Map;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record MapDecorationsMock(Map<String, DecorationEntry> decorations) implements MapDecorations
+{
+
+	@Override
+	public @Nullable DecorationEntry decoration(String id)
+	{
+		return decorations.get(id);
+	}
+
+	public record DecorationEntryMock(MapCursor.Type type, double x, double z,
+									  float rotation) implements DecorationEntry
+	{
+
+	}
+
+	static class BuilderMock implements Builder
+	{
+
+		ImmutableMap.Builder<String, DecorationEntry> entries = new ImmutableMap.Builder<>();
+
+		@Override
+		public Builder put(String id, DecorationEntry entry)
+		{
+			this.entries.put(id, entry);
+			return this;
+		}
+
+		@Override
+		public Builder putAll(Map<String, DecorationEntry> entries)
+		{
+			this.entries.putAll(entries);
+			return this;
+		}
+
+		@Override
+		public MapDecorations build()
+		{
+			return new MapDecorationsMock(entries.build());
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/MapIdMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/MapIdMock.java
@@ -1,0 +1,10 @@
+package io.papermc.paper.datacomponent.item;
+
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+record MapIdMock(int id) implements MapId
+{
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/MapItemColorMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/MapItemColorMock.java
@@ -1,0 +1,46 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Color;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public class MapItemColorMock implements MapItemColor
+{
+
+	private final int rgb;
+
+	public MapItemColorMock(int rgb)
+	{
+		this.rgb = rgb;
+	}
+
+	@Override
+	public Color color()
+	{
+		return Color.fromRGB(rgb);
+	}
+
+	static class BuilderMock implements Builder
+	{
+
+		private Color color = Color.fromRGB(4603950);
+
+		@Override
+		public Builder color(Color color)
+		{
+			this.color = color;
+			return this;
+		}
+
+		@Override
+		public MapItemColor build()
+		{
+			Preconditions.checkNotNull(color);
+			return new MapItemColorMock(color.asRGB());
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/OminousBottleAmplifierMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/OminousBottleAmplifierMock.java
@@ -1,0 +1,10 @@
+package io.papermc.paper.datacomponent.item;
+
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+record OminousBottleAmplifierMock(int amplifier) implements OminousBottleAmplifier
+{
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/PotDecorationsMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/PotDecorationsMock.java
@@ -1,0 +1,54 @@
+package io.papermc.paper.datacomponent.item;
+
+import org.bukkit.inventory.ItemType;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record PotDecorationsMock(@Nullable ItemType back, @Nullable ItemType left,
+								 @Nullable ItemType right, @Nullable ItemType front) implements PotDecorations
+{
+	static class BuilderMock implements PotDecorations.Builder
+	{
+		private @Nullable ItemType back;
+		private @Nullable ItemType left;
+		private @Nullable ItemType right;
+		private @Nullable ItemType front;
+
+		@Override
+		public Builder back(@Nullable ItemType back)
+		{
+			this.back = back;
+			return this;
+		}
+
+		@Override
+		public Builder left(@Nullable ItemType left)
+		{
+			this.left = left;
+			return this;
+		}
+
+		@Override
+		public Builder right(@Nullable ItemType right)
+		{
+			this.right = right;
+			return this;
+		}
+
+		@Override
+		public Builder front(@Nullable ItemType front)
+		{
+			this.front = front;
+			return this;
+		}
+
+		@Override
+		public PotDecorations build()
+		{
+			return new PotDecorationsMock(back, left, right, front);
+		}
+
+	}
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/PotionContentsMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/PotionContentsMock.java
@@ -1,0 +1,121 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Color;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionType;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public class PotionContentsMock implements PotionContents
+{
+
+	private final @Nullable PotionType potion;
+	private final @Nullable Color customColor;
+	private final List<PotionEffect> customEffects;
+	private final @Nullable String customName;
+
+	private PotionContentsMock(@Nullable PotionType potion, @Nullable Color customColor, List<PotionEffect> customEffects, @Nullable String customName)
+	{
+		this.potion = potion;
+		this.customColor = customColor;
+		this.customEffects = customEffects;
+		this.customName = customName;
+	}
+
+	@Override
+	public @Nullable PotionType potion()
+	{
+		return potion;
+	}
+
+	@Override
+	public @Nullable Color customColor()
+	{
+		return customColor == null ? null : Color.fromRGB(customColor.asRGB());
+	}
+
+	@Override
+	public @Unmodifiable List<PotionEffect> customEffects()
+	{
+		return customEffects;
+	}
+
+	@Override
+	public @Nullable String customName()
+	{
+		return customName;
+	}
+
+	@Override
+	public @Unmodifiable List<PotionEffect> allEffects()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public Color computeEffectiveColor()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	static class BuilderMock implements Builder
+	{
+
+		private final List<PotionEffect> customEffects = new ArrayList<>();
+		private @Nullable PotionType potion;
+		private @Nullable Color color;
+		private @Nullable String customName;
+
+		@Override
+		public Builder potion(@Nullable PotionType type)
+		{
+			this.potion = type;
+			return this;
+		}
+
+		@Override
+		public Builder customColor(@Nullable Color color)
+		{
+			this.color = color;
+			return this;
+		}
+
+		@Override
+		public Builder customName(@Nullable String name)
+		{
+			Preconditions.checkArgument(name == null || name.length() <= Short.MAX_VALUE, "Custom name is longer than %s characters", Short.MAX_VALUE);
+			this.customName = name;
+			return this;
+		}
+
+		@Override
+		public Builder addCustomEffect(PotionEffect effect)
+		{
+			customEffects.add(effect);
+			return this;
+		}
+
+		@Override
+		public Builder addCustomEffects(List<PotionEffect> effects)
+		{
+			effects.forEach(this::addCustomEffect);
+			return this;
+		}
+
+		@Override
+		public PotionContents build()
+		{
+			return new PotionContentsMock(potion, color, List.copyOf(customEffects), customName);
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/RepairableMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/RepairableMock.java
@@ -1,0 +1,12 @@
+package io.papermc.paper.datacomponent.item;
+
+import io.papermc.paper.registry.set.RegistryKeySet;
+import org.bukkit.inventory.ItemType;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record RepairableMock(RegistryKeySet<ItemType> types) implements Repairable
+{
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/ResolvableProfileMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/ResolvableProfileMock.java
@@ -1,0 +1,93 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.destroystokyo.paper.profile.PlayerProfile;
+import com.destroystokyo.paper.profile.ProfileProperty;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.mockbukkit.mockbukkit.profile.PlayerProfileMock;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record ResolvableProfileMock(@Nullable UUID uuid, @Nullable String name,
+									@Unmodifiable Collection<ProfileProperty> properties) implements ResolvableProfile
+{
+
+	@Override
+	public CompletableFuture<PlayerProfile> resolve()
+	{
+		PlayerProfileMock playerProfileMock = new PlayerProfileMock(name, uuid);
+		playerProfileMock.setProperties(properties);
+		return CompletableFuture.completedFuture(playerProfileMock);
+	}
+
+	static class BuilderMock implements Builder
+	{
+		private final Set<ProfileProperty> properties = new HashSet<>();
+
+		private @Nullable String name;
+		private @Nullable UUID uuid;
+
+		@Override
+		public Builder name(@Nullable String name)
+		{
+			if (name != null)
+			{
+				Preconditions.checkArgument(name.length() <= 16, "name cannot be more than 16 characters, was %s", name.length());
+				Preconditions.checkArgument(isValidPlayerName(name), "name cannot include invalid characters, was %s", name);
+			}
+			this.name = name;
+			return this;
+		}
+
+		@Override
+		public Builder uuid(@Nullable UUID uuid)
+		{
+			this.uuid = uuid;
+			return this;
+		}
+
+		@Override
+		public Builder addProperty(ProfileProperty property)
+		{
+			Preconditions.checkNotNull(property);
+			if (!properties.contains(property))
+			{
+				int newSize = this.properties.size() + 1;
+				Preconditions.checkArgument(newSize <= 16, "Cannot have more than 16 properties, was %s", newSize);
+			}
+			properties.add(property);
+			return this;
+		}
+
+		@Override
+		public Builder addProperties(Collection<ProfileProperty> properties)
+		{
+			Preconditions.checkNotNull(properties);
+			properties.forEach(this::addProperty);
+			return this;
+		}
+
+		@Override
+		public ResolvableProfile build()
+		{
+			return new ResolvableProfileMock(uuid, name, new ImmutableSet.Builder<ProfileProperty>().addAll(properties).build());
+		}
+
+
+		private static boolean isValidPlayerName(String playerName)
+		{
+			return playerName.chars().filter(i -> i <= 32 || i >= 127).findAny().isEmpty();
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/SeededContainerLootMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/SeededContainerLootMock.java
@@ -1,0 +1,46 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import net.kyori.adventure.key.Key;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record SeededContainerLootMock(Key lootTable, long seed) implements SeededContainerLoot
+{
+
+	static class BuilderMock implements Builder
+	{
+
+		private long seed = 0L;
+		private Key key;
+
+		BuilderMock(Key key)
+		{
+			this.key = key;
+		}
+
+		@Override
+		public Builder lootTable(Key key)
+		{
+			this.key = key;
+			return this;
+		}
+
+		@Override
+		public Builder seed(long seed)
+		{
+			this.seed = seed;
+			return this;
+		}
+
+		@Override
+		public SeededContainerLoot build()
+		{
+			Preconditions.checkNotNull(key);
+			return new SeededContainerLootMock(key, seed);
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/SuspiciousStewEffectsMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/SuspiciousStewEffectsMock.java
@@ -1,0 +1,44 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import io.papermc.paper.potion.SuspiciousEffectEntry;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.Collection;
+import java.util.List;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record SuspiciousStewEffectsMock(List<SuspiciousEffectEntry> effects) implements SuspiciousStewEffects
+{
+
+	static class BuilderMock implements Builder
+	{
+
+		ImmutableList.Builder<SuspiciousEffectEntry> effects = new ImmutableList.Builder<>();
+
+		@Override
+		public Builder add(SuspiciousEffectEntry entry)
+		{
+			Preconditions.checkNotNull(entry);
+			effects.add(entry);
+			return this;
+		}
+
+		@Override
+		public Builder addAll(Collection<SuspiciousEffectEntry> entries)
+		{
+			entries.forEach(this::add);
+			return this;
+		}
+
+		@Override
+		public SuspiciousStewEffects build()
+		{
+			return new SuspiciousStewEffectsMock(effects.build());
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/ToolMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/ToolMock.java
@@ -1,0 +1,80 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import io.papermc.paper.registry.set.RegistryKeySet;
+import net.kyori.adventure.util.TriState;
+import org.bukkit.block.BlockType;
+import org.checkerframework.checker.index.qual.NonNegative;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.List;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record ToolMock(float defaultMiningSpeed, @NonNegative int damagePerBlock, List<Rule> rules,
+					   boolean canDestroyBlocksInCreative) implements Tool
+{
+
+	record RuleMock(RegistryKeySet<BlockType> blocks, @Nullable Float speed, TriState correctForDrops) implements Rule
+	{
+
+	}
+
+	static final class BuilderMock implements Builder
+	{
+
+		private final ImmutableList.Builder<Rule> rules = ImmutableList.builder();
+		private int damage = 1;
+		private float miningSpeed = 1.0F;
+		private boolean canDestroyBlocksInCreative = true;
+
+
+		@Override
+		public Builder damagePerBlock(@NonNegative int damage)
+		{
+			Preconditions.checkArgument(damage >= 0, "damage must be non-negative, was %s", damage);
+			this.damage = damage;
+			return this;
+		}
+
+		@Override
+		public Builder defaultMiningSpeed(float miningSpeed)
+		{
+			this.miningSpeed = miningSpeed;
+			return this;
+		}
+
+		@Override
+		public Builder addRule(Rule rule)
+		{
+			Preconditions.checkNotNull(rule);
+			rules.add(rule);
+			return this;
+		}
+
+		@Override
+		public Builder canDestroyBlocksInCreative(boolean canDestroyBlocksInCreative)
+		{
+			this.canDestroyBlocksInCreative = canDestroyBlocksInCreative;
+			return this;
+		}
+
+		@Override
+		public Builder addRules(Collection<Rule> rules)
+		{
+			rules.forEach(this::addRule);
+			return this;
+		}
+
+		@Override
+		public Tool build()
+		{
+			return new ToolMock(miningSpeed, damage, rules.build(), canDestroyBlocksInCreative);
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/TooltipDisplayMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/TooltipDisplayMock.java
@@ -1,0 +1,54 @@
+package io.papermc.paper.datacomponent.item;
+
+import io.papermc.paper.datacomponent.DataComponentType;
+import it.unimi.dsi.fastutil.objects.ReferenceLinkedOpenHashSet;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.Arrays;
+import java.util.Set;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record TooltipDisplayMock(boolean hideTooltip, Set<DataComponentType> hiddenComponents) implements TooltipDisplay
+{
+
+	@Override
+	public Set<DataComponentType> hiddenComponents()
+	{
+		return new ReferenceLinkedOpenHashSet<>(this.hiddenComponents);
+	}
+
+	static class BuilderMock implements Builder
+	{
+		private final Set<DataComponentType> hiddenComponents = new ReferenceLinkedOpenHashSet<>();
+		private boolean hideTooltip;
+
+		@Override
+		public Builder hideTooltip(boolean hide)
+		{
+			this.hideTooltip = hide;
+			return this;
+		}
+
+		@Override
+		public Builder addHiddenComponents(DataComponentType... components)
+		{
+			this.hiddenComponents.addAll(Arrays.asList(components));
+			return this;
+		}
+
+		@Override
+		public Builder hiddenComponents(Set<DataComponentType> components)
+		{
+			this.hiddenComponents.addAll(components);
+			return this;
+		}
+
+		@Override
+		public TooltipDisplay build()
+		{
+			return new TooltipDisplayMock(this.hideTooltip, this.hiddenComponents);
+		}
+
+	}
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/UseCooldownMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/UseCooldownMock.java
@@ -1,0 +1,39 @@
+package io.papermc.paper.datacomponent.item;
+
+import net.kyori.adventure.key.Key;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record UseCooldownMock(float seconds, @Nullable Key cooldownGroup) implements UseCooldown
+{
+
+
+	static class BuilderMock implements Builder
+	{
+
+		private final float seconds;
+		private @Nullable Key key;
+
+		BuilderMock(float seconds)
+		{
+			this.seconds = seconds;
+		}
+
+		@Override
+		public Builder cooldownGroup(@Nullable Key key)
+		{
+			this.key = key;
+			return this;
+		}
+
+		@Override
+		public UseCooldown build()
+		{
+			return new UseCooldownMock(seconds, key);
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/UseRemainderMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/UseRemainderMock.java
@@ -1,0 +1,24 @@
+package io.papermc.paper.datacomponent.item;
+
+import org.bukkit.inventory.ItemStack;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public class UseRemainderMock implements UseRemainder
+{
+
+	private final ItemStack itemStack;
+
+	UseRemainderMock(ItemStack itemStack)
+	{
+		this.itemStack = itemStack;
+	}
+
+	@Override
+	public ItemStack transformInto()
+	{
+		return itemStack.clone();
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/WeaponMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/WeaponMock.java
@@ -1,0 +1,39 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record WeaponMock(int itemDamagePerAttack, float disableBlockingForSeconds) implements Weapon
+{
+	static class BuilderMock implements Weapon.Builder
+	{
+		private int itemDamagePerAttack = 1;
+		private float disableBlockingForSeconds;
+
+		@Override
+		public Builder itemDamagePerAttack(int damage)
+		{
+			Preconditions.checkArgument(damage >= 0, "damage must be non-negative, was %s", damage);
+			this.itemDamagePerAttack = damage;
+			return this;
+		}
+
+		@Override
+		public Builder disableBlockingForSeconds(float seconds)
+		{
+			Preconditions.checkArgument(seconds >= 0.0F, "seconds must be non-negative, was %s", seconds);
+			this.disableBlockingForSeconds = seconds;
+			return this;
+		}
+
+		@Override
+		public Weapon build()
+		{
+			return new WeaponMock(this.itemDamagePerAttack, this.disableBlockingForSeconds);
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/WritableBookContentMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/WritableBookContentMock.java
@@ -1,0 +1,102 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import io.papermc.paper.text.Filtered;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.Collections;
+import java.util.List;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record WritableBookContentMock(List<Filtered<String>> pages) implements WritableBookContent
+{
+
+	@Override
+	public @Unmodifiable List<Filtered<String>> pages()
+	{
+		return Collections.unmodifiableList(this.pages);
+	}
+
+	static class BuilderMock implements WritableBookContent.Builder
+	{
+		private static void validatePageLength(String page)
+		{
+			Preconditions.checkArgument(page.length() <= 1024, "Cannot have page length more than %s, had %s", 1024, page.length());
+		}
+
+		private static void validatePageCount(int current, int add)
+		{
+			int newSize = current + add;
+			Preconditions.checkArgument(newSize <= 100, "Cannot have more than %s pages, had %s", 100, newSize);
+		}
+
+		private final List<Filtered<String>> pages = new ObjectArrayList<>();
+
+		@Override
+		public Builder addPage(String page)
+		{
+			validatePageLength(page);
+			validatePageCount(this.pages.size(), 1);
+			this.pages.add(Filtered.of(page, null));
+			return this;
+		}
+
+		@Override
+		public Builder addPages(List<String> pages)
+		{
+			validatePageCount(this.pages.size(), pages.size());
+
+			for(String page : pages)
+			{
+				validatePageLength(page);
+				this.pages.add(Filtered.of(page, null));
+			}
+
+			return this;
+		}
+
+		@Override
+		public Builder addFilteredPage(Filtered<String> page)
+		{
+			validatePageLength(page.raw());
+			if (page.filtered() != null)
+			{
+				validatePageLength(page.filtered());
+			}
+
+			validatePageCount(this.pages.size(), 1);
+			this.pages.add(Filtered.of(page.raw(), page.filtered()));
+			return this;
+		}
+
+		@Override
+		public Builder addFilteredPages(List<Filtered<String>> pages)
+		{
+			validatePageCount(this.pages.size(), pages.size());
+
+			for(Filtered<String> page : pages)
+			{
+				validatePageLength(page.raw());
+				if (page.filtered() != null)
+				{
+					validatePageLength(page.filtered());
+				}
+
+				this.pages.add(Filtered.of(page.raw(), page.filtered()));
+			}
+
+			return this;
+		}
+
+		@Override
+		public WritableBookContent build()
+		{
+			return new WritableBookContentMock(this.pages);
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/WrittenBookContentMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/WrittenBookContentMock.java
@@ -1,0 +1,152 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.google.common.base.Preconditions;
+import io.papermc.paper.text.Filtered;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentLike;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import org.checkerframework.common.value.qual.IntRange;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.List;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record WrittenBookContentMock(
+		Filtered<String> title,
+		String author,
+		int generation,
+		List<Filtered<Component>> pages,
+		boolean resolved
+) implements WrittenBookContent
+{
+
+	static class BuilderMock implements WrittenBookContent.Builder
+	{
+		private static void validateTitle(String title)
+		{
+			Preconditions.checkArgument(title.length() <= 32, "Title cannot be longer than %s, was %s", 32, title.length());
+		}
+
+		private static void validatePageLength(Component page)
+		{
+			String flagPage = GsonComponentSerializer.gson().serializeToTree(page).getAsString();
+			Preconditions.checkArgument(flagPage.length() <= 32767, "Cannot have page length more than %s, had %s", 32767, flagPage.length());
+		}
+
+		private final List<Filtered<Component>> pages = new ObjectArrayList<>();
+		private Filtered<String> title;
+		private String author;
+		private int generation = 0;
+		private boolean resolved = false;
+
+		BuilderMock(Filtered<String> title, String author)
+		{
+			validateTitle(title.raw());
+			if (title.filtered() != null)
+			{
+				validateTitle(title.filtered());
+			}
+
+			this.title = title;
+			this.author = author;
+		}
+
+		@Override
+		public Builder title(String title)
+		{
+			validateTitle(title);
+			this.title = Filtered.of(title, null);
+			return this;
+		}
+
+		@Override
+		public Builder filteredTitle(Filtered<String> title)
+		{
+			validateTitle(title.raw());
+			if (title.filtered() != null)
+			{
+				validateTitle(title.filtered());
+			}
+
+			this.title = Filtered.of(title.raw(), title.filtered());
+			return this;
+		}
+
+		@Override
+		public Builder author(String author)
+		{
+			this.author = author;
+			return this;
+		}
+
+		@Override
+		public Builder generation(@IntRange(from = 0L, to = 3L) int generation)
+		{
+			Preconditions.checkArgument(generation >= 0 && generation <= 3, "generation must be between %s and %s, was %s", 0, 3, generation);
+			this.generation = generation;
+			return this;
+		}
+
+		@Override
+		public Builder resolved(boolean resolved)
+		{
+			this.resolved = resolved;
+			return this;
+		}
+
+		@Override
+		public Builder addPage(ComponentLike page)
+		{
+			Component component = page.asComponent();
+			validatePageLength(component);
+			// TODO: this.pages.add(Filterable.passThrough(PaperAdventure.asVanilla()));
+			return this;
+		}
+
+		@Override
+		public Builder addPages(List<? extends ComponentLike> pages)
+		{
+			for(ComponentLike page : pages)
+			{
+				Component component = page.asComponent();
+				validatePageLength(component);
+				// this.pages.add(Filterable.passThrough(PaperAdventure.asVanilla(component)));
+			}
+
+			return this;
+		}
+
+		@Override
+		public Builder addFilteredPage(Filtered<? extends ComponentLike> page)
+		{
+			Component raw = page.raw().asComponent();
+			validatePageLength(raw);
+			Component filtered = null;
+			if (page.filtered() != null)
+			{
+				filtered = page.filtered().asComponent();
+				validatePageLength(filtered);
+			}
+
+			// this.pages.add(new Filterable(PaperAdventure.asVanilla(raw), Optional.ofNullable(filtered).map(PaperAdventure::asVanilla)));
+			return this;
+		}
+
+		@Override
+		public Builder addFilteredPages(List<Filtered<? extends ComponentLike>> pages)
+		{
+			pages.forEach(this::addFilteredPage);
+			return this;
+		}
+
+		@Override
+		public WrittenBookContent build()
+		{
+			return new WrittenBookContentMock(this.title, this.author, this.generation, new ObjectArrayList(this.pages), this.resolved);
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/attribute/AttributeModifierDisplayBridgeMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/attribute/AttributeModifierDisplayBridgeMock.java
@@ -1,0 +1,29 @@
+package io.papermc.paper.datacomponent.item.attribute;
+
+import net.kyori.adventure.text.ComponentLike;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+@SuppressWarnings({ "UnstableApiUsage" })
+public class AttributeModifierDisplayBridgeMock implements AttributeModifierDisplayBridge
+{
+
+	@Override
+	public AttributeModifierDisplay.Default reset()
+	{
+		return new AttributeModifierDisplayMock.DefaultMock();
+	}
+
+	@Override
+	public AttributeModifierDisplay.Hidden hidden()
+	{
+		return new AttributeModifierDisplayMock.HiddenMock();
+	}
+
+	@Override
+	public AttributeModifierDisplay.OverrideText override(ComponentLike text)
+	{
+		return new AttributeModifierDisplayMock.OverrideTextMock(text.asComponent());
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/attribute/AttributeModifierDisplayMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/attribute/AttributeModifierDisplayMock.java
@@ -1,0 +1,25 @@
+package io.papermc.paper.datacomponent.item.attribute;
+
+import lombok.experimental.UtilityClass;
+import net.kyori.adventure.text.Component;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+@UtilityClass
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public class AttributeModifierDisplayMock implements AttributeModifierDisplay
+{
+
+	record HiddenMock() implements Hidden
+	{
+	}
+
+	record DefaultMock() implements Default
+	{
+	}
+
+	record OverrideTextMock(Component text) implements OverrideText
+	{
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/blocksattacks/BlocksAttacksBridgeMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/blocksattacks/BlocksAttacksBridgeMock.java
@@ -1,0 +1,22 @@
+package io.papermc.paper.datacomponent.item.blocksattacks;
+
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+@SuppressWarnings({ "UnstableApiUsage" })
+public class BlocksAttacksBridgeMock implements BlocksAttacksBridge
+{
+
+	@Override
+	public DamageReduction.Builder blocksAttacksDamageReduction()
+	{
+		return new DamageReductionMock.BuilderMock();
+	}
+
+	@Override
+	public ItemDamageFunction.Builder blocksAttacksItemDamageFunction()
+	{
+		return new ItemDamageFunctionMock.BuilderMock();
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/blocksattacks/DamageReductionMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/blocksattacks/DamageReductionMock.java
@@ -1,0 +1,62 @@
+package io.papermc.paper.datacomponent.item.blocksattacks;
+
+import com.google.common.base.Preconditions;
+import io.papermc.paper.registry.set.RegistryKeySet;
+import org.bukkit.damage.DamageType;
+import org.checkerframework.checker.index.qual.Positive;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record DamageReductionMock(float horizontalBlockingAngle,
+								  @Nullable RegistryKeySet<DamageType> type,
+								  float base,
+								  float factor) implements DamageReduction
+{
+
+	static class BuilderMock implements Builder
+	{
+		private @Nullable RegistryKeySet<DamageType> type;
+		private float horizontalBlockingAngle = 90.0F;
+		private float base = 0.0F;
+		private float factor = 1.0F;
+
+		@Override
+		public Builder type(@Nullable RegistryKeySet<DamageType> type)
+		{
+			this.type = type;
+			return this;
+		}
+
+		@Override
+		public Builder horizontalBlockingAngle(@Positive float horizontalBlockingAngle)
+		{
+			Preconditions.checkArgument(horizontalBlockingAngle > 0.0F, "horizontalBlockingAngle must be positive and not zero, was %s", horizontalBlockingAngle);
+			this.horizontalBlockingAngle = horizontalBlockingAngle;
+			return this;
+		}
+
+		@Override
+		public Builder base(float base)
+		{
+			this.base = base;
+			return this;
+		}
+
+		@Override
+		public Builder factor(float factor)
+		{
+			this.factor = factor;
+			return this;
+		}
+
+		@Override
+		public DamageReduction build()
+		{
+			return new DamageReductionMock(this.horizontalBlockingAngle, this.type, this.base, this.factor);
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/blocksattacks/ItemDamageFunctionMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/blocksattacks/ItemDamageFunctionMock.java
@@ -1,0 +1,54 @@
+package io.papermc.paper.datacomponent.item.blocksattacks;
+
+import com.google.common.base.Preconditions;
+import org.checkerframework.checker.index.qual.NonNegative;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public record ItemDamageFunctionMock(float threshold, float base, float factor) implements ItemDamageFunction
+{
+
+	@Override
+	public int damageToApply(float damageAmount)
+	{
+		return damageAmount < this.threshold ? 0 : (int) Math.floor(this.base + this.factor * damageAmount);
+	}
+
+	static class BuilderMock implements Builder
+	{
+		private float threshold = 1.0F;
+		private float base = 0.0F;
+		private float factor = 1.0F;
+
+		@Override
+		public Builder threshold(@NonNegative float threshold)
+		{
+			Preconditions.checkArgument(threshold >= 0.0F, "threshold must be non-negative, was %s", threshold);
+			this.threshold = threshold;
+			return this;
+		}
+
+		@Override
+		public Builder base(float base)
+		{
+			this.base = base;
+			return this;
+		}
+
+		@Override
+		public Builder factor(float factor)
+		{
+			this.factor = factor;
+			return this;
+		}
+
+		@Override
+		public ItemDamageFunction build()
+		{
+			return new ItemDamageFunctionMock(this.threshold, this.base, this.factor);
+		}
+
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/consumable/ConsumableTypesBridgeMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/consumable/ConsumableTypesBridgeMock.java
@@ -1,0 +1,46 @@
+package io.papermc.paper.datacomponent.item.consumable;
+
+import io.papermc.paper.registry.set.RegistryKeySet;
+import net.kyori.adventure.key.Key;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.List;
+
+@NullMarked
+@SuppressWarnings({ "UnstableApiUsage" })
+public class ConsumableTypesBridgeMock implements ConsumableTypesBridge
+{
+
+	@Override
+	public ConsumeEffect.ApplyStatusEffects applyStatusEffects(List<PotionEffect> effectList, float probability)
+	{
+		return new ConsumeEffectMock.ApplyStatusEffectsMock(effectList, probability);
+	}
+
+	@Override
+	public ConsumeEffect.RemoveStatusEffects removeStatusEffects(RegistryKeySet<PotionEffectType> effectTypes)
+	{
+		return new ConsumeEffectMock.RemoveStatusEffectsMock(effectTypes);
+	}
+
+	@Override
+	public ConsumeEffect.ClearAllStatusEffects clearAllStatusEffects()
+	{
+		return new ConsumeEffectMock.ClearAllStatusEffectsMock();
+	}
+
+	@Override
+	public ConsumeEffect.PlaySound playSoundEffect(Key sound)
+	{
+		return new ConsumeEffectMock.PlaySoundMock(sound);
+	}
+
+	@Override
+	public ConsumeEffect.TeleportRandomly teleportRandomlyEffect(float diameter)
+	{
+		return new ConsumeEffectMock.TeleportRandomlyMock(diameter);
+	}
+
+}

--- a/src/main/java/io/papermc/paper/datacomponent/item/consumable/ConsumeEffectMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/consumable/ConsumeEffectMock.java
@@ -1,0 +1,33 @@
+package io.papermc.paper.datacomponent.item.consumable;
+
+import io.papermc.paper.registry.set.RegistryKeySet;
+import lombok.experimental.UtilityClass;
+import net.kyori.adventure.key.Key;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.List;
+
+@NullMarked
+@UtilityClass
+@SuppressWarnings({ "NonExtendableApiUsage", "UnstableApiUsage" })
+public class ConsumeEffectMock implements ConsumeEffect
+{
+
+	record TeleportRandomlyMock(float diameter) implements TeleportRandomly
+	{}
+
+	record RemoveStatusEffectsMock(RegistryKeySet<PotionEffectType> removeEffects) implements RemoveStatusEffects
+	{}
+
+	record PlaySoundMock(Key sound) implements PlaySound
+	{}
+
+	record ClearAllStatusEffectsMock() implements ClearAllStatusEffects
+	{}
+
+	record ApplyStatusEffectsMock(List<PotionEffect> effects, float probability) implements ApplyStatusEffects
+	{}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/registry/RegistryMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/registry/RegistryMock.java
@@ -184,7 +184,7 @@ public class RegistryMock<T extends Keyed> implements Registry<T>
 	@Override
 	public @org.jspecify.annotations.Nullable NamespacedKey getKey(T t)
 	{
-		throw new UnimplementedOperationException();
+		return t.getKey();
 	}
 
 	@Override

--- a/src/main/resources/META-INF/services/io.papermc.paper.datacomponent.item.ItemComponentTypesBridge
+++ b/src/main/resources/META-INF/services/io.papermc.paper.datacomponent.item.ItemComponentTypesBridge
@@ -1,0 +1,1 @@
+io.papermc.paper.datacomponent.item.ItemComponentTypesBridgeMock

--- a/src/main/resources/META-INF/services/io.papermc.paper.datacomponent.item.attribute.AttributeModifierDisplayBridge
+++ b/src/main/resources/META-INF/services/io.papermc.paper.datacomponent.item.attribute.AttributeModifierDisplayBridge
@@ -1,0 +1,1 @@
+io.papermc.paper.datacomponent.item.attribute.AttributeModifierDisplayBridgeMock

--- a/src/main/resources/META-INF/services/io.papermc.paper.datacomponent.item.blocksattacks.BlocksAttacksBridge
+++ b/src/main/resources/META-INF/services/io.papermc.paper.datacomponent.item.blocksattacks.BlocksAttacksBridge
@@ -1,0 +1,1 @@
+io.papermc.paper.datacomponent.item.blocksattacks.BlocksAttacksBridgeMock

--- a/src/test/java/io/papermc/paper/datacomponent/item/ItemComponentTypesBridgeMockTest.java
+++ b/src/test/java/io/papermc/paper/datacomponent/item/ItemComponentTypesBridgeMockTest.java
@@ -1,0 +1,538 @@
+package io.papermc.paper.datacomponent.item;
+
+import com.destroystokyo.paper.profile.PlayerProfile;
+import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.registry.TypedKey;
+import io.papermc.paper.registry.set.RegistryKeySet;
+import io.papermc.paper.registry.set.RegistrySet;
+import io.papermc.paper.registry.tag.TagKey;
+import io.papermc.paper.text.Filtered;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.util.TriState;
+import org.bukkit.JukeboxSong;
+import org.bukkit.Material;
+import org.bukkit.block.BlockType;
+import org.bukkit.damage.DamageType;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.ItemType;
+import org.bukkit.map.MapCursor;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+import org.mockbukkit.mockbukkit.profile.PlayerProfileMock;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("UnstableApiUsage")
+@ExtendWith(MockBukkitExtension.class)
+class ItemComponentTypesBridgeMockTest
+{
+
+	private final ItemComponentTypesBridgeMock bridge = new ItemComponentTypesBridgeMock();
+
+	@Test
+	void givenChargedProjectiles()
+	{
+		ChargedProjectiles.Builder actual = bridge.chargedProjectiles();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenPotDecorations()
+	{
+		PotDecorations.Builder actual = bridge.potDecorations();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenLore()
+	{
+		ItemLore.Builder actual = bridge.lore();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenItemEnchantments()
+	{
+		ItemEnchantments.Builder actual = bridge.enchantments();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenItemAttributeModifiers()
+	{
+		ItemAttributeModifiers.Builder actual = bridge.modifiers();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenFoodProperties()
+	{
+		FoodProperties.Builder actual = bridge.food();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenDyedItemColor()
+	{
+		DyedItemColor.Builder actual = bridge.dyedItemColor();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenPotionContents()
+	{
+		PotionContents.Builder actual = bridge.potionContents();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenBundleContents()
+	{
+		BundleContents.Builder actual = bridge.bundleContents();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenSuspiciousStewEffects()
+	{
+		SuspiciousStewEffects.Builder actual = bridge.suspiciousStewEffects();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenMapItemColor()
+	{
+		MapItemColor.Builder actual = bridge.mapItemColor();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenMapDecorations()
+	{
+		MapDecorations.Builder actual = bridge.mapDecorations();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Nested
+	class UseRemainderTests
+	{
+
+		@Test
+		void givenValidItemReturnsUseRemainder()
+		{
+			ItemStack item = ItemStack.of(Material.DIAMOND_PICKAXE);
+
+			UseRemainder actual = bridge.useRemainder(item);
+
+			assertNotNull(actual);
+			assertEquals(item, actual.transformInto());
+		}
+
+		@Test
+		void givenNullItemThrowsException()
+		{
+			assertThrows(IllegalArgumentException.class, () -> bridge.useRemainder(null));
+		}
+
+	}
+
+	@Nested
+	class UseCooldownTest
+	{
+
+		@Test
+		void givenPositiveSecondsReturnsBuilder()
+		{
+			float seconds = 1.0f;
+
+			UseCooldown.Builder actual = bridge.useCooldown(seconds);
+
+			assertNotNull(actual);
+		}
+
+		@Test
+		void givenZeroOrNegativeSecondsThrowsException()
+		{
+			assertThrows(IllegalArgumentException.class, () -> bridge.useCooldown(0));
+			assertThrows(IllegalArgumentException.class, () -> bridge.useCooldown(-2.5f));
+		}
+
+	}
+
+	@Nested
+	class EnchantableTest
+	{
+
+		@Test
+		void givenPositiveLevelReturnsEnchantable()
+		{
+			int level = 3;
+
+			Enchantable actual = bridge.enchantable(level);
+
+			assertNotNull(actual);
+			assertEquals(3, actual.value());
+		}
+
+		@Test
+		void givenZeroOrNegativeLevelThrowsException()
+		{
+			assertThrows(IllegalArgumentException.class, () -> bridge.enchantable(0));
+			assertThrows(IllegalArgumentException.class, () -> bridge.enchantable(-1));
+		}
+
+	}
+
+	@Nested
+	class OminousBottleAmplifierTest
+	{
+
+		@ParameterizedTest
+		@ValueSource(ints = {0, 1, 2, 3, 4})
+		void givenAmplifierInRangeReturnsInstance(int amplifier)
+		{
+			OminousBottleAmplifier actual = bridge.ominousBottleAmplifier(amplifier);
+			assertNotNull(actual);
+			assertEquals(amplifier, actual.amplifier());
+		}
+
+		@Test
+		void givenAmplifierOutOfRangeThrowsException()
+		{
+			assertThrows(IllegalArgumentException.class, () -> bridge.ominousBottleAmplifier(-1));
+			assertThrows(IllegalArgumentException.class, () -> bridge.ominousBottleAmplifier(5));
+		}
+
+	}
+
+	@Nested
+	class ResolvableProfileTest
+	{
+
+		@Test
+		void givenValidProfileReturnsInstance()
+		{
+			UUID uuid = UUID.randomUUID();
+			PlayerProfile profile = new PlayerProfileMock("TestPlayer", uuid);
+			io.papermc.paper.datacomponent.item.ResolvableProfile actual = bridge.resolvableProfile(profile);
+			assertEquals("TestPlayer", actual.name());
+			assertEquals(uuid, actual.uuid());
+		}
+
+	}
+
+	@Nested
+	class RuleTest
+	{
+
+		@Test
+		void givenValidInputsReturnsRule()
+		{
+			TypedKey<@NonNull BlockType> stoneKey = TypedKey.create(RegistryKey.BLOCK, Key.key("minecraft", "stone"));
+			TypedKey<@NonNull BlockType> dirtKey = TypedKey.create(RegistryKey.BLOCK, Key.key("minecraft", "dirt"));
+			RegistryKeySet<@NonNull BlockType> blocks = RegistrySet.keySet(RegistryKey.BLOCK, List.of(stoneKey, dirtKey));
+
+			Tool.Rule actual = bridge.rule(blocks, 1.0f, TriState.TRUE);
+
+			assertNotNull(actual);
+			assertEquals(blocks, actual.blocks());
+			assertEquals(1.0f, actual.speed());
+			assertEquals(TriState.TRUE, actual.correctForDrops());
+		}
+
+	}
+
+	@Nested
+	class DamageResistantTest
+	{
+		@Test
+		void givenDamageResistantType()
+		{
+			TagKey<@NonNull DamageType> type = TagKey.create(RegistryKey.DAMAGE_TYPE, DamageType.ARROW.key());
+
+			DamageResistant actual = bridge.damageResistant(type);
+
+			assertNotNull(actual);
+			assertEquals(type, actual.types());
+		}
+
+		@Test
+		void givenNullTagKeyThrowsException()
+		{
+			assertThrows(NullPointerException.class, () -> bridge.damageResistant(null));
+		}
+
+	}
+
+	@Nested
+	class RepairableTest
+	{
+		@Test
+		void givenDamageResistantType()
+		{
+			TypedKey<@NonNull ItemType> diamondPickaxe = TypedKey.create(RegistryKey.ITEM, ItemType.DIAMOND_PICKAXE.key());
+			RegistryKeySet<@NonNull ItemType> type = RegistrySet.keySet(RegistryKey.ITEM, diamondPickaxe);
+
+			Repairable actual = bridge.repairable(type);
+
+			assertNotNull(actual);
+			assertEquals(type, actual.types());
+		}
+
+		@Test
+		void givenNullRegistryKeySetThrows()
+		{
+			assertThrows(NullPointerException.class, () -> bridge.repairable(null));
+		}
+
+	}
+
+	@Nested
+	class DecorationEntryTest
+	{
+
+		@Test
+		void givenValidInputsReturnsDecorationEntry()
+		{
+			MapCursor.Type type = MapCursor.Type.RED_X;
+			double x = 1.0;
+			double z = 2.0;
+			float rotation = 0.5f;
+
+			MapDecorationsMock.DecorationEntry actual = bridge.decorationEntry(type, x, z, rotation);
+
+			assertNotNull(actual);
+			assertEquals(type, actual.type());
+			assertEquals(x, actual.x());
+			assertEquals(z, actual.z());
+			assertEquals(rotation, actual.rotation());
+		}
+
+	}
+
+	@Nested
+	class MapIdTest
+	{
+
+		@Test
+		void givenIdReturnsMapId()
+		{
+			int id = 123;
+
+			MapId actual = bridge.mapId(id);
+
+			assertNotNull(actual);
+			assertEquals(id, actual.id());
+		}
+
+	}
+
+	@Nested
+	class JukeboxPlayableTest
+	{
+
+		@Test
+		void givenSongReturnsBuilder()
+		{
+			JukeboxSong song = JukeboxSong.BLOCKS;
+
+			JukeboxPlayable.Builder actual = bridge.jukeboxPlayable(song);
+
+			assertNotNull(actual);
+		}
+
+	}
+
+	@Nested
+	class EquippableTest
+	{
+
+		@Test
+		void givenSlotReturnsBuilder()
+		{
+			EquipmentSlot slot = EquipmentSlot.HAND;
+
+			Equippable.Builder actual = bridge.equippable(slot);
+
+			assertNotNull(actual);
+		}
+
+	}
+
+	@Nested
+	class WrittenBookContentTest
+	{
+
+		@Test
+		void givenTitleAndAuthorReturnsBuilder()
+		{
+			Filtered<@NonNull String> title = Filtered.of("My Title", null);
+			String author = "Author";
+
+			WrittenBookContent.Builder actual = bridge.writtenBookContent(title, author);
+
+			assertNotNull(actual);
+		}
+
+	}
+
+	@Test
+	void givenWritableBookContent()
+	{
+		WritableBookContent.Builder actual = bridge.writeableBookContent();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenLodestoneTrackerMock()
+	{
+		LodestoneTrackerMock.Builder actual = bridge.lodestoneTracker();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenFireworks()
+	{
+		Fireworks.Builder actual = bridge.fireworks();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenResolvableProfile()
+	{
+		ResolvableProfile.Builder actual = bridge.resolvableProfile();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenBannerPatternLayers()
+	{
+		BannerPatternLayers.Builder actual = bridge.bannerPatternLayers();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenBlockItemDataProperties()
+	{
+		BlockItemDataProperties.Builder actual = bridge.blockItemStateProperties();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenItemContainerContents()
+	{
+		ItemContainerContents.Builder actual = bridge.itemContainerContents();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenTool()
+	{
+		Tool.Builder actual = bridge.tool();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenItemAdventurePredicate()
+	{
+		ItemAdventurePredicate.Builder actual = bridge.itemAdventurePredicate();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenCustomModelData()
+	{
+		CustomModelData.Builder actual = bridge.customModelData();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenConsumable()
+	{
+		Consumable.Builder actual = bridge.consumable();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenDeathProtection()
+	{
+		DeathProtection.Builder actual = bridge.deathProtection();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenBlocksAttacks()
+	{
+		BlocksAttacks.Builder actual = bridge.blocksAttacks();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenTooltipDisplay()
+	{
+		TooltipDisplay.Builder actual = bridge.tooltipDisplay();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenWeapon()
+	{
+		Weapon.Builder actual = bridge.weapon();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Nested
+	class SeededContainerLootTest
+	{
+
+		@Test
+		void givenKeyReturnsBuilder()
+		{
+			Key key = Key.key("minecraft", "loot_table");
+
+			SeededContainerLoot.Builder actual = bridge.seededContainerLoot(key);
+
+			assertNotNull(actual);
+		}
+
+	}
+
+}

--- a/src/test/java/io/papermc/paper/datacomponent/item/attribute/AttributeModifierDisplayBridgeMockTest.java
+++ b/src/test/java/io/papermc/paper/datacomponent/item/attribute/AttributeModifierDisplayBridgeMockTest.java
@@ -1,0 +1,37 @@
+package io.papermc.paper.datacomponent.item.attribute;
+
+import net.kyori.adventure.text.Component;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SuppressWarnings("UnstableApiUsage")
+class AttributeModifierDisplayBridgeMockTest
+{
+	private final AttributeModifierDisplayBridgeMock bridge = new AttributeModifierDisplayBridgeMock();
+
+	@Test
+	void givenHidden()
+	{
+		AttributeModifierDisplay.Hidden actual = bridge.hidden();
+		assertNotNull(actual);
+	}
+
+	@Test
+	void givenDefault()
+	{
+		AttributeModifierDisplay.Default actual = bridge.reset();
+		assertNotNull(actual);
+	}
+
+	@Test
+	void givenOverrideText()
+	{
+		Component component = Component.text("Hello");
+		AttributeModifierDisplay.OverrideText actual = bridge.override(component);
+		assertNotNull(actual);
+		assertEquals(component, actual.text());
+	}
+
+}

--- a/src/test/java/io/papermc/paper/datacomponent/item/blocksattacks/BlocksAttacksBridgeMockTest.java
+++ b/src/test/java/io/papermc/paper/datacomponent/item/blocksattacks/BlocksAttacksBridgeMockTest.java
@@ -1,0 +1,29 @@
+package io.papermc.paper.datacomponent.item.blocksattacks;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SuppressWarnings("UnstableApiUsage")
+class BlocksAttacksBridgeMockTest
+{
+
+	private final BlocksAttacksBridgeMock bridge = new BlocksAttacksBridgeMock();
+
+	@Test
+	void givenDamageReduction()
+	{
+		DamageReduction.Builder actual = bridge.blocksAttacksDamageReduction();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+	@Test
+	void givenItemDamageFunction()
+	{
+		ItemDamageFunction.Builder actual = bridge.blocksAttacksItemDamageFunction();
+		assertNotNull(actual);
+		assertNotNull(actual.build());
+	}
+
+}

--- a/src/test/java/io/papermc/paper/datacomponent/item/consumable/ConsumableTypesBridgeMockTest.java
+++ b/src/test/java/io/papermc/paper/datacomponent/item/consumable/ConsumableTypesBridgeMockTest.java
@@ -1,0 +1,47 @@
+package io.papermc.paper.datacomponent.item.consumable;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.Sound;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SuppressWarnings("UnstableApiUsage")
+@ExtendWith(MockBukkitExtension.class)
+class ConsumableTypesBridgeMockTest
+{
+
+	private final ConsumableTypesBridgeMock bridge = new ConsumableTypesBridgeMock();
+
+	@Test
+	void givenClearAllStatusEffects()
+	{
+		ConsumeEffect.ClearAllStatusEffects actual = bridge.clearAllStatusEffects();
+		assertNotNull(actual);
+	}
+
+	@Test
+	void givenPlaySound()
+	{
+		NamespacedKey key = Registry.SOUNDS.getKey(Sound.AMBIENT_CAVE);
+		assertNotNull(key);
+
+		ConsumeEffect.PlaySound actual = bridge.playSoundEffect(key);
+		assertNotNull(actual);
+		assertEquals(key, actual.sound());
+	}
+
+	@Test
+	void givenTeleportRandomly()
+	{
+		float diameter = 20;
+		ConsumeEffect.TeleportRandomly actual = bridge.teleportRandomlyEffect(diameter);
+		assertNotNull(actual);
+		assertEquals(diameter, actual.diameter());
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/registry/RegistryMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/registry/RegistryMockTest.java
@@ -6,8 +6,12 @@ import io.papermc.paper.registry.TypedKey;
 import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
+import org.bukkit.block.BlockType;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.generator.structure.Structure;
 import org.bukkit.inventory.ItemType;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -142,6 +146,15 @@ class RegistryMockTest
 				.filter(entityType -> entityType != org.bukkit.entity.EntityType.UNKNOWN)
 				.count();
 		assertEquals(enumCount, registryCount);
+	}
+
+	@Test
+	void getKey()
+	{
+		BlockType.Typed<@NonNull BlockData> key = BlockType.STONE;
+		@Nullable NamespacedKey actual = Registry.BLOCK.getKey(key);
+		assertNotNull(actual);
+		assertEquals("minecraft:stone", actual.asString());
 	}
 
 	static Stream<RegistryKey<? extends Keyed>> getValues()


### PR DESCRIPTION
# Description

Most of the code in this PR is taken from @Thorinwasher PR's (https://github.com/MockBukkit/MockBukkit/pull/1361). I tried to move the classes that were already implemented in that PR so that we can create smaller PR's. This PR only contains the basic tools to work with the Data Component (all interfaces inside `io.papermc.paper.datacomponent.item`).

# Checklist

The following items should be checked before the pull request can be merged.

- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
