### PR TITLE
Register Brigadier commands when a plugin enables

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
@@ -8,8 +8,6 @@ import com.google.common.base.Preconditions;
 import io.papermc.paper.ban.BanListType;
 import io.papermc.paper.datapack.DatapackManager;
 import io.papermc.paper.math.Position;
-import io.papermc.paper.plugin.lifecycle.event.registrar.ReloadableRegistrarEvent;
-import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.threadedregions.scheduler.AsyncScheduler;
 import io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler;
@@ -149,7 +147,6 @@ import org.mockbukkit.mockbukkit.inventory.meta.components.ToolComponentMock;
 import org.mockbukkit.mockbukkit.inventory.meta.components.UseCooldownComponentMock;
 import org.mockbukkit.mockbukkit.map.MapViewMock;
 import org.mockbukkit.mockbukkit.plugin.PluginManagerMock;
-import org.mockbukkit.mockbukkit.plugin.lifecycle.event.LifecycleEventRunnerMock;
 import org.mockbukkit.mockbukkit.profile.PlayerProfileMock;
 import org.mockbukkit.mockbukkit.scheduler.BukkitSchedulerMock;
 import org.mockbukkit.mockbukkit.scheduler.paper.FoliaAsyncScheduler;
@@ -246,7 +243,6 @@ public class ServerMock extends Server.Spigot implements Server
 	private @NotNull String respawnWorldName = unsafe.getMainLevelName();
 	private final @NotNull ServerConfiguration serverConfiguration = new ServerConfiguration();
 	private int pauseWhenEmptyTime = 60;
-	private boolean commandsInitialized = false;
 
 	/**
 	 * Constructs a new ServerMock and sets it up.
@@ -1241,11 +1237,6 @@ public class ServerMock extends Server.Spigot implements Server
 	public boolean dispatchCommand(@NotNull CommandSender sender, @NotNull String commandLine)
 	{
 		AsyncCatcher.catchOp("command dispatch");
-		if (!commandsInitialized)
-		{
-			LifecycleEventRunnerMock.INSTANCE.callReloadableRegistrarEvent(LifecycleEvents.COMMANDS, PaperCommandsMock.INSTANCE, Plugin.class, ReloadableRegistrarEvent.Cause.INITIAL);
-			this.commandsInitialized = true;
-		}
 		if (sender instanceof Player player)
 		{
 			PlayerCommandPreprocessEvent event = new PlayerCommandPreprocessEvent(player, commandLine);

--- a/src/main/java/org/mockbukkit/mockbukkit/command/brigadier/PaperCommandsMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/command/brigadier/PaperCommandsMock.java
@@ -55,6 +55,16 @@ public class PaperCommandsMock implements Commands, PaperRegistrarMock<Lifecycle
 		this.invalid = true;
 	}
 
+	/**
+	 * Re-arms this registrar after a previous firing invalidated it, so the {@code COMMANDS} event can be
+	 * fired again -- once per plugin enable, and again on reload. Without it the second firing throws, because
+	 * the first handler to ask for the dispatcher fails the validity check.
+	 */
+	public void setValid()
+	{
+		this.invalid = false;
+	}
+
 	public void newDispatcher()
 	{
 		this.invalid = false;

--- a/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMock.java
@@ -1,5 +1,8 @@
 package org.mockbukkit.mockbukkit.plugin;
 
+import org.mockbukkit.mockbukkit.command.brigadier.PaperCommandsMock;
+import io.papermc.paper.plugin.lifecycle.event.registrar.ReloadableRegistrarEvent;
+import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
 import com.destroystokyo.paper.event.server.ServerExceptionEvent;
 import com.destroystokyo.paper.exception.ServerEventException;
 import com.google.common.base.Preconditions;
@@ -674,6 +677,13 @@ public class PluginManagerMock extends PermissionManagerMock implements PluginMa
 		{
 			JavaPluginUtils.setEnabled((JavaPlugin) plugin, true);
 			callEvent(new PluginEnableEvent(plugin));
+			// onEnable has returned, so this plugin can no longer register lifecycle handlers: every
+			// COMMANDS handler it will ever have exists now. Fire for this plugin alone, leaving the
+			// handlers of plugins enabled earlier untouched.
+			PaperCommandsMock.INSTANCE.setValid();
+			LifecycleEventRunnerMock.INSTANCE.callReloadableRegistrarEvent(LifecycleEvents.COMMANDS,
+					PaperCommandsMock.INSTANCE, Plugin.class, ReloadableRegistrarEvent.Cause.INITIAL,
+					owner -> owner == plugin);
 		}
 	}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/plugin/lifecycle/event/LifecycleEventRunnerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/plugin/lifecycle/event/LifecycleEventRunnerMock.java
