### PR TITLE
fix(meta): align ItemMeta equals/hashCode with Paper

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -22,6 +22,7 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.Tag;
 import org.bukkit.attribute.Attribute;
+import org.bukkit.tag.DamageTypeTags;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.configuration.serialization.DelegateDeserialization;
 import org.bukkit.damage.DamageType;
@@ -123,7 +124,6 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	private @NotNull PersistentDataContainerMock persistentDataContainer = new PersistentDataContainerMock();
 	private boolean unbreakable = false;
 	private boolean hideTooltip;
-	private boolean fireResistant;
 	private boolean glider;
 	private @Nullable Integer maxStackSize = null;
 	private @Nullable Boolean enchantmentGlintOverride = null;
@@ -198,7 +198,11 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 			this.customModelData = new CustomModelDataComponentMock(meta.getCustomModelDataComponent());
 		}
 		hideTooltip = meta.isHideTooltip();
-		fireResistant = meta.isFireResistant();
+		if (meta.hasDamageResistant() && meta.getDamageResistant() != null)
+		{
+			this.damageResistant = meta.getDamageResistant().getKey();
+		}
+		glider = meta.isGlider();
 		if (meta.hasMaxStackSize())
 		{
 			maxStackSize = meta.getMaxStackSize();
@@ -218,6 +222,42 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 		if (meta.hasEnchantable())
 		{
 			enchantable = meta.getEnchantable();
+		}
+		if (meta.hasTooltipStyle())
+		{
+			tooltipStyle = meta.getTooltipStyle();
+		}
+		if (meta.hasItemModel())
+		{
+			itemModel = meta.getItemModel();
+		}
+		if (meta.hasUseRemainder())
+		{
+			useRemainder = meta.getUseRemainder();
+		}
+		if (meta.hasUseCooldown())
+		{
+			useCooldown = meta.getUseCooldown();
+		}
+		if (meta.hasFood())
+		{
+			foodComponent = meta.getFood();
+		}
+		if (meta.hasTool())
+		{
+			toolComponent = meta.getTool();
+		}
+		if (meta.hasEquippable())
+		{
+			equippableComponent = meta.getEquippable();
+		}
+		if (meta.hasJukeboxPlayable())
+		{
+			jukeboxPlayableComponent = meta.getJukeboxPlayable();
+		}
+		if (meta instanceof ItemMetaMock m && m.hasBlockData())
+		{
+			this.blockData = new HashMap<>(m.getBlockData());
 		}
 	}
 
@@ -361,12 +401,22 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 				customModelData,
 				maxDamage,
 				hideTooltip,
-				fireResistant,
+				damageResistant,
 				maxStackSize,
 				enchantmentGlintOverride,
 				rarity,
 				itemName,
-				enchantable);
+				enchantable,
+				glider,
+				tooltipStyle,
+				itemModel,
+				useRemainder,
+				useCooldown,
+				foodComponent,
+				toolComponent,
+				equippableComponent,
+				jukeboxPlayableComponent,
+				blockData);
 	}
 
 	@Override
@@ -412,7 +462,8 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 				&& isLoreEquals(meta)
 				&& isUnbreakable() == meta.isUnbreakable()
 				&& isHideTooltip() == meta.isHideTooltip()
-				&& isFireResistant() == meta.isFireResistant()
+				&& Objects.equals(hasDamageResistant(), meta.hasDamageResistant())
+				&& (!hasDamageResistant() || Objects.equals(getDamageResistant(), meta.getDamageResistant()))
 				&& Objects.equals(getEnchants(), meta.getEnchants())
 				&& Objects.equals(hasMaxStackSize(), meta.hasMaxStackSize())
 				&& (!hasMaxStackSize() || Objects.equals(getMaxStackSize(), meta.getMaxStackSize()))
@@ -427,7 +478,30 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 				&& Objects.equals(hasAttributeModifiers(), meta.hasAttributeModifiers())
 				&& (!hasAttributeModifiers() || Objects.equals(getAttributeModifiers(), meta.getAttributeModifiers()))
 				&& Objects.equals(getItemFlags(), meta.getItemFlags())
