### PR TITLE
Implement server tick metrics

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
@@ -205,6 +205,8 @@ public class ServerMock extends Server.Spigot implements Server
 {
 
 	private Component motd = Component.text("A Minecraft Server");
+	private double[] tps = { 20.0, 20.0, 20.0 };
+	private long[] tickTimes = new long[100];
 	private static final Component NO_PERMISSION = Component.text("I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error.", NamedTextColor.RED);
 
 	private final Logger logger = Logger.getLogger("ServerMock");
@@ -2182,22 +2184,50 @@ public class ServerMock extends Server.Spigot implements Server
 	@Override
 	public @NotNull double[] getTPS()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.tps.clone();
+	}
+
+	/**
+	 * Sets the ticks-per-second averages this server reports. A real server derives these from how long its ticks
+	 * actually took, which a mock has no way to observe, so a test that cares about server load sets them directly.
+	 *
+	 * @param oneMinute      The one-minute average.
+	 * @param fiveMinutes    The five-minute average.
+	 * @param fifteenMinutes The fifteen-minute average.
+	 */
+	public void setTPS(double oneMinute, double fiveMinutes, double fifteenMinutes)
+	{
+		this.tps = new double[]{ oneMinute, fiveMinutes, fifteenMinutes };
 	}
 
 	@Override
 	public @NotNull long[] getTickTimes()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.tickTimes.clone();
+	}
+
+	/**
+	 * Sets the durations of the most recent ticks, in nanoseconds. {@link #getAverageTickTime()} is derived from
+	 * these, so the two cannot disagree.
+	 *
+	 * @param tickTimes The tick durations in nanoseconds, most recent last. Must not be empty.
+	 */
+	public void setTickTimes(long @NotNull ... tickTimes)
+	{
+		Preconditions.checkArgument(tickTimes != null, "Tick times cannot be null");
+		Preconditions.checkArgument(tickTimes.length > 0, "Tick times cannot be empty");
+		this.tickTimes = tickTimes.clone();
 	}
 
 	@Override
 	public double getAverageTickTime()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		long total = 0;
+		for (long tickTime : this.tickTimes)
+		{
+			total += tickTime;
+		}
+		return (double) total / this.tickTimes.length / 1_000_000.0;
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/ServerMockTest.java
@@ -128,6 +128,7 @@ import static org.bukkit.Bukkit.getPauseWhenEmptyTime;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -149,6 +150,71 @@ class ServerMockTest
 
 	@MockBukkitInject
 	private ServerMock server;
+
+	@Test
+	void getTPS_DefaultsToTwenty()
+	{
+		assertArrayEquals(new double[]{ 20.0, 20.0, 20.0 }, server.getTPS());
+	}
+
+	@Test
+	void getTPS_ReturnsACopy()
+	{
+		server.getTPS()[0] = 1.0;
+		assertEquals(20.0, server.getTPS()[0]);
+	}
+
+	@Test
+	void setTPS_IsRetained()
+	{
+		server.setTPS(19.5, 18.0, 12.25);
+		assertArrayEquals(new double[]{ 19.5, 18.0, 12.25 }, server.getTPS());
+	}
+
+	@Test
+	void getTickTimes_DefaultsToOneHundredZeroes()
+	{
+		assertArrayEquals(new long[100], server.getTickTimes());
+	}
+
+	@Test
+	void getTickTimes_ReturnsACopy()
+	{
+		server.getTickTimes()[0] = 5L;
+		assertEquals(0L, server.getTickTimes()[0]);
+	}
+
+	@Test
+	void setTickTimes_IsRetained()
+	{
+		server.setTickTimes(1L, 2L, 3L);
+		assertArrayEquals(new long[]{ 1L, 2L, 3L }, server.getTickTimes());
+	}
+
+	@Test
+	void setTickTimes_Null()
+	{
+		assertThrows(IllegalArgumentException.class, () -> server.setTickTimes((long[]) null));
+	}
+
+	@Test
+	void setTickTimes_Empty()
+	{
+		assertThrows(IllegalArgumentException.class, server::setTickTimes);
+	}
+
+	@Test
+	void getAverageTickTime_DefaultsToZero()
+	{
+		assertEquals(0.0, server.getAverageTickTime());
+	}
+
+	@Test
+	void getAverageTickTime_IsTheMeanOfTheTickTimesInMilliseconds()
+	{
+		server.setTickTimes(1_000_000L, 2_000_000L, 3_000_000L);
+		assertEquals(2.0, server.getAverageTickTime());
+	}
 
 	@Test
 	void class_NumberOfPlayers_Zero()
@@ -2592,5 +2658,6 @@ class EventDenier implements Listener
 	{
 		event.setResult(PlayerLoginEvent.Result.KICK_OTHER);
 	}
+
 
 }


### PR DESCRIPTION
`ServerMock#getTPS`, `getTickTimes` and `getAverageTickTime` were all unimplemented, so anything reporting on server load could not be tested.

```java
Bukkit.getTPS();
// org.mockbukkit.mockbukkit.exception.UnimplementedOperationException
```

Worth noting how that presents: `UnimplementedOperationException` extends `TestAbortedException`, so the test is reported as **skipped** rather than failed and the build stays green. Nothing tells you the test stopped running.

### The fix

`getTPS` and `getTickTimes` return stored values; `getAverageTickTime` is **derived from the tick times** rather than stored alongside them. That is the part worth a second look: if the average were its own field, a test could set tick times and an average that disagreed with each other, and code under test would see a server that cannot exist. Deriving it means the two cannot contradict.

Both getters hand back a copy, so a caller cannot reach in and mutate the server's state through the returned array.

### Why there are setters

A mock cannot observe how long its own ticks took — there is no real tick loop to measure. So `setTPS` and `setTickTimes` let a test state what the server should report, which is the only way code that reacts to load can be exercised at all. Neither has a Bukkit setter; both are MockBukkit-specific and documented as such.

`setTickTimes` rejects null and empty, since an empty array would make the average a division by zero.

### Tests

Ten: defaults for all three, both getters returning copies rather than the live array, the setters round-tripping, the average being the mean in milliseconds, and the two rejection cases.

Full suite green: 20617 tests, 0 failures. 12 added lines, 0 uncovered, checkstyle clean.