@@ -92,7 +92,7 @@ public class LifecycleEventRunnerMock
 	 */
 	public <O extends LifecycleEventOwner, R extends PaperRegistrarMock<? super O>> void callReloadableRegistrarEvent(final LifecycleEventType<O, ? extends ReloadableRegistrarEvent<? super R>, ?> lifecycleEventType, final R registrar, final Class<? extends O> ownerClass, final ReloadableRegistrarEvent.Cause cause, final Predicate<? super O> ownerFilter)
 	{
-		this.callEvent((LifecycleEventType<O, ReloadableRegistrarEvent<? super R>, ?>) lifecycleEventType, new RegistrarEventMock.ReloadableMock<>(registrar, ownerClass, cause), owner -> ownerClass.isInstance(owner) && ownerFilter.test(owner));
+		this.callEvent((LifecycleEventType<O, ReloadableRegistrarEvent<? super R>, ?>) lifecycleEventType, new RegistrarEventMock.ReloadableMock<>(registrar, ownerClass, cause), ((Predicate<O>) ownerClass::isInstance).and(ownerFilter));
 	}
 
 	public <O extends LifecycleEventOwner, E extends PaperLifecycleEventMock> void callEvent(LifecycleEventType<O, ? super E, ?> eventType, E event, Predicate<? super O> ownerPredicate)

--- a/src/main/java/org/mockbukkit/mockbukkit/plugin/lifecycle/event/LifecycleEventRunnerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/plugin/lifecycle/event/LifecycleEventRunnerMock.java
@@ -72,7 +72,27 @@ public class LifecycleEventRunnerMock
 
 	public <O extends LifecycleEventOwner, R extends PaperRegistrarMock<? super O>> void callReloadableRegistrarEvent(final LifecycleEventType<O, ? extends ReloadableRegistrarEvent<? super R>, ?> lifecycleEventType, final R registrar, final Class<? extends O> ownerClass, final ReloadableRegistrarEvent.Cause cause)
 	{
-		this.callEvent((LifecycleEventType<O, ReloadableRegistrarEvent<? super R>, ?>) lifecycleEventType, new RegistrarEventMock.ReloadableMock<>(registrar, ownerClass, cause), ownerClass::isInstance);
+		callReloadableRegistrarEvent(lifecycleEventType, registrar, ownerClass, cause, owner -> true);
+	}
+
+	/**
+	 * Fires a reloadable registrar event for the owners matching {@code ownerFilter} only.
+	 * <p>
+	 * Handlers are kept in a plain list with no record of having run, so firing for every owner a second time
+	 * would re-run side effects that already happened. Filtering to the plugin that just enabled keeps each
+	 * handler to exactly one run.
+	 *
+	 * @param lifecycleEventType The event type to fire.
+	 * @param registrar          The registrar handed to each handler.
+	 * @param ownerClass         The owner type this event is scoped to.
+	 * @param cause              Why the event is being fired.
+	 * @param ownerFilter        Which of those owners should have their handlers run.
+	 * @param <O>                The owner type.
+	 * @param <R>                The registrar type.
+	 */
+	public <O extends LifecycleEventOwner, R extends PaperRegistrarMock<? super O>> void callReloadableRegistrarEvent(final LifecycleEventType<O, ? extends ReloadableRegistrarEvent<? super R>, ?> lifecycleEventType, final R registrar, final Class<? extends O> ownerClass, final ReloadableRegistrarEvent.Cause cause, final Predicate<? super O> ownerFilter)
+	{
+		this.callEvent((LifecycleEventType<O, ReloadableRegistrarEvent<? super R>, ?>) lifecycleEventType, new RegistrarEventMock.ReloadableMock<>(registrar, ownerClass, cause), owner -> ownerClass.isInstance(owner) && ownerFilter.test(owner));
 	}
 
 	public <O extends LifecycleEventOwner, E extends PaperLifecycleEventMock> void callEvent(LifecycleEventType<O, ? super E, ?> eventType, E event, Predicate<? super O> ownerPredicate)

--- a/src/test/java/org/mockbukkit/mockbukkit/command/brigadier/PaperCommandsMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/command/brigadier/PaperCommandsMockTest.java
@@ -7,6 +7,9 @@ import io.papermc.paper.command.brigadier.BasicCommand;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
+import io.papermc.paper.plugin.lifecycle.event.registrar.ReloadableRegistrarEvent;
+import org.bukkit.plugin.Plugin;
+import org.mockbukkit.mockbukkit.plugin.lifecycle.event.LifecycleEventRunnerMock;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -20,6 +23,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @ExtendWith(MockBukkitExtension.class)
 class PaperCommandsMockTest
