### PR TITLE
feat: implement PlayerCommandPreprocessEvent

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
@@ -67,6 +67,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.entity.SpawnCategory;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.event.server.MapInitializeEvent;
@@ -1246,6 +1247,16 @@ public class ServerMock extends Server.Spigot implements Server
 		{
 			LifecycleEventRunnerMock.INSTANCE.callReloadableRegistrarEvent(LifecycleEvents.COMMANDS, PaperCommandsMock.INSTANCE, Plugin.class, ReloadableRegistrarEvent.Cause.INITIAL);
 			this.commandsInitialized = true;
+		}
+		if (sender instanceof Player player)
+		{
+			PlayerCommandPreprocessEvent event = new PlayerCommandPreprocessEvent(player, commandLine);
+			if (event.isCancelled())
+			{
+				return true;
+			}
+			pluginManager.callEvent(event);
+			commandLine = event.getMessage();
 		}
 		String[] commands = commandLine.split(" ");
 		String commandLabel = commands[0];

--- a/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
@@ -1251,11 +1251,11 @@ public class ServerMock extends Server.Spigot implements Server
 		if (sender instanceof Player player)
 		{
 			PlayerCommandPreprocessEvent event = new PlayerCommandPreprocessEvent(player, commandLine);
+			pluginManager.callEvent(event);
 			if (event.isCancelled())
 			{
 				return true;
 			}
-			pluginManager.callEvent(event);
 			commandLine = event.getMessage();
 		}
 		String[] commands = commandLine.split(" ");

--- a/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
@@ -710,6 +710,24 @@ class ServerMockTest
 	}
 
 	@Test
