### PR TITLE
Scheduler miscellaneous improvements

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -546,8 +546,15 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	@Override
 	public @NotNull List<BukkitTask> getPendingTasks()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		List<BukkitTask> pendingTasks = new ArrayList<>();
+		for (ScheduledTask task : scheduledTasks.getCurrentTaskList())
+		{
+			if (!task.isCancelled())
+			{
+				pendingTasks.add(task);
+			}
+		}
+		return Collections.unmodifiableList(pendingTasks);
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -521,7 +521,8 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	@Override
 	public boolean isCurrentlyRunning(int taskId)
 	{
-		return scheduledTasks.tasks.containsKey(taskId);
+		ScheduledTask task = scheduledTasks.getTask(taskId);
+		return task != null && task.isRunning();
 	}
 
 	@Override
@@ -748,6 +749,11 @@ public class BukkitSchedulerMock implements BukkitScheduler
 			}
 			tasks.put(task.getTaskId(), task);
 			return true;
+		}
+
+		private @Nullable ScheduledTask getTask(int taskId)
+		{
+			return tasks.get(taskId);
 		}
 
 		protected final @NotNull List<ScheduledTask> getCurrentTaskList()

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -335,7 +335,6 @@ public class BukkitSchedulerMock implements BukkitScheduler
 					continue;
 				}
 				task.cancel();
-				cancelTask(task.getTaskId());
 				throw new TaskCancelledException("Forced Cancellation of task owned by " + task.getOwner().getName());
 			}
 			pool.shutdownNow();
