### PR TITLE
Alternate unimplemented operation handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,10 @@ These exception extends `AssumptionException` and will cause the test to be skip
 These exceptions should just be ignored, though pull requests that add functionality to MockBukkit are always welcome!
 If you don't want to add the required methods yourself you can also request the method on the issues page.
 
+> [!TIP]
+> If you prefer the tests to not be skipped, you can make every test throw `UnimplementedOperationFailure` 
+> instead by setting the system property `mockbukkit.unimplementedoperation.fail` to `true`
+
 ## :headphones: Discord Server
 
 You can also find us on discord by the way!

--- a/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProviderMock.java
+++ b/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProviderMock.java
@@ -43,163 +43,163 @@ public class VanillaArgumentProviderMock implements VanillaArgumentProvider
 	@Override
 	public ArgumentType<Component> component()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<Key> key()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<Integer> time(int min)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<Style> style()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public <T> ArgumentType<T> resource(RegistryKey<T> registryKey)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public <T> ArgumentType<TypedKey<T>> resourceKey(RegistryKey<T> registryKey)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<SignedMessageResolver> signedMessage()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<EntitySelectorArgumentResolver> entity()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<HeightMap> heightMap()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<TextColor> hexColor()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<BlockState> blockState()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<LookAnchor> entityAnchor()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<RotationResolver> rotation()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<PlayerProfileListResolver> playerProfiles()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<Mirror> templateMirror()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<DoubleRangeProvider> doubleRange()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<IntegerRangeProvider> integerRange()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<ColumnFinePositionResolver> columnFinePosition(boolean centerIntegers)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<StructureRotation> templateRotation()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<BlockPositionResolver> blockPosition()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<FinePositionResolver> finePosition(boolean centerIntegers)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<ItemStackPredicate> itemStackPredicate()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<Criteria> objectiveCriteria()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<GameMode> gameMode()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<AxisSet> axes()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<EntitySelectorArgumentResolver> entities()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<World> world()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -217,49 +217,49 @@ public class VanillaArgumentProviderMock implements VanillaArgumentProvider
 	@Override
 	public ArgumentType<UUID> uuid()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<NamedTextColor> namedColor()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<ItemStack> itemStack()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<AngleResolver> angle()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<DisplaySlot> scoreboardDisplaySlot()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<ColumnBlockPositionResolver> columnBlockPosition()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<BlockInWorldPredicate> blockInWorldPredicate()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ArgumentType<NamespacedKey> namespacedKey()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/io/papermc/paper/datacomponent/item/ItemComponentTypesBridgeMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/ItemComponentTypesBridgeMock.java
@@ -151,13 +151,13 @@ public class ItemComponentTypesBridgeMock implements ItemComponentTypesBridge
 	@Override
 	public ResolvableProfile.SkinPatchBuilder skinPatch()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ResolvableProfile.SkinPatch emptySkinPatch()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/io/papermc/paper/datacomponent/item/PotionContentsMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/PotionContentsMock.java
@@ -57,13 +57,13 @@ public class PotionContentsMock implements PotionContents
 	@Override
 	public @Unmodifiable List<PotionEffect> allEffects()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public Color computeEffectiveColor()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	static class BuilderMock implements Builder