+	void performCommand_PlayerCommandPreprocessEventAlterCommand()
+	{
+		String alteredMessage = "mockcommand argA argB";
+		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
+		server.getPluginManager().registerEvents(new Listener() {
+			@EventHandler
+			public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent e) {
+				e.setMessage(alteredMessage);
+			}
+		}, plugin);
+		plugin.commandReturns = true;
+		Player player = server.addPlayer();
+		assertTrue(server.dispatchCommand(player, "mockcommand argA argB"));
+		assertThat(server.getPluginManager(), hasFiredFilteredEvent(PlayerCommandPreprocessEvent.class, event ->
+				alteredMessage.equalsIgnoreCase(event.getMessage())));
+	}
+
+	@Test
 	void getEntities_NoEntities_EmptySet()
 	{
 		assertTrue(server.getEntities().isEmpty(), "Entities set was not empty");

--- a/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
@@ -714,9 +714,11 @@ class ServerMockTest
 	{
 		String alteredMessage = "mockcommand argA argB";
 		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
-		server.getPluginManager().registerEvents(new Listener() {
+		server.getPluginManager().registerEvents(new Listener()
+		{
 			@EventHandler
-			public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent e) {
+			public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent e)
+			{
 				e.setMessage(alteredMessage);
 			}
 		}, plugin);
@@ -731,9 +733,11 @@ class ServerMockTest
 	void performCommand_PlayerCommandPreprocessEventCancellable()
 	{
 		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
-		server.getPluginManager().registerEvents(new Listener() {
+		server.getPluginManager().registerEvents(new Listener()
+		{
 			@EventHandler
-			public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent e) {
+			public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent e)
+			{
 				e.setCancelled(true);
 			}
 		}, plugin);

--- a/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
@@ -728,6 +728,32 @@ class ServerMockTest
 	}
 
 	@Test
+	void performCommand_PlayerCommandPreprocessEventCancellable()
+	{
+		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
+		server.getPluginManager().registerEvents(new Listener() {
+			@EventHandler
+			public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent e) {
+				e.setCancelled(true);
+			}
+		}, plugin);
+		plugin.commandReturns = true;
+		Player player = server.addPlayer();
+		server.dispatchCommand(player, "mockcommand argA argB");
+		assertNull(plugin.command);
+	}
+
+	@Test
+	void performCommand_PlayerCommandPreprocessEventIsNotCalledForConsoleSender()
+	{
+		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
+		plugin.commandReturns = true;
+		String message = "mockcommand argA argB";
+		assertTrue(server.dispatchCommand(server.getConsoleSender(), message));
+		assertThat(server.getPluginManager(), hasNotFiredEventInstance(PlayerCommandPreprocessEvent.class));
+	}
+
+	@Test
 	void getEntities_NoEntities_EmptySet()
 	{
 		assertTrue(server.getEntities().isEmpty(), "Entities set was not empty");

--- a/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
@@ -44,6 +44,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerKickEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
@@ -694,6 +695,18 @@ class ServerMockTest
 		assertEquals("argA", plugin.commandArguments[0]);
 		assertEquals("argB", plugin.commandArguments[1]);
 		assertSame(player, plugin.commandSender);
+	}
+
+	@Test
+	void performCommand_PlayerCommandPreprocessEventIsCalled()
+	{
+		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
+		plugin.commandReturns = true;
+		Player player = server.addPlayer();
+		String message = "mockcommand argA argB";
+		assertTrue(server.dispatchCommand(player, message));
+		assertThat(server.getPluginManager(), hasFiredFilteredEvent(PlayerCommandPreprocessEvent.class, event ->
+				message.equalsIgnoreCase(event.getMessage())));
 	}
 
 	@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
@@ -432,9 +432,11 @@ class PlayerMockTest
 	{
 		String alteredMessage = "mockcommand argA argB";
 		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
-		server.getPluginManager().registerEvents(new Listener() {
+		server.getPluginManager().registerEvents(new Listener()
+		{
 			@EventHandler
-			public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent e) {
+			public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent e)
+			{
 				e.setMessage(alteredMessage);
 			}
 		}, plugin);
@@ -448,9 +450,11 @@ class PlayerMockTest
 	void performCommand_PlayerCommandPreprocessEventCancellable()
 	{
 		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
-		server.getPluginManager().registerEvents(new Listener() {
+		server.getPluginManager().registerEvents(new Listener()
+		{
 			@EventHandler
-			public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent e) {
+			public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent e)
+			{
 				e.setCancelled(true);
 			}
 		}, plugin);

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
@@ -421,7 +421,6 @@ class PlayerMockTest
 	{
 		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
 		plugin.commandReturns = true;
-		Player player = server.addPlayer();
 		String message = "mockcommand argA argB";
 		assertTrue(player.performCommand(message));
 		assertThat(server.getPluginManager(), hasFiredFilteredEvent(PlayerCommandPreprocessEvent.class, event ->
@@ -440,7 +439,6 @@ class PlayerMockTest
 			}
 		}, plugin);
 		plugin.commandReturns = true;
-		Player player = server.addPlayer();
 		assertTrue(player.performCommand("mockcommand argA argB"));
 		assertThat(server.getPluginManager(), hasFiredFilteredEvent(PlayerCommandPreprocessEvent.class, event ->
 				alteredMessage.equalsIgnoreCase(event.getMessage())));
@@ -457,7 +455,6 @@ class PlayerMockTest
 			}
 		}, plugin);
 		plugin.commandReturns = true;
-		Player player = server.addPlayer();
 		player.performCommand("mockcommand argA argB");
 		assertNull(plugin.command);
 	}

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
@@ -423,7 +423,7 @@ class PlayerMockTest
 		plugin.commandReturns = true;
 		Player player = server.addPlayer();
 		String message = "mockcommand argA argB";
-		assertTrue(server.dispatchCommand(player, message));
+		assertTrue(player.performCommand(message));
 		assertThat(server.getPluginManager(), hasFiredFilteredEvent(PlayerCommandPreprocessEvent.class, event ->
 				message.equalsIgnoreCase(event.getMessage())));
 	}
@@ -441,7 +441,7 @@ class PlayerMockTest
 		}, plugin);
 		plugin.commandReturns = true;
 		Player player = server.addPlayer();
