### PR TITLE
fix: remove duplicate version and use test scope for paper-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Also here you can extract the manifest version this way:
       <groupId>io.papermc.paper</groupId>
       <artifactId>paper-api</artifactId>
       <version>${paper.version.from.mockbukkit}</version>
-      <version>test</version>
+      <scope>test</scope>
   </dependency>
 </dependencies>
 ```
@@ -217,7 +217,7 @@ use [JitPack](https://jitpack.io/#MockBukkit/MockBukkit) as your maven repositor
       <groupId>io.papermc.paper</groupId>
       <artifactId>paper-api</artifactId>
       <version>${paper.version.from.mockbukkit}</version>
-      <version>test</version>
+      <scope>test</scope>
   </dependency>
 </dependencies>
 ```


### PR DESCRIPTION
# Description
This PR fixes incorrect `paper-api` dependency definitions in the README.

Two duplicate `<version>` entries were removed and the dependencies are now correctly marked with `<scope>test</scope>`.

# Checklist
- [x] Code follows existing style.
- [ ] Unit tests added (if applicable).