### PR TITLE
Add support for multiple block data

### DIFF
--- a/metaminer/src/main/java/org/mockbukkit/metaminer/internal/MaterialDataGenerator.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/internal/MaterialDataGenerator.java
@@ -12,11 +12,12 @@ import org.bukkit.block.data.Directional;
 import org.bukkit.block.data.Hatchable;
 import org.bukkit.block.data.Levelled;
 import org.bukkit.block.data.MultipleFacing;
+import org.bukkit.block.data.type.Beehive;
 import org.bukkit.block.data.type.ChiseledBookshelf;
 import org.bukkit.block.data.type.CreakingHeart;
 import org.bukkit.block.data.type.Farmland;
-import org.bukkit.block.data.type.RespawnAnchor;
 import org.bukkit.block.data.type.Leaves;
+import org.bukkit.block.data.type.RespawnAnchor;
 import org.bukkit.block.data.type.Sapling;
 import org.bukkit.block.data.type.TurtleEgg;
 import org.jetbrains.annotations.NotNull;
@@ -161,8 +162,8 @@ public class MaterialDataGenerator implements DataGenerator
 		if (data instanceof RespawnAnchor respawnAnchor)
 		{
 			obj.addProperty("maxCharges", String.valueOf(respawnAnchor.getMaximumCharges()));
-    }
-    
+    	}
+
 		if (data instanceof ChiseledBookshelf chiseledBookshelf)
 		{
 			obj.addProperty("maxOccupiedSlots", chiseledBookshelf.getMaximumOccupiedSlots());
@@ -179,6 +180,11 @@ public class MaterialDataGenerator implements DataGenerator
 		{
 			obj.addProperty("maxDistance", leaves.getMaximumDistance());
 			obj.addProperty("minDistance", leaves.getMinimumDistance());
+		}
+
+		if (data instanceof Beehive beehive)
+		{
+			obj.addProperty("maxHoneyLevel", beehive.getMaximumHoneyLevel());
 		}
 	}
 

--- a/metaminer/src/main/java/org/mockbukkit/metaminer/internal/MaterialDataGenerator.java
+++ b/metaminer/src/main/java/org/mockbukkit/metaminer/internal/MaterialDataGenerator.java
@@ -13,6 +13,7 @@ import org.bukkit.block.data.Hatchable;
 import org.bukkit.block.data.Levelled;
 import org.bukkit.block.data.MultipleFacing;
 import org.bukkit.block.data.type.Beehive;
+import org.bukkit.block.data.type.Cake;
 import org.bukkit.block.data.type.ChiseledBookshelf;
 import org.bukkit.block.data.type.CreakingHeart;
 import org.bukkit.block.data.type.Farmland;
@@ -185,6 +186,11 @@ public class MaterialDataGenerator implements DataGenerator
 		if (data instanceof Beehive beehive)
 		{
 			obj.addProperty("maxHoneyLevel", beehive.getMaximumHoneyLevel());
+		}
+
+		if (data instanceof Cake cake)
+		{
+			obj.addProperty("maxBites", cake.getMaximumBites());
 		}
 	}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BeehiveDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BeehiveDataMock.java
