### PR TITLE
RFC: test-facing builders for damage and death events

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/event/DamageEventBuilder.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/event/DamageEventBuilder.java
@@ -1,0 +1,104 @@
+package org.mockbukkit.mockbukkit.event;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.damage.DamageSource;
+import org.bukkit.damage.DamageType;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Builds an {@link EntityDamageByEntityEvent} without the caller having to touch a deprecated constructor.
+ * <p>
+ * Obtain one from {@link MockEvents#damage()}.
+ */
+public class DamageEventBuilder
+{
+
+	private Entity damager;
+	private Entity target;
+	private double amount = 1.0;
+	private DamageType damageType = DamageType.GENERIC;
+	private EntityDamageEvent.@Nullable DamageCause cause;
+
+	DamageEventBuilder()
+	{
+	}
+
+	/**
+	 * @param damager The entity dealing the damage.
+	 * @return This builder.
+	 */
+	public @NotNull DamageEventBuilder by(@NotNull Entity damager)
+	{
+		Preconditions.checkArgument(damager != null, "Damager cannot be null");
+		this.damager = damager;
+		return this;
+	}
+
+	/**
+	 * @param target The entity taking the damage.
+	 * @return This builder.
+	 */
+	public @NotNull DamageEventBuilder to(@NotNull Entity target)
+	{
+		Preconditions.checkArgument(target != null, "Target cannot be null");
+		this.target = target;
+		return this;
+	}
+
+	/**
+	 * @param amount How much damage is dealt. Defaults to 1.
+	 * @return This builder.
+	 */
+	public @NotNull DamageEventBuilder amount(double amount)
+	{
+		this.amount = amount;
+		return this;
+	}
+
+	/**
+	 * @param damageType The damage type carried on the source. Defaults to {@link DamageType#GENERIC}.
+	 * @return This builder.
+	 */
+	public @NotNull DamageEventBuilder type(@NotNull DamageType damageType)
+	{
+		Preconditions.checkArgument(damageType != null, "Damage type cannot be null");
+		this.damageType = damageType;
+		return this;
+	}
+
+	/**
+	 * @param cause The cause reported by {@link EntityDamageEvent#getCause()}. Defaults to
+	 *              {@code ENTITY_ATTACK}.
+	 * @return This builder.
+	 */
+	public @NotNull DamageEventBuilder cause(EntityDamageEvent.@NotNull DamageCause cause)
+	{
+		Preconditions.checkArgument(cause != null, "Cause cannot be null");
+		this.cause = cause;
+		return this;
+	}
+
+	/**
+	 * @return The built event, not yet fired.
+	 */
+	public @NotNull EntityDamageByEntityEvent build()
+	{
+		Preconditions.checkState(this.damager != null, "A damager is required -- call by(...)");
+		Preconditions.checkState(this.target != null, "A target is required -- call to(...)");
+
+		DamageSource source = DamageSource.builder(this.damageType)
+				.withDirectEntity(this.damager)
+				.withCausingEntity(this.damager)
+				.build();
+		EntityDamageEvent.DamageCause damageCause = this.cause == null
+				? EntityDamageEvent.DamageCause.ENTITY_ATTACK
+				: this.cause;
+
+		return new EntityDamageByEntityEvent(this.damager, this.target, damageCause, source, this.amount);
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/event/DeathEventBuilder.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/event/DeathEventBuilder.java
@@ -1,0 +1,118 @@
+package org.mockbukkit.mockbukkit.event;
+
+import com.google.common.base.Preconditions;
+import net.kyori.adventure.text.Component;
+import org.bukkit.damage.DamageSource;
+import org.bukkit.damage.DamageType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builds a {@link PlayerDeathEvent} without the caller having to spell out six arguments, four of which are almost
+ * always the same placeholder.
+ * <p>
+ * Obtain one from {@link MockEvents#death()}.
+ */
+public class DeathEventBuilder
+{
+
+	private Player victim;
+	private DamageType damageType = DamageType.GENERIC;
+	private List<ItemStack> drops = new ArrayList<>();
+	private int droppedExp = 0;
+	private @Nullable Component deathMessage;
+	private boolean keepInventory = false;
+
+	DeathEventBuilder()
+	{
+	}
+
+	/**
+	 * @param victim The player who died.
+	 * @return This builder.
+	 */
+	public @NotNull DeathEventBuilder of(@NotNull Player victim)
+	{
+		Preconditions.checkArgument(victim != null, "Victim cannot be null");
+		this.victim = victim;
+		return this;
+	}
+
+	/**
+	 * @param damageType What killed them. Defaults to {@link DamageType#GENERIC}.
+	 * @return This builder.
+	 */
+	public @NotNull DeathEventBuilder type(@NotNull DamageType damageType)
+	{
+		Preconditions.checkArgument(damageType != null, "Damage type cannot be null");
+		this.damageType = damageType;
+		return this;
+	}
+
+	/**
+	 * @param drops What the player drops. Defaults to nothing.
+	 * @return This builder.
+	 */
+	public @NotNull DeathEventBuilder drops(@NotNull List<ItemStack> drops)
+	{
+		Preconditions.checkArgument(drops != null, "Drops cannot be null");
+		this.drops = new ArrayList<>(drops);
+		return this;
+	}
+
+	/**
+	 * @param droppedExp How much experience drops. Defaults to zero.
+	 * @return This builder.
+	 */
+	public @NotNull DeathEventBuilder droppedExp(int droppedExp)
+	{
+		Preconditions.checkArgument(droppedExp >= 0, "Dropped experience cannot be negative");
+		this.droppedExp = droppedExp;
+		return this;
+	}
+
+	/**
+	 * @param deathMessage The message announced, or null for none.
+	 * @return This builder.
+	 */
+	public @NotNull DeathEventBuilder deathMessage(@Nullable Component deathMessage)
+	{
+		this.deathMessage = deathMessage;
+		return this;
+	}
+
+	/**
+	 * @param keepInventory Whether the player keeps their inventory. Defaults to false.
+	 * @return This builder.
+	 */
+	public @NotNull DeathEventBuilder keepInventory(boolean keepInventory)
+	{
+		this.keepInventory = keepInventory;
+		return this;
+	}
+
+	/**
+	 * @return The built event, not yet fired.
+	 */
+	public @NotNull PlayerDeathEvent build()
+	{
+		Preconditions.checkState(this.victim != null, "A victim is required -- call of(...)");
+
+		DamageSource source = DamageSource.builder(this.damageType).build();
+		Component message = this.deathMessage == null ? Component.empty() : this.deathMessage;
+
+		// The trailing boolean here is doExpDrop, not keepInventory -- an easy one to get backwards, which is
+		// part of why this builder exists. keepInventory has its own setter.
+		PlayerDeathEvent event = new PlayerDeathEvent(this.victim, source, this.drops, this.droppedExp,
+				message, true);
+		event.setKeepInventory(this.keepInventory);
+		return event;
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/event/MockEvents.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/event/MockEvents.java
@@ -1,0 +1,40 @@
+package org.mockbukkit.mockbukkit.event;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Entry point for building the events a test needs to fire by hand.
+ * <p>
+ * Bukkit's damage and death events have no undeprecated constructor a test can call, so plugin suites end up
+ * carrying {@code @SuppressWarnings("removal")} and rediscovering the same argument traps. These builders own that
+ * so the test does not have to.
+ */
+public final class MockEvents
+{
+
+	private MockEvents()
+	{
+		throw new UnsupportedOperationException("Utility class");
+	}
+
+	/**
+	 * Starts building an {@link org.bukkit.event.entity.EntityDamageByEntityEvent}.
+	 *
+	 * @return A new damage event builder.
+	 */
+	public static @NotNull DamageEventBuilder damage()
+	{
+		return new DamageEventBuilder();
+	}
+
+	/**
+	 * Starts building a {@link org.bukkit.event.entity.PlayerDeathEvent}.
+	 *
+	 * @return A new death event builder.
+	 */
+	public static @NotNull DeathEventBuilder death()
+	{
+		return new DeathEventBuilder();
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/event/MockEventsTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/event/MockEventsTest.java
@@ -1,0 +1,154 @@
+package org.mockbukkit.mockbukkit.event;
+
+import net.kyori.adventure.text.Component;
+import org.bukkit.Material;
+import org.bukkit.damage.DamageType;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+import org.mockbukkit.mockbukkit.MockBukkitInject;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.inventory.ItemStackMock;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockBukkitExtension.class)
+class MockEventsTest
+{
+
+	@MockBukkitInject
+	private ServerMock server;
+
+	@Test
+	void damage_BuildsAnEventWithTheGivenParticipants()
+	{
+		PlayerMock attacker = server.addPlayer();
+		PlayerMock victim = server.addPlayer();
+
+		EntityDamageByEntityEvent event = MockEvents.damage().by(attacker).to(victim).amount(6.0).build();
+
+		assertEquals(attacker, event.getDamager());
+		assertEquals(victim, event.getEntity());
+		assertEquals(6.0, event.getDamage());
+	}
+
+	@Test
+	void damage_DefaultsToAnEntityAttackOfOne()
+	{
+		PlayerMock attacker = server.addPlayer();
+
+		EntityDamageByEntityEvent event = MockEvents.damage().by(attacker).to(server.addPlayer()).build();
+
+		assertEquals(1.0, event.getDamage());
+		assertEquals(EntityDamageEvent.DamageCause.ENTITY_ATTACK, event.getCause());
+		assertEquals(DamageType.GENERIC, event.getDamageSource().getDamageType());
+	}
+
+	@Test
+	void damage_CarriesTypeAndCause()
+	{
+		PlayerMock attacker = server.addPlayer();
+
+		EntityDamageByEntityEvent event = MockEvents.damage()
+				.by(attacker).to(server.addPlayer())
+				.type(DamageType.ARROW)
+				.cause(EntityDamageEvent.DamageCause.PROJECTILE)
+				.build();
+
+		assertEquals(DamageType.ARROW, event.getDamageSource().getDamageType());
+		assertEquals(EntityDamageEvent.DamageCause.PROJECTILE, event.getCause());
+		assertEquals(attacker, event.getDamageSource().getCausingEntity());
+	}
+
+	@Test
+	void damage_RejectsMissingParticipants()
+	{
+		PlayerMock player = server.addPlayer();
+
+		assertThrows(IllegalStateException.class, () -> MockEvents.damage().to(player).build());
+		assertThrows(IllegalStateException.class, () -> MockEvents.damage().by(player).build());
+	}
+
+	@Test
+	void damage_RejectsNulls()
+	{
+		assertThrows(IllegalArgumentException.class, () -> MockEvents.damage().by(null));
+		assertThrows(IllegalArgumentException.class, () -> MockEvents.damage().to(null));
+		assertThrows(IllegalArgumentException.class, () -> MockEvents.damage().type(null));
+		assertThrows(IllegalArgumentException.class, () -> MockEvents.damage().cause(null));
+	}
+
+	@Test
+	void death_BuildsAnEventForTheVictim()
+	{
+		PlayerMock victim = server.addPlayer();
+
+		PlayerDeathEvent event = MockEvents.death().of(victim).build();
+
+		assertEquals(victim, event.getEntity());
+		assertEquals(0, event.getDroppedExp());
+		assertTrue(event.getDrops().isEmpty());
+		assertFalse(event.getKeepInventory());
+		assertEquals(Component.empty(), event.deathMessage());
+		assertEquals(DamageType.GENERIC, event.getDamageSource().getDamageType());
+	}
+
+	@Test
+	void death_CarriesEverythingItIsGiven()
+	{
+		PlayerMock victim = server.addPlayer();
+		List<ItemStack> drops = List.of(new ItemStackMock(Material.STONE));
+
+		PlayerDeathEvent event = MockEvents.death()
+				.of(victim)
+				.type(DamageType.PLAYER_ATTACK)
+				.drops(drops)
+				.droppedExp(7)
+				.deathMessage(Component.text("gone"))
+				.keepInventory(true)
+				.build();
+
+		assertEquals(DamageType.PLAYER_ATTACK, event.getDamageSource().getDamageType());
+		assertEquals(1, event.getDrops().size());
+		assertEquals(7, event.getDroppedExp());
+		assertEquals(Component.text("gone"), event.deathMessage());
+		assertTrue(event.getKeepInventory());
+	}
+
+	@Test
+	void death_RejectsBadInput()
+	{
+		assertThrows(IllegalStateException.class, () -> MockEvents.death().build());
+		assertThrows(IllegalArgumentException.class, () -> MockEvents.death().of(null));
+		assertThrows(IllegalArgumentException.class, () -> MockEvents.death().type(null));
+		assertThrows(IllegalArgumentException.class, () -> MockEvents.death().drops(null));
+		assertThrows(IllegalArgumentException.class, () -> MockEvents.death().droppedExp(-1));
+	}
+
+	@Test
+	void death_AcceptsANullMessage()
+	{
+		PlayerDeathEvent event = MockEvents.death().of(server.addPlayer()).deathMessage(null).build();
+
+		assertEquals(Component.empty(), event.deathMessage());
+	}
+
+	@Test
+	void mockEvents_CannotBeInstantiated() throws Exception
+	{
+		var constructor = MockEvents.class.getDeclaredConstructor();
+		constructor.setAccessible(true);
+		assertThrows(java.lang.reflect.InvocationTargetException.class, constructor::newInstance);
+	}
+
+}


### PR DESCRIPTION
> **Proposal / request for comment — please do not merge as-is.**
> This adds new API surface rather than filling in a stub, so the shape is a suggestion and I would rather agree it than land it. Happy to rename, reshape, move the package, or close this if you would rather not own it. The problem it describes is real either way, and that part is worth reading even if the answer is no.

## The problem

There is no way to construct `EntityDamageByEntityEvent` from a test without a deprecation warning.

Every constructor is deprecated. The two not marked for removal take a `Map<DamageModifier, Double>`, and `DamageModifier` is itself deprecated — so there is no spelling that compiles clean. What plugin suites end up with:

```java
// Paper has deprecated every EntityDamageByEntityEvent constructor; this is the readable one.
@SuppressWarnings("removal")
private static EntityDamageByEntityEvent hit(Entity damager, Entity target, double damage)
{
	return new EntityDamageByEntityEvent(damager, target,
			EntityDamageEvent.DamageCause.ENTITY_ATTACK,
			DamageSource.builder(DamageType.PLAYER_ATTACK).build(), damage);
}
```

That helper is copied into three test classes in the suite I work on, one of them carrying the same comment twice. It is noise, and worse, it trains people to suppress removal warnings in test code.

There is a second trap. The obvious modern-looking call:

```java
new EntityDamageByEntityEvent(damager, target, cause, source,
		Map.of(DamageModifier.BASE, 1.0),
		Map.of(DamageModifier.BASE, d -> d), false);
```

throws `NullPointerException: Cannot invoke "Object.equals(Object)" because "o" is null` from `ImmutableCollections$Map1.containsKey` — the constructor probes the map with a null key, which `Map.of()` rejects. You must pass a `HashMap`. That cost a round trip to diagnose and the message names neither the cause nor the fix.

`PlayerDeathEvent` has the same shape of problem: six arguments of which four are always the same placeholder.

## What this proposes

```java
EntityDamageByEntityEvent event = MockEvents.damage()
		.by(attacker).to(victim).amount(6.0)
		.type(DamageType.ARROW)
		.cause(DamageCause.PROJECTILE)
		.build();

PlayerDeathEvent death = MockEvents.death()
		.of(victim)
		.type(DamageType.PLAYER_ATTACK)
		.droppedExp(7)
		.build();
```

The awkwardness lives once, inside MockBukkit, instead of in every plugin's tests.

## This already caught something

Writing it turned up that the trailing boolean on the six-argument `PlayerDeathEvent` constructor is **`doExpDrop`, not `keepInventory`** — easy to get backwards, and a test that gets it backwards still looks correct while asserting nothing. The builder sets `keepInventory` through its own setter so the meaning is explicit rather than positional. That is a fair illustration of why the wrapper earns its keep.

## Open questions

1. Do you want this in MockBukkit at all, or is event construction the plugin's own problem?
2. Is `org.mockbukkit.mockbukkit.event.MockEvents` the right home and name?
3. Should the damage builder also cover `EntityDamageEvent` (no damager), and the death builder the exp/level overloads? Both were left out to keep the surface small until there is a direction.

## State

11 tests, all defaults, every setter, the validation paths and the null-message case. Full suite green: 20617 tests, 0 failures. 60 added lines, 0 uncovered, checkstyle clean.

Background for the problem statement, if useful: MOCKBUKKIT3.md §4 in the notes I raised #1609 and #1610 from.