-				&& Objects.equals(getPersistentDataContainer(), meta.getPersistentDataContainer());
+				&& Objects.equals(getPersistentDataContainer(), meta.getPersistentDataContainer())
+				&& isGlider() == meta.isGlider()
+				&& Objects.equals(hasItemName(), meta.hasItemName())
+				&& (!hasItemName() || Objects.equals(itemName(), meta.itemName()))
+				&& Objects.equals(hasTooltipStyle(), meta.hasTooltipStyle())
+				&& (!hasTooltipStyle() || Objects.equals(getTooltipStyle(), meta.getTooltipStyle()))
+				&& Objects.equals(hasItemModel(), meta.hasItemModel())
+				&& (!hasItemModel() || Objects.equals(getItemModel(), meta.getItemModel()))
+				&& Objects.equals(hasUseRemainder(), meta.hasUseRemainder())
+				&& (!hasUseRemainder() || Objects.equals(getUseRemainder(), meta.getUseRemainder()))
+				&& Objects.equals(hasUseCooldown(), meta.hasUseCooldown())
+				&& (!hasUseCooldown() || Objects.equals(getUseCooldown(), meta.getUseCooldown()))
+				&& Objects.equals(hasFood(), meta.hasFood())
+				&& (!hasFood() || Objects.equals(getFood(), meta.getFood()))
+				&& Objects.equals(hasTool(), meta.hasTool())
+				&& (!hasTool() || Objects.equals(getTool(), meta.getTool()))
+				&& Objects.equals(hasEquippable(), meta.hasEquippable())
+				&& (!hasEquippable() || Objects.equals(getEquippable(), meta.getEquippable()))
+				&& Objects.equals(hasJukeboxPlayable(), meta.hasJukeboxPlayable())
+				&& (!hasJukeboxPlayable() || Objects.equals(getJukeboxPlayable(), meta.getJukeboxPlayable()))
+				&& (!(meta instanceof ItemMetaMock other)
+						? !hasBlockData()
+						: Objects.equals(hasBlockData(), other.hasBlockData())
+						&& (!hasBlockData() || Objects.equals(getBlockData(), other.getBlockData())));
 	}
 
 	@Override
@@ -714,10 +788,6 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 		{
 			map.put(HIDE_TOOLTIP, this.hideTooltip);
 		}
