### PR TITLE
feat: implement ItemStack cooldown methods in HumanEntityMock

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/HumanEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/HumanEntityMock.java
@@ -39,7 +39,9 @@ import org.mockbukkit.mockbukkit.world.WorldMock;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -59,6 +61,7 @@ public abstract class HumanEntityMock extends LivingEntityMock implements HumanE
 	private final Set<NamespacedKey> discoveredRecipes = new HashSet<>();
 	private final PlayerInventoryMock inventory = new PlayerInventoryMock(this);
 	private final EnderChestInventoryMock enderChest = new EnderChestInventoryMock(this);
+	private final Map<Material, Integer> cooldowns = new HashMap<>();
 	private InventoryView inventoryView;
 	private @NotNull ItemStack cursor = ItemStack.empty();
 	private @NotNull GameMode gameMode = GameMode.SURVIVAL;
@@ -372,10 +375,11 @@ public abstract class HumanEntityMock extends LivingEntityMock implements HumanE
 	@Override
 	public boolean hasCooldown(@NotNull ItemStack itemStack)
 	{
-		Preconditions.checkArgument(itemStack != null, "Material cannot be null");
+		Preconditions.checkArgument(itemStack != null, "ItemStack cannot be null");
 
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Material material = itemStack.getType();
+		Integer cooldown = this.cooldowns.get(material);
+		return cooldown != null && cooldown > 0;
 	}
 
 	@Override
@@ -383,17 +387,25 @@ public abstract class HumanEntityMock extends LivingEntityMock implements HumanE
 	{
 		Preconditions.checkArgument(itemStack != null, "ItemStack cannot be null");
 
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Material material = itemStack.getType();
+		return this.cooldowns.getOrDefault(material, 0);
 	}
 
 	@Override
 	public void setCooldown(@NotNull ItemStack itemStack, int ticks)
 	{
 		Preconditions.checkArgument(itemStack != null, "ItemStack cannot be null");
+		Preconditions.checkArgument(ticks >= 0, "Cooldown ticks must be greater than or equal to 0");
 
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Material material = itemStack.getType();
+		if (ticks <= 0)
+		{
+			this.cooldowns.remove(material);
+		}
+		else
+		{
+			this.cooldowns.put(material, ticks);
+		}
 	}
 
 	@Override
