### PR TITLE
26.1 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ If you want to see some projects that are using MockBukkit right now, feel free 
   (75+ Unit Tests)
 - [axelrindle/PocketKnife](https://github.com/axelrindle/PocketKnife/tree/main/api/src/test/kotlin)
   (50+ Unit Tests)
+- [ez-plugins/EzEconomy](https://github.com/ez-plugins/EzEconomy/tree/main/ezeconomy-bukkit/src/test/java/com/skyblockexp/ezeconomy)
+  (50+ Unit Tests)
 - *and more! (If you want to see your plugin here, open up an issue and we'll consider adding it)*
 
 You can also have a look at our documentation where we outline various examples and tricks on how to use MockBukkit

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
     <a href="https://github.com/MockBukkit/MockBukkit/actions/">
         <img alt="Build Status" src="https://github.com/MockBukkit/MockBukkit/actions/workflows/publish.yml/badge.svg" />
     </a>
-    <a href="https://central.sonatype.com/artifact/org.mockbukkit.mockbukkit/mockbukkit-v1.21">
-        <img alt="Maven Central" src="https://img.shields.io/maven-central/v/org.mockbukkit.mockbukkit/mockbukkit-v1.21?color=1bcc94&logo=apache-maven" />
+    <a href="https://central.sonatype.com/artifact/org.mockbukkit.mockbukkit/mockbukkit-v26.1">
+        <img alt="Maven Central" src="https://img.shields.io/maven-central/v/org.mockbukkit.mockbukkit/mockbukkit-v26.1?color=1bcc94&logo=apache-maven" />
     </a>
-    <a href="https://javadoc.io/doc/org.mockbukkit.mockbukkit/mockbukkit-v1.21">
-        <img alt="Javadocs" src="https://javadoc.io/badge2/org.mockbukkit.mockbukkit/mockbukkit-v1.21/javadoc.svg" />
+    <a href="https://javadoc.io/doc/org.mockbukkit.mockbukkit/mockbukkit-v26.1">
+        <img alt="Javadocs" src="https://javadoc.io/badge2/org.mockbukkit.mockbukkit/mockbukkit-v26.1/javadoc.svg" />
     </a>
     <a href="https://sonarcloud.io/project/issues?resolved=false&types=CODE_SMELL&id=MockBukkit_MockBukkit">
         <img alt="Code Smells" src="https://sonarcloud.io/api/project_badges/measure?project=MockBukkit_MockBukkit&metric=code_smells">
@@ -51,7 +51,7 @@ MockBukkit can easily be included in your project using either Maven or gradle.
 > [!TIP]
 > Currently, the newest version available is
 >
-> [![ALTERNATE-TEXT](https://img.shields.io/maven-central/v/org.mockbukkit.mockbukkit/mockbukkit-v1.21?color=1bcc94&logo=apache-maven)](https://central.sonatype.com/artifact/org.mockbukkit.mockbukkit/mockbukkit-v1.21)
+> [![ALTERNATE-TEXT](https://img.shields.io/maven-central/v/org.mockbukkit.mockbukkit/mockbukkit-v26.1?color=1bcc94&logo=apache-maven)](https://central.sonatype.com/artifact/org.mockbukkit.mockbukkit/mockbukkit-v26.1)
 
 > Note: The Breaking Changes intended for 3.0 were already made in 2.145.1. Due to an Error it didn't get properly
 > tagged
@@ -92,7 +92,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.mockbukkit.mockbukkit:mockbukkit-v1.21:${paperVersion}'
+    testImplementation 'org.mockbukkit.mockbukkit:mockbukkit-v26.1:${paperVersion}'
 }
 ```
 
@@ -106,7 +106,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'com.github.MockBukkit:MockBukkit:v1.21-SNAPSHOT'
+    testImplementation 'com.github.MockBukkit:MockBukkit:v26.1-SNAPSHOT'
     testImplementation 'io.papermc.paper:paper-api:${paperVersion}'
 }
 ```
@@ -175,7 +175,7 @@ Also here you can extract the manifest version this way:
 <dependencies>
   <dependency>
     <groupId>org.mockbukkit.mockbukkit</groupId>
-    <artifactId>mockbukkit-v1.21</artifactId>
+    <artifactId>mockbukkit-v26.1</artifactId>
     <version>[version]</version>
     <scope>test</scope>
   </dependency>
@@ -210,7 +210,7 @@ use [JitPack](https://jitpack.io/#MockBukkit/MockBukkit) as your maven repositor
   <dependency>
     <groupId>com.github.MockBukkit</groupId>
     <artifactId>MockBukkit</artifactId>
-    <version>v1.21-SNAPSHOT</version>
+    <version>v26.1-SNAPSHOT</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -222,7 +222,7 @@ use [JitPack](https://jitpack.io/#MockBukkit/MockBukkit) as your maven repositor
 </dependencies>
 ```
 
-Note: use `v1.13-SNAPSHOT` to test a Bukkit 1.13 plugin or any other version if
+Note: use `v26.1-SNAPSHOT` to test against Paper API 26.1, or any other version if
 the [branch](https://github.com/MockBukkit/MockBukkit/branches) exists.
 These branches will not be receiving patches actively, but any issues will be resolved and any pull requests on them
 will be accepted.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -152,6 +152,7 @@ sourceSets {
 			javaSources {
 				property("mockBukkitVersion", getFullVersion())
 				property("paperApiFullVersion", project.property("paper.api.full-version").toString())
+				property("paperApiVersion", project.property("paper.api.version").toString())
 				property("buildTime", System.currentTimeMillis().toString())
 				property("branch", run("git", "rev-parse", "--abbrev-ref", "HEAD"))
 				property("commit", run("git", "rev-parse", "HEAD"))

--- a/src/main/java-templates/org/mockbukkit/mockbukkit/BuildParameters.java.peb
+++ b/src/main/java-templates/org/mockbukkit/mockbukkit/BuildParameters.java.peb
@@ -4,6 +4,7 @@ public class BuildParameters
 {
 	public static final String MOCK_BUKKIT_VERSION = "{{ mockBukkitVersion }}";
 	public static final String PAPER_API_FULL_VERSION = "{{ paperApiFullVersion }}";
+	public static final String PAPER_API_VERSION = "{{ paperApiVersion }}";
 	public static final long BUILD_TIME = Long.parseLong("{{ buildTime }}");
 	public static final String BRANCH = "{{ branch }}";
 	public static final String COMMIT = "{{ commit }}";

--- a/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
@@ -647,7 +647,7 @@ public class ServerMock extends Server.Spigot implements Server
 	@Override
 	public @NotNull String getMinecraftVersion()
 	{
-		return this.getBukkitVersion().split("-")[0];
+		return BuildParameters.PAPER_API_VERSION;
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/services/ServerBuildInfoMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/services/ServerBuildInfoMock.java
@@ -45,7 +45,7 @@ public class ServerBuildInfoMock implements ServerBuildInfo
 	@Override
 	public @NotNull String minecraftVersionName()
 	{
-		return BuildParameters.PAPER_API_FULL_VERSION.split("-")[0];
+		return BuildParameters.PAPER_API_VERSION;
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/util/UnsafeValuesMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/util/UnsafeValuesMock.java
@@ -94,7 +94,8 @@ public class UnsafeValuesMock implements UnsafeValues
 					"1.18",
 					"1.19",
 					"1.20",
-					"1.21"
+					"1.21",
+					"26.1"
 			);
 	private static final String PROPERTY_SCHEMA_VERSION = "schema_version";
 

--- a/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
@@ -273,7 +273,7 @@ class ServerMockTest
 	@Test
 	void getVersion_CorrectPattern()
 	{
-		assertTrue(server.getVersion().matches("MockBukkit \\(MC: (\\d)\\.(\\d+)\\.?(\\d+?)?\\)"));
+		assertTrue(server.getVersion().matches("MockBukkit \\(MC: \\d+\\.\\d+(?:\\.\\d+)?\\)"));
 	}
 
 	@Test
@@ -285,7 +285,7 @@ class ServerMockTest
 	@Test
 	void getBukkitVersion_CorrectPattern()
 	{
-		assertTrue(server.getBukkitVersion().matches("1\\.[0-9]+(\\.[0-9]+)?-.*SNAPSHOT.*"));
+		assertTrue(server.getBukkitVersion().matches("\\d+\\.\\d+.*"));
 	}
 
 	@Test
@@ -297,7 +297,7 @@ class ServerMockTest
 	@Test
 	void getMinecraftVersion_CorrectPattern()
 	{
-		assertTrue(server.getMinecraftVersion().matches("1\\.[0-9]+(\\.[0-9]+)?"));
+		assertTrue(server.getMinecraftVersion().matches("\\d+\\.[0-9]+(\\.[0-9]+)?"));
 	}
 
 	@Test
@@ -2429,7 +2429,7 @@ class ServerMockTest
 				Iterable<Tag<Fluid>> fluidTag = server.getTags(Tag.REGISTRY_FLUIDS, Fluid.class);
 
 				assertNotNull(fluidTag);
-				assertEquals(2, Iterables.size(fluidTag));
+				assertEquals(6, Iterables.size(fluidTag));
 			}
 
 			@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/HangingSignDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/HangingSignDataMockTest.java
@@ -46,7 +46,7 @@ class HangingSignDataMockTest
 		@Test
 		void givenDefaultValue()
 		{
-			assertEquals(BlockFace.SOUTH, sign.getRotation());
+			assertEquals(BlockFace.NORTH, sign.getRotation());
 		}
 
 		@ParameterizedTest

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/RotatableDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/RotatableDataMockTest.java
@@ -32,7 +32,7 @@ class RotatableDataMockTest
 		@Test
 		void givenDefaultValue()
 		{
-			assertEquals(BlockFace.SOUTH, rotatable.getRotation());
+			assertEquals(BlockFace.NORTH, rotatable.getRotation());
 		}
 
 		@ParameterizedTest

--- a/src/test/java/org/mockbukkit/mockbukkit/block/data/SignDataMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/data/SignDataMockTest.java
@@ -26,7 +26,7 @@ class SignDataMockTest
 		@Test
 		void givenDefaultValue()
 		{
-			assertEquals(BlockFace.SOUTH, sign.getRotation());
+			assertEquals(BlockFace.NORTH, sign.getRotation());
 		}
 
 		@ParameterizedTest

--- a/src/test/java/org/mockbukkit/mockbukkit/tags/RegistryTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/tags/RegistryTest.java
@@ -32,7 +32,7 @@ class RegistryTest
 
 	static Stream<Tag<?>> getEmptyTags()
 	{
-		return Stream.of(Tag.INCORRECT_FOR_NETHERITE_TOOL, Tag.INCORRECT_FOR_DIAMOND_TOOL);
+		return Stream.of(Tag.INCORRECT_FOR_NETHERITE_TOOL, Tag.INCORRECT_FOR_DIAMOND_TOOL, Tag.SUPPORTS_FROGSPAWN);
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/tags/TagRegistryTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/tags/TagRegistryTest.java
@@ -110,7 +110,7 @@ class TagRegistryTest
 		{
 			@NotNull Map<NamespacedKey, Tag<?>> actual = TagRegistry.FLUIDS.getTags();
 			assertNotNull(actual);
-			assertEquals(2, actual.size());
+			assertEquals(6, actual.size());
 		}
 
 		@Test


### PR DESCRIPTION
# Description

Updates MockBukkit to target **Paper API 26.1** (`26.1.1.build.29-alpha`, Java 25).

**Production changes (`fix: allow 26.* format to be valid`):**
- Added `PAPER_API_VERSION` field to `BuildParameters.java.peb` (template) and exposed it via the blossom build config, so the short version string (e.g. `26.1`) is available separately from the full build string.
- `ServerMock.getMinecraftVersion()` now returns `BuildParameters.PAPER_API_VERSION` instead of parsing `getBukkitVersion()`.
- `ServerBuildInfoMock.minecraftVersionName()` / `minecraftVersionId()` now return `BuildParameters.PAPER_API_VERSION` instead of splitting `PAPER_API_FULL_VERSION`.
- `UnsafeValuesMock`: added `"26.1"` to `COMPATIBLE_API_VERSIONS` so `checkSupported` passes for the current server version.

**Test changes (`fix: update tests for Paper 26.1`):**
- Updated version-pattern assertions in `ServerMockTest` and `ServerBuildInfoMockTest` to match the new `26.x` version format.
- Updated fluid tag count assertions (`TagRegistryTest`, `ServerMockTest`) from 2 → 6 to reflect the additional fluid tags added in Paper 26.1.
- Added `Tag.SUPPORTS_FROGSPAWN` to the empty-tag exclusion list in `RegistryTest`.
- Corrected default rotation assertions in `RotatableDataMockTest`, `HangingSignDataMockTest`, and `SignDataMockTest` from `SOUTH` → `NORTH` (the underlying `material_data.json` encodes `rotation: '8'` which maps to `NORTH`).

# Checklist

- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
