### PR TITLE
Implement InternalAPIBridge.restricted

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/MockBukkitInternalAPIBridge.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/MockBukkitInternalAPIBridge.java
@@ -76,7 +76,11 @@ public class MockBukkitInternalAPIBridge implements InternalAPIBridge
 	@Override
 	public Predicate<CommandSourceStack> restricted(Predicate<CommandSourceStack> predicate)
 	{
-		throw new UnimplementedOperationException();
+		Preconditions.checkArgument(predicate != null, "Predicate cannot be null");
+		// Paper wraps the predicate so the node is not sent to clients that fail it, while staying executable
+		// by senders that pass. There is no client to withhold it from here, so the predicate is returned as
+		// given: execution is gated correctly, and the hiding half is a no-op.
+		return predicate;
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/command/brigadier/PaperCommandsMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/command/brigadier/PaperCommandsMockTest.java
@@ -20,6 +20,10 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @ExtendWith(MockBukkitExtension.class)
 class PaperCommandsMockTest
@@ -76,6 +80,51 @@ class PaperCommandsMockTest
 	BasicCommand createBasicCommand()
 	{
 		return (commandSourceStack, args) -> arguments = Arrays.asList((Object[]) args);
+	}
+
+
+	@Test
+	void restrictedNodeLoadsAndStaysExecutable()
+	{
+		AtomicBoolean ran = new AtomicBoolean(false);
+		PluginMock.builder().withOnEnable((pluginMock) ->
+				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
+						event.registrar().register(Commands.literal("restricted_command")
+								.requires(Commands.restricted(source -> true))
+								.executes(context ->
+								{
+									ran.set(true);
+									return com.mojang.brigadier.Command.SINGLE_SUCCESS;
+								}).build()))).build();
+
+		serverMock.dispatchCommand(serverMock.getConsoleSender(), "restricted_command");
+
+		assertTrue(ran.get());
+	}
+
+	@Test
+	void restrictedNodeIsRefusedWhenThePredicateFails()
+	{
+		AtomicBoolean ran = new AtomicBoolean(false);
+		PluginMock.builder().withOnEnable((pluginMock) ->
+				pluginMock.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event ->
+						event.registrar().register(Commands.literal("denied_command")
+								.requires(Commands.restricted(source -> false))
+								.executes(context ->
+								{
+									ran.set(true);
+									return com.mojang.brigadier.Command.SINGLE_SUCCESS;
+								}).build()))).build();
+
+		serverMock.dispatchCommand(serverMock.getConsoleSender(), "denied_command");
+
+		assertFalse(ran.get());
+	}
+
+	@Test
+	void restrictedRejectsANullPredicate()
+	{
+		assertThrows(IllegalArgumentException.class, () -> Commands.restricted(null));
 	}
 
 }


### PR DESCRIPTION
`Commands.restricted(...)` routes through `MockBukkitInternalAPIBridge#restricted`, which was a stub that threw. A plugin using it could not be loaded under MockBukkit at all.

```java
event.registrar().register(Commands.literal("probe")
		.then(Commands.literal("hidden")
				.requires(Commands.restricted(src -> true))
				.executes(c -> 1))
		.build());
```

```
java.lang.RuntimeException: Could not run 'commands' lifecycle event handler from ProbePlugin v0.0.0
	at ...LifecycleEventRunnerMock.lambda$callEvent$2(LifecycleEventRunnerMock.java:93)
Caused by: org.mockbukkit.mockbukkit.exception.UnimplementedOperationException
	at ...MockBukkitInternalAPIBridge.restricted(MockBukkitInternalAPIBridge.java:79)
	at io.papermc.paper.command.brigadier.Commands.restricted(Commands.java:100)
```

The blast radius is what makes this worse than a normal stub: it throws *inside* the `COMMANDS` handler, so it takes down the entire registration rather than the one node that used it. Every other command that plugin registers disappears too, and the exception the test sees is a `RuntimeException` about a lifecycle handler rather than anything naming `restricted`.

### The fix

Return the predicate as given.

### What this does and does not do

Paper's contract has two halves: the node stays executable by senders who pass the predicate, and it is not sent to clients who do not. This delivers the first — execution is gated correctly, and a sender failing the predicate is refused.

It does **not** deliver the hiding half. That needs the completion path to filter by `canUse`, which it does not currently do, and which is #1608. Until that lands, a restricted node is still offered in tab completion. I would rather say so plainly than have someone discover it later and assume the mock is faithful.

Worth noting the two are separable in practice: without this change the plugin cannot load at all, so this is useful on its own even while the hiding half is outstanding.

### Tests

Three: a restricted node loads and remains executable when the predicate passes, it is refused when the predicate fails, and a null predicate is rejected rather than stored.

Full suite green: 20610 tests, 0 failures. 2 added lines, 0 uncovered, checkstyle clean.