@@ -730,6 +729,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	private static class TaskList
 	{
 
+		// Do not directly access this field from outside TaskList, use a method
 		private final @NotNull Map<Integer, ScheduledTask> tasks;
 
 		private TaskList()

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -102,9 +102,10 @@ public class BukkitSchedulerMock implements BukkitScheduler
 		waitAsyncTasksFinished();
 		shutdownPool(pool);
 
-		if (asyncException.get() != null)
+		Exception asyncException = this.asyncException.get(); // Single read from volatile variable
+		if (asyncException != null)
 		{
-			throw new AsyncTaskException(asyncException.get());
+			throw new AsyncTaskException(asyncException);
 		}
 
 		waitAsyncEventsFinished();

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -261,7 +261,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	/**
 	 * Perform a number of ticks on the server.
 	 *
-	 * @param ticks The number of ticks to executed.
+	 * @param ticks The number of ticks to execute.
 	 */
 	public void performTicks(long ticks)
 	{

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -528,14 +528,8 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	@Override
 	public boolean isQueued(int taskId)
 	{
-		for (ScheduledTask task : scheduledTasks.getCurrentTaskList())
-		{
-			if (task.getTaskId() == taskId)
-			{
-				return !task.isCancelled();
-			}
-		}
-		return false;
+		ScheduledTask task = scheduledTasks.getTask(taskId);
+		return task != null && !task.isCancelled();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -218,8 +218,8 @@ public class BukkitSchedulerMock implements BukkitScheduler
 			}
 			else
 			{
-				pool.submit(wrapTask(task));
 				task.submitted();
+				pool.submit(wrapTask(task));
 			}
 
 			if (task instanceof RepeatingTask repeatingTask)

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/ScheduledTask.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/ScheduledTask.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 /**
@@ -22,7 +23,7 @@ public class ScheduledTask implements BukkitTask, BukkitWorker
 	private final int id;
 	private final Plugin plugin;
 	private final boolean isSync;
-	private volatile boolean isCancelled = false;
+	private final AtomicBoolean isCancelled = new AtomicBoolean(false);
 	private volatile long scheduledTick;
 	private volatile boolean running;
 	private final @Nullable Runnable runnable;
@@ -204,14 +205,17 @@ public class ScheduledTask implements BukkitTask, BukkitWorker
 	@Override
 	public boolean isCancelled()
 	{
-		return this.isCancelled;
+		return this.isCancelled.get();
 	}
 
 	@Override
 	public void cancel()
 	{
-		this.isCancelled = true;
-		this.cancelListeners.forEach(Runnable::run);
+		boolean wasCancelled = this.isCancelled.getAndSet(true);
+		if (!wasCancelled)
+		{
+			this.cancelListeners.forEach(Runnable::run);
+		}
 	}
 
 	/**

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/ScheduledTask.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/ScheduledTask.java
@@ -219,8 +219,9 @@ public class ScheduledTask implements BukkitTask, BukkitWorker
 	 *
 	 * @param callback The callback which gets executed when the task is cancelled.
 	 */
-	public void addOnCancelled(Runnable callback)
+	public void addOnCancelled(@NotNull Runnable callback)
 	{
+		Preconditions.checkNotNull(callback, "Runnable cannot be null");
 		this.cancelListeners.add(callback);
 	}
 

--- a/src/test/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMockTest.java
@@ -542,11 +542,13 @@ class BukkitSchedulerMockTest
 	@Test
 	void taskIsRunning()
 	{
-		BukkitTask bukkitTask = scheduler.runTaskTimer(null, () ->
+		AtomicBoolean running = new AtomicBoolean(false);
+		scheduler.runTaskTimer(null, (task) ->
 		{
+			running.set(scheduler.isCurrentlyRunning(task.getTaskId()));
 		}, 1L, 1L);
 		scheduler.performOneTick();
-		assertTrue(scheduler.isCurrentlyRunning(bukkitTask.getTaskId()));
+		assertTrue(running.get());
 	}
 
 	@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMockTest.java
@@ -23,6 +23,7 @@ import org.mockbukkit.mockbukkit.plugin.TestPlugin;
 import org.mockbukkit.mockbukkit.world.WorldMock;
 
 import java.lang.reflect.Field;
+import java.util.List;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
@@ -555,6 +556,54 @@ class BukkitSchedulerMockTest
 	void taskNotRunning()
 	{
 		assertFalse(scheduler.isCurrentlyRunning(Integer.MAX_VALUE));
+	}
+
+	@Test
+	void pendingTasks()
+	{
+		BukkitTask done = scheduler.runTask(null, () ->
+		{
+		});
+		scheduler.performOneTick();
+
+		BukkitTask task = scheduler.runTask(null, () ->
+		{
+		});
+		List<BukkitTask> pending = scheduler.getPendingTasks();
+		assertTrue(pending.contains(task));
+		assertFalse(pending.contains(done));
+	}
+
+	@Test
+	void taskRunningQueuedPending()
+	{
+		AtomicBoolean run = new AtomicBoolean(false);
+		BukkitTask done = scheduler.runTask(null, () ->
+		{
+		});
+		scheduler.runTaskLater(null, task ->
+		{
+			BukkitTask toRun = scheduler.runTask(null, () ->
+			{
+				throw new RuntimeException("Task wasn't supposed to run");
+			});
+			assertFalse(scheduler.isCurrentlyRunning(done.getTaskId()));
+			assertFalse(scheduler.isQueued(done.getTaskId()));
+			assertFalse(scheduler.getPendingTasks().contains(done));
+
+			assertTrue(scheduler.isCurrentlyRunning(task.getTaskId()));
+			assertTrue(scheduler.isQueued(task.getTaskId()));
+			assertTrue(scheduler.getPendingTasks().contains(task));
+
+			assertFalse(scheduler.isCurrentlyRunning(toRun.getTaskId()));
+			assertTrue(scheduler.isQueued(toRun.getTaskId()));
+			assertTrue(scheduler.getPendingTasks().contains(toRun));
+
+			run.set(true);
+		}, 2);
+
+		scheduler.performTicks(2);
+		assertTrue(run.get(), "Did not run");
 	}
 
 	@Test


### PR DESCRIPTION
# Description

While implementing #1509 I noticed a couple of improvements that could be applied to the scheduler code. I would suggest to review this commit by commit. I decided to make only one PR, but I can split it up if you prefer so.

Major changes introduced in this PR:
* Tasks' cancel listeners are not run again if the task is already cancelled. This ensures the `cancel` method can be called multiple times
* Implements `getPendingTasks()`
* `isCurrentlyRunning` was implemented incorrectly. I checked the new implementation behaves like the latest Spigot/Paper 1.21.11 build and added the test I used to the unit tests (`taskRunningQueuedPending`).

# Checklist

The following items should be checked before the pull request can be merged.

- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
