### PR TITLE
fix(meta): ItemMeta equals/hashCode ignores CustomModelDataComponent

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -122,7 +122,6 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	private @NotNull Set<ItemFlag> hideFlags = EnumSet.noneOf(ItemFlag.class);
 	private @NotNull PersistentDataContainerMock persistentDataContainer = new PersistentDataContainerMock();
 	private boolean unbreakable = false;
-	private @Nullable Integer customModelData = null;
 	private boolean hideTooltip;
 	private boolean fireResistant;
 	private boolean glider;
@@ -136,7 +135,7 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	private @Nullable NamespacedKey tooltipStyle;
 	private @Nullable NamespacedKey damageResistant;
 
-	private @Nullable CustomModelDataComponent customModelDataComponent;
+	private @Nullable CustomModelDataComponent customModelData;
 	private @Nullable UseCooldownComponent useCooldown;
 	private @Nullable FoodComponent foodComponent;
 	private @Nullable ToolComponent toolComponent;
@@ -194,7 +193,13 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 			this.persistentDataContainer = new PersistentDataContainerMock(m.persistentDataContainer);
 		}
 		unbreakable = meta.isUnbreakable();
-		customModelData = meta.hasCustomModelData() ? meta.getCustomModelData() : null;
+		if (meta.hasCustomModelDataComponent())
+		{
+			CustomModelDataComponent c = meta.getCustomModelDataComponent();
+			this.customModelData = CustomModelDataComponentMock.builder()
+					.floats(c.getFloats()).flags(c.getFlags())
+					.strings(c.getStrings()).colors(c.getColors()).build();
+		}
 		hideTooltip = meta.isHideTooltip();
 		fireResistant = meta.isFireResistant();
 		if (meta.hasMaxStackSize())
@@ -414,8 +419,8 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 				&& Objects.equals(getEnchants(), meta.getEnchants())
 				&& Objects.equals(hasMaxStackSize(), meta.hasMaxStackSize())
 				&& (!hasMaxStackSize() || Objects.equals(getMaxStackSize(), meta.getMaxStackSize()))
-				&& Objects.equals(hasCustomModelData(), meta.hasCustomModelData())
-				&& (!hasCustomModelData() || Objects.equals(getCustomModelData(), meta.getCustomModelData()))
+				&& Objects.equals(hasCustomModelDataComponent(), meta.hasCustomModelDataComponent())
+				&& (!hasCustomModelDataComponent() || Objects.equals(getCustomModelDataComponent(), meta.getCustomModelDataComponent()))
 				&& Objects.equals(hasEnchantmentGlintOverride(), meta.hasEnchantmentGlintOverride())
 				&& (!hasEnchantmentGlintOverride() || Objects.equals(getEnchantmentGlintOverride(), meta.getEnchantmentGlintOverride()))
 				&& Objects.equals(hasRarity(), meta.hasRarity())
@@ -822,7 +827,7 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 			lore(loreList);
 		}
 
-		customModelData = NbtParser.parseInteger(args.get(CUSTOM_MODEL_DATA));
+		setCustomModelData(NbtParser.parseInteger(args.get(CUSTOM_MODEL_DATA)));
 		enchantable = NbtParser.parseInteger(args.get(ENCHANTABLE));
 		damage = NbtParser.parseInteger(args.get(DAMAGE));
 		maxDamage = NbtParser.parseInteger(args.get(MAX_DAMAGE));
