### PR TITLE
Stop a command outliving its plugin from throwing

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/command/brigadier/ApiCommandMetaMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/command/brigadier/ApiCommandMetaMock.java
@@ -6,7 +6,6 @@ import org.bukkit.plugin.Plugin;
 import org.jspecify.annotations.Nullable;
 
 import java.util.List;
-import java.util.Objects;
 
 public record ApiCommandMetaMock(@Nullable PluginMeta pluginMeta, @Nullable String description, List<String> aliases,
 								 @Nullable String helpCommandNamespace, boolean serverSideOnly)
@@ -17,10 +16,18 @@ public record ApiCommandMetaMock(@Nullable PluginMeta pluginMeta, @Nullable Stri
 		aliases = List.copyOf(aliases);
 	}
 
+	/**
+	 * The plugin that registered this command, if it is still registered with the server.
+	 * <p>
+	 * Returns null once that plugin is gone -- during a reload, for instance, the command outlives the plugin
+	 * instance that added it -- which is why the return is nullable.
+	 *
+	 * @return The owning plugin, or null if it has no plugin meta or is no longer registered.
+	 */
 	@Nullable
 	public Plugin plugin()
 	{
-		return this.pluginMeta == null ? null : Objects.requireNonNull(Bukkit.getPluginManager().getPlugin(this.pluginMeta.getName()));
+		return this.pluginMeta == null ? null : Bukkit.getPluginManager().getPlugin(this.pluginMeta.getName());
 	}
 
 	public ApiCommandMetaMock withAliases(List<String> registeredAliases)

--- a/src/test/java/org/mockbukkit/mockbukkit/command/brigadier/PaperCommandsMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/command/brigadier/PaperCommandsMockTest.java
@@ -7,6 +7,8 @@ import io.papermc.paper.command.brigadier.BasicCommand;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
+import io.papermc.paper.plugin.configuration.PluginMeta;
+import org.mockbukkit.mockbukkit.MockBukkit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -20,6 +22,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 @ExtendWith(MockBukkitExtension.class)
 class PaperCommandsMockTest
@@ -27,6 +32,41 @@ class PaperCommandsMockTest
 
 	@MockBukkitInject
 	private ServerMock serverMock;
+
+	@Test
+	void clearingCommandsAfterThePluginIsGone()
+	{
+		PluginMock.builder().withOnEnable((pluginMock) ->
+				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
+						event.registrar().register(Commands.literal("orphaned_command").executes(context ->
+								Command.SINGLE_SUCCESS).build()))).build();
+		serverMock.dispatchCommand(serverMock.getConsoleSender(), "orphaned_command");
+
+		// What reload() does: the plugin goes, the command it registered does not.
+		MockBukkit.getMock().getPluginManager().clearPlugins();
+
+		assertDoesNotThrow(() -> serverMock.getCommandMap().clearCommands());
+	}
+
+	@Test
+	void metaWithoutPluginMetaHasNoPlugin()
+	{
+		ApiCommandMetaMock meta = new ApiCommandMetaMock(null, "description", List.of(), null, false);
+
+		assertNull(meta.plugin());
+	}
+
+	@Test
+	void metaPluginIsNullOnceThePluginIsGone()
+	{
+		PluginMeta meta = MockBukkit.createMockPlugin("VanishingPlugin").getPluginMeta();
+		ApiCommandMetaMock metaMock = new ApiCommandMetaMock(meta, "description", List.of(), null, false);
+		assertNotNull(metaMock.plugin());
+
+		MockBukkit.getMock().getPluginManager().clearPlugins();
+
+		assertNull(metaMock.plugin());
+	}
 	List<Object> arguments = List.of();
 
 	@ParameterizedTest


### PR DESCRIPTION
`ServerMock#reload()` throws `NullPointerException` if any Brigadier command has been registered.

```
java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:233)
	at org.mockbukkit.mockbukkit.command.brigadier.ApiCommandMetaMock.plugin(ApiCommandMetaMock.java:23)
	at org.mockbukkit.mockbukkit.command.brigadier.BrigadierUtils.wrapNode(BrigadierUtils.java:96)
	at ...bukkit.BukkitBrigadierForwardingMapMock.nodeToEntry(BukkitBrigadierForwardingMapMock.java:103)
	at ...bukkit.BukkitBrigadierForwardingMapMock.entrySet(BukkitBrigadierForwardingMapMock.java:95)
	at org.bukkit.command.SimpleCommandMap.clearCommands(SimpleCommandMap.java:179)
	at org.mockbukkit.mockbukkit.ServerMock.reload(ServerMock.java:1667)
```

### Cause

```java
@Nullable
public Plugin plugin()
{
	return this.pluginMeta == null ? null : Objects.requireNonNull(Bukkit.getPluginManager().getPlugin(this.pluginMeta.getName()));
}
```

The method is annotated `@Nullable` and then makes it impossible to return null for a command that has plugin meta. That holds right up until the plugin stops being registered — which is exactly what reload does, before walking the command map to clear it. The command outlives the plugin instance that added it, the lookup returns null, and `requireNonNull` turns a normal state into a crash.

### Fix

Return the lookup result as-is, matching the declared `@Nullable`, and document why null is a real answer rather than a defect.

### Tests

- Clearing the command map after the owning plugin is gone no longer throws. This is the reload path, reproduced directly — `reload()` itself cannot re-instantiate a builder-made `PluginMock`, which is a separate limitation and would have made the test about the wrong thing.
- `plugin()` returns null once the plugin is gone, and null when there is no plugin meta at all.

Full suite green: 20610 tests, 0 failures. `ApiCommandMetaMock#plugin` at 100% line and branch.

### Note

Found while working on #1615, but it reproduces on an unmodified checkout of this branch — registering a command through the `COMMANDS` lifecycle event, dispatching once so the old lazy initialisation runs, then calling `reload()`. Independent of that change, so it is here on its own.
