### PR TITLE
Implement getWorldContainer

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
@@ -171,6 +171,7 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.UncheckedIOException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
@@ -1922,8 +1923,14 @@ public class ServerMock extends Server.Spigot implements Server
 	@Override
 	public @NotNull File getWorldContainer()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		try
+		{
+			return getPluginManager().createTemporaryDirectory("worlds");
+		}
+		catch (IOException e)
+		{
+			throw new UncheckedIOException("Could not create the world container", e);
+		}
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
@@ -114,6 +114,8 @@ import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import org.mockbukkit.mockbukkit.plugin.PluginManagerMock;
+import java.io.UncheckedIOException;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Base64;
@@ -149,6 +151,58 @@ class ServerMockTest
 
 	@MockBukkitInject
 	private ServerMock server;
+
+	@Test
+	void getWorldContainer_WrapsAFailureToCreateTheDirectory()
+	{
+		ServerMock failing = new ServerMock()
+		{
+			@Override
+			public @NotNull PluginManagerMock getPluginManager()
+			{
+				return new PluginManagerMock(this)
+				{
+					@Override
+					public @NotNull File createTemporaryDirectory(@NotNull String name) throws IOException
+					{
+						throw new IOException("no space left on device");
+					}
+				};
+			}
+		};
+
+		assertThrows(UncheckedIOException.class, failing::getWorldContainer);
+	}
+
+	@Test
+	void getWorldContainer_ExistsAndIsADirectory()
+	{
+		File container = server.getWorldContainer();
+
+		assertTrue(container.isDirectory());
+	}
+
+	@Test
+	void getWorldContainer_IsStableAcrossCalls()
+	{
+		assertEquals(server.getWorldContainer(), server.getWorldContainer());
+	}
+
+	@Test
+	void getWorldContainer_SitsInsideTheTemporaryDirectory() throws IOException
+	{
+		assertEquals(server.getPluginManager().getParentTemporaryDirectory(),
+				server.getWorldContainer().getParentFile());
+	}
+
+	@Test
+	void getWorldContainer_CanHoldAWorldFolder() throws IOException
+	{
+		File world = new File(server.getWorldContainer(), "world");
+
+		assertTrue(world.mkdirs());
+		assertTrue(new File(world, "level.dat").createNewFile());
+	}
 
 	@Test
 	void class_NumberOfPlayers_Zero()


### PR DESCRIPTION
`ServerMock#getWorldContainer` was unimplemented, so any plugin that resolves a world folder on disk could not be tested.

```java
new File(Bukkit.getWorldContainer(), worldName);
// org.mockbukkit.mockbukkit.exception.UnimplementedOperationException
```

This one is worth calling out because of how quietly it fails. `UnimplementedOperationException` extends `TestAbortedException`, so the test is reported as **skipped**, not failed, and the build stays green. In our own suite a test class sat at 100% skipped for its entire existence on exactly this call — its setup loaded a plugin, the plugin created a world, and the whole class vanished from the run without anything saying so. It was found only when someone measured coverage and asked why a well-tested class had none.

### The fix

Return a `worlds` directory inside the plugin manager's temporary directory.

That directory already exists and is already deleted when the server is unmocked, so this needs no lifecycle of its own — no new cleanup path, nothing to leak, and nothing extra to get wrong on Windows where an open handle can defeat a delete.

A failure to create it surfaces as `UncheckedIOException`, since the Bukkit signature cannot throw.

### Tests

Five: the container exists and is a directory, it is stable across calls, it sits inside the temporary directory, it can actually hold a world folder with a file in it, and a failure to create it is wrapped rather than swallowed.

Full suite green: 20612 tests, 0 failures. `getWorldContainer` at 100% line coverage, checkstyle clean.

### Note

`getLevelDirectory` sits directly below this one and is also a stub, but it does not exist on this branch's API — it is Paper 26 only — so it is out of scope here.
