### PR TITLE
Avoid possible deadlocks in scheduler

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -238,9 +238,17 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	/**
 	 * Perform one tick on the server.
 	 */
-	public synchronized void performOneTick()
+	public void performOneTick()
 	{
-		currentTick++;
+		// Using a synchronized block here is necessary to avoid tasks being skipped by processTasks().
+		// runTask*(..) methods will synchronize with this synchronized block and keep the lock from the moment they read
+		// currentTick to when they register their task into scheduledTasks. This ensures that the main thread will wait
+		// for the async threads to register their tasks before incrementing currentTick. Thus, since the delay of every
+		// task is always >= 1, tasks scheduled during a tick can never be skipped
+		synchronized (this)
+		{
+			currentTick++;
+		}
 
 		processWorlds();
 		processEntities();
@@ -286,17 +294,12 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	public void waitAsyncTasksFinished()
 	{
 		// Cancel repeating tasks so they don't run forever.
-		synchronized (scheduledTasks.tasks)
-		{
-			scheduledTasks.tasks.entrySet().stream()
-					.filter(entry -> entry.getValue() instanceof RepeatingTask)
-					.forEach(entry -> scheduledTasks.cancelTask(entry.getKey()));
+		scheduledTasks.cancelRepeatingTasks();
 
-			// Make sure all tasks get to execute. (except for repeating asynchronous tasks, they only will fire once)
-			while (scheduledTasks.getScheduledTaskCount() > 0)
-			{
-				performOneTick();
-			}
+		// Make sure all tasks get to execute. (except for repeating asynchronous tasks, they only will fire once)
+		while (scheduledTasks.getScheduledTaskCount() > 0)
+		{
+			performOneTick();
 		}
 
 		// Wait for all tasks to finish executing.
@@ -372,45 +375,51 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	}
 
 	@Override
-	public synchronized @NotNull BukkitTask runTask(@NotNull Plugin plugin, @NotNull Runnable task)
+	public @NotNull BukkitTask runTask(@NotNull Plugin plugin, @NotNull Runnable task)
 	{
 		return runTaskLater(plugin, task, 1L);
 	}
 
 	@Override
 	@Deprecated(since = "1.7.10")
-	public synchronized @NotNull BukkitTask runTask(@NotNull Plugin plugin, @NotNull BukkitRunnable task)
+	public @NotNull BukkitTask runTask(@NotNull Plugin plugin, @NotNull BukkitRunnable task)
 	{
 		return runTask(plugin, (Runnable) task);
 	}
 
 	@Override
-	public synchronized @NotNull BukkitTask runTaskLater(@NotNull Plugin plugin, @NotNull Runnable task, long delay)
+	public @NotNull BukkitTask runTaskLater(@NotNull Plugin plugin, @NotNull Runnable task, long delay)
 	{
 		delay = Math.max(delay, 1);
-		ScheduledTask scheduledTask = new ScheduledTask(id.getAndIncrement(), plugin, true, currentTick + delay, task);
-		scheduledTasks.addTask(scheduledTask);
-		return scheduledTask;
+		synchronized (this) // See comment at the start of performOneTick()
+		{
+			ScheduledTask scheduledTask = new ScheduledTask(id.getAndIncrement(), plugin, true, currentTick + delay, task);
+			scheduledTasks.addTask(scheduledTask);
+			return scheduledTask;
+		}
 	}
 
 	@Override
-	public synchronized @NotNull BukkitTask runTaskTimer(@NotNull Plugin plugin, @NotNull Runnable task, long delay, long period)
+	public @NotNull BukkitTask runTaskTimer(@NotNull Plugin plugin, @NotNull Runnable task, long delay, long period)
 	{
 		delay = Math.max(delay, 1);
-		RepeatingTask repeatingTask = new RepeatingTask(id.getAndIncrement(), plugin, true, currentTick + delay, period, task);
-		scheduledTasks.addTask(repeatingTask);
-		return repeatingTask;
+		synchronized (this) // See comment at the start of performOneTick()
+		{
+			RepeatingTask repeatingTask = new RepeatingTask(id.getAndIncrement(), plugin, true, currentTick + delay, period, task);
+			scheduledTasks.addTask(repeatingTask);
+			return repeatingTask;
+		}
 	}
 
 	@Override
 	@Deprecated(since = "1.7.10")
-	public synchronized @NotNull BukkitTask runTaskTimer(@NotNull Plugin plugin, @NotNull BukkitRunnable task, long delay, long period)
+	public @NotNull BukkitTask runTaskTimer(@NotNull Plugin plugin, @NotNull BukkitRunnable task, long delay, long period)
 	{
 		return runTaskTimer(plugin, (Runnable) task, delay, period);
 	}
 
 	@Override
-	public synchronized int scheduleSyncDelayedTask(@NotNull Plugin plugin, @NotNull Runnable task, long delay)
+	public int scheduleSyncDelayedTask(@NotNull Plugin plugin, @NotNull Runnable task, long delay)
 	{
 		Logger.getLogger(LOGGER_NAME).warning("Consider using runTaskLater instead of scheduleSyncDelayTask");
 		return runTaskLater(plugin, task, delay).getTaskId();
@@ -418,14 +427,14 @@ public class BukkitSchedulerMock implements BukkitScheduler
 
 	@Override
 	@Deprecated(since = "1.7.10")
-	public synchronized int scheduleSyncDelayedTask(@NotNull Plugin plugin, @NotNull BukkitRunnable task, long delay)
+	public int scheduleSyncDelayedTask(@NotNull Plugin plugin, @NotNull BukkitRunnable task, long delay)
 	{
 		Logger.getLogger(LOGGER_NAME).warning("Consider using runTaskLater instead of scheduleSyncDelayTask");
 		return runTaskLater(plugin, (Runnable) task, delay).getTaskId();
 	}
 
 	@Override
-	public synchronized int scheduleSyncDelayedTask(@NotNull Plugin plugin, @NotNull Runnable task)
+	public int scheduleSyncDelayedTask(@NotNull Plugin plugin, @NotNull Runnable task)
 	{
 		Logger.getLogger(LOGGER_NAME).warning("Consider using runTask instead of scheduleSyncDelayTask");
 		return runTask(plugin, task).getTaskId();
@@ -433,14 +442,14 @@ public class BukkitSchedulerMock implements BukkitScheduler
 
 	@Override
 	@Deprecated(since = "1.7.10")
-	public synchronized int scheduleSyncDelayedTask(@NotNull Plugin plugin, @NotNull BukkitRunnable task)
+	public int scheduleSyncDelayedTask(@NotNull Plugin plugin, @NotNull BukkitRunnable task)
 	{
 		Logger.getLogger(LOGGER_NAME).warning("Consider using runTask instead of scheduleSyncDelayTask");
 		return runTask(plugin, (Runnable) task).getTaskId();
 	}
 
 	@Override
-	public synchronized int scheduleSyncRepeatingTask(@NotNull Plugin plugin, @NotNull Runnable task, long delay, long period)
+	public int scheduleSyncRepeatingTask(@NotNull Plugin plugin, @NotNull Runnable task, long delay, long period)
 	{
 		Logger.getLogger(LOGGER_NAME).warning("Consider using runTaskTimer instead of scheduleSyncRepeatingTask");
 		return runTaskTimer(plugin, task, delay, period).getTaskId();
@@ -448,7 +457,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 
 	@Override
 	@Deprecated(since = "1.7.10")
-	public synchronized int scheduleSyncRepeatingTask(@NotNull Plugin plugin, @NotNull BukkitRunnable task, long delay, long period)
+	public int scheduleSyncRepeatingTask(@NotNull Plugin plugin, @NotNull BukkitRunnable task, long delay, long period)
 	{
 		Logger.getLogger(LOGGER_NAME).warning("Consider using runTaskTimer instead of scheduleSyncRepeatingTask");
 		return runTaskTimer(plugin, (Runnable) task, delay, period).getTaskId();
@@ -456,7 +465,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 
 	@Override
 	@Deprecated(since = "1.5")
-	public synchronized int scheduleAsyncDelayedTask(@NotNull Plugin plugin, @NotNull Runnable task, long delay)
+	public int scheduleAsyncDelayedTask(@NotNull Plugin plugin, @NotNull Runnable task, long delay)
 	{
 		Logger.getLogger(LOGGER_NAME)
 				.warning("Consider using runTaskLaterAsynchronously instead of scheduleAsyncDelayedTask");
@@ -465,7 +474,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 
 	@Override
 	@Deprecated(since = "1.5")
-	public synchronized int scheduleAsyncDelayedTask(@NotNull Plugin plugin, @NotNull Runnable task)
+	public int scheduleAsyncDelayedTask(@NotNull Plugin plugin, @NotNull Runnable task)
 	{
 		Logger.getLogger(LOGGER_NAME)
 				.warning("Consider using runTaskAsynchronously instead of scheduleAsyncDelayedTask");
@@ -474,7 +483,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 
 	@Override
 	@Deprecated(since = "1.5")
-	public synchronized int scheduleAsyncRepeatingTask(@NotNull Plugin plugin, @NotNull Runnable task, long delay, long period)
+	public int scheduleAsyncRepeatingTask(@NotNull Plugin plugin, @NotNull Runnable task, long delay, long period)
 	{
 		Logger.getLogger(LOGGER_NAME)
 				.warning("Consider using runTaskTimerAsynchronously instead of scheduleAsyncRepeatingTask");
@@ -482,7 +491,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	}
 
 	@Override
-	public synchronized <T> @NotNull Future<T> callSyncMethod(@NotNull Plugin plugin, @NotNull Callable<T> task)
+	public <T> @NotNull Future<T> callSyncMethod(@NotNull Plugin plugin, @NotNull Callable<T> task)
 	{
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
@@ -544,95 +553,119 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	}
 
 	@Override
-	public synchronized @NotNull BukkitTask runTaskAsynchronously(@NotNull Plugin plugin, @NotNull Runnable task)
+	public @NotNull BukkitTask runTaskAsynchronously(@NotNull Plugin plugin, @NotNull Runnable task)
 	{
+		long currentTick;
+		synchronized (this) // See comment at the start of performOneTick()
+		{
+			currentTick = this.currentTick; // There's no task registration here, no need to synchronize further
+		}
+
 		ScheduledTask scheduledTask = new ScheduledTask(id.getAndIncrement(), plugin, false, currentTick, new AsyncRunnable(task));
 		pool.execute(wrapTask(scheduledTask));
 		return scheduledTask;
 	}
 
 	@Override
-	public synchronized @NotNull BukkitTask runTaskAsynchronously(@NotNull Plugin plugin, @NotNull BukkitRunnable task)
+	public @NotNull BukkitTask runTaskAsynchronously(@NotNull Plugin plugin, @NotNull BukkitRunnable task)
 	{
 		return runTaskAsynchronously(plugin, (Runnable) task);
 	}
 
 	@Override
-	public synchronized @NotNull BukkitTask runTaskLater(@NotNull Plugin plugin, @NotNull BukkitRunnable task, long delay)
+	public @NotNull BukkitTask runTaskLater(@NotNull Plugin plugin, @NotNull BukkitRunnable task, long delay)
 	{
 		return runTaskLater(plugin, (Runnable) task, delay);
 	}
 
 	@Override
-	public synchronized @NotNull BukkitTask runTaskLaterAsynchronously(@NotNull Plugin plugin, @NotNull Runnable task, long delay)
+	public @NotNull BukkitTask runTaskLaterAsynchronously(@NotNull Plugin plugin, @NotNull Runnable task, long delay)
 	{
 		delay = Math.max(delay, 1);
-		ScheduledTask scheduledTask = new ScheduledTask(id.getAndIncrement(), plugin, false, currentTick + delay,
-				new AsyncRunnable(task));
-		scheduledTasks.addTask(scheduledTask);
-		return scheduledTask;
+		synchronized (this) // See comment at the start of performOneTick()
+		{
+			ScheduledTask scheduledTask = new ScheduledTask(id.getAndIncrement(), plugin, false, currentTick + delay,
+					new AsyncRunnable(task));
+			scheduledTasks.addTask(scheduledTask);
+			return scheduledTask;
+		}
 	}
 
 	@Override
-	public synchronized @NotNull BukkitTask runTaskLaterAsynchronously(@NotNull Plugin plugin, @NotNull BukkitRunnable task, long delay)
+	public @NotNull BukkitTask runTaskLaterAsynchronously(@NotNull Plugin plugin, @NotNull BukkitRunnable task, long delay)
 	{
 		return runTaskLaterAsynchronously(plugin, (Runnable) task, delay);
 	}
 
 	@Override
-	public synchronized @NotNull BukkitTask runTaskTimerAsynchronously(@NotNull Plugin plugin, @NotNull Runnable task, long delay, long period)
+	public @NotNull BukkitTask runTaskTimerAsynchronously(@NotNull Plugin plugin, @NotNull Runnable task, long delay, long period)
 	{
 		delay = Math.max(delay, 1);
-		RepeatingTask scheduledTask = new RepeatingTask(id.getAndIncrement(), plugin, false, currentTick + delay, period,
-				new AsyncRunnable(task));
-		scheduledTasks.addTask(scheduledTask);
-		return scheduledTask;
+		synchronized (this) // See comment at the start of performOneTick()
+		{
+			RepeatingTask scheduledTask = new RepeatingTask(id.getAndIncrement(), plugin, false, currentTick + delay, period,
+					new AsyncRunnable(task));
+			scheduledTasks.addTask(scheduledTask);
+			return scheduledTask;
+		}
 	}
 
 	@Override
-	public synchronized @NotNull BukkitTask runTaskTimerAsynchronously(@NotNull Plugin plugin, @NotNull BukkitRunnable task, long delay, long period)
+	public @NotNull BukkitTask runTaskTimerAsynchronously(@NotNull Plugin plugin, @NotNull BukkitRunnable task, long delay, long period)
 	{
 		return runTaskTimerAsynchronously(plugin, (Runnable) task, delay, period);
 	}
 
 	@Override
-	public synchronized void runTask(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task)
+	public void runTask(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task)
 	{
 		runTaskLater(plugin, task, 0L);
 	}
 
 	@Override
-	public synchronized void runTaskAsynchronously(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task)
+	public void runTaskAsynchronously(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task)
 	{
-		ScheduledTask scheduledTask = new ScheduledTask(this.id.getAndIncrement(), plugin, false, this.currentTick, task);
+		long currentTick;
+		synchronized (this) // See comment at the start of performOneTick()
+		{
+			currentTick = this.currentTick; // There's no task registration here, no need to synchronize further
+		}
+
+		ScheduledTask scheduledTask = new ScheduledTask(this.id.getAndIncrement(), plugin, false, currentTick, task);
 		pool.execute(wrapTask(scheduledTask));
 	}
 
 	@Override
-	public synchronized void runTaskLater(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, long delay)
+	public void runTaskLater(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, long delay)
 	{
 		delay = Math.max(delay, 1);
-		ScheduledTask scheduledTask = new ScheduledTask(id.getAndIncrement(), plugin, true, currentTick + delay, task);
-		scheduledTasks.addTask(scheduledTask);
+		synchronized (this) // See comment at the start of performOneTick()
+		{
+			ScheduledTask scheduledTask = new ScheduledTask(id.getAndIncrement(), plugin, true, currentTick + delay, task);
+			scheduledTasks.addTask(scheduledTask);
+		}
 	}
 
 	@Override
-	public synchronized void runTaskLaterAsynchronously(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, long delay)
+	public void runTaskLaterAsynchronously(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, long delay)
 	{
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
 	}
 
 	@Override
-	public synchronized void runTaskTimer(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, long delay, long period)
+	public void runTaskTimer(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, long delay, long period)
 	{
 		delay = Math.max(delay, 1);
-		RepeatingTask repeatingTask = new RepeatingTask(id.getAndIncrement(), plugin, true, currentTick + delay, period, task);
-		scheduledTasks.addTask(repeatingTask);
+		synchronized (this) // See comment at the start of performOneTick()
+		{
+			RepeatingTask repeatingTask = new RepeatingTask(id.getAndIncrement(), plugin, true, currentTick + delay, period, task);
+			scheduledTasks.addTask(repeatingTask);
+		}
 	}
 
 	@Override
-	public synchronized void runTaskTimerAsynchronously(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, long delay, long period)
+	public void runTaskTimerAsynchronously(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, long delay, long period)
 	{
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
@@ -752,16 +785,37 @@ public class BukkitSchedulerMock implements BukkitScheduler
 
 		protected boolean cancelTask(int taskID)
 		{
+			ScheduledTask task;
 			synchronized (tasks)
 			{
-				ScheduledTask task = tasks.get(taskID);
-				if (task != null)
-				{
-					task.cancel();
-					return true;
-				}
+				task = tasks.get(taskID);
+			}
+
+			if (task != null)
+			{
+				task.cancel();
+				return true;
 			}
 			return false;
+		}
+
+		protected void cancelRepeatingTasks()
+		{
+			List<RepeatingTask> toCancel = new ArrayList<>();
+			synchronized (tasks)
+			{
+				for (ScheduledTask task : tasks.values())
+				{
+					if (task instanceof RepeatingTask repeatingTask)
+					{
+						toCancel.add(repeatingTask);
+					}
+				}
+			}
+			for (RepeatingTask task : toCancel)
+			{
+				task.cancel();
+			}
 		}
 
 	}

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -12,6 +12,7 @@ import org.bukkit.scheduler.BukkitWorker;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
+import org.mockbukkit.mockbukkit.AsyncCatcher;
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.ServerMock;
 import org.mockbukkit.mockbukkit.entity.EntityMock;
@@ -240,6 +241,8 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	 */
 	public void performOneTick()
 	{
+		AsyncCatcher.catchOp("server tick");
+
 		// Using a synchronized block here is necessary to avoid tasks being skipped by processTasks().
 		// runTask*(..) methods will synchronize with this synchronized block and keep the lock from the moment they read
 		// currentTick to when they register their task into scheduledTasks. This ensures that the main thread will wait

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/ScheduledTask.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/ScheduledTask.java
@@ -8,10 +8,9 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 
 /**
@@ -28,7 +27,7 @@ public class ScheduledTask implements BukkitTask, BukkitWorker
 	private volatile boolean running;
 	private final @Nullable Runnable runnable;
 	private final @Nullable Consumer<? super BukkitTask> consumer;
-	private final List<Runnable> cancelListeners = Collections.synchronizedList(new LinkedList<>());
+	private final List<Runnable> cancelListeners = new CopyOnWriteArrayList<>(); // Needed to not hold any lock when calling cancellation listeners
 	private volatile Thread thread;
 	private volatile boolean submitted = false;
 


### PR DESCRIPTION
# Description

The current implementation performs the entirety of the server ticking logic while holding a `synchronized` lock (on the scheduler instance). This can lead to deadlocks when scheduling and running tasks with async threads.

An example of possible deadlock is the following (assume there exists a lock named `lock`):

**Main thread**
```java
runTask(myPlugin, () -> {
    lock.lock();
    // ...
    lock.unlock();
});
performOneTick();
```

**Async thread**
```java
lock.lock();
runTask(myPlugin, () -> {});
lock.unlock();
```

A possible execution which results in a deadlock is:
- Main thread registers the task
- Async thread takes the `lock` lock
- Main thread calls `performOneTick()`, taking the lock on the scheduler instance
- Main thread runs the registered task and tries to take the `lock` lock, which is held by the async thread
- Async thread calls `runTask` and tries to take the lock on the scheduler instance, which is held by the main thread
- Deadlock!


To prevent deadlocks, this PR reduces the scope of the synchronized blocks, making sure no user-provided task is run while holding a lock.

# Checklist

The following items should be checked before the pull request can be merged.

- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