@@ -743,6 +755,19 @@ public abstract class HumanEntityMock extends LivingEntityMock implements HumanE
 	{
 		// TODO: Auto generated stub
 		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public void tick()
+	{
+		super.tick();
+
+		// Decrease all cooldowns by 1 tick
+		this.cooldowns.entrySet().removeIf(entry ->
+		{
+			entry.setValue(entry.getValue() - 1);
+			return entry.getValue() <= 0;
+		});
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/HumanEntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/HumanEntityMockTest.java
@@ -601,4 +601,177 @@ class HumanEntityMockTest
 
 	}
 
+	@Nested
+	class ItemStackCooldown
+	{
+
+		@Test
+		void setCooldown_SetsCooldownForItemStack()
+		{
+			ItemStackMock item = new ItemStackMock(Material.ENDER_PEARL);
+			human.setCooldown(item, 20);
+
+			assertEquals(20, human.getCooldown(item));
+			assertTrue(human.hasCooldown(item));
+		}
+
+		@Test
+		void setCooldown_ZeroTicks_RemovesCooldown()
+		{
+			ItemStackMock item = new ItemStackMock(Material.ENDER_PEARL);
+			human.setCooldown(item, 20);
+			human.setCooldown(item, 0);
+
+			assertEquals(0, human.getCooldown(item));
+			assertFalse(human.hasCooldown(item));
+		}
+
+		@Test
+		void getCooldown_NoCooldown_ReturnsZero()
+		{
+			ItemStackMock item = new ItemStackMock(Material.ENDER_PEARL);
+
+			assertEquals(0, human.getCooldown(item));
+		}
+
+		@Test
+		void hasCooldown_NoCooldown_ReturnsFalse()
+		{
+			ItemStackMock item = new ItemStackMock(Material.ENDER_PEARL);
+
+			assertFalse(human.hasCooldown(item));
+		}
+
+		@Test
+		void setCooldown_DifferentItemsShareMaterialCooldown()
+		{
+			ItemStackMock item1 = new ItemStackMock(Material.ENDER_PEARL);
+			ItemStackMock item2 = new ItemStackMock(Material.ENDER_PEARL);
+
+			human.setCooldown(item1, 30);
+
+			assertEquals(30, human.getCooldown(item2));
+			assertTrue(human.hasCooldown(item2));
+		}
+
+		@Test
+		void setCooldown_DifferentMaterialsHaveSeparateCooldowns()
+		{
+			ItemStackMock enderPearl = new ItemStackMock(Material.ENDER_PEARL);
+			ItemStackMock chorus = new ItemStackMock(Material.CHORUS_FRUIT);
+
+			human.setCooldown(enderPearl, 20);
+			human.setCooldown(chorus, 40);
+
+			assertEquals(20, human.getCooldown(enderPearl));
+			assertEquals(40, human.getCooldown(chorus));
+		}
+
+		@Test
+		void setCooldown_UpdatesExistingCooldown()
+		{
+			ItemStackMock item = new ItemStackMock(Material.ENDER_PEARL);
+
+			human.setCooldown(item, 20);
+			assertEquals(20, human.getCooldown(item));
+
+			human.setCooldown(item, 50);
+			assertEquals(50, human.getCooldown(item));
+		}
+
+		@Test
+		void setCooldown_MaterialDelegatesToItemStack()
+		{
+			human.setCooldown(Material.ENDER_PEARL, 25);
+
+			ItemStackMock item = new ItemStackMock(Material.ENDER_PEARL);
+			assertEquals(25, human.getCooldown(item));
+			assertTrue(human.hasCooldown(item));
+		}
+
+		@Test
+		void hasCooldown_MaterialDelegatesToItemStack()
+		{
+			ItemStackMock item = new ItemStackMock(Material.ENDER_PEARL);
+			human.setCooldown(item, 30);
+
+			assertTrue(human.hasCooldown(Material.ENDER_PEARL));
+		}
+
+		@Test
+		void getCooldown_MaterialDelegatesToItemStack()
+		{
+			ItemStackMock item = new ItemStackMock(Material.ENDER_PEARL);
+			human.setCooldown(item, 35);
+
+			assertEquals(35, human.getCooldown(Material.ENDER_PEARL));
+		}
+
+		@Test
+		void tick_DecreasesCooldownByOne()
+		{
+			ItemStackMock item = new ItemStackMock(Material.ENDER_PEARL);
+			human.setCooldown(item, 5);
+
+			human.tick();
+
+			assertEquals(4, human.getCooldown(item));
+			assertTrue(human.hasCooldown(item));
+		}
+
+		@Test
+		void tick_RemovesCooldownWhenReachesZero()
+		{
+			ItemStackMock item = new ItemStackMock(Material.ENDER_PEARL);
+			human.setCooldown(item, 1);
+
+			human.tick();
+
+			assertEquals(0, human.getCooldown(item));
+			assertFalse(human.hasCooldown(item));
+		}
+
+		@Test
+		void tick_MultipleTicks_DecreasesCooldown()
+		{
+			ItemStackMock item = new ItemStackMock(Material.ENDER_PEARL);
+			human.setCooldown(item, 10);
+
+			for (int i = 0; i < 5; i++)
+			{
+				human.tick();
+			}
+
+			assertEquals(5, human.getCooldown(item));
+			assertTrue(human.hasCooldown(item));
+		}
+
+		@Test
+		void tick_HandlesMultipleCooldownsSimultaneously()
+		{
+			ItemStackMock enderPearl = new ItemStackMock(Material.ENDER_PEARL);
+			ItemStackMock chorus = new ItemStackMock(Material.CHORUS_FRUIT);
+
+			human.setCooldown(enderPearl, 10);
+			human.setCooldown(chorus, 5);
+
+			human.tick();
+
+			assertEquals(9, human.getCooldown(enderPearl));
+			assertEquals(4, human.getCooldown(chorus));
+
+			// Tick 4 more times
+			for (int i = 0; i < 4; i++)
+			{
+				human.tick();
+			}
+
+			assertEquals(5, human.getCooldown(enderPearl));
+			assertEquals(0, human.getCooldown(chorus));
+			assertTrue(human.hasCooldown(enderPearl));
+			assertFalse(human.hasCooldown(chorus));
+		}
+
+	}
+
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/HumanEntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/HumanEntityMockTest.java
@@ -713,7 +713,7 @@ class HumanEntityMockTest
 			ItemStackMock item = new ItemStackMock(Material.ENDER_PEARL);
 			human.setCooldown(item, 5);
 
-			human.tick();
+			server.getScheduler().performTicks(1);
 
 			assertEquals(4, human.getCooldown(item));
 			assertTrue(human.hasCooldown(item));
@@ -725,7 +725,7 @@ class HumanEntityMockTest
 			ItemStackMock item = new ItemStackMock(Material.ENDER_PEARL);
 			human.setCooldown(item, 1);
 
-			human.tick();
+			server.getScheduler().performTicks(1);
 
 			assertEquals(0, human.getCooldown(item));
 			assertFalse(human.hasCooldown(item));
@@ -737,10 +737,7 @@ class HumanEntityMockTest
 			ItemStackMock item = new ItemStackMock(Material.ENDER_PEARL);
 			human.setCooldown(item, 10);
 
-			for (int i = 0; i < 5; i++)
-			{
-				human.tick();
-			}
+			server.getScheduler().performTicks(5);
 
 			assertEquals(5, human.getCooldown(item));
 			assertTrue(human.hasCooldown(item));
@@ -755,16 +752,12 @@ class HumanEntityMockTest
 			human.setCooldown(enderPearl, 10);
 			human.setCooldown(chorus, 5);
 
-			human.tick();
+			server.getScheduler().performTicks(1);
 
 			assertEquals(9, human.getCooldown(enderPearl));
 			assertEquals(4, human.getCooldown(chorus));
 
-			// Tick 4 more times
-			for (int i = 0; i < 4; i++)
-			{
-				human.tick();
-			}
+			server.getScheduler().performTicks(4);
 
 			assertEquals(5, human.getCooldown(enderPearl));
 			assertEquals(0, human.getCooldown(chorus));

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/HumanEntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/HumanEntityMockTest.java
@@ -15,6 +15,7 @@ import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerGameModeChangeEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.MainHand;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -32,7 +33,9 @@ import org.mockbukkit.mockbukkit.inventory.InventoryViewMock;
 import org.mockbukkit.mockbukkit.inventory.ItemStackMock;
 import org.mockbukkit.mockbukkit.inventory.SimpleInventoryViewMock;
 
+import java.lang.reflect.Field;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -45,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockbukkit.mockbukkit.matcher.plugin.PluginManagerFiredEventFilterMatcher.hasFiredFilteredEvent;
 
@@ -627,6 +631,47 @@ class HumanEntityMockTest
 		}
 
 		@Test
