### PR TITLE
Add Player Argument Type for Brigadier

### DIFF
--- a/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProviderMock.java
+++ b/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProviderMock.java
@@ -1,0 +1,265 @@
+package io.papermc.paper.command.brigadier.argument;
+
+import com.mojang.brigadier.arguments.ArgumentType;
+import io.papermc.paper.command.brigadier.argument.predicate.BlockInWorldPredicate;
+import io.papermc.paper.command.brigadier.argument.predicate.ItemStackPredicate;
+import io.papermc.paper.command.brigadier.argument.range.DoubleRangeProvider;
+import io.papermc.paper.command.brigadier.argument.range.IntegerRangeProvider;
+import io.papermc.paper.command.brigadier.argument.resolvers.AngleResolver;
+import io.papermc.paper.command.brigadier.argument.resolvers.BlockPositionResolver;
+import io.papermc.paper.command.brigadier.argument.resolvers.ColumnBlockPositionResolver;
+import io.papermc.paper.command.brigadier.argument.resolvers.ColumnFinePositionResolver;
+import io.papermc.paper.command.brigadier.argument.resolvers.FinePositionResolver;
+import io.papermc.paper.command.brigadier.argument.resolvers.PlayerProfileListResolver;
+import io.papermc.paper.command.brigadier.argument.resolvers.RotationResolver;
+import io.papermc.paper.command.brigadier.argument.resolvers.selector.EntitySelectorArgumentResolver;
+import io.papermc.paper.command.brigadier.argument.resolvers.selector.PlayerSelectorArgumentResolver;
+import io.papermc.paper.entity.LookAnchor;
+import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.registry.TypedKey;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextColor;
+import org.bukkit.GameMode;
+import org.bukkit.HeightMap;
+import org.bukkit.NamespacedKey;
+import org.bukkit.World;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.structure.Mirror;
+import org.bukkit.block.structure.StructureRotation;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.scoreboard.Criteria;
+import org.bukkit.scoreboard.DisplaySlot;
+import org.mockbukkit.mockbukkit.command.brigadier.argument.PlayerArgumentTypeMock;
+import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
+
+import java.util.UUID;
+
+public class VanillaArgumentProviderMock implements VanillaArgumentProvider
+{
+
+	@Override
+	public ArgumentType<Component> component()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<Key> key()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<Integer> time(int min)
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<Style> style()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public <T> ArgumentType<T> resource(RegistryKey<T> registryKey)
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public <T> ArgumentType<TypedKey<T>> resourceKey(RegistryKey<T> registryKey)
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<SignedMessageResolver> signedMessage()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<EntitySelectorArgumentResolver> entity()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<HeightMap> heightMap()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<TextColor> hexColor()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<BlockState> blockState()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<LookAnchor> entityAnchor()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<RotationResolver> rotation()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<PlayerProfileListResolver> playerProfiles()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<Mirror> templateMirror()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<DoubleRangeProvider> doubleRange()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<IntegerRangeProvider> integerRange()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<ColumnFinePositionResolver> columnFinePosition(boolean centerIntegers)
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<StructureRotation> templateRotation()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<BlockPositionResolver> blockPosition()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<FinePositionResolver> finePosition(boolean centerIntegers)
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<ItemStackPredicate> itemStackPredicate()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<Criteria> objectiveCriteria()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<GameMode> gameMode()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<AxisSet> axes()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<EntitySelectorArgumentResolver> entities()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<World> world()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<PlayerSelectorArgumentResolver> player()
+	{
+		return new PlayerArgumentTypeMock();
+	}
+
+	@Override
+	public ArgumentType<PlayerSelectorArgumentResolver> players()
+	{
+		return new PlayerArgumentTypeMock(false);
+	}
+
+	@Override
+	public ArgumentType<UUID> uuid()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<NamedTextColor> namedColor()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<ItemStack> itemStack()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<AngleResolver> angle()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<DisplaySlot> scoreboardDisplaySlot()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<ColumnBlockPositionResolver> columnBlockPosition()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<BlockInWorldPredicate> blockInWorldPredicate()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public ArgumentType<NamespacedKey> namespacedKey()
+	{
+		throw new UnimplementedOperationException();
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/command/brigadier/argument/PlayerArgumentTypeMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/command/brigadier/argument/PlayerArgumentTypeMock.java
@@ -1,0 +1,37 @@
+package org.mockbukkit.mockbukkit.command.brigadier.argument;
+
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import io.papermc.paper.command.brigadier.argument.resolvers.selector.PlayerSelectorArgumentResolver;
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public class PlayerArgumentTypeMock implements ArgumentType<PlayerSelectorArgumentResolver>
+{
+
+	private final boolean single;
+
+	public PlayerArgumentTypeMock()
+	{
+		this(true);
+	}
+
+	public PlayerArgumentTypeMock(boolean single)
+	{
+		this.single = single;
+	}
+
+	@Override
+	public PlayerSelectorArgumentResolver parse(StringReader reader) throws CommandSyntaxException
+	{
+		int start = reader.getCursor();
+		while (reader.canRead() && !Character.isWhitespace(reader.peek()))
+		{
+			reader.skip();
+		}
+		String input = reader.getString().substring(start, reader.getCursor());
+		return new PlayerSelectorArgumentResolverMock(input, single);
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/command/brigadier/argument/PlayerSelectorArgumentResolverMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/command/brigadier/argument/PlayerSelectorArgumentResolverMock.java
@@ -86,7 +86,8 @@ public class PlayerSelectorArgumentResolverMock implements PlayerSelectorArgumen
 			case "@r" ->
 			{
 				List<Player> players = new ArrayList<>(Bukkit.getOnlinePlayers());
-				if (players.isEmpty()) {
+				if (players.isEmpty())
+				{
 					yield Collections.emptyList();
 				}
 				Collections.shuffle(players);

--- a/src/main/java/org/mockbukkit/mockbukkit/command/brigadier/argument/PlayerSelectorArgumentResolverMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/command/brigadier/argument/PlayerSelectorArgumentResolverMock.java
@@ -1,0 +1,97 @@
+package org.mockbukkit.mockbukkit.command.brigadier.argument;
+
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import io.papermc.paper.command.brigadier.argument.resolvers.selector.PlayerSelectorArgumentResolver;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@ApiStatus.Internal
+public class PlayerSelectorArgumentResolverMock implements PlayerSelectorArgumentResolver
+{
+
+	private final String input;
+	private final boolean single;
+
+	public PlayerSelectorArgumentResolverMock(String input, boolean single)
+	{
+		this.input = input;
+		this.single = single;
+	}
+
+	@Override
+	public @NotNull List<Player> resolve(@NotNull CommandSourceStack source)
+	{
+		if (single && input.equals("@a"))
+		{
+			String message = org.mockbukkit.mockbukkit.adventure.Languages.getInstance().getOrDefault("command.expected.a_single_player", "Only one player is allowed, but the provided selector allows more than one");
+			source.getSender().sendMessage(message);
+			return Collections.emptyList();
+		}
+
+		List<Player> resolved;
+		if (input.startsWith("@"))
+		{
+			resolved = resolveSelector(input, source);
+		}
+		else
+		{
+			Player player = Bukkit.getPlayer(input);
+			resolved = player != null ? List.of(player) : Collections.emptyList();
+		}
+		if (resolved.isEmpty() && single)
+		{
+			String message = org.mockbukkit.mockbukkit.adventure.Languages.getInstance().getOrDefault("argument.entity.notfound.player", "No player was found");
+			source.getSender().sendMessage(message);
+		}
+		return resolved;
+	}
+
+	private List<Player> resolveSelector(String selector, CommandSourceStack source)
+	{
+		return switch (selector)
+		{
+			case "@a" -> new ArrayList<>(Bukkit.getOnlinePlayers());
+			case "@p" ->
+			{
+				org.bukkit.Location sourceLocation = source.getLocation();
+				org.bukkit.World sourceWorld = sourceLocation.getWorld();
+				if (sourceWorld == null)
+				{
+					yield Collections.emptyList();
+				}
+				Player nearest = null;
+				double nearestDistance = Double.MAX_VALUE;
+				for (Player player : Bukkit.getOnlinePlayers())
+				{
+					if (!player.getWorld().equals(sourceWorld))
+					{
+						continue;
+					}
+					double distance = player.getLocation().distanceSquared(sourceLocation);
+					if (distance < nearestDistance)
+					{
+						nearestDistance = distance;
+						nearest = player;
+					}
+				}
+				yield nearest != null ? List.of(nearest) : Collections.emptyList();
+			}
+			case "@r" ->
+			{
+				List<Player> players = new ArrayList<>(Bukkit.getOnlinePlayers());
+				if (players.isEmpty()) yield Collections.emptyList();
+				Collections.shuffle(players);
+				yield List.of(players.get(0));
+			}
+			case "@s" -> (source.getExecutor() instanceof Player player) ? List.of(player) : Collections.emptyList();
+			default -> Collections.emptyList();
+		};
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/command/brigadier/argument/PlayerSelectorArgumentResolverMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/command/brigadier/argument/PlayerSelectorArgumentResolverMock.java
@@ -6,6 +6,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.mockbukkit.mockbukkit.adventure.Languages;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -29,7 +30,7 @@ public class PlayerSelectorArgumentResolverMock implements PlayerSelectorArgumen
 	{
 		if (single && input.equals("@a"))
 		{
-			String message = org.mockbukkit.mockbukkit.adventure.Languages.getInstance().getOrDefault("command.expected.a_single_player", "Only one player is allowed, but the provided selector allows more than one");
+			String message = Languages.getInstance().getOrDefault("command.expected.a_single_player", "Only one player is allowed, but the provided selector allows more than one");
 			source.getSender().sendMessage(message);
 			return Collections.emptyList();
 		}
@@ -46,7 +47,7 @@ public class PlayerSelectorArgumentResolverMock implements PlayerSelectorArgumen
 		}
 		if (resolved.isEmpty() && single)
 		{
-			String message = org.mockbukkit.mockbukkit.adventure.Languages.getInstance().getOrDefault("argument.entity.notfound.player", "No player was found");
+			String message = Languages.getInstance().getOrDefault("argument.entity.notfound.player", "No player was found");
 			source.getSender().sendMessage(message);
 		}
 		return resolved;
@@ -85,9 +86,11 @@ public class PlayerSelectorArgumentResolverMock implements PlayerSelectorArgumen
 			case "@r" ->
 			{
 				List<Player> players = new ArrayList<>(Bukkit.getOnlinePlayers());
-				if (players.isEmpty()) yield Collections.emptyList();
+				if (players.isEmpty()) {
+					yield Collections.emptyList();
+				}
 				Collections.shuffle(players);
-				yield List.of(players.get(0));
+				yield List.of(players.getFirst());
 			}
 			case "@s" -> (source.getExecutor() instanceof Player player) ? List.of(player) : Collections.emptyList();
 			default -> Collections.emptyList();

--- a/src/main/resources/META-INF/services/io.papermc.paper.command.brigadier.argument.VanillaArgumentProvider
+++ b/src/main/resources/META-INF/services/io.papermc.paper.command.brigadier.argument.VanillaArgumentProvider
@@ -1,0 +1,1 @@
+io.papermc.paper.command.brigadier.argument.VanillaArgumentProviderMock

--- a/src/test/java/org/mockbukkit/mockbukkit/command/brigadier/argument/PlayerArgumentTypeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/command/brigadier/argument/PlayerArgumentTypeMockTest.java
@@ -1,19 +1,16 @@
 package org.mockbukkit.mockbukkit.command.brigadier.argument;
 
-import com.mojang.brigadier.Command;
-import io.papermc.paper.command.brigadier.Commands;
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
-import io.papermc.paper.command.brigadier.argument.resolvers.selector.PlayerSelectorArgumentResolver;
-import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
 import org.bukkit.Location;
-import org.bukkit.entity.Player;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockbukkit.mockbukkit.MockBukkitExtension;
 import org.mockbukkit.mockbukkit.MockBukkitInject;
 import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.command.CommandSourceStackMock;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
-import org.mockbukkit.mockbukkit.plugin.PluginMock;
 
 import java.util.List;
 
@@ -27,201 +24,118 @@ class PlayerArgumentTypeMockTest
 	private ServerMock serverMock;
 
 	@Test
-	void playerArgumentType_ResolveByName()
+	void playerArgumentType_ResolveByName() throws CommandSyntaxException
 	{
-		Player player = serverMock.addPlayer("MockPlayer");
-		PluginMock.builder().withOnEnable(pluginMock ->
-				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
-						event.registrar().register(
-								Commands.literal("testplayer")
-										.then(Commands.argument("player", ArgumentTypes.player())
-												.executes(context ->
-												{
-													PlayerSelectorArgumentResolver resolver = context.getArgument("player", PlayerSelectorArgumentResolver.class);
-													List<Player> resolved = resolver.resolve(context.getSource());
-													assertEquals(1, resolved.size());
-													assertEquals(player, resolved.getFirst());
-													return Command.SINGLE_SUCCESS;
-												}))
-										.build(),
-								null,
-								List.of()
-						))).build();
-		serverMock.dispatchCommand(serverMock.getConsoleSender(), "testplayer MockPlayer");
+		var reader = new StringReader("notch");
+
+		var notch = serverMock.addPlayer("notch");
+		var stack = CommandSourceStackMock.from(notch);
+
+		var actual = ArgumentTypes.player().parse(reader, notch).resolve(stack);
+
+		assertEquals(List.of(notch), actual);
 	}
 
 	@Test
-	void playerArgumentType_ResolveBySelector_All_FailsForSingle()
+	void playerArgumentType_ResolveBySelector_All_FailsForSingle() throws CommandSyntaxException
 	{
+		var reader = new StringReader("@a");
+
+		var notch = serverMock.addPlayer("notch");
+		var stack = CommandSourceStackMock.from(notch);
+
+		var actual = ArgumentTypes.player().parse(reader, notch).resolve(stack);
+
+		assertEquals(List.of(), actual);
+		notch.assertSaid("Only one player is allowed, but the provided selector allows more than one");
+	}
+
+	@Test
+	void playerArgumentType_ResolveBySelector_All_SucceedsForMultiple() throws CommandSyntaxException
+	{
+		var reader = new StringReader("@a");
+
+		var player1 = serverMock.addPlayer("Player1");
+		var player2 = serverMock.addPlayer("Player2");
+		var console = serverMock.getConsoleSender();
+		var stack = CommandSourceStackMock.from(console);
+
+		var actual = ArgumentTypes.players().parse(reader, console).resolve(stack);
+
+		assertEquals(List.of(player1, player2), actual);
+	}
+
+	@Test
+	void playerArgumentType_ResolveBySelector_Self() throws CommandSyntaxException
+	{
+		var reader = new StringReader("@s");
+
+		var player = serverMock.addPlayer("MockPlayer");
+		var stack = CommandSourceStackMock.from(player);
+
+		var actual = ArgumentTypes.player().parse(reader, player).resolve(stack);
+
+		assertEquals(List.of(player), actual);
+	}
+
+	@Test
+	void playerArgumentType_ResolveBySelector_Nearest_FromConsole() throws CommandSyntaxException
+	{
+		var reader = new StringReader("@p");
+
 		serverMock.addPlayer("Player1");
-		serverMock.addPlayer("Player2");
-		PluginMock.builder().withOnEnable(pluginMock ->
-				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
-						event.registrar().register(
-								Commands.literal("testplayer")
-										.then(Commands.argument("player", ArgumentTypes.player())
-												.executes(context ->
-												{
-													PlayerSelectorArgumentResolver resolver = context.getArgument("player", PlayerSelectorArgumentResolver.class);
-													List<Player> resolved = resolver.resolve(context.getSource());
-													assertEquals(0, resolved.size());
-													return Command.SINGLE_SUCCESS;
-												}))
-										.build(),
-								null,
-								List.of()
-						))).build();
-		serverMock.dispatchCommand(serverMock.getConsoleSender(), "testplayer @a");
-		serverMock.getConsoleSender().assertSaid("Only one player is allowed, but the provided selector allows more than one");
+		var console = serverMock.getConsoleSender();
+		var stack = CommandSourceStackMock.from(console);
+
+		var actual = ArgumentTypes.player().parse(reader, console).resolve(stack);
+
+		assertEquals(List.of(), actual);
+		console.assertSaid("No player was found");
 	}
 
 	@Test
-	void playerArgumentType_ResolveBySelector_All_SucceedsForMultiple()
+	void playerArgumentType_ResolveBySelector_Nearest_FromPlayer() throws CommandSyntaxException
 	{
-		serverMock.addPlayer("Player1");
-		serverMock.addPlayer("Player2");
-		PluginMock.builder().withOnEnable(pluginMock ->
-				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
-						event.registrar().register(
-								Commands.literal("testplayers")
-										.then(Commands.argument("players", ArgumentTypes.players())
-												.executes(context ->
-												{
-													PlayerSelectorArgumentResolver resolver = context.getArgument("players", PlayerSelectorArgumentResolver.class);
-													List<Player> resolved = resolver.resolve(context.getSource());
-													assertEquals(2, resolved.size());
-													return Command.SINGLE_SUCCESS;
-												}))
-										.build(),
-								null,
-								List.of()
-						))).build();
-		serverMock.dispatchCommand(serverMock.getConsoleSender(), "testplayers @a");
-	}
+		var reader = new StringReader("@p");
 
-	@Test
-	void playerArgumentType_ResolveBySelector_Self()
-	{
-		Player player = serverMock.addPlayer("MockPlayer");
-		PluginMock.builder().withOnEnable(pluginMock ->
-				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
-						event.registrar().register(
-								Commands.literal("testplayer")
-										.then(Commands.argument("player", ArgumentTypes.player())
-												.executes(context ->
-												{
-													PlayerSelectorArgumentResolver resolver = context.getArgument("player", PlayerSelectorArgumentResolver.class);
-													List<Player> resolved = resolver.resolve(context.getSource());
-													assertEquals(1, resolved.size());
-													assertEquals(player, resolved.get(0));
-													return Command.SINGLE_SUCCESS;
-												}))
-										.build(),
-								null,
-								List.of()
-						))).build();
-		serverMock.dispatchCommand(player, "testplayer @s");
-	}
-
-	@Test
-	void playerArgumentType_ResolveBySelector_Nearest_FromConsole()
-	{
-		serverMock.addPlayer("Player1");
-
-		PluginMock.builder().withOnEnable(pluginMock ->
-				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
-						event.registrar().register(
-								Commands.literal("testplayer")
-										.then(Commands.argument("player", ArgumentTypes.player())
-												.executes(context ->
-												{
-													PlayerSelectorArgumentResolver resolver = context.getArgument("player", PlayerSelectorArgumentResolver.class);
-													List<Player> resolved = resolver.resolve(context.getSource());
-													assertEquals(0, resolved.size());
-													return Command.SINGLE_SUCCESS;
-												}))
-										.build(),
-								null,
-								List.of()
-						))).build();
-		serverMock.dispatchCommand(serverMock.getConsoleSender(), "testplayer @p");
-		serverMock.getConsoleSender().assertSaid("No player was found");
-	}
-
-	@Test
-	void playerArgumentType_ResolveBySelector_Nearest_FromPlayer()
-	{
 		PlayerMock player1 = serverMock.addPlayer("Player1");
 		player1.setLocation(new Location(player1.getWorld(), 0, 0, 0));
 		PlayerMock player2 = serverMock.addPlayer("Player2");
 		player2.setLocation(new Location(player2.getWorld(), 100, 0, 0));
+		var stack = CommandSourceStackMock.from(player1);
 
-		PluginMock.builder().withOnEnable(pluginMock ->
-				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
-						event.registrar().register(
-								Commands.literal("testplayer")
-										.then(Commands.argument("player", ArgumentTypes.player())
-												.executes(context ->
-												{
-													PlayerSelectorArgumentResolver resolver = context.getArgument("player", PlayerSelectorArgumentResolver.class);
-													List<Player> resolved = resolver.resolve(context.getSource());
-													assertEquals(1, resolved.size());
-													assertEquals(player1, resolved.get(0));
-													return Command.SINGLE_SUCCESS;
-												}))
-										.build(),
-								null,
-								List.of()
-						))).build();
-		serverMock.dispatchCommand(player1, "testplayer @p");
+		var actual = ArgumentTypes.player().parse(reader, player1).resolve(stack);
+
+		assertEquals(List.of(player1), actual);
 	}
 
 	@Test
-	void playerArgumentType_ResolveBySelector_Random()
+	void playerArgumentType_ResolveBySelector_Random() throws CommandSyntaxException
 	{
+		var reader = new StringReader("@r");
+
 		serverMock.addPlayer("Player1");
 		serverMock.addPlayer("Player2");
+		var console = serverMock.getConsoleSender();
+		var stack = CommandSourceStackMock.from(console);
 
-		PluginMock.builder().withOnEnable(pluginMock ->
-				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
-						event.registrar().register(
-								Commands.literal("testplayer")
-										.then(Commands.argument("player", ArgumentTypes.player())
-												.executes(context ->
-												{
-													PlayerSelectorArgumentResolver resolver = context.getArgument("player", PlayerSelectorArgumentResolver.class);
-													List<Player> resolved = resolver.resolve(context.getSource());
-													assertEquals(1, resolved.size());
-													return Command.SINGLE_SUCCESS;
-												}))
-										.build(),
-								null,
-								List.of()
-						))).build();
-		serverMock.dispatchCommand(serverMock.getConsoleSender(), "testplayer @r");
+		var actual = ArgumentTypes.player().parse(reader, console).resolve(stack);
+
+		assertEquals(1, actual.size());
 	}
 
 	@Test
-	void playerArgumentType_ResolveByName_NotFound()
+	void playerArgumentType_ResolveByName_NotFound() throws CommandSyntaxException
 	{
-		PluginMock.builder().withOnEnable(pluginMock ->
-				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
-						event.registrar().register(
-								Commands.literal("testplayer")
-										.then(Commands.argument("player", ArgumentTypes.player())
-												.executes(context ->
-												{
-													PlayerSelectorArgumentResolver resolver = context.getArgument("player", PlayerSelectorArgumentResolver.class);
-													List<Player> resolved = resolver.resolve(context.getSource());
-													assertEquals(0, resolved.size());
-													return Command.SINGLE_SUCCESS;
-												}))
-										.build(),
-								null,
-								List.of()
-						))).build();
-		serverMock.dispatchCommand(serverMock.getConsoleSender(), "testplayer OfflinePlayer");
-		serverMock.getConsoleSender().assertSaid("No player was found");
+		var reader = new StringReader("OfflinePlayer");
+
+		var console = serverMock.getConsoleSender();
+		var stack = CommandSourceStackMock.from(console);
+
+		var actual = ArgumentTypes.player().parse(reader, console).resolve(stack);
+
+		assertEquals(List.of(), actual);
+		console.assertSaid("No player was found");
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/command/brigadier/argument/PlayerArgumentTypeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/command/brigadier/argument/PlayerArgumentTypeMockTest.java
@@ -1,0 +1,227 @@
+package org.mockbukkit.mockbukkit.command.brigadier.argument;
+
+import com.mojang.brigadier.Command;
+import io.papermc.paper.command.brigadier.Commands;
+import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
+import io.papermc.paper.command.brigadier.argument.resolvers.selector.PlayerSelectorArgumentResolver;
+import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+import org.mockbukkit.mockbukkit.MockBukkitInject;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.plugin.PluginMock;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockBukkitExtension.class)
+class PlayerArgumentTypeMockTest
+{
+
+	@MockBukkitInject
+	private ServerMock serverMock;
+
+	@Test
+	void playerArgumentType_ResolveByName()
+	{
+		Player player = serverMock.addPlayer("MockPlayer");
+		PluginMock.builder().withOnEnable(pluginMock ->
+				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
+						event.registrar().register(
+								Commands.literal("testplayer")
+										.then(Commands.argument("player", ArgumentTypes.player())
+												.executes(context ->
+												{
+													PlayerSelectorArgumentResolver resolver = context.getArgument("player", PlayerSelectorArgumentResolver.class);
+													List<Player> resolved = resolver.resolve(context.getSource());
+													assertEquals(1, resolved.size());
+													assertEquals(player, resolved.getFirst());
+													return Command.SINGLE_SUCCESS;
+												}))
+										.build(),
+								null,
+								List.of()
+						))).build();
+		serverMock.dispatchCommand(serverMock.getConsoleSender(), "testplayer MockPlayer");
+	}
+
+	@Test
+	void playerArgumentType_ResolveBySelector_All_FailsForSingle()
+	{
+		serverMock.addPlayer("Player1");
+		serverMock.addPlayer("Player2");
+		PluginMock.builder().withOnEnable(pluginMock ->
+				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
+						event.registrar().register(
+								Commands.literal("testplayer")
+										.then(Commands.argument("player", ArgumentTypes.player())
+												.executes(context ->
+												{
+													PlayerSelectorArgumentResolver resolver = context.getArgument("player", PlayerSelectorArgumentResolver.class);
+													List<Player> resolved = resolver.resolve(context.getSource());
+													assertEquals(0, resolved.size());
+													return Command.SINGLE_SUCCESS;
+												}))
+										.build(),
+								null,
+								List.of()
+						))).build();
+		serverMock.dispatchCommand(serverMock.getConsoleSender(), "testplayer @a");
+		serverMock.getConsoleSender().assertSaid("Only one player is allowed, but the provided selector allows more than one");
+	}
+
+	@Test
+	void playerArgumentType_ResolveBySelector_All_SucceedsForMultiple()
+	{
+		serverMock.addPlayer("Player1");
+		serverMock.addPlayer("Player2");
+		PluginMock.builder().withOnEnable(pluginMock ->
+				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
+						event.registrar().register(
+								Commands.literal("testplayers")
+										.then(Commands.argument("players", ArgumentTypes.players())
+												.executes(context ->
+												{
+													PlayerSelectorArgumentResolver resolver = context.getArgument("players", PlayerSelectorArgumentResolver.class);
+													List<Player> resolved = resolver.resolve(context.getSource());
+													assertEquals(2, resolved.size());
+													return Command.SINGLE_SUCCESS;
+												}))
+										.build(),
+								null,
+								List.of()
+						))).build();
+		serverMock.dispatchCommand(serverMock.getConsoleSender(), "testplayers @a");
+	}
+
+	@Test
+	void playerArgumentType_ResolveBySelector_Self()
+	{
+		Player player = serverMock.addPlayer("MockPlayer");
+		PluginMock.builder().withOnEnable(pluginMock ->
+				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
+						event.registrar().register(
+								Commands.literal("testplayer")
+										.then(Commands.argument("player", ArgumentTypes.player())
+												.executes(context ->
+												{
+													PlayerSelectorArgumentResolver resolver = context.getArgument("player", PlayerSelectorArgumentResolver.class);
+													List<Player> resolved = resolver.resolve(context.getSource());
+													assertEquals(1, resolved.size());
+													assertEquals(player, resolved.get(0));
+													return Command.SINGLE_SUCCESS;
+												}))
+										.build(),
+								null,
+								List.of()
+						))).build();
+		serverMock.dispatchCommand(player, "testplayer @s");
+	}
+
+	@Test
+	void playerArgumentType_ResolveBySelector_Nearest_FromConsole()
+	{
+		serverMock.addPlayer("Player1");
+
+		PluginMock.builder().withOnEnable(pluginMock ->
+				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
+						event.registrar().register(
+								Commands.literal("testplayer")
+										.then(Commands.argument("player", ArgumentTypes.player())
+												.executes(context ->
+												{
+													PlayerSelectorArgumentResolver resolver = context.getArgument("player", PlayerSelectorArgumentResolver.class);
+													List<Player> resolved = resolver.resolve(context.getSource());
+													assertEquals(0, resolved.size());
+													return Command.SINGLE_SUCCESS;
+												}))
+										.build(),
+								null,
+								List.of()
+						))).build();
+		serverMock.dispatchCommand(serverMock.getConsoleSender(), "testplayer @p");
+		serverMock.getConsoleSender().assertSaid("No player was found");
+	}
+
+	@Test
+	void playerArgumentType_ResolveBySelector_Nearest_FromPlayer()
+	{
+		PlayerMock player1 = serverMock.addPlayer("Player1");
+		player1.setLocation(new Location(player1.getWorld(), 0, 0, 0));
+		PlayerMock player2 = serverMock.addPlayer("Player2");
+		player2.setLocation(new Location(player2.getWorld(), 100, 0, 0));
+
+		PluginMock.builder().withOnEnable(pluginMock ->
+				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
+						event.registrar().register(
+								Commands.literal("testplayer")
+										.then(Commands.argument("player", ArgumentTypes.player())
+												.executes(context ->
+												{
+													PlayerSelectorArgumentResolver resolver = context.getArgument("player", PlayerSelectorArgumentResolver.class);
+													List<Player> resolved = resolver.resolve(context.getSource());
+													assertEquals(1, resolved.size());
+													assertEquals(player1, resolved.get(0));
+													return Command.SINGLE_SUCCESS;
+												}))
+										.build(),
+								null,
+								List.of()
+						))).build();
+		serverMock.dispatchCommand(player1, "testplayer @p");
+	}
+
+	@Test
+	void playerArgumentType_ResolveBySelector_Random()
+	{
+		serverMock.addPlayer("Player1");
+		serverMock.addPlayer("Player2");
+
+		PluginMock.builder().withOnEnable(pluginMock ->
+				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
+						event.registrar().register(
+								Commands.literal("testplayer")
+										.then(Commands.argument("player", ArgumentTypes.player())
+												.executes(context ->
+												{
+													PlayerSelectorArgumentResolver resolver = context.getArgument("player", PlayerSelectorArgumentResolver.class);
+													List<Player> resolved = resolver.resolve(context.getSource());
+													assertEquals(1, resolved.size());
+													return Command.SINGLE_SUCCESS;
+												}))
+										.build(),
+								null,
+								List.of()
+						))).build();
+		serverMock.dispatchCommand(serverMock.getConsoleSender(), "testplayer @r");
+	}
+
+	@Test
+	void playerArgumentType_ResolveByName_NotFound()
+	{
+		PluginMock.builder().withOnEnable(pluginMock ->
+				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
+						event.registrar().register(
+								Commands.literal("testplayer")
+										.then(Commands.argument("player", ArgumentTypes.player())
+												.executes(context ->
+												{
+													PlayerSelectorArgumentResolver resolver = context.getArgument("player", PlayerSelectorArgumentResolver.class);
+													List<Player> resolved = resolver.resolve(context.getSource());
+													assertEquals(0, resolved.size());
+													return Command.SINGLE_SUCCESS;
+												}))
+										.build(),
+								null,
+								List.of()
+						))).build();
+		serverMock.dispatchCommand(serverMock.getConsoleSender(), "testplayer OfflinePlayer");
+		serverMock.getConsoleSender().assertSaid("No player was found");
+	}
+
+}


### PR DESCRIPTION
# Description
Added `ArgumentTypes.player()` and `ArgumentTypes.players()` as discussed a while ago in https://discord.com/channels/792754410576019477/809866076606693427/1396918734945521685

The error messages are the same as the ones you get from Paper
<img width="836" height="272" alt="image" src="https://github.com/user-attachments/assets/1909db6f-6ed7-48d3-bf33-586fad590166" />

I am looking for some feedback on how I am asserting, as I don't personally like that they are in the command implementation.

All other ArgumentTypes are UOEs, if this PR is merged, I will also be implementing the other ones.

# Checklist
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
