### PR TITLE
feat: add Adventure pointers to EntityMock and PlayerMock

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/EntityMock.java
@@ -7,6 +7,7 @@ import io.papermc.paper.datacomponent.DataComponentType;
 import io.papermc.paper.entity.LookAnchor;
 import io.papermc.paper.entity.TeleportFlag;
 import io.papermc.paper.threadedregions.scheduler.EntityScheduler;
+import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.pointer.Pointers;
 import net.kyori.adventure.pointer.PointersSupplier;
 import net.kyori.adventure.text.Component;
@@ -93,8 +94,8 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 
 	private static final AtomicInteger ENTITY_COUNTER = new AtomicInteger();
 	static final PointersSupplier<EntityMock> POINTERS_SUPPLIER = PointersSupplier.<EntityMock>builder()
-			.resolving(net.kyori.adventure.identity.Identity.DISPLAY_NAME, EntityMock::name)
-			.resolving(net.kyori.adventure.identity.Identity.UUID, EntityMock::getUniqueId)
+			.resolving(Identity.DISPLAY_NAME, EntityMock::name)
+			.resolving(Identity.UUID, EntityMock::getUniqueId)
 			.build();
 
 	private final Set<String> tags = Sets.newHashSet();

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/EntityMock.java
@@ -7,6 +7,8 @@ import io.papermc.paper.datacomponent.DataComponentType;
 import io.papermc.paper.entity.LookAnchor;
 import io.papermc.paper.entity.TeleportFlag;
 import io.papermc.paper.threadedregions.scheduler.EntityScheduler;
+import net.kyori.adventure.pointer.Pointers;
+import net.kyori.adventure.pointer.PointersSupplier;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.Style;
@@ -90,6 +92,10 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 {
 
 	private static final AtomicInteger ENTITY_COUNTER = new AtomicInteger();
+	static final PointersSupplier<EntityMock> POINTERS_SUPPLIER = PointersSupplier.<EntityMock>builder()
+			.resolving(net.kyori.adventure.identity.Identity.DISPLAY_NAME, EntityMock::name)
+			.resolving(net.kyori.adventure.identity.Identity.UUID, EntityMock::getUniqueId)
+			.build();
 
 	private final Set<String> tags = Sets.newHashSet();
 	protected final @NotNull ServerMock server;
@@ -1591,6 +1597,12 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	public @NotNull ItemStack getPickItemStack()
 	{
 		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public @NotNull Pointers pointers()
+	{
+		return POINTERS_SUPPLIER.view(this);
 	}
 
 	public void tick()

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
@@ -18,6 +18,8 @@ import net.kyori.adventure.bossbar.BossBarImplementation;
 import net.kyori.adventure.chat.SignedMessage;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.pointer.Pointers;
+import net.kyori.adventure.pointer.PointersSupplier;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
@@ -166,6 +168,12 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 {
 
 	private static final Component DEFAULT_KICK_COMPONENT = Component.text("You are not whitelisted on this server!");
+	private static final PointersSupplier<PlayerMock> POINTERS_SUPPLIER = PointersSupplier.<PlayerMock>builder()
+			.parent(EntityMock.POINTERS_SUPPLIER)
+			.resolving(Identity.NAME, PlayerMock::getName)
+			.resolving(Identity.DISPLAY_NAME, PlayerMock::displayName)
+			.resolving(Identity.LOCALE, PlayerMock::locale)
+			.build();
 
 	private @NotNull GameMode previousGamemode = super.getGameMode();
 	private @Nullable WeatherType playerWeather = null;
@@ -3374,6 +3382,12 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public PlayerGameConnection getConnection()
 	{
 		throw new UnimplementedOperationException();
+	}
+
+	@Override
+	public @NotNull Pointers pointers()
+	{
+		return POINTERS_SUPPLIER.view(this);
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/EntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/EntityMockTest.java
@@ -1,5 +1,6 @@
 package org.mockbukkit.mockbukkit.entity;
 
+import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.ClickEvent;
@@ -32,6 +33,7 @@ import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.permissions.PermissionDefault;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -331,6 +333,26 @@ class EntityMockTest
 		UUID uuid = UUID.randomUUID();
 		entity = new SimpleEntityMock(server, uuid);
 		assertEquals(uuid, entity.getUniqueId());
+	}
+
+	@Test
+	void pointers_DisplayName_Default_CorrectName()
+	{
+		assertEquals(Component.text("entity"), entity.pointers().get(Identity.DISPLAY_NAME).get());
+	}
+
+	@Test
+	@Disabled("name() is not implemented correctly (https://github.com/MockBukkit/MockBukkit/issues/1582)")
+	void pointers_DisplayName_setCustomName()
+	{
+		entity.setCustomName("Some Custom Name");
+		assertEquals(Component.text("Some Custom name"), entity.pointers().get(Identity.DISPLAY_NAME).get());
+	}
+
+	@Test
+	void pointers_UUID_Correct()
+	{
+		assertEquals(entity.getUniqueId(), entity.pointers().get(Identity.UUID).get());
 	}
 
 	@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
@@ -253,6 +253,38 @@ class PlayerMockTest
 	}
 
 	@Test
+	void pointers_name_CorrectName()
+	{
+		assertEquals("player", player.pointers().get(Identity.NAME).get());
+	}
+
+	@Test
+	void pointers_displayName_Default_CorrectName()
+	{
+		assertEquals(Component.text("player"), player.pointers().get(Identity.DISPLAY_NAME).get());
+	}
+
+	@Test
+	void pointers_displayName_setDisplayName()
+	{
+		player.setDisplayName("Custom Display Name");
+		assertEquals("player", player.pointers().get(Identity.NAME).get());
+		assertEquals(Component.text("Custom Display Name"), player.pointers().get(Identity.DISPLAY_NAME).get());
+	}
+
+	@Test
+	void pointers_UUID_Correct()
+	{
+		assertEquals(player.getUniqueId(), player.pointers().get(Identity.UUID).get());
+	}
+
+	@Test
+	void pointers_locale_Correct()
+	{
+		assertEquals(player.locale(), player.pointers().get(Identity.LOCALE).get());
+	}
+
+	@Test
 	void getPreviousGameMode()
 	{
 		player.setGameMode(GameMode.SURVIVAL);


### PR DESCRIPTION
# Description
This PR adds the following Adventure identity pointers to both EntityMock and PlayerMock: name, display name, uuid and locale. Those pointers have the same semantics as the ones actually implemented in Paper:
https://github.com/PaperMC/Paper/blob/0ae1b4239e9559516917f86bfcac404a091c710c/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java#L228-L233
https://github.com/PaperMC/Paper/blob/0ae1b4239e9559516917f86bfcac404a091c710c/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java#L91-L95

One test is disabled because of a difference in semantics between MockBukkit and Paper (reported at #1582) 

# Checklist

The following items should be checked before the pull request can be merged.

- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
