### PR TITLE
Credit indirect kills to the player behind them

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -191,6 +191,38 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		return !isDead();
 	}
 
+	/**
+	 * Works out which player, if any, should be credited with this entity's death, following the same order
+	 * {@code CraftLivingEntity} uses: the entity that dealt the damage directly, then the entity that caused it, then
+	 * the shooter behind a projectile. Checking only the direct entity would miss every indirect kill, so an arrow
+	 * fired by a player would leave the killer unset here while setting it on a real server.
+	 *
+	 * @return the player to credit, or null if the last damage cannot be traced back to one.
+	 */
+	private @Nullable Player deriveKiller()
+	{
+		EntityDamageEvent lastDamage = getLastDamageCause();
+		if (lastDamage == null)
+		{
+			return null;
+		}
+
+		DamageSource source = lastDamage.getDamageSource();
+		if (source.getDirectEntity() instanceof Player player)
+		{
+			return player;
+		}
+		if (source.getCausingEntity() instanceof Player player)
+		{
+			return player;
+		}
+		if (source.getDirectEntity() instanceof Projectile projectile && projectile.getShooter() instanceof Player player)
+		{
+			return player;
+		}
+		return null;
+	}
+
 	@Override
 	public void setHealth(double health)
 	{
@@ -201,10 +233,11 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		}
 
 		DamageSource dmg;
-		if (getLastDamageCause() != null && getLastDamageCause().getDamageSource().getDirectEntity() instanceof Player player)
+		Player killer = deriveKiller();
+		if (killer != null)
 		{
 			dmg = DamageSource.builder(DamageType.PLAYER_ATTACK).build();
-			setKiller(player);
+			setKiller(killer);
 		}
 		else
 		{

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -233,11 +233,11 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		}
 
 		DamageSource dmg;
-		Player killer = deriveKiller();
-		if (killer != null)
+		Player derivedKiller = deriveKiller();
+		if (derivedKiller != null)
 		{
 			dmg = DamageSource.builder(DamageType.PLAYER_ATTACK).build();
-			setKiller(killer);
+			setKiller(derivedKiller);
 		}
 		else
 		{

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
@@ -3,6 +3,8 @@ package org.mockbukkit.mockbukkit.entity;
 import net.kyori.adventure.util.TriState;
 import org.bukkit.Location;
 import org.bukkit.attribute.Attribute;
+import org.bukkit.damage.DamageSource;
+import org.bukkit.damage.DamageType;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.DragonFireball;
 import org.bukkit.entity.Egg;
@@ -933,6 +935,84 @@ class LivingEntityMockTest
 	{
 		// Should not throw, just do nothing
 		assertDoesNotThrow(() -> livingEntity.setActiveItemRemainingTime(10));
+	}
+
+
+	@Test
+	void setHealthZero_NoLastDamage_LeavesKillerUnset()
+	{
+		livingEntity.setHealth(0);
+		assertNull(livingEntity.getKiller());
+	}
+
+	@Test
+	void setHealthZero_DirectPlayerDamager_SetsKiller()
+	{
+		PlayerMock attacker = server.addPlayer();
+
+		killWith(DamageSource.builder(DamageType.PLAYER_ATTACK).withDirectEntity(attacker).build());
+
+		assertEquals(attacker, livingEntity.getKiller());
+	}
+
+	@Test
+	void setHealthZero_ProjectileWithCausingPlayer_SetsKiller()
+	{
+		PlayerMock shooter = server.addPlayer();
+		Arrow arrow = launchArrow();
+
+		killWith(DamageSource.builder(DamageType.ARROW)
+				.withDirectEntity(arrow)
+				.withCausingEntity(shooter)
+				.build());
+
+		assertEquals(shooter, livingEntity.getKiller());
+	}
+
+	@Test
+	void setHealthZero_ProjectileShotByPlayer_SetsKiller()
+	{
+		PlayerMock shooter = server.addPlayer();
+		Arrow arrow = launchArrow();
+		arrow.setShooter(shooter);
+
+		killWith(DamageSource.builder(DamageType.ARROW).withDirectEntity(arrow).build());
+
+		assertEquals(shooter, livingEntity.getKiller());
+	}
+
+	@Test
+	void setHealthZero_ProjectileWithoutShooter_LeavesKillerUnset()
+	{
+		Arrow arrow = launchArrow();
+
+		killWith(DamageSource.builder(DamageType.ARROW).withDirectEntity(arrow).build());
+
+		assertNull(livingEntity.getKiller());
+	}
+
+	@Test
+	void setHealthZero_NonPlayerDamager_LeavesKillerUnset()
+	{
+		killWith(DamageSource.builder(DamageType.MOB_ATTACK).withDirectEntity(livingEntity).build());
+
+		assertNull(livingEntity.getKiller());
+	}
+
+	private @NotNull Arrow launchArrow()
+	{
+		WorldMock world = server.addSimpleWorld("arrow-world");
+		Location location = livingEntity.getLocation();
+		location.setWorld(world);
+		livingEntity.setLocation(location);
+		return livingEntity.launchProjectile(Arrow.class);
+	}
+
+	private void killWith(@NotNull DamageSource source)
+	{
+		livingEntity.setLastDamageCause(
+				new EntityDamageEvent(livingEntity, EntityDamageEvent.DamageCause.CUSTOM, source, 1.0));
+		livingEntity.setHealth(0);
 	}
 
 }


### PR DESCRIPTION
`LivingEntityMock#setHealth(0)` derives the killer from the damage source's **direct** entity only:

```java
if (getLastDamageCause() != null
        && getLastDamageCause().getDamageSource().getDirectEntity() instanceof Player player)
{
    setKiller(player);
}
```

For an arrow kill the direct entity is the arrow, not the shooter, so `getKiller()` stays null here while a real server sets it. The same applies to anything indirect: projectiles, TNT, potions.

This is a behavioural divergence from `CraftLivingEntity` rather than a missing feature, which is why it is worth fixing even though a workaround exists — a test that calls `setKiller` by hand asserts on state the test itself set, not on state the mock derived.

### The fix

Resolves in the order `CraftLivingEntity` uses:

1. direct entity, if it is a player
2. causing entity, if it is a player
3. the shooter behind a projectile, if it is a player

Extracted into a private `deriveKiller()` with a javadoc explaining the ordering.

### Tests

6 tests, one per branch: no last damage, a direct player hit, a projectile with a causing player, a projectile whose shooter is a player, a projectile with no shooter, and a non-player damager.

Worth noting how the red phase looked — the four tests describing *existing* behaviour passed immediately and only the two projectile cases failed, which isolates the defect to that one condition.

100% coverage: `deriveKiller` 11/11 lines and 10/10 branches, `setHealth` 16/16 lines and 6/6 branches.

Full suite green: 20613 tests, 0 failures.

### Deliberately not included

Paper also applies a 100-tick kill-credit window, so a victim that dies long after the last hit is not credited. That needs damage-time tracking and would change behaviour for existing death tests, so it felt like a separate change rather than part of a divergence fix. Happy to add it here or in a follow-up if you would prefer it bundled.
