### PR TITLE
ci: harden and clean up GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: Build
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           java-version: 25
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Run unit tests
         run: ./gradlew test --refresh-dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,4 +23,4 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Run unit tests
-        run: ./gradlew test --refresh-dependencies
+        run: ./gradlew test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,15 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs: a newer push to the same PR makes in-flight runs stale.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,5 +28,5 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
-      - name: Run unit tests
-        run: ./gradlew test
+      - name: Compile and assemble
+        run: ./gradlew assemble testClasses

--- a/.github/workflows/bump-label-check.yml
+++ b/.github/workflows/bump-label-check.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   has-release-label:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       # agilepathway/pull-request-label-checker v1.6.65
       - uses: docker://agilepathway/pull-request-label-checker@sha256:14f5f3dfda922496d07d53494e2d2b42885165f90677a1c03d600059b7706a61

--- a/.github/workflows/bump-label-check.yml
+++ b/.github/workflows/bump-label-check.yml
@@ -17,7 +17,8 @@ jobs:
   has-release-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: docker://agilepathway/pull-request-label-checker:latest
+      # agilepathway/pull-request-label-checker v1.6.65
+      - uses: docker://agilepathway/pull-request-label-checker@sha256:14f5f3dfda922496d07d53494e2d2b42885165f90677a1c03d600059b7706a61
         id: release-label
         with:
           one_of: release/major,release/minor,release/patch,release/none

--- a/.github/workflows/bump-label-check.yml
+++ b/.github/workflows/bump-label-check.yml
@@ -10,6 +10,9 @@ on:
       - unlabeled
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   has-release-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5
@@ -28,7 +28,7 @@ jobs:
         run: ./gradlew jacocoTestReport --refresh-dependencies
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test results to Codecov

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Run unit tests
-        run: ./gradlew jacocoTestReport --refresh-dependencies
+        run: ./gradlew jacocoTestReport
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Run unit tests
-        run: ./gradlew jacocoTestReport
+        run: ./gradlew jacocoTestReport :metaminer:test
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -16,13 +16,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           java-version: 25
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Run unit tests
         run: ./gradlew jacocoTestReport --refresh-dependencies
@@ -33,7 +33,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: build/test-results/test/TEST-*.xml

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ minecraft/v* ]
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -33,8 +33,9 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
           files: build/test-results/test/TEST-*.xml
           codecov_yml_path: ./codecov.yml

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -8,9 +8,15 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs: a newer push to the same PR/branch makes in-flight runs stale.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -6,9 +6,15 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs: a newer push to the same PR makes in-flight runs stale.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   checkstyle:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -3,6 +3,9 @@ name: Linting
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   checkstyle:
     runs-on: ubuntu-latest

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -14,13 +14,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           java-version: 25
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Run checkstyle in source code
         run: ./gradlew checkstyleMain --refresh-dependencies

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Run checkstyle in source code
-        run: ./gradlew checkstyleMain --refresh-dependencies
+        run: ./gradlew checkstyleMain
 
       - name: Run checkstyle in test code
-        run: ./gradlew checkstyleTest --refresh-dependencies
+        run: ./gradlew checkstyleTest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
-      - name: Build with Gradle
-        run: ./gradlew build -x test
+      - name: Assemble artifacts
+        run: ./gradlew assemble
 
       - name: Run unit tests
         run: ./gradlew test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,13 +33,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           java-version: 25
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Build with Gradle
         run: ./gradlew build -x test --refresh-dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Build with Gradle
-        run: ./gradlew build -x test --refresh-dependencies
+        run: ./gradlew build -x test
 
       - name: Run unit tests
         run: ./gradlew test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,10 @@ on:
         required: true
         type: string
         description: "The version to publish (no v prefix)"
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches: [ minecraft/v* ]
 
