### PR TITLE
Implement client brand name and current input on PlayerMock

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/InputMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/InputMock.java
@@ -1,6 +1,7 @@
 package org.mockbukkit.mockbukkit.entity;
 
 import lombok.Builder;
+import lombok.Getter;
 import org.bukkit.Input;
 
 /**
@@ -17,8 +18,8 @@ import org.bukkit.Input;
  * @param sprint   Whether the sprint key is pressed.
  */
 @Builder
-public record InputMock(boolean forward, boolean backward, boolean left, boolean right, boolean jump, boolean sneak,
-						boolean sprint) implements Input
+public record InputMock(@Getter boolean forward, @Getter boolean backward, @Getter boolean left,
+						@Getter boolean right, @Getter boolean jump, @Getter boolean sneak, @Getter boolean sprint) implements Input
 {
 
 	/**
@@ -29,48 +30,6 @@ public record InputMock(boolean forward, boolean backward, boolean left, boolean
 	public static InputMock none()
 	{
 		return builder().build();
-	}
-
-	@Override
-	public boolean isForward()
-	{
-		return this.forward;
-	}
-
-	@Override
-	public boolean isBackward()
-	{
-		return this.backward;
-	}
-
-	@Override
-	public boolean isLeft()
-	{
-		return this.left;
-	}
-
-	@Override
-	public boolean isRight()
-	{
-		return this.right;
-	}
-
-	@Override
-	public boolean isJump()
-	{
-		return this.jump;
-	}
-
-	@Override
-	public boolean isSneak()
-	{
-		return this.sneak;
-	}
-
-	@Override
-	public boolean isSprint()
-	{
-		return this.sprint;
 	}
 
 	/**

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/InputMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/InputMock.java
@@ -1,5 +1,6 @@
 package org.mockbukkit.mockbukkit.entity;
 
+import lombok.Builder;
 import org.bukkit.Input;
 
 /**
@@ -15,6 +16,7 @@ import org.bukkit.Input;
  * @param sneak    Whether the sneak key is pressed.
  * @param sprint   Whether the sprint key is pressed.
  */
+@Builder
 public record InputMock(boolean forward, boolean backward, boolean left, boolean right, boolean jump, boolean sneak,
 						boolean sprint) implements Input
 {
@@ -26,7 +28,7 @@ public record InputMock(boolean forward, boolean backward, boolean left, boolean
 	 */
 	public static InputMock none()
 	{
-		return new InputMock(false, false, false, false, false, false, false);
+		return builder().build();
 	}
 
 	@Override
@@ -69,6 +71,169 @@ public record InputMock(boolean forward, boolean backward, boolean left, boolean
 	public boolean isSprint()
 	{
 		return this.sprint;
+	}
+
+	/**
+	 * Builds an {@link InputMock}. Every key defaults to released, so only the pressed ones need naming. Each key has a
+	 * no argument shorthand that presses it, next to a setter that takes the value explicitly.
+	 */
+	public static class InputMockBuilder
+	{
+
+		/**
+		 * Presses the forward key.
+		 *
+		 * @return This builder.
+		 */
+		public InputMockBuilder forward()
+		{
+			return forward(true);
+		}
+
+		/**
+		 * Sets whether the forward key is pressed.
+		 *
+		 * @param forward Whether the key is pressed.
+		 * @return This builder.
+		 */
+		public InputMockBuilder forward(boolean forward)
+		{
+			this.forward = forward;
+			return this;
+		}
+
+		/**
+		 * Presses the backward key.
+		 *
+		 * @return This builder.
+		 */
+		public InputMockBuilder backward()
+		{
+			return backward(true);
+		}
+
+		/**
+		 * Sets whether the backward key is pressed.
+		 *
+		 * @param backward Whether the key is pressed.
+		 * @return This builder.
+		 */
+		public InputMockBuilder backward(boolean backward)
+		{
+			this.backward = backward;
+			return this;
+		}
+
+		/**
+		 * Presses the left key.
+		 *
+		 * @return This builder.
+		 */
+		public InputMockBuilder left()
+		{
+			return left(true);
+		}
+
+		/**
+		 * Sets whether the left key is pressed.
+		 *
+		 * @param left Whether the key is pressed.
+		 * @return This builder.
+		 */
+		public InputMockBuilder left(boolean left)
+		{
+			this.left = left;
+			return this;
+		}
+
+		/**
+		 * Presses the right key.
+		 *
+		 * @return This builder.
+		 */
+		public InputMockBuilder right()
+		{
+			return right(true);
+		}
+
+		/**
+		 * Sets whether the right key is pressed.
+		 *
+		 * @param right Whether the key is pressed.
+		 * @return This builder.
+		 */
+		public InputMockBuilder right(boolean right)
+		{
+			this.right = right;
+			return this;
+		}
+
+		/**
+		 * Presses the jump key.
+		 *
+		 * @return This builder.
+		 */
+		public InputMockBuilder jump()
+		{
+			return jump(true);
+		}
+
+		/**
+		 * Sets whether the jump key is pressed.
+		 *
+		 * @param jump Whether the key is pressed.
+		 * @return This builder.
+		 */
+		public InputMockBuilder jump(boolean jump)
+		{
+			this.jump = jump;
+			return this;
+		}
+
+		/**
+		 * Presses the sneak key.
+		 *
+		 * @return This builder.
+		 */
+		public InputMockBuilder sneak()
+		{
+			return sneak(true);
+		}
+
+		/**
+		 * Sets whether the sneak key is pressed.
+		 *
+		 * @param sneak Whether the key is pressed.
+		 * @return This builder.
+		 */
+		public InputMockBuilder sneak(boolean sneak)
+		{
+			this.sneak = sneak;
+			return this;
+		}
+
+		/**
+		 * Presses the sprint key.
+		 *
+		 * @return This builder.
+		 */
+		public InputMockBuilder sprint()
+		{
+			return sprint(true);
+		}
+
+		/**
+		 * Sets whether the sprint key is pressed.
+		 *
+		 * @param sprint Whether the key is pressed.
+		 * @return This builder.
+		 */
+		public InputMockBuilder sprint(boolean sprint)
+		{
+			this.sprint = sprint;
+			return this;
+		}
+
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/InputMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/InputMock.java
@@ -1,0 +1,74 @@
+package org.mockbukkit.mockbukkit.entity;
+
+import org.bukkit.Input;
+
+/**
+ * A simple {@link Input} holding which movement keys a player is pressing. Bukkit only exposes {@code Input} as an
+ * interface with no implementation, so tests that need to drive
+ * {@link org.bukkit.entity.Player#getCurrentInput()} have nothing to hand it otherwise.
+ *
+ * @param forward  Whether the forward key is pressed.
+ * @param backward Whether the backward key is pressed.
+ * @param left     Whether the left key is pressed.
+ * @param right    Whether the right key is pressed.
+ * @param jump     Whether the jump key is pressed.
+ * @param sneak    Whether the sneak key is pressed.
+ * @param sprint   Whether the sprint key is pressed.
+ */
+public record InputMock(boolean forward, boolean backward, boolean left, boolean right, boolean jump, boolean sneak,
+						boolean sprint) implements Input
+{
+
+	/**
+	 * An input with nothing pressed, which is what a player who is standing still reports.
+	 *
+	 * @return An input with every key released.
+	 */
+	public static InputMock none()
+	{
+		return new InputMock(false, false, false, false, false, false, false);
+	}
+
+	@Override
+	public boolean isForward()
+	{
+		return this.forward;
+	}
+
+	@Override
+	public boolean isBackward()
+	{
+		return this.backward;
+	}
+
+	@Override
+	public boolean isLeft()
+	{
+		return this.left;
+	}
+
+	@Override
+	public boolean isRight()
+	{
+		return this.right;
+	}
+
+	@Override
+	public boolean isJump()
+	{
+		return this.jump;
+	}
+
+	@Override
+	public boolean isSneak()
+	{
+		return this.sneak;
+	}
+
+	@Override
+	public boolean isSprint()
+	{
+		return this.sprint;
+	}
+
+}

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
@@ -183,6 +183,8 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	private int expCooldown = 0;
 	private int deathScreenScore = 0;
 	private int playerListOrder = 0;
+	private @Nullable String clientBrandName = null;
+	private @NotNull Input currentInput = InputMock.none();
 	private boolean sprinting = false;
 	private boolean allowFlight = false;
 	private boolean flying = false;
@@ -2091,8 +2093,19 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public @NotNull Input getCurrentInput()
 	{
-		//TODO: Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.currentInput;
+	}
+
+	/**
+	 * Sets the input this player is reporting, so a test can drive movement-key handling directly. There is no Bukkit
+	 * setter for this -- on a real server the value arrives from the client.
+	 *
+	 * @param currentInput The input to report from {@link #getCurrentInput()}.
+	 */
+	public void setCurrentInput(@NotNull Input currentInput)
+	{
+		Preconditions.checkArgument(currentInput != null, "Input cannot be null");
+		this.currentInput = currentInput;
 	}
 
 	@Override
@@ -2914,8 +2927,18 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public @Nullable String getClientBrandName()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.clientBrandName;
+	}
+
+	/**
+	 * Sets the brand name this player's client reports, so a test can stand in for a modded or non-vanilla client.
+	 * There is no Bukkit setter for this -- on a real server the value arrives over the brand plugin channel.
+	 *
+	 * @param clientBrandName The brand to report, or null for a client that has not sent one.
+	 */
+	public void setClientBrandName(@Nullable String clientBrandName)
+	{
+		this.clientBrandName = clientBrandName;
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/InputMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/InputMockTest.java
@@ -38,17 +38,21 @@ class InputMockTest
 	}
 
 	@Test
-	void builderPressesOnlyTheNamedKeys()
+	void eachShorthandPressesOnlyItsOwnKey()
 	{
-		InputMock input = InputMock.builder().forward().right().build();
+		assertEquals(new InputMock(true, false, false, false, false, false, false), InputMock.builder().forward().build());
+		assertEquals(new InputMock(false, true, false, false, false, false, false), InputMock.builder().backward().build());
+		assertEquals(new InputMock(false, false, true, false, false, false, false), InputMock.builder().left().build());
+		assertEquals(new InputMock(false, false, false, true, false, false, false), InputMock.builder().right().build());
+		assertEquals(new InputMock(false, false, false, false, true, false, false), InputMock.builder().jump().build());
+		assertEquals(new InputMock(false, false, false, false, false, true, false), InputMock.builder().sneak().build());
+		assertEquals(new InputMock(false, false, false, false, false, false, true), InputMock.builder().sprint().build());
+	}
 
-		assertTrue(input.isForward());
-		assertTrue(input.isRight());
-		assertFalse(input.isBackward());
-		assertFalse(input.isLeft());
-		assertFalse(input.isJump());
-		assertFalse(input.isSneak());
-		assertFalse(input.isSprint());
+	@Test
+	void shorthandsChain()
+	{
+		assertEquals(new InputMock(true, false, false, true, false, false, false), InputMock.builder().forward().right().build());
 	}
 
 	@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/InputMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/InputMockTest.java
@@ -2,6 +2,7 @@ package org.mockbukkit.mockbukkit.entity;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -34,6 +35,42 @@ class InputMockTest
 		assertFalse(input.isJump());
 		assertFalse(input.isSneak());
 		assertFalse(input.isSprint());
+	}
+
+	@Test
+	void builderPressesOnlyTheNamedKeys()
+	{
+		InputMock input = InputMock.builder().forward().right().build();
+
+		assertTrue(input.isForward());
+		assertTrue(input.isRight());
+		assertFalse(input.isBackward());
+		assertFalse(input.isLeft());
+		assertFalse(input.isJump());
+		assertFalse(input.isSneak());
+		assertFalse(input.isSprint());
+	}
+
+	@Test
+	void builderTakesExplicitValues()
+	{
+		InputMock input = InputMock.builder()
+				.forward(true)
+				.backward(false)
+				.left(true)
+				.right(false)
+				.jump(true)
+				.sneak(false)
+				.sprint(true)
+				.build();
+
+		assertEquals(new InputMock(true, false, true, false, true, false, true), input);
+	}
+
+	@Test
+	void builderDefaultsToNothingPressed()
+	{
+		assertEquals(InputMock.none(), InputMock.builder().build());
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/InputMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/InputMockTest.java
@@ -1,0 +1,39 @@
+package org.mockbukkit.mockbukkit.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class InputMockTest
+{
+
+	@Test
+	void accessorsReflectTheConstructorArguments()
+	{
+		InputMock input = new InputMock(true, false, true, false, true, false, true);
+
+		assertTrue(input.isForward());
+		assertFalse(input.isBackward());
+		assertTrue(input.isLeft());
+		assertFalse(input.isRight());
+		assertTrue(input.isJump());
+		assertFalse(input.isSneak());
+		assertTrue(input.isSprint());
+	}
+
+	@Test
+	void noneHasNothingPressed()
+	{
+		InputMock input = InputMock.none();
+
+		assertFalse(input.isForward());
+		assertFalse(input.isBackward());
+		assertFalse(input.isLeft());
+		assertFalse(input.isRight());
+		assertFalse(input.isJump());
+		assertFalse(input.isSneak());
+		assertFalse(input.isSprint());
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
@@ -13,6 +13,7 @@ import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.Input;
 import org.bukkit.BanEntry;
 import org.bukkit.Bukkit;
 import org.bukkit.DyeColor;
@@ -3366,6 +3367,53 @@ class PlayerMockTest
 			assertEquals(value, player.getAffectsSpawning());
 		}
 
+	}
+
+
+	@Test
+	void getClientBrandName_DefaultsToNull()
+	{
+		assertNull(player.getClientBrandName());
+	}
+
+	@Test
+	void setClientBrandName_IsRetained()
+	{
+		player.setClientBrandName("vanilla");
+		assertEquals("vanilla", player.getClientBrandName());
+
+		player.setClientBrandName(null);
+		assertNull(player.getClientBrandName());
+	}
+
+	@Test
+	void getCurrentInput_DefaultsToNothingPressed()
+	{
+		Input input = player.getCurrentInput();
+
+		assertFalse(input.isForward());
+		assertFalse(input.isBackward());
+		assertFalse(input.isLeft());
+		assertFalse(input.isRight());
+		assertFalse(input.isJump());
+		assertFalse(input.isSneak());
+		assertFalse(input.isSprint());
+	}
+
+	@Test
+	void setCurrentInput_IsRetained()
+	{
+		Input input = new InputMock(true, false, true, false, true, false, true);
+
+		player.setCurrentInput(input);
+
+		assertSame(input, player.getCurrentInput());
+	}
+
+	@Test
+	void setCurrentInput_Null()
+	{
+		assertThrows(IllegalArgumentException.class, () -> player.setCurrentInput(null));
 	}
 
 }


### PR DESCRIPTION
`PlayerMock#getClientBrandName` and `getCurrentInput` were both unimplemented, so anything that reacts to what the client is or what it is pressing could not be tested.

```java
player.getClientBrandName();   // org.mockbukkit.mockbukkit.exception.UnimplementedOperationException
player.getCurrentInput();      // same
```

Worth noting how that presents: `UnimplementedOperationException` extends `TestAbortedException`, so the test is reported as **skipped** rather than failed and the build stays green. Nothing tells you the test stopped running.

### Why there are setters

Neither value has a Bukkit setter, and both are things the *client* tells the server: the brand arrives over the `minecraft:brand` plugin channel after login, and the input is sent as the player presses keys. There is no server-side call that sets either.

That leaves a test with no way to arrange the state it wants to exercise, so each gets a MockBukkit-specific `setClientBrandName` / `setCurrentInput`, documented as standing in for what the client would have sent.

### Why InputMock exists

`org.bukkit.Input` is an interface with seven accessors and no implementation anywhere in the API — nothing to hand to `setCurrentInput`. `InputMock` is a record implementing it, plus `InputMock.none()` for the common case of a player standing still, which is also what `getCurrentInput` returns by default.

### Tests

Seven: the brand defaults to null and round trips including back to null, the input defaults to nothing pressed, a set input is returned as given, null is rejected, and `InputMock` reports each of its seven keys independently plus the `none()` shorthand.

Full suite green: 20614 tests, 0 failures. 16 added lines, 0 uncovered, checkstyle clean.