--- a/src/main/java/io/papermc/paper/datacomponent/item/ResolvableProfileMock.java
+++ b/src/main/java/io/papermc/paper/datacomponent/item/ResolvableProfileMock.java
@@ -28,7 +28,7 @@ public record ResolvableProfileMock(@Nullable UUID uuid, @Nullable String name,
 	@Override
 	public boolean dynamic()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -42,13 +42,13 @@ public record ResolvableProfileMock(@Nullable UUID uuid, @Nullable String name,
 	@Override
 	public SkinPatch skinPatch()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void applySkinToPlayerHeadContents(PlayerHeadObjectContents.@NotNull Builder builder)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	static class BuilderMock implements Builder
@@ -101,13 +101,13 @@ public record ResolvableProfileMock(@Nullable UUID uuid, @Nullable String name,
 		@Override
 		public Builder skinPatch(SkinPatch patch)
 		{
-			throw new UnimplementedOperationException();
+			throw UnimplementedOperationException.exception();
 		}
 
 		@Override
 		public Builder skinPatch(Consumer<SkinPatchBuilder> configure)
 		{
-			throw new UnimplementedOperationException();
+			throw UnimplementedOperationException.exception();
 		}
 
 		@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/MockBukkitInternalAPIBridge.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/MockBukkitInternalAPIBridge.java
@@ -67,7 +67,7 @@ public class MockBukkitInternalAPIBridge implements InternalAPIBridge
 	@Override
 	public CombatEntry createCombatEntry(LivingEntity entity, DamageSource damageSource, float damage)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -84,21 +84,21 @@ public class MockBukkitInternalAPIBridge implements InternalAPIBridge
 	@Override
 	public Predicate<CommandSourceStack> restricted(Predicate<CommandSourceStack> predicate)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public ResolvableProfile defaultMannequinProfile()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public SkinParts.Mutable allSkinParts()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
@@ -731,7 +731,7 @@ public class ServerMock extends Server.Spigot implements Server
 	public @NotNull CommandSender createCommandSender(@NotNull Consumer<? super Component> feedback)
 	{
 		//TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	/**
@@ -821,7 +821,7 @@ public class ServerMock extends Server.Spigot implements Server
 			case CRAFTER:
 				yield new CrafterInventoryMock(owner);
 			default:
-				throw new UnimplementedOperationException("Inventory type not yet supported");
+				throw UnimplementedOperationException.exception("Inventory type not yet supported");
 		};
 
 		if (title != null)
@@ -882,7 +882,7 @@ public class ServerMock extends Server.Spigot implements Server
 	public @NotNull Merchant createMerchant(@Nullable Component title)
 	{
 		//TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -901,7 +901,7 @@ public class ServerMock extends Server.Spigot implements Server
 	public boolean isTickingWorlds()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -933,7 +933,7 @@ public class ServerMock extends Server.Spigot implements Server
 	public WorldBorder createWorldBorder()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1020,7 +1020,7 @@ public class ServerMock extends Server.Spigot implements Server
 	@Override
 	public boolean forcesDefaultGameMode()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1182,21 +1182,21 @@ public class ServerMock extends Server.Spigot implements Server
 	public @NotNull ItemStack craftItem(@NotNull ItemStack[] craftingMatrix, @NotNull World world, @NotNull Player player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull ItemCraftResult craftItemResult(@NotNull ItemStack[] craftingMatrix, @NotNull World world)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull ItemCraftResult craftItemResult(@NotNull ItemStack[] craftingMatrix, @NotNull World world, @NotNull Player player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1438,32 +1438,32 @@ public class ServerMock extends Server.Spigot implements Server
 	@Override
 	public boolean isLoggingIPs()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull List<String> getInitialEnabledPacks()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull List<String> getInitialDisabledPacks()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull ServerTickManager getServerTickManager()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable ResourcePack getServerResourcePack()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	/**
@@ -1482,7 +1482,7 @@ public class ServerMock extends Server.Spigot implements Server
 	public String getResourcePack()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@NotNull
@@ -1490,7 +1490,7 @@ public class ServerMock extends Server.Spigot implements Server
 	public String getResourcePackHash()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@NotNull
@@ -1498,14 +1498,14 @@ public class ServerMock extends Server.Spigot implements Server
 	public String getResourcePackPrompt()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isResourcePackRequired()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1585,7 +1585,7 @@ public class ServerMock extends Server.Spigot implements Server
 	public long getConnectionThrottle()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1726,7 +1726,7 @@ public class ServerMock extends Server.Spigot implements Server
 	public void reloadData()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1745,7 +1745,7 @@ public class ServerMock extends Server.Spigot implements Server
 	public void savePlayers()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1758,7 +1758,7 @@ public class ServerMock extends Server.Spigot implements Server
 	public @NotNull Map<String, String[]> getCommandAliases()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1824,7 +1824,7 @@ public class ServerMock extends Server.Spigot implements Server
 	@Override
 	public io.papermc.paper.configuration.ServerConfiguration getServerConfig()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	/**
@@ -1876,7 +1876,7 @@ public class ServerMock extends Server.Spigot implements Server
 	public void shutdown()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1917,21 +1917,21 @@ public class ServerMock extends Server.Spigot implements Server
 	@Override
 	public <B extends BanList<E>, E> @NotNull B getBanList(@NotNull BanListType<B> type)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull File getWorldContainer()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Path getLevelDirectory()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1945,7 +1945,7 @@ public class ServerMock extends Server.Spigot implements Server
 	public @NotNull Merchant createMerchant(String title)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1958,7 +1958,7 @@ public class ServerMock extends Server.Spigot implements Server
 	public @NotNull Merchant createMerchant()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	/**
@@ -2038,7 +2038,7 @@ public class ServerMock extends Server.Spigot implements Server
 	public @NotNull ServerLinks getServerLinks()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2137,14 +2137,14 @@ public class ServerMock extends Server.Spigot implements Server
 	public void setIdleTimeout(int threshold)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getIdleTimeout()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2191,35 +2191,35 @@ public class ServerMock extends Server.Spigot implements Server
 	public @NotNull double[] getTPS()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull long[] getTickTimes()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public double getAverageTickTime()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public Advancement getAdvancement(NamespacedKey key)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Iterator<Advancement> advancementIterator()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2385,14 +2385,14 @@ public class ServerMock extends Server.Spigot implements Server
 	public LootTable getLootTable(NamespacedKey key)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull ItemStack createExplorerMap(World world, Location location, StructureType structureType)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2400,7 +2400,7 @@ public class ServerMock extends Server.Spigot implements Server
 												boolean findUnexplored)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2412,7 +2412,7 @@ public class ServerMock extends Server.Spigot implements Server
 												 boolean findUnexplored)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2448,7 +2448,7 @@ public class ServerMock extends Server.Spigot implements Server
 	public @NotNull List<Entity> selectEntities(CommandSender sender, String selector)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@NotNull
@@ -2634,21 +2634,21 @@ public class ServerMock extends Server.Spigot implements Server
 	public void reloadPermissions()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean reloadCommandAliases()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean suggestPlayerNamesWhenNullTabCompletions()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2697,21 +2697,21 @@ public class ServerMock extends Server.Spigot implements Server
 	public boolean isStopping()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull MobGoals getMobGoals()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull DatapackManager getDatapackManager()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@NotNull
@@ -2719,7 +2719,7 @@ public class ServerMock extends Server.Spigot implements Server
 	public YamlConfiguration getConfig()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2793,7 +2793,7 @@ public class ServerMock extends Server.Spigot implements Server
 	public @NotNull PotionBrewer getPotionBrewer()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2860,7 +2860,7 @@ public class ServerMock extends Server.Spigot implements Server
 	public boolean isPaused()
 	{
 		//TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2879,7 +2879,7 @@ public class ServerMock extends Server.Spigot implements Server
 	public void allowPausing(@NotNull Plugin plugin, boolean b)
 	{
 		//TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2899,21 +2899,21 @@ public class ServerMock extends Server.Spigot implements Server
 	public boolean isAcceptingTransfers()
 	{
 		//TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull EntityFactory getEntityFactory()
 	{
 		//TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Iterable<? extends Audience> audiences()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	/**

--- a/src/main/java/org/mockbukkit/mockbukkit/ban/IpBanEntryMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/ban/IpBanEntryMock.java
@@ -96,14 +96,14 @@ public class IpBanEntryMock implements BanEntry<InetAddress>
 	public void save()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void remove()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/ban/MockBukkitProfileBanEntry.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/ban/MockBukkitProfileBanEntry.java
@@ -94,14 +94,14 @@ public class MockBukkitProfileBanEntry implements BanEntry<PlayerProfile>
 	public void save()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void remove()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/ban/PaperProfileBanEntryMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/ban/PaperProfileBanEntryMock.java
@@ -94,14 +94,14 @@ public class PaperProfileBanEntryMock implements BanEntry<PlayerProfile>
 	public void save()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void remove()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/BlockMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/BlockMock.java
@@ -320,7 +320,7 @@ public class BlockMock implements Block
 	public @NotNull Biome getComputedBiome()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -334,7 +334,7 @@ public class BlockMock implements Block
 	public boolean isValidTool(@NotNull ItemStack itemStack)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -348,35 +348,35 @@ public class BlockMock implements Block
 	public boolean isBlockPowered()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isBlockIndirectlyPowered()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isBlockFacePowered(@NotNull BlockFace face)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isBlockFaceIndirectlyPowered(@NotNull BlockFace face)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getBlockPower(@NotNull BlockFace face)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -427,7 +427,7 @@ public class BlockMock implements Block
 	public boolean isBuildable()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 
 	}
 
@@ -436,7 +436,7 @@ public class BlockMock implements Block
 	public @NotNull BlockSoundGroup getSoundGroup()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 
 	}
 
@@ -444,7 +444,7 @@ public class BlockMock implements Block
 	public @NotNull SoundGroup getBlockSoundGroup()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -452,7 +452,7 @@ public class BlockMock implements Block
 	public @NotNull String getTranslationKey()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -465,21 +465,21 @@ public class BlockMock implements Block
 	public void tick()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void fluidTick()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void randomTick()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -522,21 +522,21 @@ public class BlockMock implements Block
 	public double getTemperature()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public double getHumidity()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull PistonMoveReaction getPistonMoveReaction()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -598,21 +598,21 @@ public class BlockMock implements Block
 	public boolean isPassable()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public RayTraceResult rayTrace(@NotNull Location start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull BoundingBox getBoundingBox()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@NotNull
@@ -620,7 +620,7 @@ public class BlockMock implements Block
 	public VoxelShape getCollisionShape()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	/**
@@ -640,35 +640,35 @@ public class BlockMock implements Block
 	public boolean applyBoneMeal(@NotNull BlockFace face)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isPreferredTool(@NotNull ItemStack tool)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public float getBreakSpeed(@NotNull Player player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean canPlace(@NotNull BlockData data)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull String translationKey()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/BlockTypeMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/BlockTypeMock.java
@@ -90,7 +90,7 @@ public class BlockTypeMock<B extends BlockData> implements BlockType.Typed<B>
 	@Override
 	public <O extends BlockData> Typed<O> typed(@NotNull Class<O> blockDataType)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -115,7 +115,7 @@ public class BlockTypeMock<B extends BlockData> implements BlockType.Typed<B>
 	@Override
 	public @NotNull Class<B> getBlockDataClass()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -139,7 +139,7 @@ public class BlockTypeMock<B extends BlockData> implements BlockType.Typed<B>
 	public @Unmodifiable @NotNull Collection<B> createBlockDataStates()
 	{
 		// TODO: Auto generated stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -218,7 +218,7 @@ public class BlockTypeMock<B extends BlockData> implements BlockType.Typed<B>
 	@Deprecated(forRemoval = true, since = "1.21.1")
 	public boolean isEnabledByFeature(@NotNull World world)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMock.java
@@ -331,35 +331,35 @@ public class BlockDataMock implements BlockData
 	public @NotNull SoundGroup getSoundGroup()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getLightEmission()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isOccluding()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean requiresCorrectToolForDrops()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isSupported(@NotNull Block block)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 
 	}
 
@@ -367,7 +367,7 @@ public class BlockDataMock implements BlockData
 	public boolean isSupported(@NotNull Location location)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 
 	}
 
@@ -375,49 +375,49 @@ public class BlockDataMock implements BlockData
 	public boolean isFaceSturdy(@NotNull BlockFace face, @NotNull BlockSupport support)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull VoxelShape getCollisionShape(@NotNull Location location)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Color getMapColor()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Material getPlacementMaterial()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void rotate(@NotNull StructureRotation rotation)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void mirror(@NotNull Mirror mirror)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void copyTo(@NotNull BlockData blockData)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -430,35 +430,35 @@ public class BlockDataMock implements BlockData
 	public float getDestroySpeed(@NotNull ItemStack itemStack, boolean considerEnchants)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isRandomlyTicked()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isReplaceable()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isPreferredTool(@NotNull ItemStack tool)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull PistonMoveReaction getPistonMoveReaction()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockRegistry.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/data/BlockDataMockRegistry.java
@@ -142,7 +142,7 @@ public class BlockDataMockRegistry
 		MaterialData materialData = blockData.get(material);
 		if (materialData == null)
 		{
-			throw new UnimplementedOperationException(String.format("Material %s is not implemented yet.", material));
+			throw UnimplementedOperationException.exception(String.format("Material %s is not implemented yet.", material));
 		}
 		return materialData.limitations();
 	}

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/AbstractFurnaceStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/AbstractFurnaceStateMock.java
@@ -111,7 +111,7 @@ public abstract class AbstractFurnaceStateMock extends ContainerStateMock implem
 	public @NotNull Map<CookingRecipe<?>, Integer> getRecipesUsed()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -132,28 +132,28 @@ public abstract class AbstractFurnaceStateMock extends ContainerStateMock implem
 	public int getRecipeUsedCount(@NotNull NamespacedKey furnaceRecipe)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasRecipeUsedCount(@NotNull NamespacedKey furnaceRecipe)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setRecipeUsedCount(@NotNull CookingRecipe<?> furnaceRecipe, int count)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setRecipesUsed(@NotNull Map<CookingRecipe<?>, Integer> recipesUsed)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@NotNull

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/BarrelStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/BarrelStateMock.java
@@ -97,70 +97,70 @@ public class BarrelStateMock extends LootableStateMock implements Barrel
 	public boolean isRefillEnabled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasBeenFilled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean canPlayerLoot(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasPlayerLooted(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Long getLastLooted(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean setHasPlayerLooted(@NotNull UUID player, boolean looted)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasPendingRefill()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long getLastFilled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long getNextRefill()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long setNextRefill(long refillAt)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/BeehiveStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/BeehiveStateMock.java
@@ -161,7 +161,7 @@ public class BeehiveStateMock extends TileStateMock implements Beehive
 	public @NotNull List<Bee> releaseEntities()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -169,7 +169,7 @@ public class BeehiveStateMock extends TileStateMock implements Beehive
 	{
 		Preconditions.checkNotNull(entity, "Bee cannot be null");
 		// TODO: We currently don't have a way to serialize entities so until that's done this can't be implemented.
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/BellStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/BellStateMock.java
@@ -67,56 +67,56 @@ public class BellStateMock extends TileStateMock implements Bell
 	public boolean ring(@Nullable Entity entity, @Nullable BlockFace direction)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean ring(@Nullable Entity entity)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean ring(@Nullable BlockFace direction)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean ring()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isShaking()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getShakingTicks()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isResonating()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getResonatingTicks()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/BlockStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/BlockStateMock.java
@@ -279,7 +279,7 @@ public class BlockStateMock implements BlockState
 	public byte getRawData()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -287,7 +287,7 @@ public class BlockStateMock implements BlockState
 	public void setRawData(byte data)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -300,34 +300,34 @@ public class BlockStateMock implements BlockState
 	public boolean isCollidable()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Collection<ItemStack> getDrops()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Collection<ItemStack> getDrops(@Nullable ItemStack tool)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Collection<ItemStack> getDrops(@NotNull ItemStack tool, @Nullable Entity entity)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isSuffocating()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -346,7 +346,7 @@ public class BlockStateMock implements BlockState
 	{
 		if (this.getClass() != BlockStateMock.class)
 		{
-			throw new UnimplementedOperationException(this.getClass().getSimpleName() +
+			throw UnimplementedOperationException.exception(this.getClass().getSimpleName() +
 					" does not provide a .copy() implementation! This is a bug.");
 		}
 		return new BlockStateMock(this);
@@ -356,7 +356,7 @@ public class BlockStateMock implements BlockState
 	public @NotNull BlockState copy(@NotNull Location location)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -376,7 +376,7 @@ public class BlockStateMock implements BlockState
 	{
 		if (this.getClass() != BlockStateMock.class)
 		{
-			throw new UnimplementedOperationException(this.getClass().getSimpleName() +
+			throw UnimplementedOperationException.exception(this.getClass().getSimpleName() +
 					" does not provide a .getSnapshot() implementation! This is a bug.");
 		}
 		return new BlockStateMock(this);

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/BrushableBlockStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/BrushableBlockStateMock.java
@@ -58,25 +58,25 @@ public class BrushableBlockStateMock extends TileStateMock implements BrushableB
 	@Override
 	public void setLootTable(@Nullable LootTable table, long seed)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable LootTable getLootTable()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setSeed(long seed)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long getSeed()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/ChestStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/ChestStateMock.java
@@ -99,7 +99,7 @@ public class ChestStateMock extends LootableStateMock implements Chest
 	public boolean isBlocked()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -124,70 +124,70 @@ public class ChestStateMock extends LootableStateMock implements Chest
 	public boolean isRefillEnabled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasBeenFilled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean canPlayerLoot(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasPlayerLooted(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Long getLastLooted(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean setHasPlayerLooted(@NotNull UUID player, boolean looted)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasPendingRefill()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long getLastFilled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long getNextRefill()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long setNextRefill(long refillAt)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/ChiseledBookshelfStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/ChiseledBookshelfStateMock.java
@@ -62,7 +62,7 @@ public class ChiseledBookshelfStateMock extends TileStateMock implements Chisele
 	@Override
 	public int getSlot(@NotNull Vector position)
 	{
-		throw new UnimplementedOperationException("Not supported yet.");
+		throw UnimplementedOperationException.exception("Not supported yet.");
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/ConduitStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/ConduitStateMock.java
@@ -69,63 +69,63 @@ public class ConduitStateMock extends TileStateMock implements Conduit
 	public boolean isActive()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Collection<Block> getFrameBlocks()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull BoundingBox getHuntingArea()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasTarget()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean setTarget(@Nullable LivingEntity target)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getFrameBlockCount()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isHunting()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getRange()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable LivingEntity getTarget()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/CrafterStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/CrafterStateMock.java
@@ -95,70 +95,70 @@ public class CrafterStateMock extends LootableStateMock implements Crafter
 	public boolean isRefillEnabled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasBeenFilled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean canPlayerLoot(UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasPlayerLooted(UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Long getLastLooted(UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean setHasPlayerLooted(UUID player, boolean looted)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasPendingRefill()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long getLastFilled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long getNextRefill()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long setNextRefill(long refillAt)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/CreatureSpawnerStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/CreatureSpawnerStateMock.java
@@ -212,49 +212,49 @@ public class CreatureSpawnerStateMock extends TileStateMock implements CreatureS
 	public @NotNull List<SpawnerEntry> getPotentialSpawns()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setPotentialSpawns(@NotNull Collection<SpawnerEntry> entries)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void addPotentialSpawn(@NotNull SpawnerEntry spawnerEntry)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void addPotentialSpawn(@NotNull EntitySnapshot snapshot, int weight, @Nullable SpawnRule spawnRule)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setSpawnedEntity(@NotNull SpawnerEntry spawnerEntry)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setSpawnedEntity(@NotNull EntitySnapshot snapshot)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable EntitySnapshot getSpawnedEntity()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/DecoratedPotStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/DecoratedPotStateMock.java
@@ -68,7 +68,7 @@ public class DecoratedPotStateMock extends LootableStateMock implements Decorate
 	@Override
 	public void startWobble(@NotNull WobbleStyle wobbleStyle)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/DispenserProjectileSourceMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/DispenserProjectileSourceMock.java
@@ -37,21 +37,21 @@ class DispenserProjectileSourceMock implements BlockProjectileSource
 	public <T extends Projectile> @NotNull T launchProjectile(@NotNull Class<? extends T> projectile)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public <T extends Projectile> @NotNull T launchProjectile(@NotNull Class<? extends T> projectile, Vector velocity)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public <T extends Projectile> @NotNull T launchProjectile(@NotNull Class<? extends T> projectile, @Nullable Vector velocity, @Nullable Consumer<? super T> function)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/DispenserStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/DispenserStateMock.java
@@ -89,77 +89,77 @@ public class DispenserStateMock extends LootableStateMock implements Dispenser
 	public boolean dispense()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isRefillEnabled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasBeenFilled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean canPlayerLoot(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasPlayerLooted(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Long getLastLooted(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean setHasPlayerLooted(@NotNull UUID player, boolean looted)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasPendingRefill()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long getLastFilled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long getNextRefill()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long setNextRefill(long refillAt)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/DropperStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/DropperStateMock.java
@@ -75,77 +75,77 @@ public class DropperStateMock extends LootableStateMock implements Dropper
 	public void drop()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isRefillEnabled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasBeenFilled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean canPlayerLoot(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasPlayerLooted(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Long getLastLooted(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean setHasPlayerLooted(@NotNull UUID player, boolean looted)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasPendingRefill()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long getLastFilled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long getNextRefill()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long setNextRefill(long refillAt)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/EnderChestStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/EnderChestStateMock.java
@@ -85,7 +85,7 @@ public class EnderChestStateMock extends TileStateMock implements EnderChest
 	public boolean isBlocked()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/HopperStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/HopperStateMock.java
@@ -76,84 +76,84 @@ public class HopperStateMock extends LootableStateMock implements Hopper
 	public boolean isRefillEnabled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasBeenFilled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean canPlayerLoot(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasPlayerLooted(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Long getLastLooted(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean setHasPlayerLooted(@NotNull UUID player, boolean looted)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasPendingRefill()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long getLastFilled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long getNextRefill()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long setNextRefill(long refillAt)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setTransferCooldown(@Range(from = 0L, to = 2147483647L) int cooldown)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getTransferCooldown()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/JukeboxStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/JukeboxStateMock.java
@@ -87,7 +87,7 @@ public class JukeboxStateMock extends TileStateMock implements Jukebox
 	public boolean hasRecord()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -113,7 +113,7 @@ public class JukeboxStateMock extends TileStateMock implements Jukebox
 	public boolean startPlaying()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -144,14 +144,14 @@ public class JukeboxStateMock extends TileStateMock implements Jukebox
 	public @NotNull JukeboxInventory getInventory()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull JukeboxInventory getSnapshotInventory()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/LockableTileStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/LockableTileStateMock.java
@@ -53,7 +53,7 @@ public abstract class LockableTileStateMock extends TileStateMock implements Loc
 	public void setLockItem(@Nullable ItemStack itemStack)
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/LootableStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/LootableStateMock.java
@@ -42,7 +42,7 @@ public abstract class LootableStateMock extends ContainerStateMock implements Lo
 	public @Nullable LootTable getLootTable()
 	{
 		// TODO Auto-generated method stub
-		throw new  UnimplementedOperationException("getLootTable");
+		throw UnimplementedOperationException.exception("getLootTable");
 	}
 
 	@Override
@@ -55,7 +55,7 @@ public abstract class LootableStateMock extends ContainerStateMock implements Lo
 	public void setLootTable(@Nullable LootTable table, long seed)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException("setLootTable");
+		throw UnimplementedOperationException.exception("setLootTable");
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/MovingPistonStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/MovingPistonStateMock.java
@@ -36,28 +36,28 @@ public class MovingPistonStateMock extends TileStateMock implements MovingPiston
 	public BlockData getMovingBlock()
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public BlockFace getDirection()
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isExtending()
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isPistonHead()
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/SculkCatalystStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/SculkCatalystStateMock.java
@@ -65,14 +65,14 @@ public class SculkCatalystStateMock extends TileStateMock implements SculkCataly
 	public void bloom(@NotNull Block block, int charges)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void bloom(@NotNull Position position, int charge)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/SculkShriekerStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/SculkShriekerStateMock.java
@@ -81,7 +81,7 @@ public class SculkShriekerStateMock extends TileStateMock implements SculkShriek
 	public void tryShriek(@Nullable Player player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/ShulkerBoxStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/ShulkerBoxStateMock.java
@@ -145,70 +145,70 @@ public class ShulkerBoxStateMock extends LootableStateMock implements ShulkerBox
 	public boolean isRefillEnabled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasBeenFilled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean canPlayerLoot(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasPlayerLooted(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Long getLastLooted(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean setHasPlayerLooted(@NotNull UUID player, boolean looted)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasPendingRefill()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long getLastFilled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long getNextRefill()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long setNextRefill(long refillAt)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/SignStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/SignStateMock.java
@@ -114,14 +114,14 @@ public class SignStateMock extends TileStateMock implements Sign
 	public boolean isEditable()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setEditable(boolean editable)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -152,14 +152,14 @@ public class SignStateMock extends TileStateMock implements Sign
 	public boolean isWaxed()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setWaxed(boolean waxed)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -176,35 +176,35 @@ public class SignStateMock extends TileStateMock implements Sign
 	public @NotNull SignSide getTargetSide(@NotNull Player player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Player getAllowedEditor()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable UUID getAllowedEditorUniqueId()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setAllowedEditorUniqueId(@Nullable UUID uuid)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Side getInteractableSideFor(double x, double z)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/SkullStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/SkullStateMock.java
@@ -84,14 +84,14 @@ public class SkullStateMock extends TileStateMock implements Skull
 	public @Nullable ResolvableProfile getProfile()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setProfile(@Nullable ResolvableProfile resolvableProfile)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -190,14 +190,14 @@ public class SkullStateMock extends TileStateMock implements Skull
 	public @Nullable NamespacedKey getNoteBlockSound()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setNoteBlockSound(@Nullable NamespacedKey noteBlockSound)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -248,13 +248,13 @@ public class SkullStateMock extends TileStateMock implements Skull
 	@Override
 	public @Nullable Component customName()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void customName(@Nullable Component component)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/TileStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/TileStateMock.java
@@ -63,7 +63,7 @@ public abstract class TileStateMock extends BlockStateMock implements TileState
 	public boolean isSnapshot()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/TrialSpawnerStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/TrialSpawnerStateMock.java
@@ -85,14 +85,14 @@ public class TrialSpawnerStateMock extends TileStateMock implements TrialSpawner
 	public int getCooldownLength()
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setCooldownLength(int ticks)
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -199,14 +199,14 @@ public class TrialSpawnerStateMock extends TileStateMock implements TrialSpawner
 	public TrialSpawnerConfiguration getNormalConfiguration()
 	{
 		// TODO: Auto generated stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public TrialSpawnerConfiguration getOminousConfiguration()
 	{
 		// TODO: Auto generated stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/VaultStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/VaultStateMock.java
@@ -98,42 +98,42 @@ public class VaultStateMock extends TileStateMock implements Vault
 	public LootTable getLootTable()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException("getLootTable");
+		throw UnimplementedOperationException.exception("getLootTable");
 	}
 
 	@Override
 	public void setLootTable(LootTable lootTable)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException("setLootTable");
+		throw UnimplementedOperationException.exception("setLootTable");
 	}
 
 	@Override
 	public @Nullable LootTable getDisplayedLootTable()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException("getDisplayedLootTable");
+		throw UnimplementedOperationException.exception("getDisplayedLootTable");
 	}
 
 	@Override
 	public void setDisplayedLootTable(@Nullable LootTable lootTable)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException("setDisplayedLootTable");
+		throw UnimplementedOperationException.exception("setDisplayedLootTable");
 	}
 
 	@Override
 	public long getNextStateUpdateTime()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException("getNextStateUpdateTime");
+		throw UnimplementedOperationException.exception("getNextStateUpdateTime");
 	}
 
 	@Override
 	public void setNextStateUpdateTime(long nextStateUpdateTime)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException("setNextStateUpdateTime");
+		throw UnimplementedOperationException.exception("setNextStateUpdateTime");
 	}
 
 	@Override
@@ -180,14 +180,14 @@ public class VaultStateMock extends TileStateMock implements Vault
 	public ItemStack getDisplayedItem()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException("setNextStateUpdateTime");
+		throw UnimplementedOperationException.exception("setNextStateUpdateTime");
 	}
 
 	@Override
 	public void setDisplayedItem(ItemStack displayedItem)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException("setNextStateUpdateTime");
+		throw UnimplementedOperationException.exception("setNextStateUpdateTime");
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/command/CommandBlockHolderMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/command/CommandBlockHolderMock.java
@@ -16,28 +16,28 @@ public interface CommandBlockHolderMock extends CommandBlockHolder
 	default @NotNull Component lastOutput()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	default void lastOutput(@Nullable Component lastOutput)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	default int getSuccessCount()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	default void setSuccessCount(int successCount)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/enchantments/EnchantmentMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/enchantments/EnchantmentMock.java
@@ -179,7 +179,7 @@ public class EnchantmentMock extends Enchantment
 	public float getDamageIncrease(int level, @NotNull EntityCategory entityCategory)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -187,7 +187,7 @@ public class EnchantmentMock extends Enchantment
 	public float getDamageIncrease(int level, @NotNull EntityType entityType)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -195,49 +195,49 @@ public class EnchantmentMock extends Enchantment
 	public @NotNull Set<EquipmentSlot> getActiveSlots()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Set<EquipmentSlotGroup> getActiveSlotGroups()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Component description()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull RegistryKeySet<ItemType> getSupportedItems()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable RegistryKeySet<ItemType> getPrimaryItems()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getWeight()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull RegistryKeySet<Enchantment> getExclusiveWith()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/AbstractArrowMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/AbstractArrowMock.java
@@ -99,21 +99,21 @@ public class AbstractArrowMock extends AbstractProjectileMock implements Abstrac
 	public boolean isInBlock()
 	{
 		// TODO: Auto generated stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Block getAttachedBlock()
 	{
 		// TODO: Auto generated stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull @Unmodifiable List<Block> getAttachedBlocks()
 	{
 		// TODO: Auto generated stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -145,41 +145,41 @@ public class AbstractArrowMock extends AbstractProjectileMock implements Abstrac
 	public @NotNull ItemStack getItem()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setItem(@NotNull ItemStack item)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable ItemStack getWeapon()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setWeapon(@NotNull ItemStack item)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull ItemStack getItemStack()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setItemStack(@NotNull ItemStack itemStack)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -211,7 +211,7 @@ public class AbstractArrowMock extends AbstractProjectileMock implements Abstrac
 	public void setShooter(@Nullable ProjectileSource projectileSource, boolean b)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/AbstractHorseMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/AbstractHorseMock.java
@@ -158,7 +158,7 @@ public abstract class AbstractHorseMock extends AnimalsMock implements AbstractH
 	public @NotNull AbstractHorseInventory getInventory()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/AbstractNautilusMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/AbstractNautilusMock.java
@@ -30,7 +30,7 @@ public class AbstractNautilusMock extends AnimalsMock implements AbstractNautilu
 	@Override
 	public ArmoredSaddledMountInventory getInventory()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/AbstractProjectileMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/AbstractProjectileMock.java
@@ -105,19 +105,19 @@ public abstract class AbstractProjectileMock extends EntityMock implements Proje
 	@Override
 	public boolean canHitEntity(@NotNull Entity entity)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void hitEntity(@NotNull Entity entity)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void hitEntity(@NotNull Entity entity, @NotNull Vector vector)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/ArmadilloMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/ArmadilloMock.java
@@ -31,19 +31,19 @@ public class ArmadilloMock extends AnimalsMock implements Armadillo
 	@Override
 	public State getState()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void rollUp()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void rollOut()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/ArmorStandMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/ArmorStandMock.java
@@ -286,21 +286,21 @@ public class ArmorStandMock extends LivingEntityMock implements ArmorStand
 	public void addEquipmentLock(@NotNull EquipmentSlot slot, @NotNull LockType lockType)
 	{
 		// TODO Equipment Locks use byte operations internally, they might be hard to implement
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void removeEquipmentLock(@NotNull EquipmentSlot slot, @NotNull LockType lockType)
 	{
 		// TODO Equipment Locks use byte operations internally, they might be hard to implement
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasEquipmentLock(@NotNull EquipmentSlot slot, @NotNull LockType lockType)
 	{
 		// TODO Equipment Locks use byte operations internally, they might be hard to implement
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -339,7 +339,7 @@ public class ArmorStandMock extends LivingEntityMock implements ArmorStand
 			case LEGS -> getLeggings();
 			case CHEST -> getChestplate();
 			case HEAD -> getHelmet();
-			case BODY, SADDLE -> throw new UnimplementedOperationException();
+			case BODY, SADDLE -> throw UnimplementedOperationException.exception();
 		};
 	}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/ArrowMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/ArrowMock.java
@@ -59,49 +59,49 @@ public class ArrowMock extends AbstractArrowMock implements Arrow
 	@Override
 	public @Nullable Color getColor()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setColor(@Nullable Color color)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasCustomEffects()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull List<PotionEffect> getCustomEffects()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean addCustomEffect(@NotNull PotionEffect effect, boolean overwrite)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean removeCustomEffect(@NotNull PotionEffectType type)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasCustomEffect(@Nullable PotionEffectType type)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void clearCustomEffects()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/BeeMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/BeeMock.java
@@ -138,28 +138,28 @@ public class BeeMock extends AnimalsMock implements Bee
 	public void setCropsGrownSincePollination(int crops)
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getCropsGrownSincePollination()
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setTicksSincePollination(int ticks)
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getTicksSincePollination()
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/BoatMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/BoatMock.java
@@ -150,7 +150,7 @@ public class BoatMock extends VehicleMock implements Boat
 	public @NotNull Status getStatus()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -180,21 +180,21 @@ public class BoatMock extends VehicleMock implements Boat
 	public boolean isLeashed()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NonNull Entity getLeashHolder() throws IllegalStateException
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean setLeashHolder(@Nullable Entity entity)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/ChestBoatMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/ChestBoatMock.java
@@ -35,76 +35,76 @@ public class ChestBoatMock extends BoatMock implements ChestBoat
 	public boolean isRefillEnabled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	public void setRefillEnabled(boolean refillEnabled)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasBeenFilled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean canPlayerLoot(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasPlayerLooted(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Long getLastLooted(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean setHasPlayerLooted(@NotNull UUID player, boolean looted)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasPendingRefill()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long getLastFilled()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long getNextRefill()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long setNextRefill(long refillAt)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -117,35 +117,35 @@ public class ChestBoatMock extends BoatMock implements ChestBoat
 	public void setLootTable(@Nullable LootTable table)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable LootTable getLootTable()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setLootTable(@Nullable LootTable lootTable, long l)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setSeed(long seed)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long getSeed()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/CommandMinecartMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/CommandMinecartMock.java
@@ -46,14 +46,14 @@ public class CommandMinecartMock extends MinecartMock implements CommandMinecart
 	public @NotNull Component lastOutput()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void lastOutput(@Nullable Component lastOutput)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 
 	}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/CopperGolemMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/CopperGolemMock.java
@@ -59,14 +59,14 @@ public class CopperGolemMock extends GolemMock implements CopperGolem
 	public @NonNull State getGolemState()
 	{
 		// TODO
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setGolemState(@NonNull State state)
 	{
 		// TODO
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/CreeperMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/CreeperMock.java
@@ -115,14 +115,14 @@ public class CreeperMock extends MonsterMock implements Creeper
 	public void ignite(@NotNull Entity entity)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Entity getIgniter()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/DisplayMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/DisplayMock.java
@@ -179,13 +179,13 @@ public class DisplayMock extends EntityMock implements Display
 	@Override
 	public @NotNull Billboard getBillboard()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setBillboard(@NotNull Billboard billboard)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/DragonBattleMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/DragonBattleMock.java
@@ -57,7 +57,7 @@ public class DragonBattleMock implements DragonBattle
 	@Override
 	public boolean generateEndPortal(boolean withPortals)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -147,7 +147,7 @@ public class DragonBattleMock implements DragonBattle
 	@Override
 	public void spawnNewGateway(@NotNull Position position)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -159,7 +159,7 @@ public class DragonBattleMock implements DragonBattle
 	@Override
 	public @NotNull @Unmodifiable List<EnderCrystal> getHealingCrystals()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/EnderDragonMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/EnderDragonMock.java
@@ -56,7 +56,7 @@ public class EnderDragonMock extends AbstractBossMock implements EnderDragon
 	@Override
 	public int getDeathAnimationTicks()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -74,7 +74,7 @@ public class EnderDragonMock extends AbstractBossMock implements EnderDragon
 	@Override
 	public @NotNull Set<ComplexEntityPart> getParts()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/EndermanMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/EndermanMock.java
@@ -51,7 +51,7 @@ public class EndermanMock extends MonsterMock implements Enderman
 	public boolean teleportRandomly()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/EntityMock.java
@@ -178,25 +178,25 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	@Override
 	public boolean hasData(@NotNull DataComponentType type)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public <T> @Nullable T getDataOrDefault(DataComponentType.@NotNull Valued<? extends T> type, @Nullable T fallback)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public <T> @Nullable T getData(DataComponentType.@NotNull Valued<T> type)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isTrackedBy(@NotNull Player player)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	/**
@@ -283,7 +283,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	public @NotNull Set<Player> getTrackedPlayers()
 	{
 		//TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -854,7 +854,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	public @NotNull Set<Player> getTrackedBy()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	/**
@@ -1155,7 +1155,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	public @NotNull CompletableFuture<Boolean> teleportAsync(@NotNull Location loc, PlayerTeleportEvent.@NotNull TeleportCause cause, @NotNull TeleportFlag @NotNull ... teleportFlags)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1222,7 +1222,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	public @NotNull PistonMoveReaction getPistonMoveReaction()
 	{
 		// TODO Auto-generated constructor stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1271,7 +1271,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	public @NotNull BlockFace getFacing()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1306,21 +1306,21 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	public @NotNull Entity copy(@NotNull Location to)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Entity copy()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable EntitySnapshot createSnapshot()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1357,21 +1357,21 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	public @NotNull HoverEvent<HoverEvent.ShowEntity> asHoverEvent()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Location getOrigin()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean fromMobSpawner()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1390,77 +1390,77 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	public boolean isUnderWater()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isInRain()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isInBubbleColumn()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isInWaterOrRain()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isInWaterOrBubbleColumn()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isInWaterOrRainOrBubbleColumn()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isInLava()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isTicking()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean spawnAt(@NotNull Location location)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean spawnAt(@NotNull Location location, CreatureSpawnEvent.@NotNull SpawnReason reason)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isInPowderedSnow()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1497,14 +1497,14 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	public void setVisibleByDefault(boolean visible)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isVisibleByDefault()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1567,7 +1567,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	public @Nullable String getAsString()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1584,13 +1584,13 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	@Override
 	public void lookAt(double v, double v1, double v2, @NotNull LookAnchor lookAnchor)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull ItemStack getPickItemStack()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	public void tick()

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/EntityTypesMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/EntityTypesMock.java
@@ -443,7 +443,7 @@ public final class EntityTypesMock
 
 			if (data == null)
 			{
-				throw new UnimplementedOperationException(String.format("Mock for entity %s was not implemented yet.", bukkitClazz.getName()));
+				throw UnimplementedOperationException.exception(String.format("Mock for entity %s was not implemented yet.", bukkitClazz.getName()));
 			}
 		}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/ExperienceOrbMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/ExperienceOrbMock.java
@@ -65,34 +65,34 @@ public class ExperienceOrbMock extends EntityMock implements ExperienceOrb
 	@Override
 	public int getCount()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setCount(int i)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable UUID getTriggerEntityId()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable UUID getSourceEntityId()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull SpawnReason getSpawnReason()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/ExplosiveMinecartMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/ExplosiveMinecartMock.java
@@ -43,13 +43,13 @@ public class ExplosiveMinecartMock extends MinecartMock implements ExplosiveMine
 	@Override
 	public float getExplosionSpeedFactor()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setExplosionSpeedFactor(float v)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -103,28 +103,28 @@ public class ExplosiveMinecartMock extends MinecartMock implements ExplosiveMine
 	public void setYield(float yield)
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public float getYield()
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setIsIncendiary(boolean isIncendiary)
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isIncendiary()
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/FireworkMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/FireworkMock.java
@@ -73,14 +73,14 @@ public class FireworkMock extends ProjectileMock implements Firework
 	public boolean setAttachedTo(@Nullable LivingEntity entity)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable LivingEntity getAttachedTo()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -88,7 +88,7 @@ public class FireworkMock extends ProjectileMock implements Firework
 	public boolean setLife(int ticks)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -96,7 +96,7 @@ public class FireworkMock extends ProjectileMock implements Firework
 	public int getLife()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -104,7 +104,7 @@ public class FireworkMock extends ProjectileMock implements Firework
 	public boolean setMaxLife(int ticks)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -112,21 +112,21 @@ public class FireworkMock extends ProjectileMock implements Firework
 	public int getMaxLife()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void detonate()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isDetonated()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -145,56 +145,56 @@ public class FireworkMock extends ProjectileMock implements Firework
 	public @Nullable UUID getSpawningEntity()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable LivingEntity getBoostedEntity()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull ItemStack getItem()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setItem(@Nullable ItemStack itemStack)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getTicksFlown()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setTicksFlown(int ticks)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getTicksToDetonate()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setTicksToDetonate(int ticks)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/FishHookMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/FishHookMock.java
@@ -186,7 +186,7 @@ public class FishHookMock extends ProjectileMock implements FishHook
 	public boolean isInOpenWater()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Nullable
@@ -278,38 +278,38 @@ public class FishHookMock extends ProjectileMock implements FishHook
 	public int getWaitTime()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setWaitTime(int ticks)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Range(from = 0L, to = 2147483647L) int getTimeUntilBite()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setTimeUntilBite(@Range(from = 1L, to = 2147483647L) int i) throws IllegalArgumentException
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void resetFishingState()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int retrieve(@NotNull EquipmentSlot slot)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@NotNull

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/GuardianMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/GuardianMock.java
@@ -51,21 +51,21 @@ public class GuardianMock extends MonsterMock implements Guardian
 	public int getLaserDuration()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setLaserTicks(int ticks)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getLaserTicks()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -84,7 +84,7 @@ public class GuardianMock extends MonsterMock implements Guardian
 	public boolean isMoving()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/HopperMinecartMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/HopperMinecartMock.java
@@ -89,14 +89,14 @@ public class HopperMinecartMock extends LootableMinecart implements HopperMineca
 	public boolean canPlayerLoot(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setLootTable(@Nullable LootTable lootTable, long l)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/HumanEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/HumanEntityMock.java
@@ -223,7 +223,7 @@ public abstract class HumanEntityMock extends LivingEntityMock implements HumanE
 	public @Nullable Firework fireworkBoost(@NotNull ItemStack fireworkItemStack)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -248,7 +248,7 @@ public abstract class HumanEntityMock extends LivingEntityMock implements HumanE
 	public boolean setWindowProperty(@NotNull InventoryView.Property prop, int value)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -267,14 +267,14 @@ public abstract class HumanEntityMock extends LivingEntityMock implements HumanE
 	public InventoryView openWorkbench(Location location, boolean force)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public InventoryView openEnchanting(Location location, boolean force)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -288,49 +288,49 @@ public abstract class HumanEntityMock extends LivingEntityMock implements HumanE
 	public InventoryView openMerchant(@NotNull Merchant merchant, boolean force)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable InventoryView openAnvil(@Nullable Location location, boolean force)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable InventoryView openCartographyTable(@Nullable Location location, boolean force)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable InventoryView openGrindstone(@Nullable Location location, boolean force)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable InventoryView openLoom(@Nullable Location location, boolean force)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable InventoryView openSmithingTable(@Nullable Location location, boolean force)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable InventoryView openStonecutter(@Nullable Location location, boolean force)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -429,7 +429,7 @@ public abstract class HumanEntityMock extends LivingEntityMock implements HumanE
 	public @Nullable Location getPotentialBedLocation()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -452,14 +452,14 @@ public abstract class HumanEntityMock extends LivingEntityMock implements HumanE
 	public boolean sleep(@NotNull Location location, boolean force)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void wakeup(boolean setSpawnLocation)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -469,14 +469,14 @@ public abstract class HumanEntityMock extends LivingEntityMock implements HumanE
 		Preconditions.checkArgument(damage >= 0, "Damage must not be negative");
 
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Location getBedLocation()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -524,21 +524,21 @@ public abstract class HumanEntityMock extends LivingEntityMock implements HumanE
 	public @Nullable Entity releaseLeftShoulderEntity()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Entity releaseRightShoulderEntity()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public float getAttackCooldown()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -611,28 +611,28 @@ public abstract class HumanEntityMock extends LivingEntityMock implements HumanE
 	public Entity getShoulderEntityLeft()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setShoulderEntityLeft(Entity entity)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public Entity getShoulderEntityRight()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setShoulderEntityRight(Entity entity)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -646,35 +646,35 @@ public abstract class HumanEntityMock extends LivingEntityMock implements HumanE
 	public void openSign(@NotNull Sign sign, @NotNull Side side)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean dropItem(boolean dropAll)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Item dropItem(int slot, int amount, boolean throwRandomly, @Nullable Consumer<Item> entityOperation)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Item dropItem(@NotNull EquipmentSlot slot, int amount, boolean throwRandomly, @Nullable Consumer<Item> entityOperation)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Item dropItem(@NotNull ItemStack itemStack, boolean throwRandomly, @Nullable Consumer<Item> entityOperation)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -754,7 +754,7 @@ public abstract class HumanEntityMock extends LivingEntityMock implements HumanE
 	public @Nullable Location getPotentialRespawnLocation()
 	{
 		// TODO: Auto generated stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/ItemMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/ItemMock.java
@@ -77,98 +77,98 @@ public class ItemMock extends EntityMock implements Item
 	public void setUnlimitedLifetime(boolean unlimited)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isUnlimitedLifetime()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setOwner(@Nullable UUID owner)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable UUID getOwner()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setThrower(@Nullable UUID thrower)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable UUID getThrower()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean canMobPickup()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setCanMobPickup(boolean canMobPickup)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean canPlayerPickup()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setCanPlayerPickup(boolean canPlayerPickup)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean willAge()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setWillAge(boolean willAge)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getHealth()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setHealth(int health)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LightningStrikeMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LightningStrikeMock.java
@@ -120,7 +120,7 @@ public class LightningStrikeMock extends EntityMock implements LightningStrike
 	@Deprecated(forRemoval = true)
 	public @NotNull LightningStrike.Spigot spigot()
 	{
-		throw new UnimplementedOperationException("spigot() method is not implemented in LightningStrikeMock");
+		throw UnimplementedOperationException.exception("spigot() method is not implemented in LightningStrikeMock");
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -279,7 +279,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	@Override
 	public void damage(double amount, @NotNull DamageSource source)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	/**
@@ -506,84 +506,84 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	public @NotNull List<Block> getLineOfSight(Set<Material> transparent, int maxDistance)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Block getTargetBlock(Set<Material> transparent, int maxDistance)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Block getTargetBlock(int maxDistance, TargetBlockInfo.@NotNull FluidMode fluidMode)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable BlockFace getTargetBlockFace(int maxDistance, TargetBlockInfo.@NotNull FluidMode fluidMode)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable TargetBlockInfo getTargetBlockInfo(int maxDistance, TargetBlockInfo.@NotNull FluidMode fluidMode)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Entity getTargetEntity(int maxDistance, boolean ignoreBlocks)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable TargetEntityInfo getTargetEntityInfo(int maxDistance, boolean ignoreBlocks)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull List<Block> getLastTwoTargetBlocks(Set<Material> transparent, int maxDistance)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Block getTargetBlockExact(int maxDistance)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Block getTargetBlockExact(int maxDistance, @NotNull FluidCollisionMode fluidCollisionMode)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable RayTraceResult rayTraceBlocks(double maxDistance)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable RayTraceResult rayTraceBlocks(double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -614,21 +614,21 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	public double getLastDamage()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setLastDamage(double damage)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getNoActionTicks()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 
 	}
 
@@ -636,7 +636,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	public void setNoActionTicks(int ticks)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 
 	}
 
@@ -846,28 +846,28 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	public boolean hasLineOfSight(@NotNull Entity other)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasLineOfSight(@NotNull Location location)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean getRemoveWhenFarAway()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setRemoveWhenFarAway(boolean remove)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Nullable
@@ -881,14 +881,14 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	public void setCanPickupItems(boolean pickup)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean getCanPickupItems()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -986,7 +986,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	{
 		Preconditions.checkNotNull(target, "Target cannot be null");
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1005,7 +1005,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	public void playHurtAnimation(float yaw)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1044,56 +1044,56 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	public @Nullable Sound getHurtSound()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Sound getDeathSound()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Sound getFallDamageSound(int fallHeight)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Sound getFallDamageSoundSmall()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Sound getFallDamageSoundBig()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Sound getDrinkingSound(@NotNull ItemStack itemStack)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Sound getEatingSound(@NotNull ItemStack itemStack)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean canBreatheUnderwater()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@NotNull
@@ -1101,7 +1101,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	public EntityCategory getCategory()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1115,77 +1115,77 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	public void setBodyYaw(float bodyYaw)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public float getBodyYaw()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setArrowsInBody(int count, boolean fireEvent)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getBeeStingerCooldown()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setBeeStingerCooldown(int ticks)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getBeeStingersInBody()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setBeeStingersInBody(int count)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setNextArrowRemoval(@Range(from = 0L, to = 2147483647L) int i)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getNextArrowRemoval()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setNextBeeStingerRemoval(@Range(from = 0L, to = 2147483647L) int i)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getNextBeeStingerRemoval()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1210,28 +1210,28 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	public int getArrowsStuck()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setArrowsStuck(int arrows)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getShieldBlockingDelay()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setShieldBlockingDelay(int delay)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1275,56 +1275,56 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	public void playPickupItemAnimation(@NotNull Item item, int quantity)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public float getHurtDirection()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setHurtDirection(float hurtDirection)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void knockback(double strength, double directionX, double directionZ)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void broadcastSlotBreak(@NotNull EquipmentSlot slot)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void broadcastSlotBreak(@NotNull EquipmentSlot slot, @NotNull Collection<Player> players)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull ItemStack damageItemStack(@NotNull ItemStack stack, int amount)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void damageItemStack(@NotNull EquipmentSlot slot, int amount)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1344,71 +1344,71 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	public @Nullable BlockFace getTargetBlockFace(int maxDistance, @NotNull FluidCollisionMode fluidMode)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable RayTraceResult rayTraceEntities(int maxDistance, boolean ignoreBlocks)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setWaypointStyle(@Nullable Key key)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setWaypointColor(@Nullable Color color)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Key getWaypointStyle()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Color getWaypointColor()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public float getForwardsMovement()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public float getUpwardsMovement()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public float getSidewaysMovement()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void heal(double amount, @NotNull EntityRegainHealthEvent.RegainReason regainReason)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean canUseEquipmentSlot(@NotNull EquipmentSlot equipmentSlot)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LootableMinecart.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LootableMinecart.java
@@ -129,28 +129,28 @@ public abstract class LootableMinecart extends MinecartMock implements LootableI
 	public void setLootTable(@Nullable LootTable table)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable LootTable getLootTable()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setSeed(long seed)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long getSeed()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/MinecartMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/MinecartMock.java
@@ -153,14 +153,14 @@ public abstract class MinecartMock extends VehicleMock implements Minecart
 	public TriState getFrictionState()
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setFrictionState(TriState triState)
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/MobMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/MobMock.java
@@ -43,70 +43,70 @@ public abstract class MobMock extends LivingEntityMock implements Mob
 	public @NotNull Pathfinder getPathfinder()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isInDaylight()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void lookAt(@NotNull Location location)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void lookAt(@NotNull Location location, float headRotationSpeed, float maxHeadPitch)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void lookAt(@NotNull Entity entity)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void lookAt(@NotNull Entity entity, float headRotationSpeed, float maxHeadPitch)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void lookAt(double x, double y, double z)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void lookAt(double x, double y, double z, float headRotationSpeed, float maxHeadPitch)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getHeadRotationSpeed()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getMaxHeadPitch()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -138,7 +138,7 @@ public abstract class MobMock extends LivingEntityMock implements Mob
 	public @Nullable Sound getAmbientSound()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -157,7 +157,7 @@ public abstract class MobMock extends LivingEntityMock implements Mob
 	public void setLootTable(@Nullable LootTable table)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Nullable
@@ -165,21 +165,21 @@ public abstract class MobMock extends LivingEntityMock implements Mob
 	public LootTable getLootTable()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setSeed(long seed)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long getSeed()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	/**
@@ -198,40 +198,40 @@ public abstract class MobMock extends LivingEntityMock implements Mob
 	public int getPossibleExperienceReward()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isAggressive()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setAggressive(boolean aggressive)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 
 	@Override
 	public boolean shouldDespawnInPeaceful()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setDespawnInPeacefulOverride(TriState triState)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public TriState getDespawnInPeacefulOverride()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/MockRangedEntity.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/MockRangedEntity.java
@@ -16,13 +16,13 @@ public interface MockRangedEntity<T extends MobMock> extends RangedEntity
 	@Override
 	default void rangedAttack(@NotNull LivingEntity target, float charge)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	default void setChargingAttack(boolean raiseHands)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	/**
@@ -34,7 +34,7 @@ public interface MockRangedEntity<T extends MobMock> extends RangedEntity
 	 */
 	default boolean hasAttackedWithCharge(LivingEntity target, float charge)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	/**
@@ -45,7 +45,7 @@ public interface MockRangedEntity<T extends MobMock> extends RangedEntity
 	 */
 	default boolean hasAttackedWhileAggressive(LivingEntity target)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/MushroomCowMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/MushroomCowMock.java
@@ -50,44 +50,44 @@ public class MushroomCowMock extends AbstractCowMock implements MushroomCow
 	@Override
 	public boolean hasEffectsForNextStew()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull List<PotionEffect> getEffectsForNextStew()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	@Deprecated(forRemoval = true, since = "1.20.2")
 	public boolean addEffectToNextStew(@NotNull PotionEffect effect, boolean overwrite)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean addEffectToNextStew(@NotNull SuspiciousEffectEntry suspiciousEffectEntry, boolean overwrite)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean removeEffectFromNextStew(@NotNull PotionEffectType type)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasEffectForNextStew(@NotNull PotionEffectType type)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void clearEffectsForNextStew()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -107,42 +107,42 @@ public class MushroomCowMock extends AbstractCowMock implements MushroomCow
 	public int getStewEffectDuration()
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setStewEffectDuration(int duration)
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable PotionEffectType getStewEffectType()
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setStewEffect(@Nullable PotionEffectType type)
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull @Unmodifiable List<SuspiciousEffectEntry> getStewEffects()
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setStewEffects(@NotNull List<SuspiciousEffectEntry> effects)
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/OfflinePlayerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/OfflinePlayerMock.java
@@ -90,7 +90,7 @@ public class OfflinePlayerMock implements OfflinePlayer
 	public boolean isConnected()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -207,13 +207,13 @@ public class OfflinePlayerMock implements OfflinePlayer
 	public @Nullable Location getRespawnLocation()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @org.jspecify.annotations.Nullable Location getRespawnLocation(boolean loadLocationAndValidate)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -240,147 +240,147 @@ public class OfflinePlayerMock implements OfflinePlayer
 	public void incrementStatistic(@NotNull Statistic statistic)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void decrementStatistic(@NotNull Statistic statistic)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void incrementStatistic(@NotNull Statistic statistic, int amount)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void decrementStatistic(@NotNull Statistic statistic, int amount)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setStatistic(@NotNull Statistic statistic, int newValue)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getStatistic(@NotNull Statistic statistic)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void incrementStatistic(@NotNull Statistic statistic, @NotNull Material material)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void decrementStatistic(@NotNull Statistic statistic, @NotNull Material material)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getStatistic(@NotNull Statistic statistic, @NotNull Material material)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void incrementStatistic(@NotNull Statistic statistic, @NotNull Material material, int amount)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void decrementStatistic(@NotNull Statistic statistic, @NotNull Material material, int amount)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setStatistic(@NotNull Statistic statistic, @NotNull Material material, int newValue)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void incrementStatistic(@NotNull Statistic statistic, @NotNull EntityType entityType)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void decrementStatistic(@NotNull Statistic statistic, @NotNull EntityType entityType)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getStatistic(@NotNull Statistic statistic, @NotNull EntityType entityType)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void incrementStatistic(@NotNull Statistic statistic, @NotNull EntityType entityType, int amount)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void decrementStatistic(@NotNull Statistic statistic, @NotNull EntityType entityType, int amount)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setStatistic(@NotNull Statistic statistic, @NotNull EntityType entityType, int newValue)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Location getLastDeathLocation()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Location getLocation()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull PersistentDataContainerView getPersistentDataContainer()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/PandaMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/PandaMock.java
@@ -166,7 +166,7 @@ public class PandaMock extends AnimalsMock implements Panda
 	public @NotNull Gene getCombinedGene()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/ParrotMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/ParrotMock.java
@@ -47,7 +47,7 @@ public class ParrotMock extends AnimalsMock implements Parrot
 	public boolean isDancing()
 	{
 		// TODO Implement when startPlaying in jukebox is implemented
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/PiglinMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/PiglinMock.java
@@ -112,31 +112,31 @@ public class PiglinMock extends PiglinAbstractMock implements Piglin
 	@Override
 	public void setDancing(boolean dancing)
 	{
-		throw new UnimplementedOperationException("SetDancing was not implemented yet.");
+		throw UnimplementedOperationException.exception("SetDancing was not implemented yet.");
 	}
 
 	@Override
 	public void setDancing(long duration)
 	{
-		throw new UnimplementedOperationException("SetDancing was not implemented yet.");
+		throw UnimplementedOperationException.exception("SetDancing was not implemented yet.");
 	}
 
 	@Override
 	public boolean isDancing()
 	{
-		throw new UnimplementedOperationException("IsDancing was not implemented yet.");
+		throw UnimplementedOperationException.exception("IsDancing was not implemented yet.");
 	}
 
 	@Override
 	public void rangedAttack(LivingEntity target, float charge)
 	{
-		throw new UnimplementedOperationException("RangedAttack was not implemented yet.");
+		throw UnimplementedOperationException.exception("RangedAttack was not implemented yet.");
 	}
 
 	@Override
 	public void setChargingAttack(boolean raiseHands)
 	{
-		throw new UnimplementedOperationException("SetChargingAttack was not implemented yet.");
+		throw UnimplementedOperationException.exception("SetChargingAttack was not implemented yet.");
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
@@ -550,7 +550,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public boolean isConnected()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -679,7 +679,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void showDemoScreen()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -707,13 +707,13 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public int getCooldown(Key key)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setCooldown(Key key, int ticks)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -935,7 +935,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public boolean isTransferred()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -943,7 +943,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void transfer(@NotNull String host, int port)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -951,7 +951,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public @NotNull CompletableFuture<byte[]> retrieveCookie(@NotNull NamespacedKey key)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -959,21 +959,21 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void storeCookie(@NotNull NamespacedKey key, @NotNull byte[] value)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getProtocolVersion()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable InetSocketAddress getVirtualHost()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1164,14 +1164,14 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void saveData()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void loadData()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1262,7 +1262,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void playSound(@NotNull Entity entity, @NotNull String sound, float volume, float pitch)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1278,28 +1278,28 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void playSound(@NotNull Entity entity, @NotNull String sound, @NotNull SoundCategory category, float volume, float pitch, long seed)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void playSound(@NotNull Entity entity, @NotNull Sound sound, @NotNull SoundCategory category, float volume, float pitch, long seed)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void playSound(@NotNull Location location, @NotNull String sound, @NotNull SoundCategory category, float volume, float pitch, long seed)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void playSound(@NotNull Location location, @NotNull Sound sound, @NotNull SoundCategory category, float volume, float pitch, long seed)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1349,7 +1349,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void playSound(@NotNull Entity entity, @NotNull String sound, @NotNull SoundCategory category, float volume, float pitch)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1496,7 +1496,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void sendBlockChanges(@NotNull Collection<BlockState> blocks)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1559,13 +1559,13 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public void sendPotionEffectChange(@NotNull LivingEntity entity, @NotNull PotionEffect effect)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void sendPotionEffectChangeRemove(@NotNull LivingEntity entity, @NotNull PotionEffectType type)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1647,7 +1647,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void setTitleTimes(int fadeInTicks, int stayTicks, int fadeOutTicks)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1655,7 +1655,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void setSubtitle(BaseComponent[] subtitle)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1663,7 +1663,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void setSubtitle(BaseComponent subtitle)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1671,7 +1671,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void showTitle(@Nullable BaseComponent[] title)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1679,7 +1679,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void showTitle(@Nullable BaseComponent title)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1687,7 +1687,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void showTitle(@Nullable BaseComponent[] title, @Nullable BaseComponent[] subtitle, int fadeInTicks, int stayTicks, int fadeOutTicks)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1695,7 +1695,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void showTitle(@Nullable BaseComponent title, @Nullable BaseComponent subtitle, int fadeInTicks, int stayTicks, int fadeOutTicks)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1710,7 +1710,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void updateTitle(@NotNull Title title)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1718,7 +1718,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void hideTitle()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1944,14 +1944,14 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void giveExp(int amount, boolean applyMending)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int applyMending(int amount)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2013,19 +2013,19 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public @Range(from = 0L, to = 2147483647L) int calculateTotalExperiencePoints()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setExperienceLevelAndProgress(@Range(from = 0L, to = 2147483647L) int totalExperience)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getExperiencePointsNeededForNextLevel()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2089,14 +2089,14 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public @NotNull Collection<EnderPearl> getEnderPearls()
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Input getCurrentInput()
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2202,21 +2202,21 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public boolean isListed(@NotNull Player other)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean unlistPlayer(@NotNull Player other)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean listPlayer(@NotNull Player other)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2281,7 +2281,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void setTexturePack(@NotNull String url)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2289,14 +2289,14 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void setResourcePack(@NotNull String url)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setResourcePack(@NotNull String url, byte[] hash)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2304,14 +2304,14 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void setResourcePack(@NotNull String url, @Nullable byte[] hash, @Nullable String prompt)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setResourcePack(@NotNull String url, byte[] hash, boolean force)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2319,28 +2319,28 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void setResourcePack(@NotNull String url, @Nullable byte[] hash, @Nullable String prompt, boolean force)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setResourcePack(@NotNull String url, byte @Nullable [] hash, @Nullable Component prompt, boolean force)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setResourcePack(@NotNull UUID uuid, @NotNull String url, @NotNull String hash, @Nullable Component resourcePackPrompt, boolean required)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setResourcePack(@NotNull UUID uuid, @NotNull String url, byte @Nullable [] hash, @Nullable Component prompt, boolean force)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2348,7 +2348,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void setResourcePack(@NotNull UUID uuid, @NotNull String s, @Nullable byte[] bytes, @Nullable String s1, boolean b)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2368,14 +2368,14 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public @Nullable WorldBorder getWorldBorder()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setWorldBorder(@Nullable WorldBorder border)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2521,7 +2521,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void resetTitle()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2662,7 +2662,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public @NotNull AdvancementProgress getAdvancementProgress(@NotNull Advancement advancement)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2687,42 +2687,42 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public int getViewDistance()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setViewDistance(int viewDistance)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getSimulationDistance()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setSimulationDistance(int simulationDistance)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getSendViewDistance()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setSendViewDistance(int viewDistance)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2766,7 +2766,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public int getClientViewDistance()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2779,7 +2779,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void openBook(@NotNull ItemStack book)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2794,56 +2794,56 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void setResourcePack(@NotNull String url, @NotNull String hash)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setResourcePack(@NotNull String url, @NotNull String hash, boolean required)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setResourcePack(@NotNull String url, @NotNull String hash, boolean required, @Nullable Component resourcePackPrompt)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public PlayerResourcePackStatusEvent.@Nullable Status getResourcePackStatus()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasResourcePack()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void addResourcePack(@NotNull UUID id, @NotNull String url, @Nullable byte[] hash, @Nullable String prompt, boolean force)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void removeResourcePack(@NotNull UUID id)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void removeResourcePacks()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2863,182 +2863,182 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public float getCooldownPeriod()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public float getCooledAttackStrength(float adjustTicks)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void resetCooldown()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public <T> @NotNull T getClientOption(@NotNull ClientOption<T> option)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Firework boostElytra(@NotNull ItemStack firework)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void sendOpLevel(byte level)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void addAdditionalChatCompletions(@NotNull Collection<String> completions)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void removeAdditionalChatCompletions(@NotNull Collection<String> completions)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable String getClientBrandName()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void addCustomChatCompletions(@NotNull Collection<String> completions)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void removeCustomChatCompletions(@NotNull Collection<String> completions)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setCustomChatCompletions(@NotNull Collection<String> completions)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void lookAt(@NotNull Entity entity, @NotNull LookAnchor playerAnchor, @NotNull LookAnchor entityAnchor)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void showElderGuardian(boolean silent)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getWardenWarningCooldown()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setWardenWarningCooldown(int cooldown)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getWardenTimeSinceLastWarning()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setWardenTimeSinceLastWarning(int time)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getWardenWarningLevel()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setWardenWarningLevel(int warningLevel)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void increaseWardenWarningLevel()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Duration getIdleDuration()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void resetIdleDuration()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull @Unmodifiable Set<Long> getSentChunkKeys()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull @Unmodifiable Set<Chunk> getSentChunks()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isChunkSent(long chunkKey)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -3072,21 +3072,21 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void sendBlockDamage(@NotNull Location loc, float progress, int destroyerIdentity)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void sendHurtAnimation(float yaw)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void sendLinks(@NotNull ServerLinks links)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -3100,7 +3100,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void sendBlockDamage(@NotNull Location loc, float progress, @NotNull Entity source)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -3260,7 +3260,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void sendEntityEffect(@NotNull EntityEffect entityEffect, @NotNull Entity entity)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	/**
@@ -3354,7 +3354,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public PlayerGiveResult give(@NotNull Collection<@NotNull ItemStack> items, boolean dropIfFull)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -3373,7 +3373,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@ApiStatus.Experimental
 	public PlayerGameConnection getConnection()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/SchoolableFishMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/SchoolableFishMock.java
@@ -31,35 +31,35 @@ public abstract class SchoolableFishMock extends FishMock implements SchoolableF
 	public void startFollowing(@NotNull SchoolableFish leader)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void stopFollowing()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getSchoolSize()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getMaxSchoolSize()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable SchoolableFish getSchoolLeader()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/SnifferMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/SnifferMock.java
@@ -118,13 +118,13 @@ public class SnifferMock extends AnimalsMock implements Sniffer
 	@Override
 	public @Nullable Location findPossibleDigLocation()
 	{
-		throw new UnimplementedOperationException("Method findPossibleDigLocation is not implemented.");
+		throw UnimplementedOperationException.exception("Method findPossibleDigLocation is not implemented.");
 	}
 
 	@Override
 	public boolean canDig()
 	{
-		throw new UnimplementedOperationException("Method canDig is not implemented.");
+		throw UnimplementedOperationException.exception("Method canDig is not implemented.");
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/SpawnerMinecartMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/SpawnerMinecartMock.java
@@ -150,49 +150,49 @@ public class SpawnerMinecartMock extends MinecartMock implements SpawnerMinecart
 	public @Nullable EntitySnapshot getSpawnedEntity()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setSpawnedEntity(@Nullable EntitySnapshot entitySnapshot)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setSpawnedEntity(@NotNull SpawnerEntry spawnerEntry)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void addPotentialSpawn(@NotNull EntitySnapshot entitySnapshot, int i, @Nullable SpawnRule spawnRule)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void addPotentialSpawn(@NotNull SpawnerEntry spawnerEntry)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setPotentialSpawns(@NotNull Collection<SpawnerEntry> collection)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull List<SpawnerEntry> getPotentialSpawns()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -211,21 +211,21 @@ public class SpawnerMinecartMock extends MinecartMock implements SpawnerMinecart
 	public boolean isActivated()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void resetTimer()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setSpawnedItem(@NotNull ItemStack itemStack)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/StorageMinecartMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/StorageMinecartMock.java
@@ -58,14 +58,14 @@ public class StorageMinecartMock extends LootableMinecart implements StorageMine
 	public boolean canPlayerLoot(@NotNull UUID player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setLootTable(@Nullable LootTable lootTable, long l)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/TNTPrimedMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/TNTPrimedMock.java
@@ -72,7 +72,7 @@ public class TNTPrimedMock extends EntityMock implements TNTPrimed
 	public void setBlockData(@NotNull BlockData blockData)
 	{
 		//TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 
 	}
 
@@ -80,7 +80,7 @@ public class TNTPrimedMock extends EntityMock implements TNTPrimed
 	public @NotNull BlockData getBlockData()
 	{
 		//TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/ThrownPotionMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/ThrownPotionMock.java
@@ -59,7 +59,7 @@ public abstract class ThrownPotionMock extends ThrowableProjectileMock implement
 	@Override
 	public void splash()
 	{
-		throw new UnimplementedOperationException("Splash function was not implemented yet!");
+		throw UnimplementedOperationException.exception("Splash function was not implemented yet!");
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/TridentMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/TridentMock.java
@@ -70,13 +70,13 @@ public class TridentMock extends AbstractArrowMock implements Trident
 	@Override
 	public @NotNull ItemStack getItem()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setItem(@NotNull ItemStack item)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/TurtleMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/TurtleMock.java
@@ -37,7 +37,7 @@ public class TurtleMock extends AnimalsMock implements Turtle
 	public boolean isLayingEgg()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -57,14 +57,14 @@ public class TurtleMock extends AnimalsMock implements Turtle
 	public boolean isGoingHome()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isDigging()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/VillagerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/VillagerMock.java
@@ -191,14 +191,14 @@ public class VillagerMock extends AbstractVillagerMock implements Villager
 	public void shakeHead()
 	{
 		// TODO:
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable ZombieVillager zombify()
 	{
 		// TODO:
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -261,13 +261,13 @@ public class VillagerMock extends AbstractVillagerMock implements Villager
 	@Override
 	public void updateDemand()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void restock()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/WardenMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/WardenMock.java
@@ -40,7 +40,7 @@ public class WardenMock extends MonsterMock implements Warden
 	public int getAnger()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -54,7 +54,7 @@ public class WardenMock extends MonsterMock implements Warden
 	public int getHighestAnger()
 	{
 		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -89,21 +89,21 @@ public class WardenMock extends MonsterMock implements Warden
 	public void clearAnger(@NotNull Entity entity)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable LivingEntity getEntityAngryAt()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setDisturbanceLocation(@NotNull Location location)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/WitherMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/WitherMock.java
@@ -116,13 +116,13 @@ public class WitherMock extends AbstractBossMock implements Wither
 	@Override
 	public void rangedAttack(@NotNull LivingEntity livingEntity, float charge)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setChargingAttack(boolean chargingAttack)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/ZombieMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/ZombieMock.java
@@ -100,70 +100,70 @@ public class ZombieMock extends MonsterMock implements Zombie
 	public boolean isDrowning()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void startDrowning(int drownedConversionTime)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void stopDrowning()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setArmsRaised(boolean raised)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isArmsRaised()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean shouldBurnInDay()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setShouldBurnInDay(boolean shouldBurnInDay)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean canBreakDoors()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setCanBreakDoors(boolean canBreakDoors)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean supportsBreakingDoors()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/ZombieVillagerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/ZombieVillagerMock.java
@@ -60,7 +60,7 @@ public class ZombieVillagerMock extends ZombieMock implements ZombieVillager
 	@Override
 	public void setConversionTime(int i, boolean b)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/data/EntityData.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/data/EntityData.java
@@ -95,7 +95,7 @@ public class EntityData
 		}
 		catch (NullPointerException | IllegalStateException e)
 		{
-			throw new UnimplementedOperationException(
+			throw UnimplementedOperationException.exception(
 					"state " + state + " for entitytype " + type + ", " + subType + " is not implemented");
 		}
 	}
@@ -116,7 +116,7 @@ public class EntityData
 		{
 			if (state == EntityState.DEFAULT)
 			{
-				throw new UnimplementedOperationException(
+				throw UnimplementedOperationException.exception(
 						"datavalue " + key + " for entitytype " + type + " is not implemented");
 			}
 			return getValueFromKey(key, subType, EntityState.DEFAULT);

--- a/src/main/java/org/mockbukkit/mockbukkit/event/GameEventMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/event/GameEventMock.java
@@ -50,14 +50,14 @@ public class GameEventMock extends GameEvent
 	public int getRange()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getVibrationLevel()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/exception/UnimplementedOperationException.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/exception/UnimplementedOperationException.java
@@ -25,7 +25,7 @@ public class UnimplementedOperationException extends TestAbortedException
 	 * Constructs a new  with a default message.
 	 */
 	@ApiStatus.Internal
-	public UnimplementedOperationException()
+	private UnimplementedOperationException()
 	{
 		this("Not implemented");
 	}
@@ -36,9 +36,37 @@ public class UnimplementedOperationException extends TestAbortedException
 	 * @param message The message.
 	 */
 	@ApiStatus.Internal
-	public UnimplementedOperationException(@NotNull String message)
+	private UnimplementedOperationException(@NotNull String message)
 	{
 		super(message);
+	}
+
+	/**
+	 *
+	 * @return Either a {@link UnimplementedOperationException} or {@link UnimplementedOperationFailure}
+	 */
+	@ApiStatus.Internal
+	public static RuntimeException exception()
+	{
+		return exception("Not implemented");
+	}
+
+	/**
+	 *
+	 * @param message The error message
+	 * @return Either a {@link UnimplementedOperationException} or {@link UnimplementedOperationFailure}
+	 */
+	@ApiStatus.Internal
+	public static RuntimeException exception(String message)
+	{
+		if ("true".equalsIgnoreCase(System.getenv("mockbukkit.unimplementedoperation.fail")))
+		{
+			return new UnimplementedOperationFailure(message);
+		}
+		else
+		{
+			return new UnimplementedOperationException(message);
+		}
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/exception/UnimplementedOperationException.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/exception/UnimplementedOperationException.java
@@ -65,7 +65,7 @@ public class UnimplementedOperationException extends TestAbortedException
 		}
 		else
 		{
-			return new UnimplementedOperationException(message);
+			return UnimplementedOperationException.exception(message);
 		}
 	}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/exception/UnimplementedOperationException.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/exception/UnimplementedOperationException.java
@@ -59,7 +59,7 @@ public class UnimplementedOperationException extends TestAbortedException
 	@ApiStatus.Internal
 	public static RuntimeException exception(String message)
 	{
-		if ("true".equalsIgnoreCase(System.getenv("mockbukkit.unimplementedoperation.fail")))
+		if (Boolean.getBoolean("mockbukkit.unimplementedoperation.fail"))
 		{
 			return new UnimplementedOperationFailure(message);
 		}

--- a/src/main/java/org/mockbukkit/mockbukkit/exception/UnimplementedOperationException.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/exception/UnimplementedOperationException.java
@@ -65,7 +65,7 @@ public class UnimplementedOperationException extends TestAbortedException
 		}
 		else
 		{
-			return UnimplementedOperationException.exception(message);
+			return new UnimplementedOperationException(message);
 		}
 	}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/exception/UnimplementedOperationFailure.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/exception/UnimplementedOperationFailure.java
@@ -1,0 +1,16 @@
+package org.mockbukkit.mockbukkit.exception;
+
+import java.io.Serial;
+
+public class UnimplementedOperationFailure extends RuntimeException
+{
+
+	@Serial
+	private static final long serialVersionUID = 109379017L;
+
+	public UnimplementedOperationFailure(String message)
+	{
+		super(message);
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/help/HelpMapMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/help/HelpMapMock.java
@@ -66,7 +66,7 @@ public class HelpMapMock implements HelpMap
 	@Override
 	public @NotNull List<String> getIgnoredPlugins()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/EntityEquipmentMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/EntityEquipmentMock.java
@@ -72,7 +72,7 @@ public class EntityEquipmentMock implements EntityEquipment
 		case BODY -> setItemInBody(item, silent);
 		case SADDLE -> setSaddleItem(item, silent);
 		default ->
-				throw new UnimplementedOperationException("EquipmentSlot " + slot + " is not implemented for EntityEquipmentMock");
+				throw UnimplementedOperationException.exception("EquipmentSlot " + slot + " is not implemented for EntityEquipmentMock");
 		}
 	}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/FurnaceInventoryMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/FurnaceInventoryMock.java
@@ -88,7 +88,7 @@ public class FurnaceInventoryMock extends InventoryMock implements FurnaceInvent
 	public boolean canSmelt(@Nullable ItemStack item)
 	{
 		//TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryMock.java
@@ -351,7 +351,7 @@ public class InventoryMock implements Inventory
 	public @Nullable InventoryHolder getHolder(boolean useSnapshot)
 	{
 		//TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -440,7 +440,7 @@ public class InventoryMock implements Inventory
 	public @NotNull HashMap<Integer, ItemStack> removeItemAnySlot(@NotNull ItemStack... items) throws IllegalArgumentException
 	{
 		//TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -659,7 +659,7 @@ public class InventoryMock implements Inventory
 	public @NotNull ListIterator<ItemStack> iterator(int index)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -713,7 +713,7 @@ public class InventoryMock implements Inventory
 		}
 		else
 		{
-			throw new UnimplementedOperationException(String.format("%s does not implement method getSnapshot", this.getClass().getSimpleName()));
+			throw UnimplementedOperationException.exception(String.format("%s does not implement method getSnapshot", this.getClass().getSimpleName()));
 		}
 	}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/InventoryViewMock.java
@@ -300,7 +300,7 @@ public abstract class InventoryViewMock implements InventoryView
 	public InventoryType.SlotType getSlotType(int slot)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -325,13 +325,13 @@ public abstract class InventoryViewMock implements InventoryView
 	public boolean setProperty(@NotNull InventoryView.Property prop, int value)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable MenuType getMenuType()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemFactoryMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemFactoryMock.java
@@ -136,28 +136,28 @@ public class ItemFactoryMock implements ItemFactory
 	public ItemStack createItemStack(@NotNull String input) throws IllegalArgumentException
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull ItemStack enchantWithLevels(@NotNull ItemStack itemStack, @Range(from = 1L, to = 30L) int levels, boolean allowTreasure, @NotNull Random random)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull ItemStack enchantWithLevels(@NotNull ItemStack itemStack, @Range(from = 1L, to = 30L) int levels, @NotNull RegistryKeySet<@NotNull Enchantment> registryKeySet, @NotNull Random random)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull HoverEvent<HoverEvent.ShowItem> asHoverEvent(@NotNull ItemStack item, @NotNull UnaryOperator<HoverEvent.ShowItem> op)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -188,7 +188,7 @@ public class ItemFactoryMock implements ItemFactory
 	public @Nullable String getI18NDisplayName(@Nullable ItemStack item)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -202,7 +202,7 @@ public class ItemFactoryMock implements ItemFactory
 	public @NotNull Content hoverContentOf(@NotNull ItemStack itemStack)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -210,7 +210,7 @@ public class ItemFactoryMock implements ItemFactory
 	public @NotNull Content hoverContentOf(@NotNull Entity entity)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -218,7 +218,7 @@ public class ItemFactoryMock implements ItemFactory
 	public @NotNull Content hoverContentOf(@NotNull Entity entity, @Nullable String customName)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -226,7 +226,7 @@ public class ItemFactoryMock implements ItemFactory
 	public @NotNull Content hoverContentOf(@NotNull Entity entity, @Nullable BaseComponent customName)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -234,35 +234,35 @@ public class ItemFactoryMock implements ItemFactory
 	public @NotNull Content hoverContentOf(@NotNull Entity entity, @NotNull BaseComponent[] customName)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Material getSpawnEgg(@Nullable EntityType type)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull ItemStack enchantItem(@NotNull Entity entity, @NotNull ItemStack item, int level, boolean allowTreasures)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull ItemStack enchantItem(@NotNull World world, @NotNull ItemStack item, int level, boolean allowTreasures)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull ItemStack enchantItem(@NotNull ItemStack item, int level, boolean allowTreasures)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemStackMock.java
@@ -242,7 +242,7 @@ public class ItemStackMock extends ItemStack
 	public @NotNull Component effectiveName()
 	{
 		// TODO:
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -447,7 +447,7 @@ public class ItemStackMock extends ItemStack
 	public int getMaxItemUseDuration(@NotNull LivingEntity entity)
 	{
 		//TODO
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	public static ItemStack empty()
@@ -502,7 +502,7 @@ public class ItemStackMock extends ItemStack
 	public void resetData(@NotNull DataComponentType type)
 	{
 		// TODO:
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -517,7 +517,7 @@ public class ItemStackMock extends ItemStack
 		}
 
 		// TODO:
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -530,7 +530,7 @@ public class ItemStackMock extends ItemStack
 	public boolean matchesWithoutData(@NotNull ItemStack item, @NotNull Set<@NotNull DataComponentType> excludeTypes, boolean ignoreCount)
 	{
 		// TODO:
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemTypeMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/ItemTypeMock.java
@@ -139,14 +139,14 @@ public class ItemTypeMock<M extends ItemMeta> implements ItemType.Typed<M>
 	@Override
 	public Typed<ItemMeta> typed()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@NotNull
 	@Override
 	public <M extends ItemMeta> Typed<M> typed(@NotNull Class<M> itemMetaType)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -194,13 +194,13 @@ public class ItemTypeMock<M extends ItemMeta> implements ItemType.Typed<M>
 	@Override
 	public @NotNull ItemStack createItemStack(@Nullable Consumer<? super M> metaConfigurator)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull ItemStack createItemStack(int amount, @Nullable Consumer<? super M> metaConfigurator)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -258,20 +258,20 @@ public class ItemTypeMock<M extends ItemMeta> implements ItemType.Typed<M>
 	public @Nullable ItemType getCraftingRemainingItem()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull @Unmodifiable Multimap<Attribute, AttributeModifier> getDefaultAttributeModifiers()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Multimap<Attribute, AttributeModifier> getDefaultAttributeModifiers(@NotNull EquipmentSlot slot)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -283,7 +283,7 @@ public class ItemTypeMock<M extends ItemMeta> implements ItemType.Typed<M>
 	@Override
 	public boolean isEnabledByFeature(@NotNull World world)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -314,21 +314,21 @@ public class ItemTypeMock<M extends ItemMeta> implements ItemType.Typed<M>
 	public <T> @Nullable T getDefaultData(DataComponentType.@NotNull Valued<T> valued)
 	{
 		//TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasDefaultData(@NotNull DataComponentType dataComponentType)
 	{
 		//TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Unmodifiable @NotNull Set<DataComponentType> getDefaultDataTypes()
 	{
 		//TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/LocationInventoryViewBuilderMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/LocationInventoryViewBuilderMock.java
@@ -48,14 +48,14 @@ public class LocationInventoryViewBuilderMock<V extends InventoryView> implement
 	public @NotNull LocationInventoryViewBuilder<V> checkReachable(boolean checkReachable)
 	{
 		// TODO: Auto generated stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull LocationInventoryViewBuilder<V> location(@Nullable Location location)
 	{
 		// TODO: Auto generated stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/MerchantInventoryViewBuilderMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/MerchantInventoryViewBuilderMock.java
@@ -48,14 +48,14 @@ public class MerchantInventoryViewBuilderMock<V extends InventoryView> implement
 	public @NotNull MerchantInventoryViewBuilder<V> merchant(@Nullable Merchant merchant)
 	{
 		// TODO: Auto generated stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull MerchantInventoryViewBuilder<V> checkReachable(boolean checkReachable)
 	{
 		// TODO: Auto generated stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/SimpleInventoryViewMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/SimpleInventoryViewMock.java
@@ -55,14 +55,14 @@ public class SimpleInventoryViewMock extends InventoryViewMock
 	public @Nullable Inventory getInventory(int rawSlot)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int convertSlot(int rawSlot)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@NotNull
@@ -70,28 +70,28 @@ public class SimpleInventoryViewMock extends InventoryViewMock
 	public InventoryType.SlotType getSlotType(int slot)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void close()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int countSlots()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean setProperty(@NotNull InventoryView.Property prop, int value)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/SmithingInventoryMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/SmithingInventoryMock.java
@@ -44,7 +44,7 @@ public class SmithingInventoryMock extends InventoryMock implements SmithingInve
 	public @Nullable Recipe getRecipe()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/BookMetaMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/BookMetaMock.java
@@ -105,70 +105,70 @@ public class BookMetaMock extends ItemMetaMock implements BookMeta
 	public @Nullable Component title()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @This @NotNull BookMeta title(@Nullable Component title)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Component author()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @This @NotNull BookMeta author(@Nullable Component author)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Unmodifiable @NotNull List<Component> pages()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Book pages(@NotNull List<Component> pages)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Component page(int page)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void page(int page, @NotNull Component data)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void addPages(@NotNull Component... pages)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NonNull BookMetaBuilder toBuilder()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -333,7 +333,7 @@ public class BookMetaMock extends ItemMetaMock implements BookMeta
 	public @NotNull Spigot spigot()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	/**

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/CompassMetaMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/CompassMetaMock.java
@@ -85,14 +85,14 @@ public class CompassMetaMock extends ItemMetaMock implements CompassMeta
 	public boolean isLodestoneCompass()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void clearLodestone()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -440,7 +440,7 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	public Set<Material> getCanDestroy()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -448,7 +448,7 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	public void setCanDestroy(Set<Material> set)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -456,7 +456,7 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	public Set<Material> getCanPlaceOn()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -464,7 +464,7 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	public void setCanPlaceOn(Set<Material> set)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -472,7 +472,7 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	public @NotNull Set<com.destroystokyo.paper.Namespaced> getDestroyableKeys()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -480,7 +480,7 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	public void setDestroyableKeys(@NotNull Collection<com.destroystokyo.paper.Namespaced> collection)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -488,7 +488,7 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	public @NotNull Set<com.destroystokyo.paper.Namespaced> getPlaceableKeys()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -496,7 +496,7 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	public void setPlaceableKeys(@NotNull Collection<com.destroystokyo.paper.Namespaced> collection)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -504,7 +504,7 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	public boolean hasPlaceableKeys()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -512,7 +512,7 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	public boolean hasDestroyableKeys()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1130,21 +1130,21 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	public String getAsString()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull String getAsComponentString()
 	{
 		//TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull CustomItemTagContainer getCustomTagContainer()
 	{
 		// This was replaced by PersistentDataContainer!
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1389,14 +1389,14 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	public @Nullable RegistryKeySet<DamageType> getDamageResistantTypes()
 	{
 		// TODO: Auto generated stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setDamageResistantTypes(@Nullable RegistryKeySet<DamageType> types)
 	{
 		// TODO: Auto generated stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/MapMetaMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/MapMetaMock.java
@@ -131,21 +131,21 @@ public class MapMetaMock extends ItemMetaMock implements MapMeta
 	public boolean hasLocationName()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable String getLocationName()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setLocationName(@Nullable String name)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/PotionMetaMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/PotionMetaMock.java
@@ -144,7 +144,7 @@ public class PotionMetaMock extends ItemMetaMock implements PotionMeta
 	@Override
 	public @NotNull @Unmodifiable List<PotionEffect> getAllEffects()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -214,7 +214,7 @@ public class PotionMetaMock extends ItemMetaMock implements PotionMeta
 	@Override
 	public @NotNull Color computeEffectiveColor()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -270,7 +270,7 @@ public class PotionMetaMock extends ItemMetaMock implements PotionMeta
 	public boolean setMainEffect(@NotNull PotionEffectType type)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/SkullMetaMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/SkullMetaMock.java
@@ -174,14 +174,14 @@ public class SkullMetaMock extends ItemMetaMock implements SkullMeta
 	public void setNoteBlockSound(@Nullable NamespacedKey noteBlockSound)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable NamespacedKey getNoteBlockSound()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	/**

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/SpawnEggMetaMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/SpawnEggMetaMock.java
@@ -59,28 +59,28 @@ public class SpawnEggMetaMock extends ItemMetaMock implements SpawnEggMeta
 	public void setSpawnedEntity(@NotNull EntitySnapshot snapshot)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable EntitySnapshot getSpawnedEntity()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable EntityType getCustomSpawnedType()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setCustomSpawnedType(@Nullable EntityType type)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/SuspiciousStewMetaMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/SuspiciousStewMetaMock.java
@@ -88,7 +88,7 @@ public class SuspiciousStewMetaMock extends ItemMetaMock implements SuspiciousSt
 	@Override
 	public boolean addCustomEffect(@NotNull SuspiciousEffectEntry suspiciousEffectEntry, boolean overwrite)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/map/MapRendererMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/map/MapRendererMock.java
@@ -17,7 +17,7 @@ public class MapRendererMock extends MapRenderer
 	public void render(@NotNull MapView map, @NotNull MapCanvas canvas, @NotNull Player player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/map/MapViewMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/map/MapViewMock.java
@@ -74,28 +74,28 @@ public class MapViewMock implements MapView
 	public int getCenterX()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getCenterZ()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setCenterX(int x)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setCenterZ(int z)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -177,28 +177,28 @@ public class MapViewMock implements MapView
 	public boolean isTrackingPosition()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setTrackingPosition(boolean trackingPosition)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isUnlimitedTracking()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setUnlimitedTracking(boolean unlimited)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/persistence/PersistentDataContainerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/persistence/PersistentDataContainerMock.java
@@ -105,7 +105,7 @@ public class PersistentDataContainerMock implements PersistentDataContainer
 	public byte @NotNull [] serializeToBytes()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -118,7 +118,7 @@ public class PersistentDataContainerMock implements PersistentDataContainer
 	public void readFromBytes(byte @NotNull [] bytes, boolean clear)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/persistence/PersistentDataContainerViewMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/persistence/PersistentDataContainerViewMock.java
@@ -52,14 +52,14 @@ public abstract class PersistentDataContainerViewMock implements PersistentDataC
 	public void copyTo(PersistentDataContainer other, boolean replace)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public byte[] serializeToBytes()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/plugin/MockBukkitConfiguredPluginClassLoader.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/plugin/MockBukkitConfiguredPluginClassLoader.java
@@ -119,7 +119,7 @@ public class MockBukkitConfiguredPluginClassLoader extends URLClassLoader implem
 	public @Nullable JavaPlugin getPlugin()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -132,7 +132,7 @@ public class MockBukkitConfiguredPluginClassLoader extends URLClassLoader implem
 	public void close()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/plugin/MockBukkitPluginLoader.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/plugin/MockBukkitPluginLoader.java
@@ -25,21 +25,21 @@ public class MockBukkitPluginLoader implements PluginLoader
 	public @NotNull Plugin loadPlugin(@NotNull File file) throws UnknownDependencyException
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull PluginDescriptionFile getPluginDescription(@NotNull File file)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Pattern[] getPluginFileFilters()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -55,7 +55,7 @@ public class MockBukkitPluginLoader implements PluginLoader
 	public void enablePlugin(@NotNull Plugin plugin)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/plugin/MockBukkitURLClassLoader.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/plugin/MockBukkitURLClassLoader.java
@@ -57,7 +57,7 @@ public class MockBukkitURLClassLoader extends URLClassLoader implements Configur
 	@Override
 	public @Nullable JavaPlugin getPlugin()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
@@ -753,7 +753,7 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	public void registerInterface(@NotNull Class<? extends PluginLoader> loader) throws IllegalArgumentException
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -799,14 +799,14 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	public Plugin[] loadPlugins(@NotNull File directory)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Plugin[] loadPlugins(@NotNull File[] files)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -971,14 +971,14 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 	public boolean isTransitiveDependency(PluginMeta pluginMeta, PluginMeta dependencyConfig)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void overridePermissionManager(@NotNull Plugin plugin, @Nullable PermissionManager permissionManager)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/plugin/lifecycle/event/TagEventTypeProviderMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/plugin/lifecycle/event/TagEventTypeProviderMock.java
@@ -16,13 +16,13 @@ public class TagEventTypeProviderMock implements TagEventTypeProvider
 	@Override
 	public <T> LifecycleEventType.Prioritizable<BootstrapContext, ReloadableRegistrarEvent<PreFlattenTagRegistrar<T>>> preFlatten(@NonNull RegistryKey<T> registryKey)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public <T> LifecycleEventType.Prioritizable<BootstrapContext, ReloadableRegistrarEvent<PostFlattenTagRegistrar<T>>> postFlatten(@NonNull RegistryKey<T> registryKey)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/potion/InternalPotionDataMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/potion/InternalPotionDataMock.java
@@ -53,7 +53,7 @@ public class InternalPotionDataMock implements PotionType.InternalPotionData
 	{
 		if (potionEffects == null)
 		{
-			throw new UnimplementedOperationException("Unimplemented potion: " + namespacedKey);
+			throw UnimplementedOperationException.exception("Unimplemented potion: " + namespacedKey);
 		}
 		return potionEffects;
 	}
@@ -61,7 +61,7 @@ public class InternalPotionDataMock implements PotionType.InternalPotionData
 	@Override
 	public boolean isInstant()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/potion/PotionEffectTypeMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/potion/PotionEffectTypeMock.java
@@ -134,7 +134,7 @@ public class PotionEffectTypeMock extends PotionEffectType
 	public @NotNull PotionEffectTypeCategory getCategory()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/profile/PlayerProfileMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/profile/PlayerProfileMock.java
@@ -170,49 +170,49 @@ public class PlayerProfileMock implements PlayerProfile
 	public boolean isComplete()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull CompletableFuture<PlayerProfile> update()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean completeFromCache()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean completeFromCache(boolean onlineMode)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean completeFromCache(boolean lookupUUID, boolean onlineMode)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean complete(boolean textures)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean complete(boolean textures, boolean onlineMode)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/registry/RegistryAccessMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/registry/RegistryAccessMock.java
@@ -202,7 +202,7 @@ public class RegistryAccessMock implements RegistryAccess
 				.map(RegistryAccessMock::getValue)
 				.filter(Objects::nonNull)
 				.findAny()
-				.orElseThrow(() -> new UnimplementedOperationException("Could not find registry for " + tClass));
+				.orElseThrow(() -> UnimplementedOperationException.exception("Could not find registry for " + tClass));
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/registry/RegistryMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/registry/RegistryMock.java
@@ -138,7 +138,7 @@ public class RegistryMock<T extends Keyed> implements Registry<T>
 		Function<JsonObject, ? extends Keyed> constructorFunction = factoryMap.get(key);
 		if (constructorFunction == null)
 		{
-			throw new UnimplementedOperationException();
+			throw UnimplementedOperationException.exception();
 		}
 
 		return constructorFunction;
@@ -205,19 +205,19 @@ public class RegistryMock<T extends Keyed> implements Registry<T>
 	@Override
 	public boolean hasTag(TagKey<T> tagKey)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public Tag<T> getTag(TagKey<T> tagKey)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public Collection<Tag<T>> getTags()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -497,7 +497,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	public <T> @NotNull Future<T> callSyncMethod(@NotNull Plugin plugin, @NotNull Callable<T> task)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -655,7 +655,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	public void runTaskLaterAsynchronously(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, long delay)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -673,7 +673,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	public void runTaskTimerAsynchronously(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, long delay, long period)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/paper/PaperScheduledTask.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/paper/PaperScheduledTask.java
@@ -36,7 +36,7 @@ public class PaperScheduledTask implements ScheduledTask
 	@Override
 	public boolean isRepeatingTask()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	public void run()
@@ -47,13 +47,13 @@ public class PaperScheduledTask implements ScheduledTask
 	@Override
 	public @NotNull CancelledState cancel()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull ExecutionState getExecutionState()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/scoreboard/ObjectiveMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scoreboard/ObjectiveMock.java
@@ -207,28 +207,28 @@ public class ObjectiveMock implements Objective
 	public boolean willAutoUpdateDisplay()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setAutoUpdateDisplay(boolean autoUpdateDisplay)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable NumberFormat numberFormat()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void numberFormat(@Nullable NumberFormat numberFormat)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/scoreboard/ScoreMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scoreboard/ScoreMock.java
@@ -105,42 +105,42 @@ public class ScoreMock implements Score
 	public boolean isTriggerable()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setTriggerable(boolean triggerable)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Component customName()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void customName(@Nullable Component customName)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable NumberFormat numberFormat()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void numberFormat(@Nullable NumberFormat numberFormat)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/sound/JukeboxSongMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/sound/JukeboxSongMock.java
@@ -39,25 +39,25 @@ public class JukeboxSongMock implements JukeboxSong
 	@Override
 	public Sound getSound()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public Component getDescription()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public float getLengthInSeconds()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getComparatorOutput()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/structure/StructureManagerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/structure/StructureManagerMock.java
@@ -60,7 +60,7 @@ public class StructureManagerMock implements StructureManager
 	{
 		Preconditions.checkArgument(structureKey != null, "NamespacedKey structureKey cannot be null");
 
-		throw new UnimplementedOperationException("Load structure was not implemented yet.");
+		throw UnimplementedOperationException.exception("Load structure was not implemented yet.");
 	}
 
 	@Override
@@ -74,7 +74,7 @@ public class StructureManagerMock implements StructureManager
 	{
 		Preconditions.checkArgument(structureKey != null, "NamespacedKey structureKey cannot be null");
 
-		throw new UnimplementedOperationException("Save structure was not implemented yet.");
+		throw UnimplementedOperationException.exception("Save structure was not implemented yet.");
 	}
 
 	@Override
@@ -99,7 +99,7 @@ public class StructureManagerMock implements StructureManager
 	{
 		Preconditions.checkArgument(structureKey != null, "NamespacedKey structureKey cannot be null");
 
-		throw new UnimplementedOperationException("Delete structure was not implemented yet.");
+		throw UnimplementedOperationException.exception("Delete structure was not implemented yet.");
 	}
 
 	@Override
@@ -107,7 +107,7 @@ public class StructureManagerMock implements StructureManager
 	{
 		Preconditions.checkArgument(structureKey != null, "NamespacedKey structureKey cannot be null");
 
-		throw new UnimplementedOperationException("Get structure file was not implemented yet.");
+		throw UnimplementedOperationException.exception("Get structure file was not implemented yet.");
 	}
 
 	@Override
@@ -124,7 +124,7 @@ public class StructureManagerMock implements StructureManager
 	{
 		Preconditions.checkArgument(inputStream != null, "inputStream cannot be null");
 
-		throw new UnimplementedOperationException("Load structure was not implemented yet.");
+		throw UnimplementedOperationException.exception("Load structure was not implemented yet.");
 	}
 
 	@Override
@@ -143,7 +143,7 @@ public class StructureManagerMock implements StructureManager
 		Preconditions.checkArgument(outputStream != null, "outputStream cannot be null");
 		Preconditions.checkArgument(structure != null, "structure cannot be null");
 
-		throw new UnimplementedOperationException("Save structure was not implemented yet.");
+		throw UnimplementedOperationException.exception("Save structure was not implemented yet.");
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/util/UnsafeValuesMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/util/UnsafeValuesMock.java
@@ -163,7 +163,7 @@ public class UnsafeValuesMock implements UnsafeValues
 	public Component resolveWithContext(Component component, CommandSender context, Entity scoreboardSubject, boolean bypassPermissions)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -173,7 +173,7 @@ public class UnsafeValuesMock implements UnsafeValues
 		{
 			return material;
 		}
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -183,7 +183,7 @@ public class UnsafeValuesMock implements UnsafeValues
 		{
 			return material;
 		}
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -203,14 +203,14 @@ public class UnsafeValuesMock implements UnsafeValues
 			return material;
 		}
 
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public BlockData fromLegacy(Material material, byte data)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -223,7 +223,7 @@ public class UnsafeValuesMock implements UnsafeValues
 	public ItemStack modifyItemStack(ItemStack stack, String arguments)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	/**
@@ -272,35 +272,35 @@ public class UnsafeValuesMock implements UnsafeValues
 	public Advancement loadAdvancement(NamespacedKey key, String advancement)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean removeAdvancement(NamespacedKey key)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public Multimap<Attribute, AttributeModifier> getDefaultAttributeModifiers(Material material, EquipmentSlot slot)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public CreativeCategory getCreativeCategory(Material material)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public VersionFetcher getVersionFetcher()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -371,13 +371,13 @@ public class UnsafeValuesMock implements UnsafeValues
 	public byte[] serializeEntity(Entity entity)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public byte @NotNull [] serializeEntity(@NotNull Entity entity, @NotNull EntitySerializationFlag... entitySerializationFlags)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -390,13 +390,13 @@ public class UnsafeValuesMock implements UnsafeValues
 	public Entity deserializeEntity(byte[] data, World world, boolean preserveUUID)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Entity deserializeEntity(byte @NotNull [] bytes, @NotNull World world, boolean b, boolean b1)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -465,7 +465,7 @@ public class UnsafeValuesMock implements UnsafeValues
 	public String getTranslationKey(Attribute attribute)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	private String handleTranslateItemEdgeCases(Material material)
@@ -527,7 +527,7 @@ public class UnsafeValuesMock implements UnsafeValues
 	public String get(Class<?> aClass, String s)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -540,7 +540,7 @@ public class UnsafeValuesMock implements UnsafeValues
 	public int nextEntityId()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -553,56 +553,56 @@ public class UnsafeValuesMock implements UnsafeValues
 	public boolean isValidRepairItemStack(@NotNull ItemStack itemToBeRepaired, @NotNull ItemStack repairMaterial)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getProtocolVersion()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasDefaultEntityAttributes(@NotNull NamespacedKey entityKey)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Attributable getDefaultEntityAttributes(@NotNull NamespacedKey entityKey)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull NamespacedKey getBiomeKey(RegionAccessor accessor, int x, int y, int z)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setBiomeKey(RegionAccessor accessor, int x, int y, int z, NamespacedKey biomeKey)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public String getStatisticCriteriaKey(@NotNull Statistic statistic)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Color getSpawnEggLayerColor(EntityType entityType, int i)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -618,7 +618,7 @@ public class UnsafeValuesMock implements UnsafeValues
 														@Nullable Player player)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -724,7 +724,7 @@ public class UnsafeValuesMock implements UnsafeValues
 	@Override
 	public @NotNull ItemStack deserializeItemHover(HoverEvent.@NotNull ShowItem showItem)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/world/ChunkMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/ChunkMock.java
@@ -75,14 +75,14 @@ public class ChunkMock implements Chunk
 	public @NotNull BlockState[] getTileEntities(boolean useSnapshot)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Collection<BlockState> getTileEntities(@NotNull Predicate<? super Block> blockPredicate, boolean useSnapshot)
 	{
 		//TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -160,7 +160,7 @@ public class ChunkMock implements Chunk
 	public @NotNull ChunkSnapshot getChunkSnapshot(boolean b, boolean b1, boolean b2, boolean b3)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -185,7 +185,7 @@ public class ChunkMock implements Chunk
 	public BlockState[] getTileEntities()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -274,35 +274,35 @@ public class ChunkMock implements Chunk
 	public boolean addPluginChunkTicket(@NotNull Plugin plugin)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean removePluginChunkTicket(@NotNull Plugin plugin)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Collection<Plugin> getPluginChunkTickets()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public long getInhabitedTime()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setInhabitedTime(long ticks)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -326,20 +326,20 @@ public class ChunkMock implements Chunk
 	@Override
 	public @NotNull Collection<GeneratedStructure> getStructures()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Collection<GeneratedStructure> getStructures(@NotNull Structure structure)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Collection<Player> getPlayersSeeingChunk()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/world/ChunkSnapshotMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/ChunkSnapshotMock.java
@@ -73,7 +73,7 @@ public class ChunkSnapshotMock implements ChunkSnapshot
 	public @NotNull Key getWorldKey()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@NotNull
@@ -98,28 +98,28 @@ public class ChunkSnapshotMock implements ChunkSnapshot
 	public int getData(int x, int y, int z)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getBlockSkyLight(int x, int y, int z)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getBlockEmittedLight(int x, int y, int z)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getHighestBlockYAt(int x, int z)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@NotNull
@@ -148,7 +148,7 @@ public class ChunkSnapshotMock implements ChunkSnapshot
 	public double getRawBiomeTemperature(int x, int y, int z)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -199,7 +199,7 @@ public class ChunkSnapshotMock implements ChunkSnapshot
 	public boolean contains(@NotNull Biome biome)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	/**

--- a/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
@@ -393,14 +393,14 @@ public class WorldMock implements World
 	public int getTileEntityCount()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getTickableTileEntityCount()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -419,7 +419,7 @@ public class WorldMock implements World
 	public boolean hasStructureAt(@NotNull Position position, @NotNull Structure structure)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -432,14 +432,14 @@ public class WorldMock implements World
 	public boolean lineOfSightExists(@NotNull Location from, @NotNull Location to)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean hasCollisionsIn(@NotNull BoundingBox boundingBox)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -706,7 +706,7 @@ public class WorldMock implements World
 	public boolean isChunkInUse(int x, int z)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -757,7 +757,7 @@ public class WorldMock implements World
 	{
 		AsyncCatcher.catchOp("chunk unload");
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -766,7 +766,7 @@ public class WorldMock implements World
 	{
 		AsyncCatcher.catchOp("chunk regenerate");
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -774,14 +774,14 @@ public class WorldMock implements World
 	public boolean refreshChunk(int x, int z)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Collection<Player> getPlayersSeeingChunk(@NotNull Chunk chunk)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 
 	}
 
@@ -789,7 +789,7 @@ public class WorldMock implements World
 	public @NotNull Collection<Player> getPlayersSeeingChunk(int i, int i1)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -855,7 +855,7 @@ public class WorldMock implements World
 	public boolean generateTree(Location location, TreeType type)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -863,14 +863,14 @@ public class WorldMock implements World
 	public boolean generateTree(Location loc, TreeType type, BlockChangeDelegate delegate)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean generateTree(Location location, Random random, TreeType type, Predicate<? super BlockState> statePredicate)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	public <T extends Entity> @NotNull T spawn(@NotNull Location location, @NotNull Class<T> clazz) throws IllegalArgumentException
@@ -1016,27 +1016,27 @@ public class WorldMock implements World
 	public @NotNull LightningStrike strikeLightning(Location loc)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull LightningStrike strikeLightningEffect(Location loc)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	public @Nullable Location findLightningRod(@NotNull Location location)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Location findLightningTarget(@NotNull Location location)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1086,14 +1086,14 @@ public class WorldMock implements World
 	public void getChunkAtAsync(int x, int z, boolean gen, boolean urgent, @NotNull Consumer<? super Chunk> cb)
 	{
 		//TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void getChunksAtAsync(int minX, int minZ, int maxX, int maxZ, boolean urgent, @NotNull Runnable cb)
 	{
 		//TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1108,7 +1108,7 @@ public class WorldMock implements World
 	public @NotNull CompletableFuture<Chunk> getChunkAtAsync(int x, int z, boolean gen, boolean urgent)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1281,42 +1281,42 @@ public class WorldMock implements World
 	public boolean createExplosion(double x, double y, double z, float power)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean createExplosion(double x, double y, double z, float power, boolean setFire)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean createExplosion(double x, double y, double z, float power, boolean setFire, boolean breakBlocks)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean createExplosion(@NotNull Location loc, float power)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean createExplosion(@NotNull Location loc, float power, boolean setFire)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean createExplosion(Entity source, @NotNull Location loc, float power, boolean setFire, boolean breakBlocks, boolean excludeSourceFromDamage)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1363,7 +1363,7 @@ public class WorldMock implements World
 	public ChunkGenerator getGenerator()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Nullable
@@ -1384,20 +1384,20 @@ public class WorldMock implements World
 	{
 		AsyncCatcher.catchOp("world save");
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull List<BlockPopulator> getPopulators()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public <T extends LivingEntity> @NotNull T spawn(@NotNull Location location, @NotNull Class<T> clazz, CreatureSpawnEvent.@NotNull SpawnReason spawnReason, boolean randomizeData, @Nullable Consumer<? super T> function) throws IllegalArgumentException
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@SuppressWarnings("deprecation")
@@ -1538,7 +1538,7 @@ public class WorldMock implements World
 	public double getTemperature(int x, int z)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1546,7 +1546,7 @@ public class WorldMock implements World
 	public double getHumidity(int x, int z)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1565,7 +1565,7 @@ public class WorldMock implements World
 	public @NotNull BiomeProvider vanillaBiomeProvider()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1614,14 +1614,14 @@ public class WorldMock implements World
 	public @NotNull File getWorldFolder()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Path getWorldPath()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -1781,14 +1781,14 @@ public class WorldMock implements World
 	public void playSound(@NotNull Entity entity, @NotNull String sound, float volume, float pitch)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void playSound(@NotNull Entity entity, @NotNull String sound, @NotNull SoundCategory category, float volume, float pitch)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2038,7 +2038,7 @@ public class WorldMock implements World
 	public boolean isChunkGenerated(int x, int z)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2067,14 +2067,14 @@ public class WorldMock implements World
 	public RayTraceResult rayTraceEntities(Location start, Vector direction, double maxDistance)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public RayTraceResult rayTraceEntities(Location start, Vector direction, double maxDistance, double raySize)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2082,7 +2082,7 @@ public class WorldMock implements World
 										   Predicate<? super Entity> filter)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2090,56 +2090,56 @@ public class WorldMock implements World
 										   Predicate<? super Entity> filter)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable BiomeSearchResult locateNearestBiome(@NotNull Location origin, int radius, int horizontalInterval, int verticalInterval, @NotNull Biome... biomes)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable BiomeSearchResult locateNearestBiome(@NotNull Location origin, int radius, @NotNull Biome... biomes)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable RayTraceResult rayTrace(@NotNull Position start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, @Nullable Predicate<? super Entity> filter, @Nullable Predicate<? super Block> canCollide)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable RayTraceResult rayTrace(@NotNull Consumer<PositionedRayTraceConfigurationBuilder> consumer)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable RayTraceResult rayTraceBlocks(@NotNull Position start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, @Nullable Predicate<? super Block> canCollide)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable RayTraceResult rayTraceEntities(@NotNull Position start, @NotNull Vector direction, double maxDistance, double raySize, @Nullable Predicate<? super Entity> filter)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public RayTraceResult rayTraceBlocks(Location start, Vector direction, double maxDistance)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2147,7 +2147,7 @@ public class WorldMock implements World
 										 FluidCollisionMode fluidCollisionMode)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2155,7 +2155,7 @@ public class WorldMock implements World
 										 FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2164,7 +2164,7 @@ public class WorldMock implements World
 								   Predicate<? super Entity> filter)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2172,7 +2172,7 @@ public class WorldMock implements World
 								  double offsetZ, double extra, T data, boolean force)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2180,7 +2180,7 @@ public class WorldMock implements World
 								  double offsetY, double offsetZ, double extra, T data, boolean force)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2189,56 +2189,56 @@ public class WorldMock implements World
 										   boolean findUnexplored)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable StructureSearchResult locateNearestStructure(@NotNull Location origin, org.bukkit.generator.structure.@NotNull StructureType structureType, int radius, boolean findUnexplored)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable StructureSearchResult locateNearestStructure(@NotNull Location origin, @NotNull Structure structure, int radius, boolean findUnexplored)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Location locateNearestBiome(@NotNull Location origin, @NotNull Biome biome, int radius)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Location locateNearestBiome(@NotNull Location origin, @NotNull Biome biome, int radius, int step)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Location locateNearestPoi(@NotNull Location origin, @NotNull PoiType poiType, @Positive int radius, PoiType.@NotNull Occupancy occupancy)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull List<PoiSearchResult> locateAllPoiInRange(@NotNull Location origin, @NotNull Predicate<PoiType> poiTypePredicate, @Positive int radius, PoiType.@NotNull Occupancy occupancy)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public <T extends Entity> @NotNull T addEntity(@NotNull T t)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2257,77 +2257,77 @@ public class WorldMock implements World
 	public @NotNull Collection<Material> getInfiniburn()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void sendGameEvent(@Nullable Entity sourceEntity, @NotNull GameEvent gameEvent, @NotNull Vector position)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean isChunkForceLoaded(int x, int z)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setChunkForceLoaded(int x, int z, boolean forced)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Collection<Chunk> getForceLoadedChunks()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean addPluginChunkTicket(int x, int z, Plugin plugin)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean removePluginChunkTicket(int x, int z, Plugin plugin)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void removePluginChunkTickets(Plugin plugin)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Collection<Plugin> getPluginChunkTickets(int x, int z)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Map<Plugin, Collection<Chunk>> getPluginChunkTickets()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Collection<Chunk> getIntersectingChunks(@NotNull BoundingBox box)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2368,40 +2368,40 @@ public class WorldMock implements World
 	public Raid locateNearestRaid(Location location, int radius)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @Nullable Raid getRaid(int id)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull List<Raid> getRaids()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	public boolean createExplosion(double x, double y, double z, float power, boolean setFire, boolean breakBlocks,
 								   Entity source)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	public boolean createExplosion(Location loc, float power, boolean setFire, boolean breakBlocks)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	public boolean createExplosion(Location loc, float power, boolean setFire, boolean breakBlocks, Entity source)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2482,7 +2482,7 @@ public class WorldMock implements World
 	public @NotNull Biome getComputedBiome(int x, int y, int z)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2536,7 +2536,7 @@ public class WorldMock implements World
 	public @NotNull FluidData getFluidData(int i, int i1, int i2)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@NotNull
@@ -2603,28 +2603,28 @@ public class WorldMock implements World
 	public boolean generateTree(@NotNull Location location, @NotNull Random random, @NotNull TreeType type)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean generateTree(@NotNull Location location, @NotNull Random random, @NotNull TreeType type, @Nullable Consumer<? super BlockState> stateConsumer)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public double getTemperature(int x, int y, int z)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public double getHumidity(int x, int y, int z)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2634,7 +2634,7 @@ public class WorldMock implements World
 		{
 			case NETHER, THE_END -> 256;
 			case NORMAL -> 384;
-			case CUSTOM -> throw new UnimplementedOperationException("We don't have support for Datapacks");
+			case CUSTOM -> throw UnimplementedOperationException.exception("We don't have support for Datapacks");
 		};
 	}
 
@@ -2742,20 +2742,20 @@ public class WorldMock implements World
 	public DragonBattle getEnderDragonBattle()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Set<FeatureFlag> getFeatureFlags()
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public boolean setSpawnLocation(int x, int y, int z, float angle)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2804,21 +2804,21 @@ public class WorldMock implements World
 	public int getViewDistance()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setViewDistance(int viewDistance)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setSimulationDistance(int simulationDistance)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2826,7 +2826,7 @@ public class WorldMock implements World
 	public int getNoTickViewDistance()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2834,40 +2834,40 @@ public class WorldMock implements World
 	public void setNoTickViewDistance(int viewDistance)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public int getSendViewDistance()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void setSendViewDistance(int viewDistance)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Collection<GeneratedStructure> getStructures(int x, int z)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Collection<GeneratedStructure> getStructures(int x, int z, @NotNull Structure structure)
 	{
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public @NotNull Spigot spigot()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2892,7 +2892,7 @@ public class WorldMock implements World
 	public int getSimulationDistance()
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
@@ -2955,35 +2955,35 @@ public class WorldMock implements World
 	public void playNote(@NotNull Location loc, @NotNull Instrument instrument, @NotNull Note note)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void playSound(@NotNull Entity entity, @NotNull String sound, @NotNull SoundCategory category, float volume, float pitch, long seed)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void playSound(@NotNull Entity entity, @NotNull Sound sound, @NotNull SoundCategory category, float volume, float pitch, long seed)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void playSound(@NotNull Location location, @NotNull String sound, @NotNull SoundCategory category, float volume, float pitch, long seed)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override
 	public void playSound(@NotNull Location location, @NotNull Sound sound, @NotNull SoundCategory category, float volume, float pitch, long seed)
 	{
 		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		throw UnimplementedOperationException.exception();
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/event/RaidMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/event/RaidMockTest.java
@@ -327,7 +327,7 @@ class RaidMockTest
 			@Override
 			public @NotNull Sound getCelebrationSound()
 			{
-				throw new UnimplementedOperationException();
+				throw UnimplementedOperationException.exception();
 			}
 		};
 	}


### PR DESCRIPTION
# Description

Fixes #1507. Checks for system property `mockbukkit.unimplementedoperation.fail` = `true`, and uses a separate exception in that case. 

# Checklist

The following items should be checked before the pull request can be merged.

- [ ] Code follows existing style.
- [ ] Unit tests added (if applicable).