@@ -1156,38 +1161,39 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	@Override
 	public boolean hasCustomModelData()
 	{
-		return this.customModelData != null;
+		return this.customModelData != null && !this.customModelData.getFloats().isEmpty();
 	}
 
 	@Override
 	public int getCustomModelData()
 	{
 		Preconditions.checkState(hasCustomModelData(), "We don't have CustomModelData! Check hasCustomModelData first!");
-		return this.customModelData;
+		return this.customModelData.getFloats().get(0).intValue();
 	}
 
 	@Override
 	public @NotNull CustomModelDataComponent getCustomModelDataComponent()
 	{
-		return this.hasCustomModelDataComponent() ? this.customModelDataComponent : CustomModelDataComponentMock.useDefault();
+		return this.hasCustomModelDataComponent() ? this.customModelData : CustomModelDataComponentMock.useDefault();
 	}
 
 	@Override
 	public void setCustomModelData(@Nullable Integer data)
 	{
-		this.customModelData = data;
+		this.customModelData = (data == null) ? null
+				: CustomModelDataComponentMock.builder().floats(List.of((float) data)).build();
 	}
 
 	@Override
 	public boolean hasCustomModelDataComponent()
 	{
-		return this.customModelDataComponent != null;
+		return this.customModelData != null;
 	}
 
 	@Override
 	public void setCustomModelDataComponent(@Nullable CustomModelDataComponent customModelDataComponent)
 	{
-		this.customModelDataComponent = customModelDataComponent;
+		this.customModelData = customModelDataComponent;
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -195,10 +195,7 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 		unbreakable = meta.isUnbreakable();
 		if (meta.hasCustomModelDataComponent())
 		{
-			CustomModelDataComponent c = meta.getCustomModelDataComponent();
-			this.customModelData = CustomModelDataComponentMock.builder()
-					.floats(c.getFloats()).flags(c.getFlags())
-					.strings(c.getStrings()).colors(c.getColors()).build();
+			this.customModelData = new CustomModelDataComponentMock(meta.getCustomModelDataComponent());
 		}
 		hideTooltip = meta.isHideTooltip();
 		fireResistant = meta.isFireResistant();

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/components/CustomModelDataComponentMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/components/CustomModelDataComponentMock.java
@@ -6,6 +6,7 @@ import lombok.EqualsAndHashCode;
 import org.bukkit.Color;
 import org.bukkit.configuration.serialization.SerializableAs;
 import org.bukkit.inventory.meta.components.CustomModelDataComponent;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.NotNullByDefault;
 import org.mockbukkit.mockbukkit.inventory.SerializableMeta;
 import org.mockbukkit.mockbukkit.util.NbtParser;
@@ -32,6 +33,11 @@ public class CustomModelDataComponentMock implements CustomModelDataComponent
 		this.flags = List.copyOf(flags);
 		this.strings = List.copyOf(strings);
 		this.colors = List.copyOf(colors);
+	}
+
+	public CustomModelDataComponentMock(@NotNull CustomModelDataComponent source)
+	{
+		this(source.getFloats(), source.getFlags(), source.getStrings(), source.getColors());
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/meta/ItemMetaMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/meta/ItemMetaMockTest.java
@@ -656,6 +656,18 @@ class ItemMetaMockTest
 	}
 
 	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	void clone_CustomModelDataComponent_IsIndependent()
+	{
+		meta.setCustomModelDataComponent(CustomModelDataComponentMock.builder().strings(List.of("original")).build());
+		ItemMetaMock cloned = meta.clone();
+
+		meta.getCustomModelDataComponent().setStrings(List.of("mutated"));
+
+		assertEquals(List.of("original"), cloned.getCustomModelDataComponent().getStrings());
+	}
+
+	@Test
 	void clone_WithDisplayName_ClonedExactly()
 	{
 		meta.setDisplayName("Some name");

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/meta/ItemMetaMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/meta/ItemMetaMockTest.java
@@ -622,6 +622,40 @@ class ItemMetaMockTest
 	}
 
 	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	void equals_setCustomModelDataAndSetCustomModelDataComponentEquivalent_True()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.setCustomModelData(42);