-		if (this.isFireResistant())
-		{
-			map.put(FIRE_RESISTANT, this.fireResistant);
-		}
 		if (this.hasDamageResistant())
 		{
 			map.put(DAMAGE_RESISTANT, this.getDamageResistant().getKey().asString());
@@ -833,12 +903,16 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 		itemModel = NbtParser.parseNamespacedKey(args.get(ITEM_MODEL));
 		unbreakable = NbtParser.parseBoolean(args.get(UNBREAKABLE), false);
 		hideTooltip = NbtParser.parseBoolean(args.get(HIDE_TOOLTIP), false);
-		fireResistant = NbtParser.parseBoolean(args.get(FIRE_RESISTANT), false);
 		maxStackSize = NbtParser.parseInteger(args.get(MAX_STACK_SIZE));
 		enchantmentGlintOverride = NbtParser.parseBoolean(args.get(ENCHANTMENT_GLINT_OVERRIDE));
 		glider = NbtParser.parseBoolean(args.get(GLIDER), false);
 		rarity = NbtParser.parseEnum(args.get(RARITY), ItemRarity.class);
 		damageResistant = NbtParser.parseNamespacedKey(args.get(DAMAGE_RESISTANT));
+		if (damageResistant == null && NbtParser.parseBoolean(args.get(FIRE_RESISTANT), false))
+		{
+			// Backwards compatibility for old FireResistant tag.
+			damageResistant = DamageTypeTags.IS_FIRE.getKey();
+		}
 
 		enchants = new HashMap<>();
 		Map<String, Integer> enchantMap = NbtParser.parseMap(args.get(ENCHANTMENTS), NbtParser::parseInteger);
@@ -1479,13 +1553,20 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 	@Override
 	public boolean isFireResistant()
 	{
-		return this.fireResistant;
+		return hasDamageResistant() && DamageTypeTags.IS_FIRE.getKey().equals(this.damageResistant);
 	}
 
 	@Override
 	public void setFireResistant(boolean fireResistant)
 	{
-		this.fireResistant = fireResistant;
+		if (fireResistant)
+		{
+			setDamageResistant(DamageTypeTags.IS_FIRE);
+		}
+		else if (isFireResistant())
+		{
+			setDamageResistant(null);
+		}
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/ItemMetaMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/ItemMetaMock.java
@@ -498,10 +498,20 @@ public class ItemMetaMock implements ItemMeta, Damageable, Repairable
 				&& (!hasEquippable() || Objects.equals(getEquippable(), meta.getEquippable()))
 				&& Objects.equals(hasJukeboxPlayable(), meta.hasJukeboxPlayable())
 				&& (!hasJukeboxPlayable() || Objects.equals(getJukeboxPlayable(), meta.getJukeboxPlayable()))
-				&& (!(meta instanceof ItemMetaMock other)
-						? !hasBlockData()
-						: Objects.equals(hasBlockData(), other.hasBlockData())
-						&& (!hasBlockData() || Objects.equals(getBlockData(), other.getBlockData())));
+				&& isBlockDataEqual(meta);
+	}
+
+	private boolean isBlockDataEqual(@NotNull ItemMeta meta)
+	{
+		if (!(meta instanceof ItemMetaMock other))
+		{
+			return !hasBlockData();
+		}
+		if (hasBlockData() != other.hasBlockData())
+		{
+			return false;
+		}
+		return !hasBlockData() || Objects.equals(getBlockData(), other.getBlockData());
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/meta/ItemMetaMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/meta/ItemMetaMockTest.java
@@ -394,6 +394,116 @@ class ItemMetaMockTest
 	}
 
 	@Test
+	void equals_ItemNameSame_True()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.itemName(Component.text("sword"));
+		meta2.itemName(Component.text("sword"));
+		assertEquals(meta, meta2);
+		assertEquals(meta2, meta);
+		assertEquals(meta.hashCode(), meta2.hashCode());
+	}
+
+	@Test
+	void equals_ItemNameDifferent_False()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.itemName(Component.text("sword"));
+		meta2.itemName(Component.text("axe"));
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
+		assertNotEquals(meta.hashCode(), meta2.hashCode());
+	}
+
+	@Test
+	void equals_GliderSame_True()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.setGlider(true);
+		meta2.setGlider(true);
+		assertEquals(meta, meta2);
+		assertEquals(meta2, meta);
+		assertEquals(meta.hashCode(), meta2.hashCode());
+	}
+
+	@Test
+	void equals_GliderDifferent_False()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.setGlider(true);
+		meta2.setGlider(false);
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
+		assertNotEquals(meta.hashCode(), meta2.hashCode());
+	}
+
+	@Test
+	void equals_TooltipStyleSame_True()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.setTooltipStyle(NamespacedKey.fromString("test:style"));
+		meta2.setTooltipStyle(NamespacedKey.fromString("test:style"));
+		assertEquals(meta, meta2);
+		assertEquals(meta2, meta);
+		assertEquals(meta.hashCode(), meta2.hashCode());
+	}
+
+	@Test
+	void equals_TooltipStyleDifferent_False()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.setTooltipStyle(NamespacedKey.fromString("test:style-a"));
+		meta2.setTooltipStyle(NamespacedKey.fromString("test:style-b"));
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
+		assertNotEquals(meta.hashCode(), meta2.hashCode());
+	}
+
+	@Test
+	void equals_ItemModelSame_True()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.setItemModel(NamespacedKey.fromString("test:model"));
+		meta2.setItemModel(NamespacedKey.fromString("test:model"));
+		assertEquals(meta, meta2);
+		assertEquals(meta2, meta);
+		assertEquals(meta.hashCode(), meta2.hashCode());
+	}
+
+	@Test
+	void equals_ItemModelDifferent_False()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.setItemModel(NamespacedKey.fromString("test:model-a"));
+		meta2.setItemModel(NamespacedKey.fromString("test:model-b"));
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
+		assertNotEquals(meta.hashCode(), meta2.hashCode());
+	}
+
+	@Test
+	void equals_DamageResistantSame_True()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.setDamageResistant(DamageTypeTags.BYPASSES_ARMOR);
+		meta2.setDamageResistant(DamageTypeTags.BYPASSES_ARMOR);
+		assertEquals(meta, meta2);
+		assertEquals(meta2, meta);
+		assertEquals(meta.hashCode(), meta2.hashCode());
+	}
+
+	@Test
+	void equals_DamageResistantDifferent_False()
+	{
+		ItemMetaMock meta2 = new ItemMetaMock();
+		meta.setDamageResistant(DamageTypeTags.BYPASSES_ARMOR);
+		meta2.setDamageResistant(DamageTypeTags.IS_FIRE);
+		assertNotEquals(meta, meta2);
+		assertNotEquals(meta2, meta);
+		assertNotEquals(meta.hashCode(), meta2.hashCode());
+	}
+
+	@Test
 	void equals_AttributeModifiersSame_True()
 	{
 		ItemMetaMock meta2 = new ItemMetaMock();
@@ -1291,6 +1401,32 @@ class ItemMetaMockTest
 	}
 
 	@Test
