### PR TITLE
Update README references to the 26.1.2 Maven artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
     <a href="https://github.com/MockBukkit/MockBukkit/actions/">
         <img alt="Build Status" src="https://github.com/MockBukkit/MockBukkit/actions/workflows/publish.yml/badge.svg" />
     </a>
-    <a href="https://central.sonatype.com/artifact/org.mockbukkit.mockbukkit/mockbukkit-v26.1">
-        <img alt="Maven Central" src="https://img.shields.io/maven-central/v/org.mockbukkit.mockbukkit/mockbukkit-v26.1?color=1bcc94&logo=apache-maven" />
+    <a href="https://central.sonatype.com/artifact/org.mockbukkit.mockbukkit/mockbukkit-v26.1.2">
+        <img alt="Maven Central" src="https://img.shields.io/maven-central/v/org.mockbukkit.mockbukkit/mockbukkit-v26.1.2?color=1bcc94&logo=apache-maven" />
     </a>
-    <a href="https://javadoc.io/doc/org.mockbukkit.mockbukkit/mockbukkit-v26.1">
-        <img alt="Javadocs" src="https://javadoc.io/badge2/org.mockbukkit.mockbukkit/mockbukkit-v26.1/javadoc.svg" />
+    <a href="https://javadoc.io/doc/org.mockbukkit.mockbukkit/mockbukkit-v26.1.2">
+        <img alt="Javadocs" src="https://javadoc.io/badge2/org.mockbukkit.mockbukkit/mockbukkit-v26.1.2/javadoc.svg" />
     </a>
     <a href="https://sonarcloud.io/project/issues?resolved=false&types=CODE_SMELL&id=MockBukkit_MockBukkit">
         <img alt="Code Smells" src="https://sonarcloud.io/api/project_badges/measure?project=MockBukkit_MockBukkit&metric=code_smells">
@@ -51,7 +51,7 @@ MockBukkit can easily be included in your project using either Maven or gradle.
 > [!TIP]
 > Currently, the newest version available is
 >
-> [![ALTERNATE-TEXT](https://img.shields.io/maven-central/v/org.mockbukkit.mockbukkit/mockbukkit-v26.1?color=1bcc94&logo=apache-maven)](https://central.sonatype.com/artifact/org.mockbukkit.mockbukkit/mockbukkit-v26.1)
+> [![ALTERNATE-TEXT](https://img.shields.io/maven-central/v/org.mockbukkit.mockbukkit/mockbukkit-v26.1.2?color=1bcc94&logo=apache-maven)](https://central.sonatype.com/artifact/org.mockbukkit.mockbukkit/mockbukkit-v26.1.2)
 
 > Note: The Breaking Changes intended for 3.0 were already made in 2.145.1. Due to an Error it didn't get properly
 > tagged
@@ -92,7 +92,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.mockbukkit.mockbukkit:mockbukkit-v26.1:${paperVersion}'
+    testImplementation 'org.mockbukkit.mockbukkit:mockbukkit-v26.1.2:${paperVersion}'
 }
 ```
 
@@ -106,7 +106,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'com.github.MockBukkit:MockBukkit:v26.1-SNAPSHOT'
+    testImplementation 'com.github.MockBukkit:MockBukkit:v26.1.2-SNAPSHOT'
     testImplementation 'io.papermc.paper:paper-api:${paperVersion}'
 }
 ```
@@ -175,7 +175,7 @@ Also here you can extract the manifest version this way:
 <dependencies>
   <dependency>
     <groupId>org.mockbukkit.mockbukkit</groupId>
-    <artifactId>mockbukkit-v26.1</artifactId>
+    <artifactId>mockbukkit-v26.1.2</artifactId>
     <version>[version]</version>
     <scope>test</scope>
   </dependency>
@@ -210,7 +210,7 @@ use [JitPack](https://jitpack.io/#MockBukkit/MockBukkit) as your maven repositor
   <dependency>
     <groupId>com.github.MockBukkit</groupId>
     <artifactId>MockBukkit</artifactId>
-    <version>v26.1-SNAPSHOT</version>
+    <version>v26.1.2-SNAPSHOT</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -222,7 +222,7 @@ use [JitPack](https://jitpack.io/#MockBukkit/MockBukkit) as your maven repositor
 </dependencies>
 ```
 
-Note: use `v26.1-SNAPSHOT` to test against Paper API 26.1, or any other version if
+Note: use `v26.1.2-SNAPSHOT` to test against Paper API 26.1.2, or any other version if
 the [branch](https://github.com/MockBukkit/MockBukkit/branches) exists.
 These branches will not be receiving patches actively, but any issues will be resolved and any pull requests on them
 will be accepted.


### PR DESCRIPTION
# Description

The [Maven artifact](https://mvnrepository.com/artifact/org.mockbukkit.mockbukkit/mockbukkit-v26.1.2/) is `mockbukkit-v26.1.2`, not `mockbukkit-v26.1` as is mentioned throughout the README. This fixes the badges being broken, along with the examples not working if anyone were to copy them.

# Checklist

The following items should be checked before the pull request can be merged.

- [ ] Code follows existing style.
- [ ] Unit tests added (if applicable).
