### PR TITLE
Implement numberFormat on ObjectiveMock and ScoreMock

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/scoreboard/ObjectiveMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scoreboard/ObjectiveMock.java
@@ -31,6 +31,7 @@ public class ObjectiveMock implements Objective
 	private @NotNull Component displayName;
 	private @Nullable DisplaySlot displaySlot;
 	private RenderType renderType;
+	private @Nullable NumberFormat numberFormat = null;
 
 	/**
 	 * Constructs a new {@link ObjectiveMock} with the provided parameters.
@@ -220,15 +221,13 @@ public class ObjectiveMock implements Objective
 	@Override
 	public @Nullable NumberFormat numberFormat()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.numberFormat;
 	}
 
 	@Override
 	public void numberFormat(@Nullable NumberFormat numberFormat)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.numberFormat = numberFormat;
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/scoreboard/ScoreMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scoreboard/ScoreMock.java
@@ -20,6 +20,7 @@ public class ScoreMock implements Score
 	private @Nullable OfflinePlayer player = null;
 	private int score = 0;
 	private boolean set = false;
+	private @Nullable NumberFormat numberFormat = null;
 
 	/**
 	 * Constructs a new {@link ScoreMock} for the provided objective with the specified entry.
@@ -132,15 +133,13 @@ public class ScoreMock implements Score
 	@Override
 	public @Nullable NumberFormat numberFormat()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.numberFormat;
 	}
 
 	@Override
 	public void numberFormat(@Nullable NumberFormat numberFormat)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.numberFormat = numberFormat;
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/scoreboard/ObjectiveMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/scoreboard/ObjectiveMockTest.java
@@ -4,6 +4,7 @@ import net.kyori.adventure.text.Component;
 import org.bukkit.scoreboard.Criteria;
 import org.bukkit.scoreboard.RenderType;
 import org.bukkit.scoreboard.Score;
+import io.papermc.paper.scoreboard.numbers.NumberFormat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -155,6 +156,29 @@ class ObjectiveMockTest
 		objective.unregister();
 		assertFalse(objective.isRegistered());
 		assertThrows(IllegalStateException.class, () -> objective.unregister());
+	}
+
+
+	@Test
+	void numberFormat_DefaultsToNull()
+	{
+		assertNull(objective.numberFormat());
+	}
+
+	@Test
+	void numberFormat_IsRetained()
+	{
+		NumberFormat format = NumberFormat.blank();
+		objective.numberFormat(format);
+		assertSame(format, objective.numberFormat());
+	}
+
+	@Test
+	void numberFormat_AcceptsNull()
+	{
+		objective.numberFormat(NumberFormat.blank());
+		objective.numberFormat(null);
+		assertNull(objective.numberFormat());
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/scoreboard/ScoreMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/scoreboard/ScoreMockTest.java
@@ -1,5 +1,6 @@
 package org.mockbukkit.mockbukkit.scoreboard;
 
+import io.papermc.paper.scoreboard.numbers.NumberFormat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,6 +11,7 @@ import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -100,6 +102,29 @@ class ScoreMockTest
 		score.resetScore();
 		assertEquals(0, score.getScore());
 		assertFalse(score.isScoreSet());
+	}
+
+
+	@Test
+	void numberFormat_DefaultsToNull()
+	{
+		assertNull(score.numberFormat());
+	}
+
+	@Test
+	void numberFormat_IsRetained()
+	{
+		NumberFormat format = NumberFormat.blank();
+		score.numberFormat(format);
+		assertSame(format, score.numberFormat());
+	}
+
+	@Test
+	void numberFormat_AcceptsNull()
+	{
+		score.numberFormat(NumberFormat.blank());
+		score.numberFormat(null);
+		assertNull(score.numberFormat());
 	}
 
 }


### PR DESCRIPTION
Implements Paper's scoreboard number-format API, which was an unimplemented stub on both `ObjectiveMock` and `ScoreMock`:

- `ObjectiveMock#numberFormat()` / `numberFormat(NumberFormat)`
- `ScoreMock#numberFormat()` / `numberFormat(NumberFormat)`

Stores the format and hands it back, nullable in both directions, matching how the neighbouring `displayName` accessors behave.

### Why

A plugin that blanks a sidebar's score column with `objective.numberFormat(NumberFormat.blank())` cannot be exercised under MockBukkit at all — the call aborts the test. Because `UnimplementedOperationException` extends `TestAbortedException` that shows up as a skip, not a failure, so it is easy to miss.

We currently work around it by installing a `ServerMock` subclass that returns a stubbed scoreboard chain purely to get past this one call, which means nothing in our suite asserts on sidebar rendering. This lets that scaffolding go.

### Tests

6 tests, three per class: the default is null, the value round trips, and null is accepted to clear it. 100% line coverage on all four methods; no branches.

Full suite green: 20613 tests, 0 failures.