@@ -27,6 +33,92 @@ class PaperCommandsMockTest
 
 	@MockBukkitInject
 	private ServerMock serverMock;
+
+	@Test
+	void firingForEveryOwnerRerunsHandlers()
+	{
+		AtomicInteger runs = new AtomicInteger();
+		PluginMock.builder().withOnEnable((pluginMock) ->
+				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
+				{
+					runs.incrementAndGet();
+					event.registrar().register(Commands.literal("all_owners_command").executes(context ->
+							Command.SINGLE_SUCCESS).build());
+				})).build();
+		assertEquals(1, runs.get());
+
+		PaperCommandsMock.INSTANCE.setValid();
+		LifecycleEventRunnerMock.INSTANCE.callReloadableRegistrarEvent(LifecycleEvents.COMMANDS,
+				PaperCommandsMock.INSTANCE, Plugin.class, ReloadableRegistrarEvent.Cause.RELOAD);
+
+		assertEquals(2, runs.get());
+		assertNotNull(serverMock.getCommandMap().getCommand("all_owners_command"));
+	}
+
+	@Test
+	void commandIsRegisteredAtEnableWithoutADispatch()
+	{
+		PluginMock.builder().withOnEnable((pluginMock) ->
+				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
+						event.registrar().register(Commands.literal("registered_at_enable").executes(context ->
+								Command.SINGLE_SUCCESS).build()))).build();
+
+		assertNotNull(serverMock.getCommandMap().getCommand("registered_at_enable"));
+	}
+
+	@Test
+	void registrarHandlerRunsExactlyOnce()
+	{
+		AtomicInteger runs = new AtomicInteger();
+		PluginMock.builder().withOnEnable((pluginMock) ->
+				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
+				{
+					runs.incrementAndGet();
+					event.registrar().register(Commands.literal("counted_command").executes(context ->
+							Command.SINGLE_SUCCESS).build());
+				})).build();
+
+		serverMock.dispatchCommand(serverMock.getConsoleSender(), "counted_command");
+		serverMock.dispatchCommand(serverMock.getConsoleSender(), "counted_command");
+
+		assertEquals(1, runs.get());
+	}
+
+	@Test
+	void asecondPluginRegistersWithoutRerunningTheFirst()
+	{
+		AtomicInteger firstRuns = new AtomicInteger();
+		PluginMock.builder().withOnEnable((pluginMock) ->
+				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
+				{
+					firstRuns.incrementAndGet();
+					event.registrar().register(Commands.literal("first_plugin_command").executes(context ->
+							Command.SINGLE_SUCCESS).build());
+				})).build();
+
+		PluginMock.builder().withOnEnable((pluginMock) ->
+				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
+						event.registrar().register(Commands.literal("second_plugin_command").executes(context ->
+								Command.SINGLE_SUCCESS).build()))).build();
+
+		assertNotNull(serverMock.getCommandMap().getCommand("first_plugin_command"));
+		assertNotNull(serverMock.getCommandMap().getCommand("second_plugin_command"));
+		assertEquals(1, firstRuns.get());
+	}
+
+
+	@Test
+	void tabCompletionWorksWithoutADispatch()
+	{
+		PluginMock.builder().withOnEnable((pluginMock) ->
+				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
+						event.registrar().register(Commands.literal("completable")
+								.then(Commands.literal("branch").executes(context -> Command.SINGLE_SUCCESS))
+								.build()))).build();
+
+		assertTrue(serverMock.getCommandMap().tabComplete(serverMock.getConsoleSender(), "completable ")
+				.contains("branch"));
+	}
 	List<Object> arguments = List.of();
 
 	@ParameterizedTest

--- a/src/test/java/org/mockbukkit/mockbukkit/command/brigadier/bukkit/BukkitBrigadierForwardingMapMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/command/brigadier/bukkit/BukkitBrigadierForwardingMapMockTest.java
@@ -132,8 +132,6 @@ class BukkitBrigadierForwardingMapMockTest
 						)
 				)
 		).build();
-		// Current implementation initializes before the first command is dispatched
-		serverMock.dispatchCommand(serverMock.getConsoleSender(), "ignored");
 		// plugin prefix and alias mutates on this, therefore 4
 		assertEquals(initial + 4, map.size());
 		assertFalse(map.isEmpty());

