### PR TITLE
Finish implementing scheduler methods

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -18,7 +18,6 @@ import org.mockbukkit.mockbukkit.ServerMock;
 import org.mockbukkit.mockbukkit.entity.EntityMock;
 import org.mockbukkit.mockbukkit.exception.AsyncTaskException;
 import org.mockbukkit.mockbukkit.exception.TaskCancelledException;
-import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 import org.mockbukkit.mockbukkit.world.WorldMock;
 import org.opentest4j.AssertionFailedError;
 
@@ -496,8 +495,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	@Override
 	public <T> @NotNull Future<T> callSyncMethod(@NotNull Plugin plugin, @NotNull Callable<T> task)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return new FutureTask<>(this, plugin, task);
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -207,7 +207,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 
 		for (ScheduledTask task : oldTasks)
 		{
-			if (task.getScheduledTick() != currentTick || task.isCancelled())
+			if (task.getScheduledTick() != currentTick || task.isSchedulingDone())
 			{
 				continue;
 			}
@@ -218,7 +218,6 @@ public class BukkitSchedulerMock implements BukkitScheduler
 			}
 			else
 			{
-				task.submitted();
 				pool.submit(wrapTask(task));
 			}
 
@@ -232,7 +231,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 			}
 			else
 			{
-				task.cancel();
+				task.setSchedulingDone();
 			}
 		}
 	}