@@ -1,0 +1,69 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.type.Beehive;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+public class BeehiveDataMock extends BlockDataMock implements Beehive
+{
+
+	public BeehiveDataMock(@NotNull Material type)
+	{
+		super(type);
+	}
+
+	protected BeehiveDataMock(BeehiveDataMock other)
+	{
+		super(other);
+	}
+
+	@Override
+	public int getHoneyLevel()
+	{
+		return this.get(BlockDataKey.HONEY_LEVEL);
+	}
+
+	@Override
+	public void setHoneyLevel(int honeyLevel)
+	{
+		this.set(BlockDataKey.HONEY_LEVEL, honeyLevel);
+	}
+
+	@Override
+	public int getMaximumHoneyLevel()
+	{
+		return this.getLimitationValue(BlockDataLimitation.Type.MAX_HONEY_LEVEL);
+	}
+
+	@Override
+	public @NotNull BlockFace getFacing()
+	{
+		return this.get(BlockDataKey.FACING);
+	}
+
+	@Override
+	public void setFacing(@NotNull BlockFace blockFace)
+	{
+		Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
+		Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+		this.set(BlockDataKey.FACING, blockFace);
+	}
+
+	@Override
+	public @NotNull Set<BlockFace> getFaces()
+	{
+		return this.getLimitationValue(BlockDataLimitation.Type.FACES);
+	}
+
+	@Override
+	@SuppressWarnings({"MethodDoesntCallSuperMethod", "java:S2975", "java:S1182"})
+	public @NotNull BeehiveDataMock clone()
+	{
+		return new BeehiveDataMock(this);
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BellDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BellDataMock.java
@@ -1,0 +1,77 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.type.Bell;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+public class BellDataMock extends BlockDataMock implements Bell
+{
+
+	public BellDataMock(@NotNull Material material)
+	{
+		super(material);
+	}
+
+	protected BellDataMock(@NotNull BellDataMock other)
+	{
+		super(other);
+	}
+
+	@Override
+	public @NotNull Attachment getAttachment()
+	{
+		return this.get(BlockDataKey.ATTACHMENT);
+	}
+
+	@Override
+	public void setAttachment(@NotNull Attachment attachment)
+	{
+		Preconditions.checkArgument(attachment != null, "attachment cannot be null!");
+		this.set(BlockDataKey.ATTACHMENT, attachment);
+	}
+
+	@Override
+	public @NotNull BlockFace getFacing()
+	{
+		return this.get(BlockDataKey.FACING);
+	}
+
+	@Override
+	public void setFacing(@NotNull BlockFace blockFace)
+	{
+		Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
+		Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+		this.set(BlockDataKey.FACING, blockFace);
+	}
+
+	@Override
+	public @NotNull Set<BlockFace> getFaces()
+	{
+		return this.getLimitationValue(BlockDataLimitation.Type.FACES);
+	}
+
+	@Override
+	public boolean isPowered()
+	{
+		return this.get(BlockDataKey.POWERED);
+	}
+
+	@Override
+	public void setPowered(boolean powered)
+	{
+		this.set(BlockDataKey.POWERED, powered);
+	}
+
+	@Override
+	@SuppressWarnings({"MethodDoesntCallSuperMethod", "java:S2975", "java:S1182"})
+	public @NotNull BellDataMock clone()
+	{
+		return new BellDataMock(this);
+	}
+
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
@@ -30,6 +30,7 @@ import org.bukkit.block.data.type.Bell;
 import org.bukkit.block.data.type.BigDripleaf;
 import org.bukkit.block.data.type.BrewingStand;
 import org.bukkit.block.data.type.BubbleColumn;
+import org.bukkit.block.data.type.Cake;
 import org.bukkit.block.data.type.Campfire;
 import org.bukkit.block.data.type.Candle;
 import org.bukkit.block.data.type.CaveVines;
@@ -153,6 +154,7 @@ public enum BlockDataKey
 	LEAVES_KEY("leaves", EnumDataDeserializer.of(Bamboo.Leaves.class), Bamboo.class::isInstance),
 	STAGE_KEY("stage", Integer::parseInt, Sapling.class::isInstance),
 	HANGING_KEY("hanging", Boolean::parseBoolean, Hangable.class::isInstance),
+	BITES("bites", Integer::parseInt, Cake.class::isInstance),
 
 	REDSTONE_EAST("east", EnumDataDeserializer.of(RedstoneWire.Connection.class), RedstoneWire.class::isInstance),
 	REDSTONE_WEST("west", EnumDataDeserializer.of(RedstoneWire.Connection.class), RedstoneWire.class::isInstance),

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
@@ -39,6 +39,7 @@ import org.bukkit.block.data.type.CommandBlock;
 import org.bukkit.block.data.type.Comparator;
 import org.bukkit.block.data.type.Crafter;
 import org.bukkit.block.data.type.CreakingHeart;
+import org.bukkit.block.data.type.DaylightDetector;
 import org.bukkit.block.data.type.DecoratedPot;
 import org.bukkit.block.data.type.Dispenser;
 import org.bukkit.block.data.type.Door;
@@ -209,6 +210,7 @@ public enum BlockDataKey
 
 	CANDLES("candles", Integer::parseInt, Candle.class::isInstance),
 	POWER("power", Integer::parseInt, AnaloguePowerable.class::isInstance),
+	IS_INVERTED("power", Boolean::parseBoolean, DaylightDetector.class::isInstance),
 
 	SNOWY("snowy", Boolean::parseBoolean, Snowable.class::isInstance),
 	ATTACHED("attached", Boolean::parseBoolean, Attachable.class::isInstance),

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
@@ -26,6 +26,7 @@ import org.bukkit.block.data.Waterlogged;
 import org.bukkit.block.data.type.Bamboo;
 import org.bukkit.block.data.type.Bed;
 import org.bukkit.block.data.type.Beehive;
+import org.bukkit.block.data.type.Bell;
 import org.bukkit.block.data.type.BigDripleaf;
 import org.bukkit.block.data.type.BrewingStand;
 import org.bukkit.block.data.type.Campfire;
@@ -158,6 +159,7 @@ public enum BlockDataKey
 	REDSTONE_SOUTH("south", EnumDataDeserializer.of(RedstoneWire.Connection.class), RedstoneWire.class::isInstance),
 
 	SCULK_SENSOR_PHASE("sculk_sensor_phase", EnumDataDeserializer.of(SculkSensorDataMock.Phase.class), SculkSensor.class::isInstance),
+	ATTACHMENT("attachment", EnumDataDeserializer.of(Bell.Attachment.class), Bell.class::isInstance),
 
 	DELAY("delay", Integer::parseInt, Repeater.class::isInstance),
 	LOCKED("locked", Boolean::parseBoolean, Repeater.class::isInstance),

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
@@ -25,6 +25,7 @@ import org.bukkit.block.data.Snowable;
 import org.bukkit.block.data.Waterlogged;
 import org.bukkit.block.data.type.Bamboo;
 import org.bukkit.block.data.type.Bed;
+import org.bukkit.block.data.type.Beehive;
 import org.bukkit.block.data.type.BigDripleaf;
 import org.bukkit.block.data.type.BrewingStand;
 import org.bukkit.block.data.type.Campfire;
@@ -229,6 +230,7 @@ public enum BlockDataKey
 
 	PERSISTENT("persistent",Boolean::parseBoolean, Leaves.class::isInstance),
 	DISTANCE("distance", Integer::parseInt, Leaves.class::isInstance),
+	HONEY_LEVEL("honey_level", Integer::parseInt, Beehive.class::isInstance),
 
 	BERRIES("berries", Boolean::parseBoolean, CaveVines.class::isInstance);
 

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
@@ -29,6 +29,7 @@ import org.bukkit.block.data.type.Beehive;
 import org.bukkit.block.data.type.Bell;
 import org.bukkit.block.data.type.BigDripleaf;
 import org.bukkit.block.data.type.BrewingStand;
+import org.bukkit.block.data.type.BubbleColumn;
 import org.bukkit.block.data.type.Campfire;
 import org.bukkit.block.data.type.Candle;
 import org.bukkit.block.data.type.CaveVines;
@@ -229,6 +230,7 @@ public enum BlockDataKey
 	HAS_BOTTLE_0("has_bottle_0", Boolean::parseBoolean, BrewingStand.class::isInstance),
 	HAS_BOTTLE_1("has_bottle_1", Boolean::parseBoolean, BrewingStand.class::isInstance),
 	HAS_BOTTLE_2("has_bottle_2", Boolean::parseBoolean, BrewingStand.class::isInstance),
+	DRAG("drag", Boolean::parseBoolean, BubbleColumn.class::isInstance),
 
 	PERSISTENT("persistent",Boolean::parseBoolean, Leaves.class::isInstance),
 	DISTANCE("distance", Integer::parseInt, Leaves.class::isInstance),

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
@@ -36,6 +36,7 @@ import org.bukkit.block.data.type.Candle;
 import org.bukkit.block.data.type.CaveVines;
 import org.bukkit.block.data.type.Chest;
 import org.bukkit.block.data.type.CommandBlock;
+import org.bukkit.block.data.type.Comparator;
 import org.bukkit.block.data.type.Crafter;
 import org.bukkit.block.data.type.CreakingHeart;
 import org.bukkit.block.data.type.DecoratedPot;
@@ -204,6 +205,7 @@ public enum BlockDataKey
 	LEVEL("level", Integer::parseInt, Levelled.class::isInstance),
 	DUSTED("dusted", Integer::parseInt, Brushable.class::isInstance),
 	MODE("mode", EnumDataDeserializer.of(TestBlock.Mode.class), TestBlock.class::isInstance),
+	COMPARATOR_MODE("mode", EnumDataDeserializer.of(Comparator.Mode.class), Comparator.class::isInstance),
 
 	CANDLES("candles", Integer::parseInt, Candle.class::isInstance),
 	POWER("power", Integer::parseInt, AnaloguePowerable.class::isInstance),

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataKey.java
@@ -43,6 +43,7 @@ import org.bukkit.block.data.type.DaylightDetector;
 import org.bukkit.block.data.type.DecoratedPot;
 import org.bukkit.block.data.type.Dispenser;
 import org.bukkit.block.data.type.Door;
+import org.bukkit.block.data.type.EndPortalFrame;
 import org.bukkit.block.data.type.Farmland;
 import org.bukkit.block.data.type.Gate;
 import org.bukkit.block.data.type.HangingMoss;
@@ -168,6 +169,7 @@ public enum BlockDataKey
 
 	DELAY("delay", Integer::parseInt, Repeater.class::isInstance),
 	LOCKED("locked", Boolean::parseBoolean, Repeater.class::isInstance),
+	EYE("eye", Boolean::parseBoolean, EndPortalFrame.class::isInstance),
 
 	ROTATION("rotation", Integer::parseInt, Rotatable.class::isInstance),
 

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataLimitation.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataLimitation.java
@@ -72,6 +72,7 @@ public class BlockDataLimitation<T, U>
 		public static final Type<Integer, Integer> MAX_HATCH = new Type<>("maxHatch", jsonElement -> BlockDataLimitation.fromValueLesserThan(jsonElement.getAsInt()));
 		public static final Type<Integer, Integer> MAX_MOISTURE = new Type<>("maxMoisture", jsonElement -> BlockDataLimitation.fromValueLesserThan(jsonElement.getAsInt()));
 		public static final Type<Integer, Integer> MAX_OCCUPIED_SLOTS = new Type<>("maxOccupiedSlots", jsonElement -> BlockDataLimitation.fromValueLesserThan(jsonElement.getAsInt()));
+		public static final Type<Integer, Integer> MAX_HONEY_LEVEL = new Type<>("maxHoneyLevel", jsonElement -> BlockDataLimitation.fromValueLesserThan(jsonElement.getAsInt()));
 		public static final Type<Set<BlockFace>, BlockFace> FACES = new Type<>("faces", jsonElement -> BlockDataLimitation.fromSet(
 				jsonElement.getAsJsonArray()
 						.asList()

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataLimitation.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataLimitation.java
@@ -73,6 +73,7 @@ public class BlockDataLimitation<T, U>
 		public static final Type<Integer, Integer> MAX_MOISTURE = new Type<>("maxMoisture", jsonElement -> BlockDataLimitation.fromValueLesserThan(jsonElement.getAsInt()));
 		public static final Type<Integer, Integer> MAX_OCCUPIED_SLOTS = new Type<>("maxOccupiedSlots", jsonElement -> BlockDataLimitation.fromValueLesserThan(jsonElement.getAsInt()));
 		public static final Type<Integer, Integer> MAX_HONEY_LEVEL = new Type<>("maxHoneyLevel", jsonElement -> BlockDataLimitation.fromValueLesserThan(jsonElement.getAsInt()));
+		public static final Type<Integer, Integer> MAX_BITES = new Type<>("maxBites", jsonElement -> BlockDataLimitation.fromValueLesserThan(jsonElement.getAsInt()));
 		public static final Type<Set<BlockFace>, BlockFace> FACES = new Type<>("faces", jsonElement -> BlockDataLimitation.fromSet(
 				jsonElement.getAsJsonArray()
 						.asList()

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
@@ -22,6 +22,7 @@ import org.bukkit.block.data.Waterlogged;
 import org.bukkit.block.data.type.AmethystCluster;
 import org.bukkit.block.data.type.Bamboo;
 import org.bukkit.block.data.type.Barrel;
+import org.bukkit.block.data.type.Beehive;
 import org.bukkit.block.data.type.BigDripleaf;
 import org.bukkit.block.data.type.BrewingStand;
 import org.bukkit.block.data.type.CalibratedSculkSensor;
@@ -102,6 +103,7 @@ public final class BlockDataMockFactory
 	private static final Map<Class<? extends BlockData>, Function<Material, BlockDataMock>> FACTORIES_BY_BLOCK_DATA = ImmutableMap.<Class<? extends BlockData>, Function<Material, BlockDataMock>>builder()
 			.put(AmethystCluster.class, AmethystClusterDataMock::new)
 			.put(Bamboo.class, m -> new BambooDataMock())
+			.put(Beehive.class, BeehiveDataMock::new)
 			.put(BigDripleaf.class, BigDripleafDataMock::new)
 			.put(BrewingStand.class, BrewingStandDataMock::new)
 			.put(Brushable.class, BrushableDataMock::new)

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
@@ -37,6 +37,7 @@ import org.bukkit.block.data.type.Cocoa;
 import org.bukkit.block.data.type.CommandBlock;
 import org.bukkit.block.data.type.Comparator;
 import org.bukkit.block.data.type.CopperBulb;
+import org.bukkit.block.data.type.CoralWallFan;
 import org.bukkit.block.data.type.Crafter;
 import org.bukkit.block.data.type.CreakingHeart;
 import org.bukkit.block.data.type.DecoratedPot;
@@ -123,6 +124,7 @@ public final class BlockDataMockFactory
 			.put(CommandBlock.class, CommandBlockDataMock::new)
 			.put(Comparator.class, ComparatorDataMock::new)
 			.put(CopperBulb.class, CopperBulbDataMock::new)
+			.put(CoralWallFan.class, CoralWallFanDataMock::new)
 			.put(Crafter.class, CrafterDataMock::new)
 			.put(CreakingHeart.class, CreakingHeartDataMock::new)
 			.put(DecoratedPot.class, m -> new DecoratedPotDataMock())

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
@@ -44,6 +44,7 @@ import org.bukkit.block.data.type.DaylightDetector;
 import org.bukkit.block.data.type.DecoratedPot;
 import org.bukkit.block.data.type.Dispenser;
 import org.bukkit.block.data.type.Dripleaf;
+import org.bukkit.block.data.type.EndPortalFrame;
 import org.bukkit.block.data.type.EnderChest;
 import org.bukkit.block.data.type.Farmland;
 import org.bukkit.block.data.type.Furnace;
@@ -133,6 +134,7 @@ public final class BlockDataMockFactory
 			.put(Dispenser.class, DispenserDataMock::new)
 			.put(Directional.class, DirectionalDataMock::new)
 			.put(Dripleaf.class, DripleafDataMock::new)
+			.put(EndPortalFrame.class, EndPortalFrameDataMock::new)
 			.put(EnderChest.class, EnderChestDataMock::new)
 			.put(Farmland.class, FarmlandDataMock::new)
 			.put(Furnace.class, FurnaceDataMock::new)

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
@@ -26,6 +26,7 @@ import org.bukkit.block.data.type.Beehive;
 import org.bukkit.block.data.type.Bell;
 import org.bukkit.block.data.type.BigDripleaf;
 import org.bukkit.block.data.type.BrewingStand;
+import org.bukkit.block.data.type.BubbleColumn;
 import org.bukkit.block.data.type.CalibratedSculkSensor;
 import org.bukkit.block.data.type.CaveVines;
 import org.bukkit.block.data.type.CaveVinesPlant;
@@ -109,6 +110,7 @@ public final class BlockDataMockFactory
 			.put(BigDripleaf.class, BigDripleafDataMock::new)
 			.put(BrewingStand.class, BrewingStandDataMock::new)
 			.put(Brushable.class, BrushableDataMock::new)
+			.put(BubbleColumn.class, BubbleColumnDataMock::new)
 			.put(CalibratedSculkSensor.class, CalibratedSculkSensorDataMock::new)
 			.put(Chest.class, ChestDataMock::new)
 			.put(ChiseledBookshelf.class, ChiseledBookshelfDataMock::new)

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
@@ -35,6 +35,7 @@ import org.bukkit.block.data.type.Chest;
 import org.bukkit.block.data.type.ChiseledBookshelf;
 import org.bukkit.block.data.type.Cocoa;
 import org.bukkit.block.data.type.CommandBlock;
+import org.bukkit.block.data.type.Comparator;
 import org.bukkit.block.data.type.Crafter;
 import org.bukkit.block.data.type.CreakingHeart;
 import org.bukkit.block.data.type.DecoratedPot;
@@ -119,6 +120,7 @@ public final class BlockDataMockFactory
 			.put(ChiseledBookshelf.class, ChiseledBookshelfDataMock::new)
 			.put(Cocoa.class, CocoaDataMock::new)
 			.put(CommandBlock.class, CommandBlockDataMock::new)
+			.put(Comparator.class, ComparatorDataMock::new)
 			.put(Crafter.class, CrafterDataMock::new)
 			.put(CreakingHeart.class, CreakingHeartDataMock::new)
 			.put(DecoratedPot.class, m -> new DecoratedPotDataMock())

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
@@ -13,6 +13,7 @@ import org.bukkit.block.data.Directional;
 import org.bukkit.block.data.Hatchable;
 import org.bukkit.block.data.Levelled;
 import org.bukkit.block.data.Lightable;
+import org.bukkit.block.data.MultipleFacing;
 import org.bukkit.block.data.Orientable;
 import org.bukkit.block.data.Powerable;
 import org.bukkit.block.data.Rail;
@@ -47,6 +48,7 @@ import org.bukkit.block.data.type.Dripleaf;
 import org.bukkit.block.data.type.EndPortalFrame;
 import org.bukkit.block.data.type.EnderChest;
 import org.bukkit.block.data.type.Farmland;
+import org.bukkit.block.data.type.Fire;
 import org.bukkit.block.data.type.Furnace;
 import org.bukkit.block.data.type.GlassPane;
 import org.bukkit.block.data.type.Grindstone;
@@ -137,6 +139,7 @@ public final class BlockDataMockFactory
 			.put(EndPortalFrame.class, EndPortalFrameDataMock::new)
 			.put(EnderChest.class, EnderChestDataMock::new)
 			.put(Farmland.class, FarmlandDataMock::new)
+			.put(Fire.class, FireDataMock::new)
 			.put(Furnace.class, FurnaceDataMock::new)
 			.put(Grindstone.class, GrindstoneDataMock::new)
 			.put(HangingMoss.class, HangingMossDataMock::new)
@@ -147,6 +150,7 @@ public final class BlockDataMockFactory
 			.put(Light.class, LightDataMock::new)
 			.put(Lightable.class, LightableDataMock::new)
 			.put(MangrovePropagule.class, MangrovePropaguleDataMock::new)
+			.put(MultipleFacing.class, MultipleFacingDataMock::new)
 			.put(NoteBlock.class, NoteBlockDataMock::new)
 			.put(Observer.class, ObserverDataMock::new)
 			.put(Orientable.class, OrientableMock::new)

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
@@ -36,6 +36,7 @@ import org.bukkit.block.data.type.ChiseledBookshelf;
 import org.bukkit.block.data.type.Cocoa;
 import org.bukkit.block.data.type.CommandBlock;
 import org.bukkit.block.data.type.Comparator;
+import org.bukkit.block.data.type.CopperBulb;
 import org.bukkit.block.data.type.Crafter;
 import org.bukkit.block.data.type.CreakingHeart;
 import org.bukkit.block.data.type.DecoratedPot;
@@ -121,6 +122,7 @@ public final class BlockDataMockFactory
 			.put(Cocoa.class, CocoaDataMock::new)
 			.put(CommandBlock.class, CommandBlockDataMock::new)
 			.put(Comparator.class, ComparatorDataMock::new)
+			.put(CopperBulb.class, CopperBulbDataMock::new)
 			.put(Crafter.class, CrafterDataMock::new)
 			.put(CreakingHeart.class, CreakingHeartDataMock::new)
 			.put(DecoratedPot.class, m -> new DecoratedPotDataMock())

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
@@ -23,6 +23,7 @@ import org.bukkit.block.data.type.AmethystCluster;
 import org.bukkit.block.data.type.Bamboo;
 import org.bukkit.block.data.type.Barrel;
 import org.bukkit.block.data.type.Beehive;
+import org.bukkit.block.data.type.Bell;
 import org.bukkit.block.data.type.BigDripleaf;
 import org.bukkit.block.data.type.BrewingStand;
 import org.bukkit.block.data.type.CalibratedSculkSensor;
@@ -104,6 +105,7 @@ public final class BlockDataMockFactory
 			.put(AmethystCluster.class, AmethystClusterDataMock::new)
 			.put(Bamboo.class, m -> new BambooDataMock())
 			.put(Beehive.class, BeehiveDataMock::new)
+			.put(Bell.class, BellDataMock::new)
 			.put(BigDripleaf.class, BigDripleafDataMock::new)
 			.put(BrewingStand.class, BrewingStandDataMock::new)
 			.put(Brushable.class, BrushableDataMock::new)

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
@@ -27,6 +27,7 @@ import org.bukkit.block.data.type.Bell;
 import org.bukkit.block.data.type.BigDripleaf;
 import org.bukkit.block.data.type.BrewingStand;
 import org.bukkit.block.data.type.BubbleColumn;
+import org.bukkit.block.data.type.Cake;
 import org.bukkit.block.data.type.CalibratedSculkSensor;
 import org.bukkit.block.data.type.CaveVines;
 import org.bukkit.block.data.type.CaveVinesPlant;
@@ -111,6 +112,7 @@ public final class BlockDataMockFactory
 			.put(BrewingStand.class, BrewingStandDataMock::new)
 			.put(Brushable.class, BrushableDataMock::new)
 			.put(BubbleColumn.class, BubbleColumnDataMock::new)
+			.put(Cake.class, CakeDataMock::new)
 			.put(CalibratedSculkSensor.class, CalibratedSculkSensorDataMock::new)
 			.put(Chest.class, ChestDataMock::new)
 			.put(ChiseledBookshelf.class, ChiseledBookshelfDataMock::new)

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
@@ -40,6 +40,7 @@ import org.bukkit.block.data.type.CopperBulb;
 import org.bukkit.block.data.type.CoralWallFan;
 import org.bukkit.block.data.type.Crafter;
 import org.bukkit.block.data.type.CreakingHeart;
+import org.bukkit.block.data.type.DaylightDetector;
 import org.bukkit.block.data.type.DecoratedPot;
 import org.bukkit.block.data.type.Dispenser;
 import org.bukkit.block.data.type.Dripleaf;
@@ -127,6 +128,7 @@ public final class BlockDataMockFactory
 			.put(CoralWallFan.class, CoralWallFanDataMock::new)
 			.put(Crafter.class, CrafterDataMock::new)
 			.put(CreakingHeart.class, CreakingHeartDataMock::new)
+			.put(DaylightDetector.class, DaylightDetectorDataMock::new)
 			.put(DecoratedPot.class, m -> new DecoratedPotDataMock())
 			.put(Dispenser.class, DispenserDataMock::new)
 			.put(Directional.class, DirectionalDataMock::new)

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockFactory.java
@@ -33,6 +33,7 @@ import org.bukkit.block.data.type.CaveVines;
 import org.bukkit.block.data.type.CaveVinesPlant;
 import org.bukkit.block.data.type.Chest;
 import org.bukkit.block.data.type.ChiseledBookshelf;
+import org.bukkit.block.data.type.Cocoa;
 import org.bukkit.block.data.type.CommandBlock;
 import org.bukkit.block.data.type.Crafter;
 import org.bukkit.block.data.type.CreakingHeart;
@@ -116,6 +117,7 @@ public final class BlockDataMockFactory
 			.put(CalibratedSculkSensor.class, CalibratedSculkSensorDataMock::new)
 			.put(Chest.class, ChestDataMock::new)
 			.put(ChiseledBookshelf.class, ChiseledBookshelfDataMock::new)
+			.put(Cocoa.class, CocoaDataMock::new)
 			.put(CommandBlock.class, CommandBlockDataMock::new)
 			.put(Crafter.class, CrafterDataMock::new)
 			.put(CreakingHeart.class, CreakingHeartDataMock::new)

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BubbleColumnDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BubbleColumnDataMock.java
@@ -1,0 +1,40 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.bukkit.block.data.type.BubbleColumn;
+import org.jetbrains.annotations.NotNull;
+
+public class BubbleColumnDataMock extends BlockDataMock implements BubbleColumn
+{
+
+	public BubbleColumnDataMock(@NotNull Material material)
+	{
+		super(material);
+	}
+
+	protected BubbleColumnDataMock(@NotNull BubbleColumnDataMock other)
+	{
+		super(other);
+	}
+
+	@Override
+	public boolean isDrag()
+	{
+		return this.get(BlockDataKey.DRAG);
+	}
+
+	@Override
+	public void setDrag(boolean drag)
+	{
+		this.set(BlockDataKey.DRAG, drag);
+	}
+
+	@Override
+	@SuppressWarnings({"MethodDoesntCallSuperMethod", "java:S2975", "java:S1182"})
+	public @NotNull BubbleColumnDataMock clone()
+	{
+		return new BubbleColumnDataMock(this);
+	}
+
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/CakeDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/CakeDataMock.java
@@ -1,0 +1,46 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.bukkit.block.data.type.Cake;
+import org.jetbrains.annotations.NotNull;
+
+public class CakeDataMock extends BlockDataMock implements Cake
+{
+
+	public CakeDataMock(@NotNull Material material)
+	{
+		super(material);
+	}
+
+	protected CakeDataMock(@NotNull CakeDataMock other)
+	{
+		super(other);
+	}
+
+	@Override
+	public int getBites()
+	{
+		return this.get(BlockDataKey.BITES);
+	}
+
+	@Override
+	public void setBites(int bites)
+	{
+		this.set(BlockDataKey.BITES, bites);
+	}
+
+	@Override
+	public int getMaximumBites()
+	{
+		return this.getLimitationValue(BlockDataLimitation.Type.MAX_BITES);
+	}
+
+	@Override
+	@SuppressWarnings({"MethodDoesntCallSuperMethod", "java:S2975", "java:S1182"})
+	public @NotNull CakeDataMock clone()
+	{
+		return new CakeDataMock(this);
+	}
+
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/CocoaDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/CocoaDataMock.java
@@ -1,0 +1,71 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.type.Cocoa;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+import static org.mockbukkit.mockbukkit.block.data.BlockDataKey.FACING;
+
+public class CocoaDataMock extends BlockDataMock implements Cocoa
+{
+
+	public CocoaDataMock(@NotNull Material material)
+	{
+		super(material);
+	}
+
+	protected CocoaDataMock(@NotNull CocoaDataMock other)
+	{
+		super(other);
+	}
+
+	@Override
+	public int getAge()
+	{
+		return this.get(BlockDataKey.AGE_KEY);
+	}
+
+	@Override
+	public void setAge(int age)
+	{
+		this.set(BlockDataKey.AGE_KEY, age);
+	}
+
+	@Override
+	public int getMaximumAge()
+	{
+		return this.getLimitationValue(BlockDataLimitation.Type.MAX_AGE);
+	}
+
+	@Override
+	public @NotNull BlockFace getFacing()
+	{
+		return this.get(FACING);
+	}
+
+	@Override
+	public void setFacing(@NotNull BlockFace blockFace)
+	{
+		Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
+		Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+		this.set(FACING, blockFace);
+	}
+
+	@Override
+	public @NotNull Set<BlockFace> getFaces()
+	{
+		return this.getLimitationValue(BlockDataLimitation.Type.FACES);
+	}
+
+	@Override
+	@SuppressWarnings({"MethodDoesntCallSuperMethod", "java:S2975", "java:S1182"})
+	public @NotNull CocoaDataMock clone()
+	{
+		return new CocoaDataMock(this);
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/ComparatorDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/ComparatorDataMock.java
@@ -1,0 +1,78 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.type.Comparator;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+import static org.mockbukkit.mockbukkit.block.data.BlockDataKey.FACING;
+
+public class ComparatorDataMock extends BlockDataMock implements Comparator
+{
+
+	public ComparatorDataMock(@NotNull Material material)
+	{
+		super(material);
+	}
+
+	protected ComparatorDataMock(@NotNull ComparatorDataMock other)
+	{
+		super(other);
+	}
+
+	@Override
+	public @NotNull Mode getMode()
+	{
+		return this.get(BlockDataKey.COMPARATOR_MODE);
+	}
+
+	@Override
+	public void setMode(@NotNull Mode mode)
+	{
+		Preconditions.checkArgument(mode != null, "mode cannot be null!");
+		this.set(BlockDataKey.COMPARATOR_MODE, mode);
+	}
+
+	@Override
+	public @NotNull BlockFace getFacing()
+	{
+		return this.get(FACING);
+	}
+
+	@Override
+	public void setFacing(@NotNull BlockFace blockFace)
+	{
+		Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
+		Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+		this.set(FACING, blockFace);
+	}
+
+	@Override
+	public @NotNull Set<BlockFace> getFaces()
+	{
+		return this.getLimitationValue(BlockDataLimitation.Type.FACES);
+	}
+
+	@Override
+	public boolean isPowered()
+	{
+		return this.get(BlockDataKey.POWERED);
+	}
+
+	@Override
+	public void setPowered(boolean powered)
+	{
+		this.set(BlockDataKey.POWERED, powered);
+	}
+
+	@Override
+	@SuppressWarnings({"MethodDoesntCallSuperMethod", "java:S2975", "java:S1182"})
+	public @NotNull ComparatorDataMock clone()
+	{
+		return new ComparatorDataMock(this);
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/CopperBulbDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/CopperBulbDataMock.java
@@ -1,0 +1,51 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.bukkit.block.data.type.CopperBulb;
+import org.jetbrains.annotations.NotNull;
+
+public class CopperBulbDataMock extends BlockDataMock implements CopperBulb
+{
+
+	public CopperBulbDataMock(@NotNull Material material)
+	{
+		super(material);
+	}
+
+	protected CopperBulbDataMock(@NotNull CopperBulbDataMock other)
+	{
+		super(other);
+	}
+
+	@Override
+	public boolean isLit()
+	{
+		return this.get(BlockDataKey.LIT);
+	}
+
+	@Override
+	public void setLit(boolean lit)
+	{
+		this.set(BlockDataKey.LIT, lit);
+	}
+
+	@Override
+	public boolean isPowered()
+	{
+		return this.get(BlockDataKey.POWERED);
+	}
+
+	@Override
+	public void setPowered(boolean powered)
+	{
+		this.set(BlockDataKey.POWERED, powered);
+	}
+
+	@Override
+	@SuppressWarnings({"MethodDoesntCallSuperMethod", "java:S2975", "java:S1182"})
+	public @NotNull CopperBulbDataMock clone()
+	{
+		return new CopperBulbDataMock(this);
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/CoralWallFanDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/CoralWallFanDataMock.java
@@ -1,0 +1,65 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.type.CoralWallFan;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+import static org.mockbukkit.mockbukkit.block.data.BlockDataKey.FACING;
+
+public class CoralWallFanDataMock extends BlockDataMock implements CoralWallFan
+{
+
+	public CoralWallFanDataMock(@NotNull Material material)
+	{
+		super(material);
+	}
+
+	protected CoralWallFanDataMock(@NotNull CoralWallFanDataMock other)
+	{
+		super(other);
+	}
+
+	@Override
+	public @NotNull BlockFace getFacing()
+	{
+		return get(FACING);
+	}
+
+	@Override
+	public void setFacing(@NotNull BlockFace blockFace)
+	{
+		Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
+		Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+		set(FACING, blockFace);
+	}
+
+	@Override
+	public @NotNull Set<BlockFace> getFaces()
+	{
+		return this.getLimitationValue(BlockDataLimitation.Type.FACES);
+	}
+
+	@Override
+	public boolean isWaterlogged()
+	{
+		return this.get(BlockDataKey.WATERLOGGED);
+	}
+
+	@Override
+	public void setWaterlogged(boolean waterlogged)
+	{
+		this.set(BlockDataKey.WATERLOGGED, waterlogged);
+	}
+
+	@Override
+	@SuppressWarnings({"MethodDoesntCallSuperMethod", "java:S2975", "java:S1182"})
+	public @NotNull CoralWallFanDataMock clone()
+	{
+		return new CoralWallFanDataMock(this);
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/DaylightDetectorDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/DaylightDetectorDataMock.java
@@ -1,0 +1,59 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Material;
+import org.bukkit.block.data.type.DaylightDetector;
+import org.jetbrains.annotations.NotNull;
+
+public class DaylightDetectorDataMock extends BlockDataMock implements DaylightDetector
+{
+
+	public DaylightDetectorDataMock(@NotNull Material material)
+	{
+		super(material);
+	}
+
+	protected DaylightDetectorDataMock(@NotNull DaylightDetectorDataMock other)
+	{
+		super(other);
+	}
+
+	@Override
+	public boolean isInverted()
+	{
+		return this.get(BlockDataKey.IS_INVERTED);
+	}
+
+	@Override
+	public void setInverted(boolean inverted)
+	{
+		this.set(BlockDataKey.IS_INVERTED, inverted);
+	}
+
+	@Override
+	public int getPower()
+	{
+		return this.get(BlockDataKey.POWER);
+	}
+
+	@Override
+	public void setPower(int power)
+	{
+		Preconditions.checkArgument(power >= 0 && power <= this.getMaximumPower(), "Power must be between 0 and %s", this.getMaximumPower());
+		this.set(BlockDataKey.POWER, power);
+	}
+
+	@Override
+	public int getMaximumPower()
+	{
+		return this.getLimitationValue(BlockDataLimitation.Type.MAX_POWER);
+	}
+
+	@Override
+	@SuppressWarnings({"MethodDoesntCallSuperMethod", "java:S2975", "java:S1182"})
+	public @NotNull DaylightDetectorDataMock clone()
+	{
+		return new DaylightDetectorDataMock(this);
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/EndPortalFrameDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/EndPortalFrameDataMock.java
@@ -1,0 +1,64 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.type.EndPortalFrame;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+public class EndPortalFrameDataMock extends BlockDataMock implements EndPortalFrame
+{
+
+	public EndPortalFrameDataMock(@NotNull Material material)
+	{
+		super(material);
+	}
+
+	protected EndPortalFrameDataMock(@NotNull EndPortalFrameDataMock other)
+	{
+		super(other);
+	}
+
+	@Override
+	public boolean hasEye()
+	{
+		return this.get(BlockDataKey.EYE);
+	}
+
+	@Override
+	public void setEye(boolean eye)
+	{
+		this.set(BlockDataKey.EYE, eye);
+	}
+
+	@Override
+	public @NotNull BlockFace getFacing()
+	{
+		return get(BlockDataKey.FACING);
+	}
+
+	@Override
+	public void setFacing(@NotNull BlockFace blockFace)
+	{
+		Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
+		Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+		set(BlockDataKey.FACING, blockFace);
+	}
+
+	@Override
+	public @NotNull Set<BlockFace> getFaces()
+	{
+		return this.getLimitationValue(BlockDataLimitation.Type.FACES);
+	}
+
+	@Override
+	@SuppressWarnings({"MethodDoesntCallSuperMethod", "java:S2975", "java:S1182"})
+	public @NotNull EndPortalFrameDataMock clone()
+	{
+		return new EndPortalFrameDataMock(this);
+	}
+
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/FenceDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/FenceDataMock.java
@@ -6,7 +6,6 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.type.Fence;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -37,9 +36,9 @@ public class FenceDataMock extends BlockDataMock implements Fence
 	public boolean hasFace(@NotNull BlockFace face)
 	{
 		Preconditions.checkArgument(getAllowedFaces().contains(face), "Illegal facing: " + face);
-		return toKey(face)
+		return MultipleFacingDataMock.toKey(face)
 				.map(super::get)
-				.map(object -> (boolean) object)
+				.map(Boolean.class::cast)
 				.orElse(false);
 	}
 
@@ -47,7 +46,7 @@ public class FenceDataMock extends BlockDataMock implements Fence
 	public void setFace(@NotNull BlockFace face, boolean has)
 	{
 		Preconditions.checkArgument(getAllowedFaces().contains(face), "Illegal facing: " + face);
-		toKey(face).ifPresent(faceKey -> super.set(faceKey, has));
+		MultipleFacingDataMock.toKey(face).ifPresent(faceKey -> super.set(faceKey, has));
 	}
 
 	@Override
@@ -81,18 +80,6 @@ public class FenceDataMock extends BlockDataMock implements Fence
 	public @NotNull FenceDataMock clone()
 	{
 		return new FenceDataMock(this);
-	}
-
-	private Optional<BlockDataKey> toKey(BlockFace blockFace)
-	{
-		try
-		{
-			return Optional.of(BlockDataKey.valueOf(blockFace.name()));
-		}
-		catch (IllegalArgumentException e)
-		{
-			return Optional.empty();
-		}
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/FireDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/FireDataMock.java
@@ -3,28 +3,44 @@ package org.mockbukkit.mockbukkit.block.data;
 import com.google.common.base.Preconditions;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
-import org.bukkit.block.data.type.GlassPane;
+import org.bukkit.block.data.type.Fire;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class GlassPaneDataMock extends BlockDataMock implements GlassPane
+import static org.mockbukkit.mockbukkit.block.data.BlockDataKey.AGE_KEY;
+
+public class FireDataMock extends BlockDataMock implements Fire
 {
 
-	/**
-	 * Constructs a new {@link GlassPaneDataMock} for the provided {@link Material}.
-	 *
-	 * @param material The material this data is for.
-	 */
-	public GlassPaneDataMock(@NotNull Material material)
+	public FireDataMock(@NotNull Material material)
 	{
 		super(material);
 	}
 
-	protected GlassPaneDataMock(@NotNull GlassPaneDataMock other)
+	protected FireDataMock(@NotNull FireDataMock other)
 	{
 		super(other);
+	}
+
+	@Override
+	public int getAge()
+	{
+		return this.get(AGE_KEY);
+	}
+
+	@Override
+	public void setAge(int age)
+	{
+		Preconditions.checkArgument(age >= 0 && age <= this.getMaximumAge(), "The age must be between 0 and %s", this.getMaximumAge());
+		this.set(AGE_KEY, age);
+	}
+
+	@Override
+	public int getMaximumAge()
+	{
+		return this.getLimitationValue(BlockDataLimitation.Type.MAX_AGE);
 	}
 
 	@Override
@@ -59,21 +75,10 @@ public class GlassPaneDataMock extends BlockDataMock implements GlassPane
 	}
 
 	@Override
-	public boolean isWaterlogged()
-	{
-		return super.get(BlockDataKey.WATERLOGGED);
-	}
-
-	@Override
-	public void setWaterlogged(boolean waterlogged)
-	{
-		super.set(BlockDataKey.WATERLOGGED,waterlogged);
-	}
-
-	@Override
 	@SuppressWarnings({"MethodDoesntCallSuperMethod", "java:S2975", "java:S1182"})
-	public @NotNull GlassPaneDataMock clone()
+	public @NotNull FireDataMock clone()
 	{
-		return new GlassPaneDataMock(this);
+		return new FireDataMock(this);
 	}
+
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/MultipleFacingDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/MultipleFacingDataMock.java
@@ -28,10 +28,7 @@ public class MultipleFacingDataMock extends BlockDataMock implements MultipleFac
 	public boolean hasFace(@NotNull BlockFace face)
 	{
 		Preconditions.checkArgument(getAllowedFaces().contains(face), "Illegal facing: " + face);
-		return toKey(face)
-				.map(super::get)
-				.map(object -> (boolean) object)
-				.orElse(false);
+		return toKey(face).map(super::get).map(object -> (boolean) object).orElse(false);
 	}
 
 	@Override
@@ -44,9 +41,7 @@ public class MultipleFacingDataMock extends BlockDataMock implements MultipleFac
 	@Override
 	public @NotNull Set<BlockFace> getFaces()
 	{
-		return getAllowedFaces().stream()
-				.filter(this::hasFace)
-				.collect(Collectors.toSet());
+		return getAllowedFaces().stream().filter(this::hasFace).collect(Collectors.toSet());
 	}
 
 	@Override
@@ -56,7 +51,7 @@ public class MultipleFacingDataMock extends BlockDataMock implements MultipleFac
 	}
 
 	@Override
-	@SuppressWarnings({"MethodDoesntCallSuperMethod", "java:S2975", "java:S1182"})
+	@SuppressWarnings({ "MethodDoesntCallSuperMethod", "java:S2975", "java:S1182" })
 	public @NotNull MultipleFacingDataMock clone()
 	{
 		return new MultipleFacingDataMock(this);
@@ -66,7 +61,7 @@ public class MultipleFacingDataMock extends BlockDataMock implements MultipleFac
 	{
 		return switch (blockFace)
 		{
-			case null ->  Optional.empty();
+			case null -> Optional.empty();
 			case NORTH -> Optional.of(BlockDataKey.NORTH);
 			case SOUTH -> Optional.of(BlockDataKey.SOUTH);
 			case EAST -> Optional.of(BlockDataKey.EAST);

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/MultipleFacingDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/MultipleFacingDataMock.java
@@ -1,0 +1,80 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.MultipleFacing;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class MultipleFacingDataMock extends BlockDataMock implements MultipleFacing
+{
+
+	public MultipleFacingDataMock(@NotNull Material material)
+	{
+		super(material);
+	}
+
+	protected MultipleFacingDataMock(@NotNull MultipleFacingDataMock other)
+	{
+		super(other);
+	}
+
+	@Override
+	public boolean hasFace(@NotNull BlockFace face)
+	{
+		Preconditions.checkArgument(getAllowedFaces().contains(face), "Illegal facing: " + face);
+		return toKey(face)
+				.map(super::get)
+				.map(object -> (boolean) object)
+				.orElse(false);
+	}
+
+	@Override
+	public void setFace(@NotNull BlockFace face, boolean has)
+	{
+		Preconditions.checkArgument(getAllowedFaces().contains(face), "Illegal facing: " + face);
+		toKey(face).ifPresent(faceKey -> super.set(faceKey, has));
+	}
+
+	@Override
+	public @NotNull Set<BlockFace> getFaces()
+	{
+		return getAllowedFaces().stream()
+				.filter(this::hasFace)
+				.collect(Collectors.toSet());
+	}
+
+	@Override
+	public @NotNull Set<BlockFace> getAllowedFaces()
+	{
+		return this.getLimitationValue(BlockDataLimitation.Type.FACES);
+	}
+
+	@Override
+	@SuppressWarnings({"MethodDoesntCallSuperMethod", "java:S2975", "java:S1182"})
+	public @NotNull MultipleFacingDataMock clone()
+	{
+		return new MultipleFacingDataMock(this);
+	}
+
+	public static Optional<BlockDataKey> toKey(@Nullable BlockFace blockFace)
+	{
+		return switch (blockFace)
+		{
+			case null ->  Optional.empty();
+			case NORTH -> Optional.of(BlockDataKey.NORTH);
+			case SOUTH -> Optional.of(BlockDataKey.SOUTH);
+			case EAST -> Optional.of(BlockDataKey.EAST);
+			case WEST -> Optional.of(BlockDataKey.WEST);
+			case UP -> Optional.of(BlockDataKey.UP);
+			case DOWN -> Optional.of(BlockDataKey.DOWN);
+			default -> throw new UnsupportedOperationException(String.format("Unsupported block facing: %s", blockFace));
+		};
+	}
+
+}

--- a/src/main/resources-autogenerated/materials/material_data.json
+++ b/src/main/resources-autogenerated/materials/material_data.json
@@ -1334,7 +1334,9 @@
 	},
 	"minecraft:cactus_flower": {},
 	"minecraft:cake": {
-		"allowedStates": {},
+		"allowedStates": {
+			"maxBites": 6
+		},
 		"defaultStates": {
 			"bites": "0"
 		}

--- a/src/main/resources-autogenerated/materials/material_data.json
+++ b/src/main/resources-autogenerated/materials/material_data.json
@@ -566,7 +566,8 @@
 				"NORTH",
 				"SOUTH",
 				"WEST"
-			]
+			],
+			"maxHoneyLevel": 5
 		},
 		"defaultStates": {
 			"facing": "north",
@@ -580,7 +581,8 @@
 				"NORTH",
 				"SOUTH",
 				"WEST"
-			]
+			],
+			"maxHoneyLevel": 5
 		},
 		"defaultStates": {
 			"facing": "north",

--- a/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
@@ -969,7 +969,6 @@ class BlockTypeMockTest
 		}
 
 		@Test
-		@Disabled("Not implemented yet #1088")
 		void givenEndPortalFrame()
 		{
 			EndPortalFrame data = BlockType.END_PORTAL_FRAME.createBlockData();

--- a/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
@@ -1230,7 +1230,6 @@ class BlockTypeMockTest
 		}
 
 		@Test
-		@Disabled("Not implemented yet #1088")
 		void givenCopperBulb()
 		{
 			CopperBulb data = BlockType.COPPER_BULB.createBlockData();

--- a/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
@@ -1069,7 +1069,6 @@ class BlockTypeMockTest
 		}
 
 		@Test
-		@Disabled("Not implemented yet #1088")
 		void givenCoralWallFan()
 		{
 			CoralWallFan data = BlockType.DEAD_BRAIN_CORAL_WALL_FAN.createBlockData();

--- a/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
@@ -1090,7 +1090,6 @@ class BlockTypeMockTest
 		}
 
 		@Test
-		@Disabled("Not implemented yet #1088")
 		void givenBubbleColumn()
 		{
 			BubbleColumn data = BlockType.BUBBLE_COLUMN.createBlockData();

--- a/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
@@ -980,7 +980,6 @@ class BlockTypeMockTest
 		}
 
 		@Test
-		@Disabled("Not implemented yet #1088")
 		void givenCocoa()
 		{
 			Cocoa data = BlockType.COCOA.createBlockData();

--- a/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
@@ -827,7 +827,6 @@ class BlockTypeMockTest
 		}
 
 		@Test
-		@Disabled("Not implemented yet #1088")
 		void givenDaylightDetector()
 		{
 			DaylightDetector data = BlockType.DAYLIGHT_DETECTOR.createBlockData();

--- a/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
@@ -919,7 +919,6 @@ class BlockTypeMockTest
 		}
 
 		@Test
-		@Disabled("Not implemented yet #1088")
 		void givenCake()
 		{
 			Cake data = BlockType.CAKE.createBlockData();

--- a/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
@@ -762,7 +762,6 @@ class BlockTypeMockTest
 		}
 
 		@Test
-		@Disabled("Not implemented yet #1088")
 		void givenFire()
 		{
 			Fire data = BlockType.FIRE.createBlockData();
@@ -925,7 +924,6 @@ class BlockTypeMockTest
 		}
 
 		@Test
-		@Disabled("Not implemented yet #1088")
 		void givenMultipleFacing()
 		{
 			MultipleFacing data = BlockType.BROWN_MUSHROOM_BLOCK.createBlockData();

--- a/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
@@ -1132,7 +1132,6 @@ class BlockTypeMockTest
 		}
 
 		@Test
-		@Disabled("Not implemented yet #1088")
 		void givenBell()
 		{
 			Bell data = BlockType.BELL.createBlockData();

--- a/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
@@ -819,7 +819,6 @@ class BlockTypeMockTest
 		}
 
 		@Test
-		@Disabled("Not implemented yet #1088")
 		void givenComparator()
 		{
 			Comparator data = BlockType.COMPARATOR.createBlockData();

--- a/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/BlockTypeMockTest.java
@@ -1168,7 +1168,6 @@ class BlockTypeMockTest
 		}
 
 		@Test
-		@Disabled("Not implemented yet #1088")
 		void givenBeeNest()
 		{
 			Beehive data = BlockType.BEE_NEST.createBlockData();
@@ -1177,7 +1176,6 @@ class BlockTypeMockTest
 		}
 
 		@Test
-		@Disabled("Not implemented yet #1088")
 		void givenBeehive()
 		{
 			Beehive data = BlockType.BEEHIVE.createBlockData();

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/BeehiveDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/BeehiveDataMockTest.java
@@ -1,0 +1,81 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockBukkitExtension.class)
+class BeehiveDataMockTest
+{
+
+	private final BeehiveDataMock beehive = new BeehiveDataMock(Material.BEEHIVE);
+
+	@Nested
+	class SetHoneyLevel
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(0, beehive.getHoneyLevel());
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = { 0, 1, 2, 3, 4, 5 })
+		void givenPossibleLineWidthValues(int expected)
+		{
+			beehive.setHoneyLevel(expected);
+
+			assertEquals(expected, beehive.getHoneyLevel());
+		}
+
+		@Test
+		void givenDefaultMaximumValue()
+		{
+			assertEquals(5, beehive.getMaximumHoneyLevel());
+		}
+
+	}
+
+	@Nested
+	class SetFacing
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(BlockFace.NORTH, beehive.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.INCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST" })
+		void givenValidValues(BlockFace face)
+		{
+			beehive.setFacing(face);
+			assertEquals(face, beehive.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.EXCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST" })
+		void givenInvalidValues(BlockFace face)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> beehive.setFacing(face));
+			assertEquals("Invalid face, only cartesian horizontal face are allowed for this property!", e.getMessage());
+		}
+
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/BellDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/BellDataMockTest.java
@@ -1,0 +1,104 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.type.Bell;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockBukkitExtension.class)
+class BellDataMockTest
+{
+
+	private final BellDataMock bell = new BellDataMock(Material.BELL);
+
+	@Nested
+	class SetAttachment
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(Bell.Attachment.FLOOR, bell.getAttachment());
+		}
+
+		@ParameterizedTest
+		@EnumSource(Bell.Attachment.class)
+		void givenPossibleAttachments(Bell.Attachment expected)
+		{
+			bell.setAttachment(expected);
+
+			assertEquals(expected, bell.getAttachment());
+		}
+
+		@Test
+		void giveNullValue()
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> bell.setAttachment(null));
+			assertEquals("attachment cannot be null!", e.getMessage());
+		}
+
+	}
+
+	@Nested
+	class SetFacing
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(BlockFace.NORTH, bell.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.INCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST" })
+		void givenValidValues(BlockFace face)
+		{
+			bell.setFacing(face);
+			assertEquals(face, bell.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.EXCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST" })
+		void givenInvalidValues(BlockFace face)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> bell.setFacing(face));
+			assertEquals("Invalid face, only cartesian horizontal face are allowed for this property!", e.getMessage());
+		}
+
+	}
+
+	@Nested
+	class SetPowered
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertFalse(bell.isPowered());
+		}
+
+		@ParameterizedTest
+		@ValueSource(booleans = { true, false })
+		void givenPossibleValues(boolean inWall)
+		{
+			bell.setPowered(inWall);
+			assertEquals(inWall, bell.isPowered());
+		}
+
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/BubbleColumnDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/BubbleColumnDataMockTest.java
@@ -1,0 +1,40 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockBukkitExtension.class)
+class BubbleColumnDataMockTest
+{
+
+	private final BubbleColumnDataMock bubbleColumn = new BubbleColumnDataMock(Material.BUBBLE_COLUMN);
+
+	@Nested
+	class SetDrag
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertTrue(bubbleColumn.isDrag());
+		}
+
+		@ParameterizedTest
+		@ValueSource(booleans = { true, false })
+		void givenPossibleValues(boolean inWall)
+		{
+			bubbleColumn.setDrag(inWall);
+			assertEquals(inWall, bubbleColumn.isDrag());
+		}
+
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/CakeDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/CakeDataMockTest.java
@@ -1,0 +1,46 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockBukkitExtension.class)
+class CakeDataMockTest
+{
+
+	private final CakeDataMock cake = new CakeDataMock(Material.CAKE);
+
+	@Nested
+	class SetBites
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(0, cake.getBites());
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = { 0, 1, 2, 3, 4, 5, 6 })
+		void givenPossibleLineWidthValues(int expected)
+		{
+			cake.setBites(expected);
+
+			assertEquals(expected, cake.getBites());
+		}
+
+		@Test
+		void givenDefaultMaximumValue()
+		{
+			assertEquals(6, cake.getMaximumBites());
+		}
+
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/CocoaDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/CocoaDataMockTest.java
@@ -1,0 +1,80 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockBukkitExtension.class)
+class CocoaDataMockTest
+{
+
+	private final CocoaDataMock cocoa = new CocoaDataMock(Material.COCOA);
+
+	@Nested
+	class SetAge
+	{
+
+		@Test
+		void getAge()
+		{
+			assertEquals(0, cocoa.getAge());
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = { 0, 1, 2 })
+		void setAge(int age)
+		{
+			cocoa.setAge(age);
+			assertEquals(age, cocoa.getAge());
+		}
+
+		@Test
+		void getMaximumAge()
+		{
+			assertEquals(2, cocoa.getMaximumAge());
+		}
+
+	}
+
+	@Nested
+	class SetFacing
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(BlockFace.NORTH, cocoa.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.INCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST" })
+		void givenValidValues(BlockFace face)
+		{
+			cocoa.setFacing(face);
+			assertEquals(face, cocoa.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.EXCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST" })
+		void givenInvalidValues(BlockFace face)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> cocoa.setFacing(face));
+			assertEquals("Invalid face, only cartesian horizontal face are allowed for this property!", e.getMessage());
+		}
+
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/ComparatorDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/ComparatorDataMockTest.java
@@ -1,0 +1,103 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.type.Comparator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockBukkitExtension.class)
+class ComparatorDataMockTest
+{
+
+	private final ComparatorDataMock comparator = new ComparatorDataMock(Material.COMPARATOR);
+
+	@Nested
+	class SetMode
+	{
+
+		@Test
+		void givenDefaultMode()
+		{
+			assertEquals(Comparator.Mode.COMPARE, comparator.getMode());
+		}
+
+		@ParameterizedTest
+		@EnumSource(Comparator.Mode.class)
+		void givenModeChange(Comparator.Mode mode)
+		{
+			comparator.setMode(mode);
+			assertEquals(mode, comparator.getMode());
+		}
+
+		@Test
+		void givenNullMode()
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> comparator.setMode(null));
+			assertEquals("mode cannot be null!", e.getMessage());
+		}
+
+	}
+
+	@Nested
+	class SetFacing
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(BlockFace.NORTH, comparator.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.INCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST" })
+		void givenValidValues(BlockFace face)
+		{
+			comparator.setFacing(face);
+			assertEquals(face, comparator.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.EXCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST" })
+		void givenInvalidValues(BlockFace face)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> comparator.setFacing(face));
+			assertEquals("Invalid face, only cartesian horizontal face are allowed for this property!", e.getMessage());
+		}
+
+	}
+
+	@Nested
+	class SetPowered
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertFalse(comparator.isPowered());
+		}
+
+		@ParameterizedTest
+		@ValueSource(booleans = { true, false })
+		void givenPossibleValues(boolean inWall)
+		{
+			comparator.setPowered(inWall);
+			assertEquals(inWall, comparator.isPowered());
+		}
+
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/CopperBulbDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/CopperBulbDataMockTest.java
@@ -1,0 +1,60 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@ExtendWith(MockBukkitExtension.class)
+class CopperBulbDataMockTest
+{
+
+	private final CopperBulbDataMock bulb = new CopperBulbDataMock(Material.COPPER_BULB);
+
+	@Nested
+	class SetLit
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertFalse(bulb.isLit());
+		}
+
+		@ParameterizedTest
+		@ValueSource(booleans = { true, false })
+		void givenPossibleValues(boolean isLit)
+		{
+			bulb.setLit(isLit);
+			assertEquals(isLit, bulb.isLit());
+		}
+
+	}
+
+	@Nested
+	class SetPowered
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertFalse(bulb.isPowered());
+		}
+
+		@ParameterizedTest
+		@ValueSource(booleans = { true, false })
+		void givenPossibleValues(boolean inWall)
+		{
+			bulb.setPowered(inWall);
+			assertEquals(inWall, bulb.isPowered());
+		}
+
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/CoralWallFanDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/CoralWallFanDataMockTest.java
@@ -1,0 +1,74 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockBukkitExtension.class)
+class CoralWallFanDataMockTest
+{
+
+	private final CoralWallFanDataMock coralWall = new CoralWallFanDataMock(Material.BUBBLE_CORAL_WALL_FAN);
+
+	@Nested
+	class SetFacing
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(BlockFace.NORTH, coralWall.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.INCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST" })
+		void givenValidValues(BlockFace face)
+		{
+			coralWall.setFacing(face);
+			assertEquals(face, coralWall.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.EXCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST" })
+		void givenInvalidValues(BlockFace face)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> coralWall.setFacing(face));
+			assertEquals("Invalid face, only cartesian horizontal face are allowed for this property!", e.getMessage());
+		}
+
+	}
+
+	@Nested
+	class SetWaterlogged
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertTrue(coralWall.isWaterlogged());
+		}
+
+		@ParameterizedTest
+		@ValueSource(booleans = { true, false })
+		void givenPossibleValues(boolean isWaterLogged)
+		{
+			coralWall.setWaterlogged(isWaterLogged);
+			assertEquals(isWaterLogged, coralWall.isWaterlogged());
+		}
+
+	}
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/DaylightDetectorDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/DaylightDetectorDataMockTest.java
@@ -1,0 +1,69 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockBukkitExtension.class)
+class DaylightDetectorDataMockTest
+{
+
+	private final DaylightDetectorDataMock daylightDetector = new DaylightDetectorDataMock(Material.DAYLIGHT_DETECTOR);
+
+	@Nested
+	class SetInverted
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertFalse(daylightDetector.isInverted());
+		}
+
+		@ParameterizedTest
+		@ValueSource(booleans = { true, false })
+		void givenPossibleValues(boolean isWaterLogged)
+		{
+			daylightDetector.setInverted(isWaterLogged);
+			assertEquals(isWaterLogged, daylightDetector.isInverted());
+		}
+
+	}
+
+	@Nested
+	class SetPower
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(0, daylightDetector.getPower());
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 })
+		void givenLevelChange(int level)
+		{
+			daylightDetector.setPower(level);
+			assertEquals(level, daylightDetector.getPower());
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = { -2, -1, 16, 17 })
+		void givenInvalidValues(int level)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> daylightDetector.setPower(level));
+			assertEquals("Power must be between 0 and 15", e.getMessage());
+		}
+
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/EndPortalFrameDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/EndPortalFrameDataMockTest.java
@@ -1,0 +1,74 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockBukkitExtension.class)
+class EndPortalFrameDataMockTest
+{
+	private final EndPortalFrameDataMock endPortal = new EndPortalFrameDataMock(Material.END_PORTAL_FRAME);
+
+	@Nested
+	class SetEye
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertFalse(endPortal.hasEye());
+		}
+
+		@ParameterizedTest
+		@ValueSource(booleans = { true, false })
+		void givenPossibleValues(boolean hasEye)
+		{
+			endPortal.setEye(hasEye);
+			assertEquals(hasEye, endPortal.hasEye());
+		}
+
+	}
+
+	@Nested
+	class SetFacing
+	{
+
+		@Test
+		void givenDefaultValue()
+		{
+			assertEquals(BlockFace.NORTH, endPortal.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.INCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST" })
+		void givenValidValues(BlockFace face)
+		{
+			endPortal.setFacing(face);
+			assertEquals(face, endPortal.getFacing());
+		}
+
+		@ParameterizedTest
+		@EnumSource(value = BlockFace.class,
+				mode = EnumSource.Mode.EXCLUDE,
+				names = { "NORTH", "SOUTH", "EAST", "WEST" })
+		void givenInvalidValues(BlockFace face)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> endPortal.setFacing(face));
+			assertEquals("Invalid face, only cartesian horizontal face are allowed for this property!", e.getMessage());
+		}
+
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/FireDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/FireDataMockTest.java
@@ -1,0 +1,118 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockBukkitExtension.class)
+class FireDataMockTest
+{
+	private final FireDataMock fire = new FireDataMock(Material.FIRE);
+
+	@Nested
+	class SetAge
+	{
+
+		@Test
+		void getAge()
+		{
+			assertEquals(0, fire.getAge());
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 })
+		void setAge(int age)
+		{
+			fire.setAge(age);
+			assertEquals(age, fire.getAge());
+		}
+
+		@Test
+		void getMaximumAge()
+		{
+			assertEquals(15, fire.getMaximumAge());
+		}
+
+	}
+
+	@Nested
+	class SetFace
+	{
+
+		private static final Set<BlockFace> VALID_FACES = Set.of(
+				BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST, BlockFace.UP
+		);
+
+		@ParameterizedTest
+		@MethodSource("getValidFaces")
+		void givenDefaultValue(BlockFace face)
+		{
+			assertFalse(fire.hasFace(face));
+		}
+
+		@ParameterizedTest
+		@MethodSource("getInvalidFaces")
+		void givenGetWithInvalidValue(BlockFace face)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> fire.hasFace(face));
+			assertEquals(String.format("Illegal facing: %s", face), e.getMessage());
+		}
+
+		@ParameterizedTest
+		@MethodSource("getValidFaces")
+		void givenValidValues(BlockFace face)
+		{
+			fire.setFace(face, true);
+			assertTrue(fire.hasFace(face));
+			assertEquals(Set.of(face), fire.getFaces());
+
+			fire.setFace(face, false);
+			assertFalse(fire.hasFace(face));
+
+			assertEquals(Collections.emptySet(), fire.getFaces());
+		}
+
+		@ParameterizedTest
+		@MethodSource("getInvalidFaces")
+		void givenInvalidValues(BlockFace face)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> fire.setFace(face, true));
+			assertEquals(String.format("Illegal facing: %s", face), e.getMessage());
+		}
+
+		@Test
+		void getAllowedFaces()
+		{
+			assertEquals(VALID_FACES, fire.getAllowedFaces());
+		}
+
+		public static Stream<Arguments> getValidFaces()
+		{
+			return VALID_FACES.stream().map(Arguments::of);
+		}
+
+		public static Stream<Arguments> getInvalidFaces()
+		{
+			return Stream.of(BlockFace.values())
+					.filter(p -> !VALID_FACES.contains(p))
+					.map(Arguments::of);
+		}
+
+	}
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/MultipleFacingDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/MultipleFacingDataMockTest.java
@@ -1,0 +1,95 @@
+package org.mockbukkit.mockbukkit.block.data;
+
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockBukkitExtension.class)
+class MultipleFacingDataMockTest
+{
+
+	private final MultipleFacingDataMock multipleFacing = new MultipleFacingDataMock(Material.MUSHROOM_STEM);
+
+	@Nested
+	class SetFace
+	{
+
+		private static final Set<BlockFace> VALID_FACES = Set.of(
+				BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST, BlockFace.UP, BlockFace.DOWN
+		);
+
+		@ParameterizedTest
+		@MethodSource("getValidFaces")
+		void givenDefaultValue(BlockFace face)
+		{
+			assertTrue(multipleFacing.hasFace(face));
+		}
+
+		@ParameterizedTest
+		@MethodSource("getInvalidFaces")
+		void givenGetWithInvalidValue(BlockFace face)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> multipleFacing.hasFace(face));
+			assertEquals(String.format("Illegal facing: %s", face), e.getMessage());
+		}
+
+		@ParameterizedTest
+		@MethodSource("getValidFaces")
+		void givenValidValues(BlockFace face)
+		{
+			multipleFacing.setFace(face, true);
+			assertTrue(multipleFacing.hasFace(face));
+			assertEquals(VALID_FACES, multipleFacing.getFaces());
+
+			multipleFacing.setFace(face, false);
+			assertFalse(multipleFacing.hasFace(face));
+
+			Set<BlockFace> faces = new HashSet<>(VALID_FACES);
+			faces.remove(face);
+			assertEquals(faces, multipleFacing.getFaces());
+		}
+
+		@ParameterizedTest
+		@MethodSource("getInvalidFaces")
+		void givenInvalidValues(BlockFace face)
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> multipleFacing.setFace(face, true));
+			assertEquals(String.format("Illegal facing: %s", face), e.getMessage());
+		}
+
+		@Test
+		void getAllowedFaces()
+		{
+			assertEquals(VALID_FACES, multipleFacing.getAllowedFaces());
+		}
+
+		public static Stream<Arguments> getValidFaces()
+		{
+			return VALID_FACES.stream().map(Arguments::of);
+		}
+
+		public static Stream<Arguments> getInvalidFaces()
+		{
+			return Stream.of(BlockFace.values())
+					.filter(p -> !VALID_FACES.contains(p))
+					.map(Arguments::of);
+		}
+
+	}
+
+}


### PR DESCRIPTION
# Description
This is a PR related with issue #1088 and implements the following block data:
- Beehive
- BeeNest
- BubbleColumn
- Cake
- Cocoa
- Comparator
- CoperBulb
- CoralWallFan
- DaylightDetector
- EndPortalFrame
- MultipleFacing
- Fire

# Checklist
The following items should be checked before the pull request can be merged.
- [X] Code follows existing style.
- [X] Unit tests added (if applicable).