-		assertTrue(server.dispatchCommand(player, "mockcommand argA argB"));
+		assertTrue(player.performCommand("mockcommand argA argB"));
 		assertThat(server.getPluginManager(), hasFiredFilteredEvent(PlayerCommandPreprocessEvent.class, event ->
 				alteredMessage.equalsIgnoreCase(event.getMessage())));
 	}

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
@@ -447,13 +447,19 @@ class PlayerMockTest
 	}
 
 	@Test
-	void performCommand_PlayerCommandPreprocessEventIsNotCalledForConsoleSender()
+	void performCommand_PlayerCommandPreprocessEventCancellable()
 	{
 		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
+		server.getPluginManager().registerEvents(new Listener() {
+			@EventHandler
+			public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent e) {
+				e.setCancelled(true);
+			}
+		}, plugin);
 		plugin.commandReturns = true;
-		String message = "mockcommand argA argB";
-		assertTrue(server.dispatchCommand(server.getConsoleSender(), message));
-		assertThat(server.getPluginManager(), hasNotFiredEventInstance(PlayerCommandPreprocessEvent.class));
+		Player player = server.addPlayer();
+		player.performCommand("mockcommand argA argB");
+		assertNull(plugin.command);
 	}
 
 	@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
@@ -46,6 +46,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerExpChangeEvent;
 import org.bukkit.event.player.PlayerExpCooldownChangeEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
@@ -413,6 +414,46 @@ class PlayerMockTest
 		assertEquals("argA", plugin.commandArguments[0]);
 		assertEquals("argB", plugin.commandArguments[1]);
 		assertSame(player, plugin.commandSender);
+	}
+
+	@Test
+	void performCommand_PlayerCommandPreprocessEventIsCalled()
+	{
+		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
+		plugin.commandReturns = true;
+		Player player = server.addPlayer();
+		String message = "mockcommand argA argB";
+		assertTrue(server.dispatchCommand(player, message));
+		assertThat(server.getPluginManager(), hasFiredFilteredEvent(PlayerCommandPreprocessEvent.class, event ->
+				message.equalsIgnoreCase(event.getMessage())));
+	}
+
+	@Test
+	void performCommand_PlayerCommandPreprocessEventAlterCommand()
+	{
+		String alteredMessage = "mockcommand argA argB";
+		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
+		server.getPluginManager().registerEvents(new Listener() {
+			@EventHandler
+			public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent e) {
+				e.setMessage(alteredMessage);
+			}
+		}, plugin);
+		plugin.commandReturns = true;
+		Player player = server.addPlayer();
+		assertTrue(server.dispatchCommand(player, "mockcommand argA argB"));
+		assertThat(server.getPluginManager(), hasFiredFilteredEvent(PlayerCommandPreprocessEvent.class, event ->
+				alteredMessage.equalsIgnoreCase(event.getMessage())));
+	}
+
+	@Test
+	void performCommand_PlayerCommandPreprocessEventIsNotCalledForConsoleSender()
+	{
+		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
+		plugin.commandReturns = true;
+		String message = "mockcommand argA argB";
+		assertTrue(server.dispatchCommand(server.getConsoleSender(), message));
+		assertThat(server.getPluginManager(), hasNotFiredEventInstance(PlayerCommandPreprocessEvent.class));
 	}
 
 	@Test


### PR DESCRIPTION
# Description

This PR implements the call of the [`PlayerCommandPreprocessEvent`](https://jd.papermc.io/paper/1.21.11/org/bukkit/event/player/PlayerCommandPreprocessEvent.html), when a player performs a command. This event is triggered when a player performs a command, and before execution is handled by a `CommandExecutor`. It enables command executions to be cancelled or altered. In the case of MockBukkit, commands are performed via either  `Server#dispatchCommand(CommandSender, String)` or `Player#performCommand(String)`.

# Checklist

The following items should be checked before the pull request can be merged.

- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