+permissions:
+  contents: read
+
 jobs:
   tag:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     outputs:
       version: ${{steps.bump-semver.outputs.new_version}}
       publish_version: ${{ steps.strip-v.outputs.version }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -20,14 +20,14 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Get merged pull request
-        uses: actions-ecosystem/action-get-merged-pull-request@v1.0.1
+        uses: actions-ecosystem/action-get-merged-pull-request@59afe90821bb0b555082ce8ff1e36b03f91553d9 # v1.0.1
         if: ${{ github.event_name == 'push' }}
         id: pr
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get release label
-        uses: actions-ecosystem/action-release-label@v1
+        uses: actions-ecosystem/action-release-label@1c7ef83d383a57bf253a2e2e9dfe1b55f445ae15 # v1.2.0
         if: ${{ steps.pr.outputs.labels != null }}
         id: release-label
         with:
@@ -35,21 +35,21 @@ jobs:
           labels: ${{ steps.pr.outputs.labels }}
 
       - name: Get latest tag
-        uses: actions-ecosystem/action-get-latest-tag@v1
+        uses: actions-ecosystem/action-get-latest-tag@b7c32daec3395a9616f88548363a42652b22d435 # v1.6.0
         if: ${{ steps.release-label.outputs.level != null }}
         id: get-latest-tag
         with:
           semver_only: true
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         if: ${{ steps.release-label.outputs.level != null }}
         with:
           java-version: 25
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         if: ${{ steps.release-label.outputs.level != null }}
 
       - name: Read Paper version from gradle.properties
@@ -63,7 +63,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Bump version
-        uses: actions-ecosystem/action-bump-semver@v1
+        uses: actions-ecosystem/action-bump-semver@34e334551143a5301f38c830e44a22273c6ff5c5 # v1.0.0
         if: ${{ steps.release-label.outputs.level != null }}
         id: bump-semver
         with:
@@ -78,7 +78,7 @@ jobs:
         run: echo "version=${NEW_VERSION#v}" >> "$GITHUB_OUTPUT"
 
       - name: Push tag
-        uses: actions-ecosystem/action-push-tag@v1
+        uses: actions-ecosystem/action-push-tag@6e82caefe706f5a729e354df7443dc82f98a414f # v1.0.0
         if: ${{ steps.bump-semver.outputs.new_version != null }}
         with:
           tag: ${{ steps.bump-semver.outputs.new_version }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -7,6 +7,14 @@ on:
 permissions:
   contents: read
 
+# Serialize releases per branch: if two PRs merge close together, the second
+# Tag run must wait for the first to finish pushing its tag and publishing,
+# otherwise both read the same "latest tag" and compute a colliding version.
+# cancel-in-progress: false — never cancel a release mid-publish; queue instead.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -65,10 +65,14 @@ jobs:
         id: paper-version
         if: ${{ steps.release-label.outputs.level != null }}
         run: |
+          # grep keeps only the "Paper ...:" lines: the gradle wrapper writes its
+          # "Downloading ...10%...100%" distribution-bootstrap progress to stdout on a
+          # cold runner, which would otherwise land in the release tag message. Filtering
+          # by line content strips it regardless of stream. (No 2>&1 — keep stderr out too.)
           {
-              echo "paper_details<<EOF"
-              ./gradlew printPaperDetails --quiet --console=plain 2>&1
-              echo "EOF"
+              echo "paper_details<<PAPER_DETAILS_EOF"
+              ./gradlew printPaperDetails --quiet --console=plain | grep '^Paper'
+              echo "PAPER_DETAILS_EOF"
           } >> "$GITHUB_OUTPUT"
 
       - name: Bump version

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   tag:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       pull-requests: read

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -17,7 +17,7 @@ jobs:
       version: ${{steps.bump-semver.outputs.new_version}}
       publish_version: ${{ steps.strip-v.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Get merged pull request
         uses: actions-ecosystem/action-get-merged-pull-request@v1.0.1

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{steps.bump-semver.outputs.new_version}}
+      publish_version: ${{ steps.strip-v.outputs.version }}
     steps:
       - uses: actions/checkout@v6
 
@@ -63,6 +64,13 @@ jobs:
           current_version: ${{ steps.get-latest-tag.outputs.tag }}
           level: ${{ steps.release-label.outputs.level }}
 
+      - name: Strip v prefix for publishing
+        id: strip-v
+        if: ${{ steps.bump-semver.outputs.new_version != null }}
+        env:
+          NEW_VERSION: ${{ steps.bump-semver.outputs.new_version }}
+        run: echo "version=${NEW_VERSION#v}" >> "$GITHUB_OUTPUT"
+
       - name: Push tag
         uses: actions-ecosystem/action-push-tag@v1
         if: ${{ steps.bump-semver.outputs.new_version != null }}
@@ -80,5 +88,5 @@ jobs:
     needs: tag
     if: ${{ needs.tag.outputs.version != null }}
     with:
-      version: $(echo ${{ needs.tag.outputs.version }} | sed -e 's:v::')
+      version: ${{ needs.tag.outputs.publish_version }}
     secrets: inherit

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -34,8 +34,20 @@ jobs:
         with:
           semver_only: true
 
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        if: ${{ steps.release-label.outputs.level != null }}
+        with:
+          java-version: 25
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        if: ${{ steps.release-label.outputs.level != null }}
+
       - name: Read Paper version from gradle.properties
         id: paper-version
+        if: ${{ steps.release-label.outputs.level != null }}
         run: |
           {
               echo "paper_details<<EOF"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -98,7 +98,7 @@ jobs:
             ${{ steps.paper-version.outputs.paper_details }}
   call-publish-workflow:
     name: Call publish workflow
-    uses: MockBukkit/Mockbukkit/.github/workflows/publish.yml@minecraft/v26
+    uses: ./.github/workflows/publish.yml
     needs: tag
     if: ${{ needs.tag.outputs.version != null }}
     with:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -95,4 +95,8 @@ jobs:
     if: ${{ needs.tag.outputs.version != null }}
     with:
       version: ${{ needs.tag.outputs.publish_version }}
-    secrets: inherit
+    secrets:
+      OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+      OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+      KEY_PASS: ${{ secrets.KEY_PASS }}
+      PRIV_KEY: ${{ secrets.PRIV_KEY }}


### PR DESCRIPTION
## Description

Hardening and cleanup pass over the GitHub Actions workflows. No application code changes. Each concern is a separate commit so it can be reviewed (and reverted) independently. Grouped below by category.

### Correctness — release pipeline

- **`tag` job had no JDK/Gradle setup.** It ran `./gradlew printPaperDetails` relying on whatever JDK the runner image happened to ship, while every other workflow explicitly sets up JDK 25 + Gradle. Added the same setup, and gated the Gradle steps on a release label being present so Gradle only runs when a release is actually being cut.
- **Publish version was computed inside a `with:` value:** `version: $(echo ${{ ... }} | sed -e 's:v::')`. `with:` inputs are not shell-evaluated — this only worked by accident because the called workflow later splices the value into a `run:` line where the shell finally expands the `$(...)`. Replaced with a dedicated step using shell parameter expansion (`${NEW_VERSION#v}`), passing the tag via an env var (no interpolation into the command) and exposing a clean job output.
- **No concurrency guard on the release workflow → racing releases.** `tag` runs on every push to `minecraft/v*`. With two PRs merged close together, the second Tag run could read the same "latest tag" as the first before it pushed, compute a colliding next version, and double-publish to Maven Central (which is immutable — so one release fails or tags collide). Added a per-branch `concurrency` group with `cancel-in-progress: false`, so releases queue and finish one at a time and are never cancelled mid-publish.
- **Publish was called via a hardcoded, mutable branch ref:** `uses: …/publish.yml@minecraft/v26`. That pin had to be bumped at every Minecraft-version promotion, and a branch ref is mutable (anyone who can push the branch can rewrite the job that runs with the signing/Maven Central secrets). Switched to the same-repo local-path form `uses: ./.github/workflows/publish.yml`, which always resolves `publish.yml` from the exact commit that triggered the run. On `minecraft/v26` this is byte-for-byte the current behaviour; it just removes the hardcoded version and always matches the branch being released.
- **Gradle wrapper download spam leaked into release tag messages.** The `printPaperDetails` step captured `./gradlew … 2>&1` into the `paper_details` output, which is spliced into the annotated tag. On a cold runner the wrapper writes its `Downloading …10%…100%` distribution-bootstrap progress to **stdout** (confirmed by forcing a cold wrapper download locally — it's stdout, not stderr, so `--quiet`/`--console=plain`/dropping `2>&1` don't suppress it), so releases got the download dump in their notes (e.g. `v4.113.4`). The step now filters to just the `Paper …:` lines with `grep '^Paper'`, drops `2>&1`, and uses a non-colliding heredoc delimiter (closing a latent `GITHUB_OUTPUT` injection footgun where a captured line equal to `EOF` would have truncated the block).

### Security — supply chain & least privilege

- **No `permissions:` blocks anywhere.** Every workflow ran with the repository-default token scope. Scoped each to what it needs: `contents: read` for build/lint/coverage/publish, `pull-requests: read` for the label check (it only does a GraphQL read of the PR's labels), and `contents: read` by default for `tag` with the tag job elevated to `contents: write` + `pull-requests: read`.
- **All external actions pinned to commit digests.** A mutable tag can be repointed to malicious code that then runs with the workflow's privileges — the attack class behind the `tj-actions/changed-files` and recent TanStack/npm compromises. This matters most for the `tag` job, which runs five `actions-ecosystem/*` actions (a dormant third-party org) with `contents: write`. The pins are behaviour-neutral: each action already resolved to the release pinned here. The version is kept in a trailing comment, and Renovate keeps digests current.
- **Label-checker was on `:latest`.** A mutable tag on a required merge gate. Pinned to the v1.6.65 image digest (currently identical to `:latest`).
- **`secrets: inherit` → explicit secrets.** The publish call forwarded every repository secret to the reusable workflow. It now passes only the four secrets `publish.yml` declares (`OSSRH_USERNAME`, `OSSRH_TOKEN`, `KEY_PASS`, `PRIV_KEY`).

### Maintenance

- **`actions/checkout` v6 → v7** and **`codecov/codecov-action` v6 → v7** — both were a major version behind. checkout v7's only notable change (blocking fork-PR checkout under `pull_request_target`/`workflow_run`) is a no-op here; codecov v7 is a GPG key-account rotation. These are the only updates that change runtime behaviour.
- **Migrated test results upload off the deprecated `codecov/test-results-action`.** That standalone action is deprecated (and still ships a Node 20 entrypoint) in favour of folding test result uploads into the main action. The step now uses `codecov/codecov-action@v7` with `report_type: test_results`, keeping the same files glob, token, and `codecov_yml_path`. Verified working on this PR's run — the upload succeeds and the deprecation warning is gone.

### Efficiency & runner hygiene

- **Dropped `--refresh-dependencies`** from the Gradle invocations. It was added when the Paper API was a mutable `-SNAPSHOT` coordinate, where the same coordinate could resolve to different artifacts over time. Paper now ships immutable, fully-qualified coordinates (e.g. `26.1.2.build.57-stable`), so a version bump is a new coordinate and triggers a fresh download on its own. Forcing a refresh every run defeated the `setup-gradle` dependency cache; removing it lets the cache work, with downloads still happening exactly when a dependency version changes.
- **Tests ran twice per PR.** The `Build` check ran `./gradlew test`, but `Coverage` runs `./gradlew jacocoTestReport`, which already runs the whole suite (`jacocoTestReport dependsOn test`) — so every PR executed the test suite on two separate runners. `Build` now runs `./gradlew assemble testClasses`: it compiles main + test sources and packages the jar without running tests, checkstyle, or jacoco. Tests run once (in `Coverage`); the three checks stay distinct files with clearer, non-overlapping concerns — **Build = it compiles & packages**, **Coverage = tests pass + coverage**, **Linting = style**. The `Build / build` check name is unchanged, so branch-protection requirements keep working untouched.
- **Per-job `timeout-minutes` on every job** (build/coverage 20, linting 15, tag 15, publish 30, label-check 10). Without them a wedged Gradle daemon or a stuck upload runs against GitHub's 6-hour default.
- **Cancel superseded PR runs.** Added a `concurrency` group with `cancel-in-progress: true` to the PR-gating workflows (build, coverage, linting), so a new push to a PR cancels its now-stale in-flight runs. The release `tag` workflow deliberately uses its own group with `cancel-in-progress: false` (queue, never cancel).

## Note for reviewers

- The `permissions:` blocks are the one change worth watching on the first real run — particularly `bump-label-check` (a required gate) and the release `tag` job — to confirm the scoped tokens are sufficient.
- The `Build` job no longer runs tests (it compiles/assembles). Tests are still gated on every PR via `Coverage`. If `Build` is a required check in branch protection, it remains valid — the check name is unchanged.

## Checklist

- [x] Code follows existing style.
- [ ] Unit tests added (if applicable). — N/A, CI configuration only.
