### PR TITLE
Implement stored-state entity flags

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/DisplayMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/DisplayMock.java
@@ -10,7 +10,6 @@ import org.joml.Matrix4f;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 import org.mockbukkit.mockbukkit.ServerMock;
-import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 
 import java.util.UUID;
 

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/DisplayMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/DisplayMock.java
@@ -18,6 +18,7 @@ public class DisplayMock extends EntityMock implements Display
 {
 
 	private Matrix4f transformationMatrix;
+	private @NotNull Billboard billboard = Billboard.FIXED;
 	private int interpolationDuration = 0;
 	private int teleportDuration = 0;
 	private float viewRange = 1.0f;
@@ -179,13 +180,14 @@ public class DisplayMock extends EntityMock implements Display
 	@Override
 	public @NotNull Billboard getBillboard()
 	{
-		throw new UnimplementedOperationException();
+		return this.billboard;
 	}
 
 	@Override
 	public void setBillboard(@NotNull Billboard billboard)
 	{
-		throw new UnimplementedOperationException();
+		Preconditions.checkArgument(billboard != null, "Billboard cannot be null");
+		this.billboard = billboard;
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/EntityMock.java
@@ -92,6 +92,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	private static final AtomicInteger ENTITY_COUNTER = new AtomicInteger();
 
 	private final Set<String> tags = Sets.newHashSet();
+	private boolean visibleByDefault = true;
 	protected final @NotNull ServerMock server;
 	private final @NotNull UUID uuid;
 	private final int id;
@@ -1496,15 +1497,13 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	@Override
 	public void setVisibleByDefault(boolean visible)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.visibleByDefault = visible;
 	}
 
 	@Override
 	public boolean isVisibleByDefault()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.visibleByDefault;
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/ItemMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/ItemMock.java
@@ -24,6 +24,8 @@ public class ItemMock extends EntityMock implements Item
 
 	// The default pickup delay
 	private int delay = 10;
+	private boolean unlimitedLifetime = false;
+	private @Nullable UUID thrower;
 	private TriState frictionState = TriState.NOT_SET;
 
 	/**
@@ -76,15 +78,13 @@ public class ItemMock extends EntityMock implements Item
 	@Override
 	public void setUnlimitedLifetime(boolean unlimited)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.unlimitedLifetime = unlimited;
 	}
 
 	@Override
 	public boolean isUnlimitedLifetime()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.unlimitedLifetime;
 	}
 
 	@Override
@@ -104,15 +104,13 @@ public class ItemMock extends EntityMock implements Item
 	@Override
 	public void setThrower(@Nullable UUID thrower)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.thrower = thrower;
 	}
 
 	@Override
 	public @Nullable UUID getThrower()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.thrower;
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -86,6 +86,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	 * How much health the entity has.
 	 */
 	protected double health;
+	private boolean removeWhenFarAway = true;
 	private int maxAirTicks = 300;
 	private int remainingAirTicks = 300;
 	/**
@@ -870,15 +871,13 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	@Override
 	public boolean getRemoveWhenFarAway()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.removeWhenFarAway;
 	}
 
 	@Override
 	public void setRemoveWhenFarAway(boolean remove)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.removeWhenFarAway = remove;
 	}
 
 	@Nullable

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/DisplayMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/DisplayMockTest.java
@@ -186,4 +186,24 @@ class DisplayMockTest
 		assertEquals(brightness, display.getBrightness());
 	}
 
+
+	@Test
+	void getBillboard_defaultsToFixed()
+	{
+		assertEquals(Display.Billboard.FIXED, display.getBillboard());
+	}
+
+	@Test
+	void setBillboard_isRetained()
+	{
+		display.setBillboard(Display.Billboard.CENTER);
+		assertEquals(Display.Billboard.CENTER, display.getBillboard());
+	}
+
+	@Test
+	void setBillboard_null()
+	{
+		assertThrows(IllegalArgumentException.class, () -> display.setBillboard(null));
+	}
+
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/EntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/EntityMockTest.java
@@ -1568,4 +1568,21 @@ class EntityMockTest
 		assertEquals(entity.getUniqueId().toString(), actual);
 	}
 
+
+	@Test
+	void isVisibleByDefault_defaultsToTrue()
+	{
+		assertTrue(entity.isVisibleByDefault());
+	}
+
+	@Test
+	void setVisibleByDefault_isRetained()
+	{
+		entity.setVisibleByDefault(false);
+		assertFalse(entity.isVisibleByDefault());
+
+		entity.setVisibleByDefault(true);
+		assertTrue(entity.isVisibleByDefault());
+	}
+
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/ItemMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/ItemMockTest.java
@@ -17,7 +17,10 @@ import org.mockbukkit.mockbukkit.world.WorldMock;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockBukkitExtension.class)
 class ItemMockTest
@@ -128,6 +131,49 @@ class ItemMockTest
 		Item entity = world.dropItem(location, item);
 
 		assertThrows(NullPointerException.class, () -> entity.setFrictionState(null));
+	}
+
+
+	@Test
+	void isUnlimitedLifetime_defaultsToFalse()
+	{
+		assertFalse(makeItem().isUnlimitedLifetime());
+	}
+
+	@Test
+	void setUnlimitedLifetime_isRetained()
+	{
+		Item item = makeItem();
+
+		item.setUnlimitedLifetime(true);
+		assertTrue(item.isUnlimitedLifetime());
+
+		item.setUnlimitedLifetime(false);
+		assertFalse(item.isUnlimitedLifetime());
+	}
+
+	@Test
+	void getThrower_defaultsToNull()
+	{
+		assertNull(makeItem().getThrower());
+	}
+
+	@Test
+	void setThrower_isRetained()
+	{
+		Item item = makeItem();
+		UUID thrower = UUID.randomUUID();
+
+		item.setThrower(thrower);
+		assertEquals(thrower, item.getThrower());
+
+		item.setThrower(null);
+		assertNull(item.getThrower());
+	}
+
+	private Item makeItem()
+	{
+		return new ItemMock(server, UUID.randomUUID(), new ItemStackMock(Material.STONE));
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
@@ -935,4 +935,21 @@ class LivingEntityMockTest
 		assertDoesNotThrow(() -> livingEntity.setActiveItemRemainingTime(10));
 	}
 
+
+	@Test
+	void getRemoveWhenFarAway_defaultsToTrue()
+	{
+		assertTrue(livingEntity.getRemoveWhenFarAway());
+	}
+
+	@Test
+	void setRemoveWhenFarAway_isRetained()
+	{
+		livingEntity.setRemoveWhenFarAway(false);
+		assertFalse(livingEntity.getRemoveWhenFarAway());
+
+		livingEntity.setRemoveWhenFarAway(true);
+		assertTrue(livingEntity.getRemoveWhenFarAway());
+	}
+
 }


### PR DESCRIPTION
Implements four getter/setter pairs in the `entity` package that were unimplemented stubs. All of them are plain stored state with no behaviour attached.

| Class | Methods | Default |
|---|---|---|
| `LivingEntityMock` | `getRemoveWhenFarAway` / `setRemoveWhenFarAway` | `true` |
| `EntityMock` | `isVisibleByDefault` / `setVisibleByDefault` | `true` |
| `DisplayMock` | `getBillboard` / `setBillboard` | `FIXED` |
| `ItemMock` | `isUnlimitedLifetime` / `setUnlimitedLifetime`, `getThrower` / `setThrower` | `false`, `null` |

`setBillboard` rejects null with `Preconditions.checkArgument`, matching the neighbouring `setTransformation`.

### Why

`UnimplementedOperationException` extends `TestAbortedException`, so a test touching any of these is reported as *skipped* rather than failed and the build stays green. That makes the gap easy to miss: in our own suite, seven tests across two classes had been silently skipping on `setRemoveWhenFarAway` because the drop-ship entity we spawn sets it.

Worth mentioning as evidence — when I wrote the tests in this PR before the implementation, **10 of the 11 reported as skipped rather than failed**.

### Tests

11 tests covering the default, the round trip in both directions, and the null argument for `setBillboard`. 100% line and branch coverage on all eight methods (`setBillboard` 3/3 lines, 2/2 branches; the rest have no branches).

Full suite green: 20613 tests, 0 failures.
