### PR TITLE
feat: implement LivingEntityMock:isHandRaised with state management

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -104,6 +104,8 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	private boolean gliding = false;
 	private boolean jumping = false;
 	private boolean riptiding = false;
+	private boolean handRaised = false;
+	private @Nullable EquipmentSlot raisedHand = null;
 
 	/**
 	 * The attributes this entity has.
@@ -1242,15 +1244,29 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	@Override
 	public boolean isHandRaised()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.handRaised;
+	}
+
+	/**
+	 * Sets whether a hand is raised and which hand is raised.
+	 *
+	 * @param handRaised Whether a hand is raised.
+	 * @param hand The hand that is raised, or null if no hand is raised.
+	 */
+	public void setHandRaised(boolean handRaised, @Nullable EquipmentSlot hand)
+	{
+		this.handRaised = handRaised;
+		this.raisedHand = hand;
 	}
 
 	@Override
 	public @NotNull EquipmentSlot getHandRaised()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		if (this.raisedHand == null)
+		{
+			throw new IllegalStateException("No hand is raised");
+		}
+		return this.raisedHand;
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -1275,6 +1275,12 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	}
 
 	@Override
+	public boolean isHandRaised()
+	{
+		return hasActiveItem();
+	}
+
+	@Override
 	public void playPickupItemAnimation(@NotNull Item item, int quantity)
 	{
 		// TODO Auto-generated method stub

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -104,8 +104,12 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	private boolean gliding = false;
 	private boolean jumping = false;
 	private boolean riptiding = false;
-	private boolean handRaised = false;
-	private @Nullable EquipmentSlot raisedHand = null;
+
+	// Active item fields
+	private @Nullable ItemStack activeItem = null;
+	private @Nullable EquipmentSlot activeItemHand = null;
+	private int activeItemUsedTicks = 0;
+	private int activeItemMaxDuration = 0;
 
 	/**
 	 * The attributes this entity has.
@@ -365,43 +369,64 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	@Override
 	public void startUsingItem(@NotNull EquipmentSlot hand)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkNotNull(hand, "Hand cannot be null");
+		Preconditions.checkArgument(hand == EquipmentSlot.HAND || hand == EquipmentSlot.OFF_HAND,
+				"Hand must be HAND or OFF_HAND");
+
+		ItemStack item = hand == EquipmentSlot.HAND
+				? equipment.getItemInMainHand()
+				: equipment.getItemInOffHand();
+
+		if (item == null || item.getType().isAir())
+		{
+			return; // Can't use air/null items
+		}
+
+		this.activeItem = item.clone();
+		this.activeItemHand = hand;
+		this.activeItemUsedTicks = 0;
+		// Default max duration for most consumable items (food, potions) is 32 ticks
+		// Bows can be held indefinitely, but we'll use a reasonable default
+		this.activeItemMaxDuration = 32;
 	}
 
 	@Override
 	public @Nullable ItemStack getItemInUse()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.activeItem;
 	}
 
 	@Override
 	public int getItemInUseTicks()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.activeItemUsedTicks;
 	}
 
 	@Override
 	public void setItemInUseTicks(int ticks)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkArgument(ticks >= 0, "Ticks must be >= 0");
+		this.activeItemUsedTicks = ticks;
 	}
 
 	@Override
 	public void completeUsingActiveItem()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		// Clear the active item (item usage is complete)
+		this.activeItem = null;
+		this.activeItemHand = null;
+		this.activeItemUsedTicks = 0;
+		this.activeItemMaxDuration = 0;
 	}
 
 	@Override
 	public int getActiveItemRemainingTime()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		if (this.activeItem == null)
+		{
+			return 0;
+		}
+		return Math.max(0, this.activeItemMaxDuration - this.activeItemUsedTicks);
 	}
 
 	protected double getEyeHeight(EntityState pose)
@@ -450,29 +475,34 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	@Override
 	public void setActiveItemRemainingTime(@Range(from = 0L, to = 2147483647L) int ticks)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkArgument(ticks >= 0, "Ticks must be >= 0");
+		if (this.activeItem == null)
+		{
+			return; // No active item, nothing to set
+		}
+		this.activeItemUsedTicks = Math.max(0, this.activeItemMaxDuration - ticks);
 	}
 
 	@Override
 	public boolean hasActiveItem()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.activeItem != null;
 	}
 
 	@Override
 	public int getActiveItemUsedTime()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.activeItemUsedTicks;
 	}
 
 	@Override
 	public @NotNull EquipmentSlot getActiveItemHand()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		if (this.activeItemHand == null)
+		{
+			throw new IllegalStateException("No active item");
+		}
+		return this.activeItemHand;
 	}
 
 	@Override
@@ -1214,59 +1244,28 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	}
 
 	@Override
-	public @Nullable ItemStack getActiveItem()
+	public @NotNull ItemStack getActiveItem()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		if (this.activeItem == null)
+		{
+			return new ItemStack(Material.AIR);
+		}
+		return this.activeItem;
 	}
 
 	@Override
 	public void clearActiveItem()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.activeItem = null;
+		this.activeItemHand = null;
+		this.activeItemUsedTicks = 0;
+		this.activeItemMaxDuration = 0;
 	}
 
 	@Override
 	public int getItemUseRemainingTime()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public int getHandRaisedTime()
-	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
-	}
-
-	@Override
-	public boolean isHandRaised()
-	{
-		return this.handRaised;
-	}
-
-	/**
-	 * Sets whether a hand is raised and which hand is raised.
-	 *
-	 * @param handRaised Whether a hand is raised.
-	 * @param hand The hand that is raised, or null if no hand is raised.
-	 */
-	public void setHandRaised(boolean handRaised, @Nullable EquipmentSlot hand)
-	{
-		this.handRaised = handRaised;
-		this.raisedHand = hand;
-	}
-
-	@Override
-	public @NotNull EquipmentSlot getHandRaised()
-	{
-		if (this.raisedHand == null)
-		{
-			throw new IllegalStateException("No hand is raised");
-		}
-		return this.raisedHand;
+		return getActiveItemRemainingTime();
 	}
 
 	@Override
@@ -1279,6 +1278,22 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	public void setJumping(boolean jumping)
 	{
 		this.jumping = jumping;
+	}
+
+	@Override
+	public boolean isHandRaised()
+	{
+		return hasActiveItem();
+	}
+
+	@Override
+	public @NotNull EquipmentSlot getHandRaised()
+	{
+		if (!hasActiveItem())
+		{
+			throw new IllegalStateException("No hand is raised");
+		}
+		return getActiveItemHand();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -377,7 +377,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 				? equipment.getItemInMainHand()
 				: equipment.getItemInOffHand();
 
-		if (item == null || item.getType().isAir())
+		if (item.getType().isAir())
 		{
 			return; // Can't use air/null items
 		}

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -1263,12 +1263,6 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	}
 
 	@Override
-	public int getItemUseRemainingTime()
-	{
-		return getActiveItemRemainingTime();
-	}
-
-	@Override
 	public boolean isJumping()
 	{
 		return this.jumping;
@@ -1278,22 +1272,6 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	public void setJumping(boolean jumping)
 	{
 		this.jumping = jumping;
-	}
-
-	@Override
-	public boolean isHandRaised()
-	{
-		return hasActiveItem();
-	}
-
-	@Override
-	public @NotNull EquipmentSlot getHandRaised()
-	{
-		if (!hasActiveItem())
-		{
-			throw new IllegalStateException("No hand is raised");
-		}
-		return getActiveItemHand();
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
@@ -31,6 +31,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityPotionEffectEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
@@ -703,6 +704,44 @@ class LivingEntityMockTest
 
 		livingArmorStand.setAI(false);
 		assertFalse(livingArmorStand.hasAI());
+	}
+
+	@Test
+	void testIsHandRaisedDefault()
+	{
+		assertFalse(livingEntity.isHandRaised());
+	}
+
+	@Test
+	void testSetHandRaisedMainHand()
+	{
+		livingEntity.setHandRaised(true, EquipmentSlot.HAND);
+		assertTrue(livingEntity.isHandRaised());
+		assertEquals(EquipmentSlot.HAND, livingEntity.getHandRaised());
+	}
+
+	@Test
+	void testSetHandRaisedOffHand()
+	{
+		livingEntity.setHandRaised(true, EquipmentSlot.OFF_HAND);
+		assertTrue(livingEntity.isHandRaised());
+		assertEquals(EquipmentSlot.OFF_HAND, livingEntity.getHandRaised());
+	}
+
+	@Test
+	void testSetHandRaisedFalse()
+	{
+		livingEntity.setHandRaised(true, EquipmentSlot.HAND);
+		assertTrue(livingEntity.isHandRaised());
+
+		livingEntity.setHandRaised(false, null);
+		assertFalse(livingEntity.isHandRaised());
+	}
+
+	@Test
+	void testGetHandRaisedWhenNotRaised()
+	{
+		assertThrows(IllegalStateException.class, () -> livingEntity.getHandRaised());
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
@@ -715,7 +715,8 @@ class LivingEntityMockTest
 	@Test
 	void testSetHandRaisedMainHand()
 	{
-		livingEntity.setHandRaised(true, EquipmentSlot.HAND);
+		livingEntity.getEquipment().setItemInMainHand(new org.bukkit.inventory.ItemStack(org.bukkit.Material.BOW));
+		livingEntity.startUsingItem(EquipmentSlot.HAND);
 		assertTrue(livingEntity.isHandRaised());
 		assertEquals(EquipmentSlot.HAND, livingEntity.getHandRaised());
 	}
@@ -723,7 +724,8 @@ class LivingEntityMockTest
 	@Test
 	void testSetHandRaisedOffHand()
 	{
-		livingEntity.setHandRaised(true, EquipmentSlot.OFF_HAND);
+		livingEntity.getEquipment().setItemInOffHand(new org.bukkit.inventory.ItemStack(org.bukkit.Material.SHIELD));
+		livingEntity.startUsingItem(EquipmentSlot.OFF_HAND);
 		assertTrue(livingEntity.isHandRaised());
 		assertEquals(EquipmentSlot.OFF_HAND, livingEntity.getHandRaised());
 	}
@@ -731,10 +733,11 @@ class LivingEntityMockTest
 	@Test
 	void testSetHandRaisedFalse()
 	{
-		livingEntity.setHandRaised(true, EquipmentSlot.HAND);
+		livingEntity.getEquipment().setItemInMainHand(new org.bukkit.inventory.ItemStack(org.bukkit.Material.BOW));
+		livingEntity.startUsingItem(EquipmentSlot.HAND);
 		assertTrue(livingEntity.isHandRaised());
 
-		livingEntity.setHandRaised(false, null);
+		livingEntity.clearActiveItem();
 		assertFalse(livingEntity.isHandRaised());
 	}
 
@@ -742,6 +745,194 @@ class LivingEntityMockTest
 	void testGetHandRaisedWhenNotRaised()
 	{
 		assertThrows(IllegalStateException.class, () -> livingEntity.getHandRaised());
+	}
+
+	// Active Item Tests
+
+	@Test
+	void testHasActiveItemDefault()
+	{
+		assertFalse(livingEntity.hasActiveItem());
+	}
+
+	@Test
+	void testStartUsingItemMainHand()
+	{
+		livingEntity.getEquipment().setItemInMainHand(new org.bukkit.inventory.ItemStack(org.bukkit.Material.APPLE));
+		livingEntity.startUsingItem(EquipmentSlot.HAND);
+
+		assertTrue(livingEntity.hasActiveItem());
+		assertEquals(org.bukkit.Material.APPLE, livingEntity.getActiveItem().getType());
+		assertEquals(EquipmentSlot.HAND, livingEntity.getActiveItemHand());
+	}
+
+	@Test
+	void testStartUsingItemOffHand()
+	{
+		livingEntity.getEquipment().setItemInOffHand(new org.bukkit.inventory.ItemStack(org.bukkit.Material.GOLDEN_APPLE));
+		livingEntity.startUsingItem(EquipmentSlot.OFF_HAND);
+
+		assertTrue(livingEntity.hasActiveItem());
+		assertEquals(org.bukkit.Material.GOLDEN_APPLE, livingEntity.getActiveItem().getType());
+		assertEquals(EquipmentSlot.OFF_HAND, livingEntity.getActiveItemHand());
+	}
+
+	@Test
+	void testStartUsingItemWithAirDoesNothing()
+	{
+		livingEntity.getEquipment().setItemInMainHand(new org.bukkit.inventory.ItemStack(org.bukkit.Material.AIR));
+		livingEntity.startUsingItem(EquipmentSlot.HAND);
+
+		assertFalse(livingEntity.hasActiveItem());
+	}
+
+	@Test
+	void testStartUsingItemInvalidHand()
+	{
+		assertThrows(IllegalArgumentException.class, () -> livingEntity.startUsingItem(EquipmentSlot.HEAD));
+	}
+
+	@Test
+	void testGetItemInUse()
+	{
+		assertNull(livingEntity.getItemInUse());
+
+		livingEntity.getEquipment().setItemInMainHand(new org.bukkit.inventory.ItemStack(org.bukkit.Material.BOW));
+		livingEntity.startUsingItem(EquipmentSlot.HAND);
+
+		assertNotNull(livingEntity.getItemInUse());
+		assertEquals(org.bukkit.Material.BOW, livingEntity.getItemInUse().getType());
+	}
+
+	@Test
+	void testGetActiveItemReturnsAirWhenNone()
+	{
+		org.bukkit.inventory.ItemStack item = livingEntity.getActiveItem();
+		assertNotNull(item);
+		assertEquals(org.bukkit.Material.AIR, item.getType());
+	}
+
+	@Test
+	void testClearActiveItem()
+	{
+		livingEntity.getEquipment().setItemInMainHand(new org.bukkit.inventory.ItemStack(org.bukkit.Material.APPLE));
+		livingEntity.startUsingItem(EquipmentSlot.HAND);
+		assertTrue(livingEntity.hasActiveItem());
+
+		livingEntity.clearActiveItem();
+		assertFalse(livingEntity.hasActiveItem());
+		assertNull(livingEntity.getItemInUse());
+	}
+
+	@Test
+	void testCompleteUsingActiveItem()
+	{
+		livingEntity.getEquipment().setItemInMainHand(new org.bukkit.inventory.ItemStack(org.bukkit.Material.APPLE));
+		livingEntity.startUsingItem(EquipmentSlot.HAND);
+		assertTrue(livingEntity.hasActiveItem());
+
+		livingEntity.completeUsingActiveItem();
+		assertFalse(livingEntity.hasActiveItem());
+	}
+
+	@Test
+	void testGetItemInUseTicks()
+	{
+		assertEquals(0, livingEntity.getItemInUseTicks());
+
+		livingEntity.getEquipment().setItemInMainHand(new org.bukkit.inventory.ItemStack(org.bukkit.Material.APPLE));
+		livingEntity.startUsingItem(EquipmentSlot.HAND);
+		assertEquals(0, livingEntity.getItemInUseTicks());
+
+		livingEntity.setItemInUseTicks(10);
+		assertEquals(10, livingEntity.getItemInUseTicks());
+	}
+
+	@Test
+	void testSetItemInUseTicks()
+	{
+		livingEntity.getEquipment().setItemInMainHand(new org.bukkit.inventory.ItemStack(org.bukkit.Material.APPLE));
+		livingEntity.startUsingItem(EquipmentSlot.HAND);
+
+		livingEntity.setItemInUseTicks(5);
+		assertEquals(5, livingEntity.getItemInUseTicks());
+		assertEquals(5, livingEntity.getActiveItemUsedTime());
+	}
+
+	@Test
+	void testSetItemInUseTicksNegativeThrows()
+	{
+		assertThrows(IllegalArgumentException.class, () -> livingEntity.setItemInUseTicks(-1));
+	}
+
+	@Test
+	void testGetActiveItemUsedTime()
+	{
+		livingEntity.getEquipment().setItemInMainHand(new org.bukkit.inventory.ItemStack(org.bukkit.Material.APPLE));
+		livingEntity.startUsingItem(EquipmentSlot.HAND);
+
+		assertEquals(0, livingEntity.getActiveItemUsedTime());
+
+		livingEntity.setItemInUseTicks(20);
+		assertEquals(20, livingEntity.getActiveItemUsedTime());
+	}
+
+	@Test
+	void testGetActiveItemHandWhenNoActiveItem()
+	{
+		assertThrows(IllegalStateException.class, () -> livingEntity.getActiveItemHand());
+	}
+
+	@Test
+	void testGetActiveItemRemainingTime()
+	{
+		assertEquals(0, livingEntity.getActiveItemRemainingTime());
+
+		livingEntity.getEquipment().setItemInMainHand(new org.bukkit.inventory.ItemStack(org.bukkit.Material.APPLE));
+		livingEntity.startUsingItem(EquipmentSlot.HAND);
+
+		// Default max duration is 32 ticks
+		int maxDuration = 32;
+		assertEquals(maxDuration, livingEntity.getActiveItemRemainingTime());
+
+		livingEntity.setItemInUseTicks(10);
+		assertEquals(maxDuration - 10, livingEntity.getActiveItemRemainingTime());
+	}
+
+	@Test
+	void testGetItemUseRemainingTime()
+	{
+		livingEntity.getEquipment().setItemInMainHand(new org.bukkit.inventory.ItemStack(org.bukkit.Material.APPLE));
+		livingEntity.startUsingItem(EquipmentSlot.HAND);
+
+		assertEquals(livingEntity.getActiveItemRemainingTime(), livingEntity.getItemUseRemainingTime());
+	}
+
+	@Test
+	void testSetActiveItemRemainingTime()
+	{
+		livingEntity.getEquipment().setItemInMainHand(new org.bukkit.inventory.ItemStack(org.bukkit.Material.APPLE));
+		livingEntity.startUsingItem(EquipmentSlot.HAND);
+
+		// Default max duration is 32 ticks
+		int maxDuration = 32;
+
+		livingEntity.setActiveItemRemainingTime(10);
+		assertEquals(10, livingEntity.getActiveItemRemainingTime());
+		assertEquals(maxDuration - 10, livingEntity.getActiveItemUsedTime());
+	}
+
+	@Test
+	void testSetActiveItemRemainingTimeNegativeThrows()
+	{
+		assertThrows(IllegalArgumentException.class, () -> livingEntity.setActiveItemRemainingTime(-1));
+	}
+
+	@Test
+	void testSetActiveItemRemainingTimeWithNoActiveItem()
+	{
+		// Should not throw, just do nothing
+		assertDoesNotThrow(() -> livingEntity.setActiveItemRemainingTime(10));
 	}
 
 }


### PR DESCRIPTION
- Added handRaised boolean field to track if a hand is raised
- Added raisedHand field to track which hand is raised (HAND or OFF_HAND)
- Implemented isHandRaised() to return the hand raised state
- Implemented getHandRaised() to return which hand is raised
- Added setHandRaised(boolean, EquipmentSlot) to allow setting state
- getHandRaised() throws IllegalStateException if no hand is raised
- Added comprehensive tests for all hand raised behaviors