--- a/src/test/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMockTest.java
@@ -50,6 +50,17 @@ import static org.mockbukkit.mockbukkit.matcher.plugin.PluginManagerFiredEventFi
 class PluginManagerMockTest
 {
 
+	@Test
+	void enablePlugin_AlreadyEnabled_DoesNothing()
+	{
+		PluginMock plugin = MockBukkit.createMockPlugin();
+		assertTrue(plugin.isEnabled());
+
+		pluginManager.enablePlugin(plugin);
+
+		assertTrue(plugin.isEnabled());
+	}
+
 	@MockBukkitInject
 	private ServerMock server;
 	private PluginManagerMock pluginManager;

--- a/src/test/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/plugin/PluginManagerMockTest.java
@@ -53,12 +53,12 @@ class PluginManagerMockTest
 	@Test
 	void enablePlugin_AlreadyEnabled_DoesNothing()
 	{
-		PluginMock plugin = MockBukkit.createMockPlugin();
-		assertTrue(plugin.isEnabled());
+		PluginMock alreadyEnabled = MockBukkit.createMockPlugin();
+		assertTrue(alreadyEnabled.isEnabled());
 
-		pluginManager.enablePlugin(plugin);
+		pluginManager.enablePlugin(alreadyEnabled);
 
-		assertTrue(plugin.isEnabled());
+		assertTrue(alreadyEnabled.isEnabled());
 	}
 
 	@MockBukkitInject


### PR DESCRIPTION
Commands registered through the `COMMANDS` lifecycle event are invisible until something dispatches a command.

```java
MockBukkit.load(MyPlugin.class);
server.getCommandMap().getCommand("mycommand");                 // null
server.getCommandMap().tabComplete(player, "mycommand ");       // null

server.dispatchCommand(sender, "this_command_does_not_exist");  // returns false

server.getCommandMap().getCommand("mycommand");                 // now it works
```

The `COMMANDS` event had exactly one trigger — a `commandsInitialized` flag inside `ServerMock#dispatchCommand`. Nothing else fired it, so anything that inspects commands rather than running them saw an empty registry. The failure mode is a bare `null` with no hint why.

### The fix

Fire the registrar at the end of `PluginManagerMock#enablePlugin`, for that plugin only.

Two supporting pieces:

- **`PaperCommandsMock#setValid()`** — `LifecycleEventRunnerMock#callEvent` invalidates the registrar when it finishes, so a second firing currently throws from the `checkState` in `getDispatcher()` rather than duplicating anything. Paper has `PaperCommands#setValid()` for exactly this reason and MockBukkit had no equivalent, so the registrar has to be re-armed before each firing.
- **An owner-filtered overload of `callReloadableRegistrarEvent`** — handlers live in a plain list with no record of having run, so firing for every owner again would re-run side effects that already happened. Filtering to the plugin that just enabled keeps every handler to exactly one run. `callEvent` was already predicate-based, so this is a small addition.

`dispatchCommand`'s lazy block and the `commandsInitialized` flag are no longer needed and are removed.

### Why the enable hook is safe

Firing from `getCommandMap()` is not — I tried that first and it broke `put_brigadier`. The command map is fetched during server construction, before any plugin exists, so the registrar fires with zero handlers and every later registration is locked out.

The enable hook does not have that problem because it is causally downstream of registration rather than merely earlier in time. `JavaPlugin#setEnabled` runs `onEnable()` and then latches `allowsLifecycleRegistration = false` — `LifecycleEventManagerMock` enforces the same thing, throwing on any later attempt. So by the time the hook runs, every `COMMANDS` handler that plugin can ever have is already registered, and firing for that plugin alone means earlier plugins are not re-run and later ones cannot be shut out. There is no flag left to get stuck.

### Behaviour changes worth flagging

- A `COMMANDS` handler that throws now fails `MockBukkit.load(...)` instead of the first `dispatchCommand`. Arguably more faithful, since Paper fails at startup, but it is a change in timing.
- With per-owner firing, a later plugin's high-priority handler no longer runs before an earlier plugin's low-priority one. Priority within a single plugin is unchanged. Nothing in the suite exercises the cross-plugin case.
- `cause()` is always `INITIAL`, including for enables during `ServerMock#reload()`.

### Tests

Six new tests: registration without a dispatch, a handler running exactly once across two dispatches, a second plugin registering without re-running the first, tab completion straight after load, and the all-owners overload still re-running handlers when asked.

`BukkitBrigadierForwardingMapMockTest#put_brigadier` carried the workaround in this repo's own suite — a dispatch of `"ignored"` with the comment *"Current implementation initializes before the first command is dispatched"*. Both are gone.

Full suite green: 20613 tests, 0 failures. 100% line and branch coverage on everything added.

### Not included

While writing the tests I found that `ServerMock#reload()` throws `NullPointerException` if any Brigadier command is registered — `clearCommands()` walks the forwarding map and `ApiCommandMetaMock#plugin()` calls `requireNonNull` on a plugin that reload has already removed. It reproduces on an unmodified checkout, so it is not caused by this change and is going in its own pull request.