@@ -282,7 +281,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 		int queuedAsync = 0;
 		for (ScheduledTask task : scheduledTasks.getCurrentTaskList())
 		{
-			if (task.isSync() || task.isCancelled() || task.isRunning())
+			if (task.isSync() || task.isSchedulingDone() || task.isRunning())
 			{
 				continue;
 			}
@@ -529,7 +528,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	public boolean isQueued(int taskId)
 	{
 		ScheduledTask task = scheduledTasks.getTask(taskId);
-		return task != null && !task.isCancelled();
+		return task != null && !task.isSchedulingDone();
 	}
 
 	@Override
@@ -549,7 +548,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 		List<BukkitTask> pendingTasks = new ArrayList<>();
 		for (ScheduledTask task : scheduledTasks.getCurrentTaskList())
 		{
-			if (!task.isCancelled())
+			if (!task.isSchedulingDone())
 			{
 				pendingTasks.add(task);
 			}
@@ -777,7 +776,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 
 				for (ScheduledTask task : tasks.values())
 				{
-					if (task.isCancelled() || task.isRunning())
+					if (task.isSchedulingDone() || task.isRunning())
 					{
 						continue;
 					}

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -560,15 +560,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	@Override
 	public @NotNull BukkitTask runTaskAsynchronously(@NotNull Plugin plugin, @NotNull Runnable task)
 	{
-		long currentTick;
-		synchronized (this) // See comment at the start of performOneTick()
-		{
-			currentTick = this.currentTick; // There's no task registration here, no need to synchronize further
-		}
-
-		ScheduledTask scheduledTask = new ScheduledTask(id.getAndIncrement(), plugin, false, currentTick, new AsyncRunnable(task));
-		pool.execute(wrapTask(scheduledTask));
-		return scheduledTask;
+		return runTaskLaterAsynchronously(plugin, task, 1);
 	}
 
 	@Override
@@ -630,14 +622,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	@Override
 	public void runTaskAsynchronously(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task)
 	{
-		long currentTick;
-		synchronized (this) // See comment at the start of performOneTick()
-		{
-			currentTick = this.currentTick; // There's no task registration here, no need to synchronize further
-		}
-
-		ScheduledTask scheduledTask = new ScheduledTask(this.id.getAndIncrement(), plugin, false, currentTick, task);
-		pool.execute(wrapTask(scheduledTask));
+		runTaskLaterAsynchronously(plugin, task, 1);
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -654,8 +654,12 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	@Override
 	public void runTaskLaterAsynchronously(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, long delay)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		delay = Math.max(delay, 1);
+		synchronized (this) // See comment at the start of performOneTick()
+		{
+			ScheduledTask scheduledTask = new ScheduledTask(id.getAndIncrement(), plugin, false, currentTick + delay, task);
+			scheduledTasks.addTask(scheduledTask);
+		}
 	}
 
 	@Override
@@ -672,8 +676,12 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	@Override
 	public void runTaskTimerAsynchronously(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, long delay, long period)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		delay = Math.max(delay, 1);
+		synchronized (this) // See comment at the start of performOneTick()
+		{
+			RepeatingTask repeatingTask = new RepeatingTask(id.getAndIncrement(), plugin, false, currentTick + delay, period, task);
+			scheduledTasks.addTask(repeatingTask);
+		}
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -405,6 +405,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	public @NotNull BukkitTask runTaskTimer(@NotNull Plugin plugin, @NotNull Runnable task, long delay, long period)
 	{
 		delay = Math.max(delay, 1);
+		period = Math.max(period, 1);
 		synchronized (this) // See comment at the start of performOneTick()
 		{
 			RepeatingTask repeatingTask = new RepeatingTask(id.getAndIncrement(), plugin, true, currentTick + delay, period, task);
@@ -597,6 +598,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	public @NotNull BukkitTask runTaskTimerAsynchronously(@NotNull Plugin plugin, @NotNull Runnable task, long delay, long period)
 	{
 		delay = Math.max(delay, 1);
+		period = Math.max(period, 1);
 		synchronized (this) // See comment at the start of performOneTick()
 		{
 			RepeatingTask scheduledTask = new RepeatingTask(id.getAndIncrement(), plugin, false, currentTick + delay, period,
@@ -650,6 +652,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	public void runTaskTimer(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, long delay, long period)
 	{
 		delay = Math.max(delay, 1);
+		period = Math.max(period, 1);
 		synchronized (this) // See comment at the start of performOneTick()
 		{
 			RepeatingTask repeatingTask = new RepeatingTask(id.getAndIncrement(), plugin, true, currentTick + delay, period, task);
@@ -661,6 +664,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 	public void runTaskTimerAsynchronously(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, long delay, long period)
 	{
 		delay = Math.max(delay, 1);
+		period = Math.max(period, 1);
 		synchronized (this) // See comment at the start of performOneTick()
 		{
 			RepeatingTask repeatingTask = new RepeatingTask(id.getAndIncrement(), plugin, false, currentTick + delay, period, task);

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/FutureTask.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/FutureTask.java
@@ -1,0 +1,87 @@
+package org.mockbukkit.mockbukkit.scheduler;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * The {@link Future} returned by {@link BukkitScheduler#callSyncMethod(Plugin, Callable)}.
+ */
+class FutureTask<T> implements Future<T>
+{
+
+	private final ScheduledTask task;
+	private final CompletableFuture<T> future = new CompletableFuture<>();
+
+	/**
+	 * Constructs and schedules a new {@link FutureTask} with the provided parameters.
+	 *
+	 * @param scheduler The {@link BukkitSchedulerMock}.
+	 * @param plugin    The plugin owning the task.
+	 * @param callable  The callable to run.
+	 */
+	public FutureTask(@NotNull BukkitSchedulerMock scheduler, @NotNull Plugin plugin, @NotNull Callable<T> callable)
+	{
+		Preconditions.checkNotNull(callable, "Callable cannot be null");
+
+		this.task = (ScheduledTask) scheduler.runTask(plugin, () ->
+		{
+			try
+			{
+				future.complete(callable.call());
+			}
+			catch (Throwable t)
+			{
+				future.completeExceptionally(t);
+			}
+		});
+		this.task.addOnCancelled(() -> future.cancel(false));
+
+		// Handle race condition when the task is cancelled before addOnCancelled is called
+		if (this.task.isCancelled())
+		{
+			future.cancel(false);
+		}
+	}
+
+	@Override
+	public boolean cancel(boolean mayInterruptIfRunning)
+	{
+		task.cancel();
+		return future.isCancelled();
+	}
+
+	@Override
+	public boolean isCancelled()
+	{
+		return future.isCancelled();
+	}
+
+	@Override
+	public boolean isDone()
+	{
+		return future.isDone();
+	}
+
+	@Override
+	public T get() throws InterruptedException, ExecutionException
+	{
+		return future.get();
+	}
+
+	@Override
+	public T get(long timeout, @NonNull TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException
+	{
+		return future.get(timeout, unit);
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/ScheduledTask.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/ScheduledTask.java
@@ -30,7 +30,7 @@ public class ScheduledTask implements BukkitTask, BukkitWorker
 	private final @Nullable Consumer<? super BukkitTask> consumer;
 	private final List<Runnable> cancelListeners = new CopyOnWriteArrayList<>(); // Needed to not hold any lock when calling cancellation listeners
 	private volatile Thread thread;
-	private volatile boolean submitted = false;
+	private volatile boolean schedulingDone = false;
 
 	/**
 	 * Constructs a new {@link ScheduledTask} with the provided parameters.
@@ -145,13 +145,23 @@ public class ScheduledTask implements BukkitTask, BukkitWorker
 	}
 
 	/**
-	 * Marks the task as being submitted to the async thread pool.
-	 * This is used to bypass the #isCancelled check if it gets updated before the task is run.
+	 * Marks the task's scheduling as being done.
 	 */
 	@ApiStatus.Internal
-	protected void submitted()
+	protected void setSchedulingDone()
 	{
-		submitted = true;
+		schedulingDone = true;
+	}
+
+	/**
+	 * Gets whether the task's scheduling is done.
+	 *
+	 * @return Whether the task's scheduling is done.
+	 */
+	@ApiStatus.Internal
+	protected boolean isSchedulingDone()
+	{
+		return schedulingDone || isCancelled(); // A cancelled task cannot be scheduled
 	}
 
 	/**
@@ -160,9 +170,8 @@ public class ScheduledTask implements BukkitTask, BukkitWorker
 	public void run()
 	{
 		thread = Thread.currentThread();
-		if (!isSync && submitted || !isCancelled())
+		if (!isCancelled())
 		{
-			submitted = false;
 			if (this.runnable != null)
 			{
 				this.runnable.run();

--- a/src/test/java/org/mockbukkit/mockbukkit/matcher/scheduler/SchedulerOverdueTasksMatcherTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/matcher/scheduler/SchedulerOverdueTasksMatcherTest.java
@@ -43,6 +43,7 @@ class SchedulerOverdueTasksMatcherTest extends AbstractMatcherTest
 				// Code will end after reaching this point, therefore no-op
 			}
 		});
+		scheduler.performOneTick();
 		taskStarted.await();
 		scheduler.saveOverdueTasks();
 		tasksSaved.countDown();

--- a/src/test/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMockTest.java
@@ -167,6 +167,7 @@ class BukkitSchedulerMockTest
 				throw new TaskCancelledException(e);
 			}
 		});
+		scheduler.performOneTick();
 		barrier.await(3L, TimeUnit.SECONDS);
 	}
 
@@ -288,7 +289,7 @@ class BukkitSchedulerMockTest
 				}
 			}
 		}, 2);
-		assertEquals(1, scheduler.getActiveRunningCount());
+		assertEquals(0, scheduler.getActiveRunningCount());
 		scheduler.performOneTick();
 		assertEquals(1, scheduler.getActiveRunningCount());
 		scheduler.performOneTick();
@@ -329,6 +330,7 @@ class BukkitSchedulerMockTest
 				}
 			}
 		});
+		scheduler.performOneTick();
 		countDownLatch.await(1, TimeUnit.SECONDS);
 
 		assertTrue(alive.get());
@@ -361,6 +363,7 @@ class BukkitSchedulerMockTest
 			{
 			}
 		});
+		scheduler.performOneTick();
 		taskStarted.await();
 		scheduler.saveOverdueTasks();
 		tasksSaved.countDown();
@@ -390,6 +393,7 @@ class BukkitSchedulerMockTest
 			{
 			}
 		});
+		scheduler.performOneTick();
 		taskStarted.await();
 		scheduler.saveOverdueTasks();
 		tasksSaved.countDown();
@@ -612,6 +616,7 @@ class BukkitSchedulerMockTest
 		CountDownLatch countDownLatch = new CountDownLatch(1);
 
 		scheduler.runTaskAsynchronously(null, bukkitTask -> countDownLatch.countDown());
+		scheduler.performOneTick();
 		assertTrue(countDownLatch.await(2, TimeUnit.SECONDS));
 	}
 

--- a/src/test/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMockTest.java
@@ -38,6 +38,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -361,6 +362,19 @@ class BukkitSchedulerMockTest
 		scheduler.setShutdownTimeout(300);
 		assertThrows(TaskCancelledException.class, () ->
 				scheduler.shutdown());
+	}
+
+	@Test
+	void asyncTask_Throws_RunTimeException()
+	{
+		scheduler.runTaskAsynchronously(null, () ->
+		{
+			throw new RuntimeException("Expected");
+		});
+		scheduler.performOneTick();
+		AsyncTaskException exception = assertThrows(AsyncTaskException.class, () -> scheduler.shutdown());
+		RuntimeException runtimeException = assertInstanceOf(RuntimeException.class, exception.getCause());
+		assertEquals("Expected", runtimeException.getMessage());
 	}
 
 	@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMockTest.java
@@ -302,45 +302,6 @@ class BukkitSchedulerMockTest
 	}
 
 	@Test
-	void longRunningTask_Throws_RunTimeException() throws InterruptedException
-	{
-		assertEquals(0, scheduler.getNumberOfQueuedAsyncTasks());
-
-		final CountDownLatch countDownLatch = new CountDownLatch(1);
-		final AtomicBoolean alive = new AtomicBoolean(true);
-
-		testTask = scheduler.runTaskAsynchronously(null, () ->
-		{
-			countDownLatch.countDown();
-			while (alive.get())
-			{
-				if (testTask.isCancelled())
-				{
-					alive.set(false);
-				}
-				try
-				{
-					Thread.sleep(SLEEP_TIME);
-				}
-				catch (InterruptedException e)
-				{
-					alive.set(false);
-					String message = "Interrupted";
-					throw new TaskCancelledException(message, e);
-				}
-			}
-		});
-		scheduler.performOneTick();
-		countDownLatch.await(1, TimeUnit.SECONDS);
-
-		assertTrue(alive.get());
-		assertEquals(1, scheduler.getActiveRunningCount());
-		scheduler.performTicks(10);
-		scheduler.setShutdownTimeout(10);
-		assertThrows(AsyncTaskException.class, () -> scheduler.shutdown());
-	}
-
-	@Test
 	void saveOverdueTasks_EmptyByDefault()
 	{
 		scheduler.saveOverdueTasks();

--- a/src/test/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMockTest.java
@@ -154,13 +154,26 @@ class BukkitSchedulerMockTest
 	{
 		final Thread mainThread = Thread.currentThread();
 
-		CyclicBarrier barrier = new CyclicBarrier(2);
+		CyclicBarrier barrier1 = new CyclicBarrier(2);
+		CyclicBarrier barrier2 = new CyclicBarrier(2);
 		scheduler.runTaskAsynchronously(null, () ->
 		{
 			assertNotEquals(mainThread, Thread.currentThread());
 			try
 			{
-				barrier.await(3L, TimeUnit.SECONDS);
+				barrier1.await(3L, TimeUnit.SECONDS);
+			}
+			catch (InterruptedException | BrokenBarrierException | TimeoutException e)
+			{
+				throw new TaskCancelledException(e);
+			}
+		});
+		scheduler.runTaskAsynchronously(null, task ->
+		{
+			assertNotEquals(mainThread, Thread.currentThread());
+			try
+			{
+				barrier2.await(3L, TimeUnit.SECONDS);
 			}
 			catch (InterruptedException | BrokenBarrierException | TimeoutException e)
 			{
@@ -168,7 +181,8 @@ class BukkitSchedulerMockTest
 			}
 		});
 		scheduler.performOneTick();
-		barrier.await(3L, TimeUnit.SECONDS);
+		barrier1.await(3L, TimeUnit.SECONDS);
+		barrier2.await(3L, TimeUnit.SECONDS);
 	}
 
 	@Test
@@ -220,6 +234,54 @@ class BukkitSchedulerMockTest
 	}
 
 	@Test
+	void runTaskTimerAsynchronously_Consumer_TaskExecutedOnSeperateThread() throws InterruptedException, BrokenBarrierException, TimeoutException
+	{
+		final Thread mainThread = Thread.currentThread();
+
+		CyclicBarrier barrier = new CyclicBarrier(2);
+		AtomicInteger count = new AtomicInteger();
+
+		scheduler.runTaskTimerAsynchronously(null, task ->
+		{
+			assertNotEquals(mainThread, Thread.currentThread());
+			try
+			{
+				if (count.incrementAndGet() == 2)
+				{
+					task.cancel();
+				}
+				barrier.await(3L, TimeUnit.SECONDS);
+			}
+			catch (InterruptedException | BrokenBarrierException | TimeoutException e)
+			{
+				task.cancel();
+				throw new TaskCancelledException(e);
+			}
+		}, 2L, 1L);
+
+		assertEquals(0, count.get());
+		assertEquals(1, scheduler.getNumberOfQueuedAsyncTasks());
+
+		scheduler.performTicks(1L);
+		assertEquals(1, scheduler.getNumberOfQueuedAsyncTasks());
+		assertEquals(0, count.get());
+
+		scheduler.performTicks(1L);
+		barrier.await(3L, TimeUnit.SECONDS);
+		assertEquals(1, scheduler.getNumberOfQueuedAsyncTasks());
+		assertEquals(1, count.get());
+
+		scheduler.performTicks(1L);
+		barrier.await(3L, TimeUnit.SECONDS);
+		assertEquals(0, scheduler.getNumberOfQueuedAsyncTasks());
+		assertEquals(2, count.get());
+
+		scheduler.performTicks(1L);
+		assertEquals(0, scheduler.getNumberOfQueuedAsyncTasks());
+		assertEquals(2, count.get());
+	}
+
+	@Test
 	void cancellingAsyncTaskDecreasesNumberOfQueuedAsyncTasks()
 	{
 		assertEquals(0, scheduler.getNumberOfQueuedAsyncTasks());
@@ -241,7 +303,7 @@ class BukkitSchedulerMockTest
 		scheduler1.runTaskLaterAsynchronously(plugin, () ->
 		{
 		}, 5);
-		scheduler1.runTaskLaterAsynchronously(plugin, () ->
+		scheduler1.runTaskLaterAsynchronously(plugin, task ->
 		{
 		}, 10);
 		BukkitTask task = scheduler1.runTaskLaterAsynchronously(null, () ->
@@ -259,7 +321,7 @@ class BukkitSchedulerMockTest
 	{
 		assertEquals(0, scheduler.getNumberOfQueuedAsyncTasks());
 		PluginMock pluginMock = MockBukkit.createMockPlugin();
-		scheduler.runTaskAsynchronously(pluginMock, () ->
+		scheduler.runTaskAsynchronously(pluginMock, task ->
 		{
 			//noinspection InfiniteLoopStatement
 			while (true)

--- a/src/test/java/org/mockbukkit/mockbukkit/scheduler/FutureTaskTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/scheduler/FutureTaskTest.java
@@ -1,0 +1,169 @@
+package org.mockbukkit.mockbukkit.scheduler;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+import org.mockbukkit.mockbukkit.MockBukkitInject;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockBukkitExtension.class)
+class FutureTaskTest
+{
+
+	@MockBukkitInject
+	private BukkitSchedulerMock scheduler;
+
+	@Test
+	void callSyncMethod_runsOnMainThread() throws ExecutionException, InterruptedException, TimeoutException
+	{
+		final Thread mainThread = Thread.currentThread();
+
+		Future<Integer> future = scheduler.callSyncMethod(null, () ->
+		{
+			assertEquals(mainThread, Thread.currentThread());
+
+			return 5;
+		});
+
+		assertFalse(future.isDone());
+		assertFalse(future.isCancelled());
+		for (var task : scheduler.getPendingTasks())
+		{
+			assertTrue(task.isSync());
+			assertFalse(task.isCancelled());
+		}
+		scheduler.performOneTick();
+		assertTrue(future.isDone());
+		assertFalse(future.isCancelled());
+		assertEquals(5, future.get(0, TimeUnit.SECONDS));
+	}
+
+	@Test
+	void callSyncMethod_runsOnMainThread_fromAsync() throws BrokenBarrierException, InterruptedException, TimeoutException
+	{
+		final Thread mainThread = Thread.currentThread();
+		CyclicBarrier barrier = new CyclicBarrier(2);
+
+		scheduler.runTaskAsynchronously(null, () ->
+		{
+			assertNotEquals(mainThread, Thread.currentThread());
+
+			Future<Integer> future = scheduler.callSyncMethod(null, () ->
+			{
+				assertEquals(mainThread, Thread.currentThread());
+
+				return 5;
+			});
+
+			try
+			{
+				barrier.await(5L, TimeUnit.SECONDS);
+				assertFalse(future.isCancelled());
+				assertEquals(5, future.get());
+				assertFalse(future.isCancelled());
+				barrier.await(5L, TimeUnit.SECONDS);
+			}
+			catch (InterruptedException | ExecutionException | TimeoutException | BrokenBarrierException e)
+			{
+				throw new RuntimeException(e);
+			}
+		});
+
+		scheduler.performOneTick();
+		barrier.await(5L, TimeUnit.SECONDS);
+		scheduler.performOneTick();
+		barrier.await(5L, TimeUnit.SECONDS);
+	}
+
+	@Test
+	void callSyncMethod_throws()
+	{
+		Future<Integer> future = scheduler.callSyncMethod(null, () ->
+		{
+			throw new RuntimeException("Expected");
+		});
+
+		assertFalse(future.isDone());
+		scheduler.performOneTick();
+		assertTrue(future.isDone());
+		ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get(0, TimeUnit.SECONDS));
+		RuntimeException runtimeException = assertInstanceOf(RuntimeException.class, exception.getCause());
+		assertEquals("Expected", runtimeException.getMessage());
+	}
+
+	@Test
+	void callSyncMethod_cancel()
+	{
+		AtomicBoolean called = new AtomicBoolean();
+		Future<Void> future = scheduler.callSyncMethod(null, () ->
+		{
+			called.set(true);
+			return null;
+		});
+
+		assertFalse(future.isDone());
+		assertFalse(future.isCancelled());
+		for (var task : scheduler.getPendingTasks())
+		{
+			assertFalse(task.isCancelled());
+		}
+		assertFalse(called.get());
+		future.cancel(false);
+		assertTrue(future.isDone());
+		assertTrue(future.isCancelled());
+		for (var task : scheduler.getPendingTasks())
+		{
+			assertTrue(task.isCancelled());
+		}
+		assertThrows(CancellationException.class, () -> future.get(0, TimeUnit.SECONDS));
+		assertFalse(called.get());
+		scheduler.performTicks(10);
+		assertFalse(called.get());
+	}
+
+	@Test
+	void callSyncMethod_cancelTask()
+	{
+		AtomicBoolean called = new AtomicBoolean();
+		Future<Void> future = scheduler.callSyncMethod(null, () ->
+		{
+			called.set(true);
+			return null;
+		});
+
+		assertFalse(future.isDone());
+		assertFalse(future.isCancelled());
+		assertFalse(called.get());
+		for (var task : scheduler.getPendingTasks())
+		{
+			assertFalse(task.isCancelled());
+			task.cancel();
+		}
+		assertTrue(future.isDone());
+		assertTrue(future.isCancelled());
+		for (var task : scheduler.getPendingTasks())
+		{
+			assertTrue(task.isCancelled());
+		}
+		assertThrows(CancellationException.class, () -> future.get(0, TimeUnit.SECONDS));
+		assertFalse(called.get());
+		scheduler.performTicks(10);
+		assertFalse(called.get());
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/scheduler/paper/FoliaAsyncSchedulerTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/scheduler/paper/FoliaAsyncSchedulerTest.java
@@ -41,6 +41,7 @@ class FoliaAsyncSchedulerTest
 		CountDownLatch latch = new CountDownLatch(1);
 		PluginMock pluginMock = MockBukkit.createMockPlugin();
 		scheduler.runNow(pluginMock, task -> latch.countDown());
+		bukkitScheduler.performOneTick();
 		assertTrue(latch.await(1, TimeUnit.SECONDS));
 	}
 
@@ -50,6 +51,7 @@ class FoliaAsyncSchedulerTest
 		CompletableFuture<Boolean> future = new CompletableFuture<>();
 		future.completeOnTimeout(false, 2, TimeUnit.SECONDS);
 		scheduler.runNow(MockBukkit.createMockPlugin(), (task) -> future.complete(!server.isPrimaryThread()));
+		bukkitScheduler.performOneTick();
 		assertTrue(future.join());
 	}
 


### PR DESCRIPTION
# Description

This PR completes the scheduler implementation, implementing `runTaskLaterAsynchronously(Plugin, Consumer)`, `runTaskTimerAsynchronously(Plugin, Consumer)` and `callSyncMethod(Plugin, Callable)`.

This also fixes `runTaskAsynchronously` to match Spigot/Paper behavior (see https://github.com/MockBukkit/MockBukkit/pull/1588#issuecomment-4928556112): now it is the same as calling `runTaskLaterAsynchronously` with a delay of `1`.

This PR is also an alternative to https://github.com/MockBukkit/MockBukkit/pull/1588 and fixes https://github.com/MockBukkit/MockBukkit/issues/1586, since [the test](https://github.com/MockBukkit/MockBukkit/blob/4cbcc1867507936ff47b00fe842430cc07191330/src/test/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMockTest.java#L304) has been removed completely. The test was relaying on the fact that `runTaskAsynchronously` was not adding the task to the task list (`scheduledTasks`). The [`scheduler.shutdown()` call](https://github.com/MockBukkit/MockBukkit/blob/4cbcc1867507936ff47b00fe842430cc07191330/src/test/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMockTest.java#L338) at the end of the test would now always throw a `TaskCancelledException`, which is already tested in [`longScheduledRunningTask_Throws_RunTimeException`](https://github.com/MockBukkit/MockBukkit/blob/4cbcc1867507936ff47b00fe842430cc07191330/src/test/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMockTest.java#L257), making the test redundant.

# Checklist

The following items should be checked before the pull request can be merged.

- [x] Code follows existing style.
- [x] Unit tests added (if applicable).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MockBukkit/codesmith/MockBukkit/pr/1596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786825471&installation_id=145442630&pr_number=1596&repository=MockBukkit%2FMockBukkit&return_to=https%3A%2F%2Fgithub.com%2FMockBukkit%2FMockBukkit%2Fpull%2F1596&signature=0470ac53d40f1fd433c67aad77a5171b967e5927970c36a6dc39e290718f91b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->