### PR TITLE
Implement teleportAsync

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/EntityMock.java
@@ -1154,8 +1154,7 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	@Override
 	public @NotNull CompletableFuture<Boolean> teleportAsync(@NotNull Location loc, PlayerTeleportEvent.@NotNull TeleportCause cause, @NotNull TeleportFlag @NotNull ... teleportFlags)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return CompletableFuture.completedFuture(teleport(loc, cause, teleportFlags));
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/EntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/EntityMockTest.java
@@ -6,6 +6,7 @@ import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.util.TriState;
 import org.bukkit.EntityEffect;
 import org.bukkit.GameMode;
+import java.util.concurrent.CompletableFuture;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -79,6 +80,26 @@ class EntityMockTest
 	private WorldMock world;
 	@MockBukkitInject
 	private SimpleEntityMock entity;
+
+	@Test
+	void teleportAsync_MovesTheEntityAndCompletesImmediately()
+	{
+		Location destination = new Location(world, 10, 64, 20);
+
+		CompletableFuture<Boolean> future = entity.teleportAsync(destination, TeleportCause.PLUGIN);
+
+		assertTrue(future.isDone());
+		assertTrue(future.getNow(false));
+		assertEquals(destination, entity.getLocation());
+	}
+
+	@Test
+	void teleportAsync_FiresTheTeleportEvent()
+	{
+		entity.teleportAsync(new Location(world, 1, 64, 1), TeleportCause.PLUGIN);
+
+		assertThat(server.getPluginManager(), hasFiredEventInstance(EntityTeleportEvent.class));
+	}
 
 	@Test
 	void getLocation_TwoInvocations_TwoClones()


### PR DESCRIPTION
`EntityMock#teleportAsync` was unimplemented, so any code that moves an entity the Paper way could not be exercised.

```java
entity.teleportAsync(destination, TeleportCause.PLUGIN);
// org.mockbukkit.mockbukkit.exception.UnimplementedOperationException
```

Worth noting how that presents: `UnimplementedOperationException` extends `TestAbortedException`, so the test is reported as *skipped* rather than failed and the build stays green. A test can stop running and nothing says so.

### The fix

Delegate to the synchronous `teleport` and hand back an already-completed future. The mock teleports immediately — there is nothing to await — and going through the same path means the teleport event fires exactly as it does for the blocking call, rather than the async variant quietly behaving differently.

### Tests

Two: the entity ends up at the destination with a future that is already done and reports success, and the teleport event still fires.

Full suite green: 20609 tests, 0 failures. `teleportAsync` at 100% line coverage, checkstyle clean.