+	void setFireResistantTrue_SetsDamageResistantToIsFire()
+	{
+		meta.setFireResistant(true);
+		assertTrue(meta.hasDamageResistant());
+		assertEquals(DamageTypeTags.IS_FIRE.getKey(), meta.getDamageResistant().getKey());
+	}
+
+	@Test
+	void setFireResistantFalse_ClearsDamageResistantWhenIsFire()
+	{
+		meta.setFireResistant(true);
+		meta.setFireResistant(false);
+		assertFalse(meta.hasDamageResistant());
+		assertFalse(meta.isFireResistant());
+	}
+
+	@Test
+	void setFireResistantFalse_LeavesNonFireDamageResistantIntact()
+	{
+		meta.setDamageResistant(DamageTypeTags.BYPASSES_ARMOR);
+		meta.setFireResistant(false);
+		assertTrue(meta.hasDamageResistant());
+		assertEquals(DamageTypeTags.BYPASSES_ARMOR.getKey(), meta.getDamageResistant().getKey());
+	}
+
+	@Test
 	void testHasEnchantable()
 	{
 		assertFalse(meta.hasEnchantable());
@@ -1942,6 +2078,44 @@ class ItemMetaMockTest
 
 			String expected = "{\"meta-type\":\"UNSPECIFIC\",\"damage-resistant\":\"minecraft:bypasses_armor\"}";
 			assertJsonEqual(expected, actual);
+		}
+
+		@Test
+		void givenFireResistant_SerializesAsDamageResistantIsFire()
+		{
+			meta.setFireResistant(true);
+
+			Map<String, Object> actual = meta.serialize();
+
+			String expected = "{\"meta-type\":\"UNSPECIFIC\",\"damage-resistant\":\"minecraft:is_fire\"}";
+			assertJsonEqual(expected, actual);
+		}
+
+		@Test
+		void givenFireResistant_RoundTrip()
+		{
+			meta.setFireResistant(true);
+
+			Map<String, Object> serialized = meta.serialize();
+			ItemMetaMock deserialized = ItemMetaMock.deserialize(serialized);
+
+			assertTrue(deserialized.isFireResistant());
+			assertTrue(deserialized.hasDamageResistant());
+			assertEquals(DamageTypeTags.IS_FIRE.getKey(), deserialized.getDamageResistant().getKey());
+		}
+
+		@Test
+		void givenLegacyFireResistant_DeserializesAsIsFire()
+		{
+			Map<String, Object> legacy = new java.util.HashMap<>();
+			legacy.put("meta-type", "UNSPECIFIC");
+			legacy.put("FireResistant", true);
+
+			ItemMetaMock deserialized = ItemMetaMock.deserialize(legacy);
+
+			assertTrue(deserialized.isFireResistant());
+			assertTrue(deserialized.hasDamageResistant());
+			assertEquals(NamespacedKey.minecraft("is_fire"), deserialized.getDamageResistant().getKey());
 		}
 
 		@Test


### PR DESCRIPTION
My plugin sorts inventories and merges loose stacks of items based on meta equality, so it's useful to me for ItemMetaMock to more accurately represent what Bukkit/Paper do. This shores up equals/hashCode a reasonable amount.

---

- align ItemMeta equals/hashCode with Paper and derive fireResistant from damageResistant
- Remove the standalone `fireResistant` field. `isFireResistant()` is now a derived check (`hasDamageResistant() && damageResistant == IS_FIRE`), matching Paper's `CraftMetaItem` semantics. `setFireResistant()` delegates to the damage-resistant field.
- Extend `equals()` and `hashCode()` to cover all modelled fields that were previously ignored: `damageResistant`, `glider`, `itemName`, `tooltipStyle`, `itemModel`, `useRemainder`, `useCooldown`, `food`, `tool`, `equippable`, `jukeboxPlayable`, and `blockData`. Fixes the equals/hashCode contract violation where `itemName` was hashed but never compared.
- Fix serialization: fire resistance now emits via `damage-resistant` (matching Paper); legacy `FireResistant: true` maps are read back as `minecraft:is_fire` for backwards compatibility.
- Copy constructor extended to copy all fields covered by equals.