+		void setCooldown_NullItemStack_ThrowsException()
+		{
+			assertThrows(IllegalArgumentException.class, () -> human.setCooldown((ItemStack) null, 10));
+		}
+
+		@Test
+		void setCooldown_NegativeTicks_ThrowsException()
+		{
+			ItemStackMock item = new ItemStackMock(Material.ENDER_PEARL);
+			assertThrows(IllegalArgumentException.class, () -> human.setCooldown(item, -1));
+		}
+
+		@Test
+		void hasCooldown_NullItemStack_ThrowsException()
+		{
+			assertThrows(IllegalArgumentException.class, () -> human.hasCooldown((ItemStack) null));
+		}
+
+		@Test
+		void getCooldown_NullItemStack_ThrowsException()
+		{
+			assertThrows(IllegalArgumentException.class, () -> human.getCooldown((ItemStack) null));
+		}
+
+		@Test
+		void hasCooldown_ZeroCooldownInMap_ReturnsFalse() throws Exception
+		{
+			// Use reflection to set a zero cooldown value in the map
+			// This tests the edge case where cooldown is not null but is <= 0
+			Field cooldownsField = HumanEntityMock.class.getDeclaredField("cooldowns");
+			cooldownsField.setAccessible(true);
+			@SuppressWarnings("unchecked")
+			Map<Material, Integer> cooldowns = (Map<Material, Integer>) cooldownsField.get(human);
+			cooldowns.put(Material.ENDER_PEARL, 0);
+
+			ItemStackMock item = new ItemStackMock(Material.ENDER_PEARL);
+			assertFalse(human.hasCooldown(item));
+			assertEquals(0, human.getCooldown(item));
+		}
+
+		@Test
 		void getCooldown_NoCooldown_ReturnsZero()
 		{
 			ItemStackMock item = new ItemStackMock(Material.ENDER_PEARL);
@@ -705,6 +750,42 @@ class HumanEntityMockTest
 			human.setCooldown(item, 35);
 
 			assertEquals(35, human.getCooldown(Material.ENDER_PEARL));
+		}
+
+		@Test
+		void setCooldown_Material_NullMaterial_ThrowsException()
+		{
+			assertThrows(IllegalArgumentException.class, () -> human.setCooldown((Material) null, 10));
+		}
+
+		@Test
+		void setCooldown_Material_NonItemMaterial_ThrowsException()
+		{
+			assertThrows(IllegalArgumentException.class, () -> human.setCooldown(Material.WATER, 10));
+		}
+
+		@Test
+		void hasCooldown_Material_NullMaterial_ThrowsException()
+		{
+			assertThrows(IllegalArgumentException.class, () -> human.hasCooldown((Material) null));
+		}
+
+		@Test
+		void hasCooldown_Material_NonItemMaterial_ThrowsException()
+		{
+			assertThrows(IllegalArgumentException.class, () -> human.hasCooldown(Material.WATER));
+		}
+
+		@Test
+		void getCooldown_Material_NullMaterial_ThrowsException()
+		{
+			assertThrows(IllegalArgumentException.class, () -> human.getCooldown((Material) null));
+		}
+
+		@Test
+		void getCooldown_Material_NonItemMaterial_ThrowsException()
+		{
+			assertThrows(IllegalArgumentException.class, () -> human.getCooldown(Material.WATER));
 		}
 
 		@Test


### PR DESCRIPTION
## Summary
  - Implemented `setCooldown(ItemStack, int)` to set/remove cooldowns for ItemStack materials
  - Implemented `hasCooldown(ItemStack)` to check for active cooldowns
  - Implemented `getCooldown(ItemStack)` to get remaining cooldown ticks
  - Added tick integration to automatically decrease cooldowns each game tick

  ## Implementation Details
  - Added `cooldowns` HashMap to store Material -> tick count mappings
  - Cooldowns are tracked by Material type (multiple ItemStacks of the same material share cooldowns)
  - Cooldowns automatically decrease by 1 each tick via the `tick()` method
  - Cooldowns are removed when they reach 0
  - Existing Material-based cooldown methods now delegate to ItemStack methods

  ## Test Plan
  - [x] Basic cooldown set/get/has operations
  - [x] Cooldown removal with zero ticks
  - [x] Multiple materials with separate cooldowns
  - [x] Tick-based cooldown decay using server scheduler
  - [x] Multiple cooldowns decreasing simultaneously
  - [x] Material-based methods delegation to ItemStack methods
  - [x] All existing tests still pass
