### PR TITLE
Add support for creating and getting worlds by NamespacedKey

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
@@ -918,15 +918,13 @@ public class ServerMock extends Server.Spigot implements Server
 	@Override
 	public @Nullable World getWorld(@NotNull NamespacedKey worldKey)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return worlds.stream().filter(world -> world.getKey().equals(worldKey)).findAny().orElse(null);
 	}
 
 	@Override
 	public @Nullable World getWorld(@NotNull Key key)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return worlds.stream().filter(world -> world.key().equals(key)).findAny().orElse(null);
 	}
 
 	@NotNull

--- a/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
@@ -146,6 +146,7 @@ public class WorldMock implements World
 
 	private Environment environment = Environment.NORMAL;
 
+	private NamespacedKey key = NamespacedKey.minecraft("overworld");
 	private String name = "World";
 	private Location spawnLocation;
 	private long gameTime = 0;
@@ -244,6 +245,7 @@ public class WorldMock implements World
 	public WorldMock(@NotNull WorldCreator creator)
 	{
 		this();
+		this.key = creator.key();
 		this.name = creator.name();
 		this.worldType = creator.type();
 		this.seed = creator.seed();
@@ -2938,8 +2940,7 @@ public class WorldMock implements World
 	@Override
 	public @NotNull NamespacedKey getKey()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return key;
 	}
 
 	public void tick()

--- a/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
@@ -7,6 +7,7 @@ import com.google.common.collect.Iterators;
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
 import com.google.common.net.InetAddresses;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.Art;
@@ -175,6 +176,20 @@ class ServerMockTest
 		assertTrue(server.unloadWorld("test", false));
 		assertEquals(0, server.getWorlds().size());
 		assertNull(server.getWorld("test"));
+	}
+
+	@Test
+	void createWorld_WorldCreator_getWorld_NamespacedKey()
+	{
+		NamespacedKey worldKey = new NamespacedKey("test", "test");
+		WorldCreator worldCreator = WorldCreator.ofKey(worldKey);
+		World world = server.createWorld(worldCreator);
+
+		assertNotNull(world);
+		assertEquals(1, server.getWorlds().size());
+		assertEquals(worldKey, world.getKey());
+		assertEquals(world, server.getWorld(worldKey));
+		assertEquals(world, server.getWorld(Key.key("test:test")));
 	}
 
 	@Test


### PR DESCRIPTION
# Description

Implemented World#getKey(), Server#getWorld(NamespacedKey) and Server#getWorld(Key). As PaperMC is moving away from world names, I think this is an important api to be implemented.

# Checklist

The following items should be checked before the pull request can be merged.

- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
