### PR TITLE
Implement strikeLightning and strikeLightningEffect

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
@@ -90,6 +90,7 @@ import org.mockbukkit.mockbukkit.ServerMock;
 import org.mockbukkit.mockbukkit.block.BlockMock;
 import org.mockbukkit.mockbukkit.block.data.BlockDataMock;
 import org.mockbukkit.mockbukkit.entity.EntityMock;
+import org.mockbukkit.mockbukkit.entity.LightningStrikeMock;
 import org.mockbukkit.mockbukkit.entity.EntityTypesMock;
 import org.mockbukkit.mockbukkit.entity.ItemEntityMock;
 import org.mockbukkit.mockbukkit.entity.ItemMock;
@@ -1012,15 +1013,15 @@ public class WorldMock implements World
 	@Override
 	public @NotNull LightningStrike strikeLightning(Location loc)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return spawn(loc, LightningStrike.class);
 	}
 
 	@Override
 	public @NotNull LightningStrike strikeLightningEffect(Location loc)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		LightningStrikeMock strike = (LightningStrikeMock) spawn(loc, LightningStrike.class);
+		strike.setEffect(true);
+		return strike;
 	}
 
 	public @Nullable Location findLightningRod(@NotNull Location location)

--- a/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
@@ -16,6 +16,7 @@ import org.bukkit.GameRule;
 import org.bukkit.GameRules;
 import org.bukkit.HeightMap;
 import org.bukkit.Location;
+import org.bukkit.entity.LightningStrike;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.Registry;
@@ -236,6 +237,40 @@ class WorldMockTest
 
 	@MockBukkitInject
 	private ServerMock server;
+
+	@Test
+	void strikeLightning_SpawnsARealStrike()
+	{
+		WorldMock world = server.addSimpleWorld("lightning");
+		Location location = new Location(world, 10, 64, 20);
+
+		LightningStrike strike = world.strikeLightning(location);
+
+		assertFalse(strike.isEffect());
+		assertEquals(location, strike.getLocation());
+	}
+
+	@Test
+	void strikeLightningEffect_SpawnsAnEffectOnlyStrike()
+	{
+		WorldMock world = server.addSimpleWorld("lightning-effect");
+		Location location = new Location(world, 10, 64, 20);
+
+		LightningStrike strike = world.strikeLightningEffect(location);
+
+		assertTrue(strike.isEffect());
+		assertEquals(location, strike.getLocation());
+	}
+
+	@Test
+	void strikeLightning_RegistersTheStrikeWithTheWorld()
+	{
+		WorldMock world = server.addSimpleWorld("lightning-registered");
+
+		LightningStrike strike = world.strikeLightning(new Location(world, 1, 64, 1));
+
+		assertTrue(world.getEntities().contains(strike));
+	}
 
 	@Test
 	void getBlockAt_StandardWorld_DefaultBlocks()
@@ -2899,5 +2934,6 @@ class WorldMockTest
 		}
 
 	}
+
 
 }


### PR DESCRIPTION
`WorldMock#strikeLightning` and `strikeLightningEffect` were both unimplemented, so anything that calls down lightning could not be tested.

```java
world.strikeLightning(location);
// org.mockbukkit.mockbukkit.exception.UnimplementedOperationException
```

Worth noting how that presents: `UnimplementedOperationException` extends `TestAbortedException`, so the test is reported as **skipped** rather than failed and the build stays green. Nothing tells you the test stopped running.

### The fix

Both spawn a `LightningStrike` through the world's normal spawn path rather than constructing one off to the side. That matters more than it looks: the strike is registered with the server and turns up in `getEntities`, `getNearbyEntities` and everything else, exactly like any other entity. A test can then assert on the strike itself instead of only on the fact that the call did not throw.

`strikeLightningEffect` marks the strike as an effect, so `isEffect()` distinguishes the two — which is the only difference a plugin can observe between them.

### Tests

Three: a real strike is not an effect and lands at the given location, an effect-only strike is, and the strike is discoverable through the world's entity list afterwards.

Full suite green: 20610 tests, 0 failures. 4 added lines, 0 uncovered, checkstyle clean.