+		meta2.setCustomModelDataComponent(CustomModelDataComponentMock.builder().floats(List.of(42f)).build());
+		assertEquals(meta, meta2);
+		assertEquals(meta2, meta);
+		assertEquals(meta.hashCode(), meta2.hashCode());
+	}
+
+	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	void equals_CustomModelDataComponentDifferent_False()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.setCustomModelDataComponent(CustomModelDataComponentMock.builder().strings(List.of("plugin:variant_a")).build());
+		meta2.setCustomModelDataComponent(CustomModelDataComponentMock.builder().strings(List.of("plugin:variant_b")).build());
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
+		assertNotEquals(meta.hashCode(), meta2.hashCode());
+	}
+
+	@Test
+	@SuppressWarnings("UnstableApiUsage")
+	void equals_CustomModelDataComponentOneWithout_False()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.setCustomModelDataComponent(CustomModelDataComponentMock.builder().strings(List.of("plugin:variant_a")).build());
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
+	}
+
+	@Test
 	void clone_WithDisplayName_ClonedExactly()
 	{
 		meta.setDisplayName("Some name");

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/meta/components/CustomModelDataComponentMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/meta/components/CustomModelDataComponentMockTest.java
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 class CustomModelDataComponentMockTest
 {
@@ -89,6 +91,46 @@ class CustomModelDataComponentMockTest
 			assertEquals(component.getStrings(), actual.getStrings());
 			assertEquals(component.getColors(), actual.getColors());
 			assertEquals(component, actual);
+		}
+
+	}
+
+	@Nested
+	class CopyConstructor
+	{
+
+		@Test
+		void givenPopulatedSource_CopiesAllFields()
+		{
+			var source = CustomModelDataComponentMock.builder()
+					.floats(List.of(1.0F, 2.0F))
+					.flags(List.of(true, false))
+					.strings(List.of("variant_a", "variant_b"))
+					.colors(List.of(Color.RED, Color.BLUE))
+					.build();
+
+			var copy = new CustomModelDataComponentMock(source);
+
+			assertEquals(source.getFloats(), copy.getFloats());
+			assertEquals(source.getFlags(), copy.getFlags());
+			assertEquals(source.getStrings(), copy.getStrings());
+			assertEquals(source.getColors(), copy.getColors());
+			assertEquals(source, copy);
+		}
+
+		@Test
+		void givenPopulatedSource_CopyIsIndependent()
+		{
+			var source = CustomModelDataComponentMock.builder()
+					.strings(List.of("original"))
+					.build();
+
+			var copy = new CustomModelDataComponentMock(source);
+			source.setStrings(List.of("mutated"));
+
+			assertNotSame(source, copy);
+			assertNotEquals(source.getStrings(), copy.getStrings());
+			assertEquals(List.of("original"), copy.getStrings());
 		}
 
 	}


### PR DESCRIPTION
# Description

## Problem

`ItemMetaMock` stored custom model data in two independent fields -- a legacy `Integer customModelData` and a separate `CustomModelDataComponent customModelDataComponent` -- but `equals()` and `hashCode()` only consulted the integer. Two `ItemMeta` instances that differed solely in their `CustomModelDataComponent` (e.g. different `strings`, `floats`, or `colors`) compared as equal and produced the same hash code, diverging from Paper's production behavior.

## Changes

**`ItemMetaMock`** -- consolidates both fields into a single `CustomModelDataComponent customModelData` field, matching `CraftMetaItem`'s design. The legacy `int` API (`hasCustomModelData` / `getCustomModelData` / `setCustomModelData`) becomes a thin view over the component's first float value. `equals()` and `hashCode()` now compare the full component, so all sub-fields participate.

**`CustomModelDataComponentMock`** -- adds a copy constructor `CustomModelDataComponentMock(CustomModelDataComponent source)` mirroring `CraftCustomModelDataComponent(CraftCustomModelDataComponent)`. This is used by `ItemMetaMock`'s copy constructor to produce independent clones, and is more future-proof than manually enumerating the four sub-fields at each call site.

## Tests added

- `equals_setCustomModelDataAndSetCustomModelDataComponentEquivalent_True` -- `setCustomModelData(42)` and `setCustomModelDataComponent(builder().floats([42f]).build())` produce equal metas.
- `equals_CustomModelDataComponentDifferent_False` -- two metas with differing component `strings` are not equal.
- `equals_CustomModelDataComponentOneWithout_False` -- asymmetric presence is not equal.
- `clone_CustomModelDataComponent_IsIndependent` -- mutating the original's component after cloning does not affect the clone.
- `CopyConstructor` suite on `CustomModelDataComponentMock` -- copies all four sub-fields and produces an independent instance.