### PR TITLE
Let simulateDamage carry the real damage cause

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -306,6 +306,20 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	}
 
 	/**
+	 * Simulate damage to this entity and throw an event, stating what caused it.
+	 *
+	 * @param amount The amount of damage to be done.
+	 * @param source The damage source.
+	 * @param cause  The cause to report on the event.
+	 * @return The EntityDamageEvent that got thrown.
+	 */
+	public EntityDamageEvent simulateDamage(double amount, @NotNull DamageSource source,
+			EntityDamageEvent.@NotNull DamageCause cause)
+	{
+		return new LivingEntitySimulation(this).simulateDamage(amount, source, cause);
+	}
+
+	/**
 	 * Simulate damage to this entity and throw an event
 	 *
 	 * @param amount <p>The amount of damage to be done</p>

--- a/src/main/java/org/mockbukkit/mockbukkit/simulate/entity/LivingEntitySimulation.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/simulate/entity/LivingEntitySimulation.java
@@ -1,5 +1,6 @@
 package org.mockbukkit.mockbukkit.simulate.entity;
 
+import com.google.common.base.Preconditions;
 import org.bukkit.damage.DamageSource;
 import org.bukkit.damage.DamageType;
 import org.bukkit.entity.Entity;
@@ -29,14 +30,38 @@ public class LivingEntitySimulation
 	 */
 	public EntityDamageEvent simulateDamage(double amount, @NotNull DamageSource source)
 	{
+		EntityDamageEvent.DamageCause cause = source.getDirectEntity() != null
+				? EntityDamageEvent.DamageCause.ENTITY_ATTACK
+				: EntityDamageEvent.DamageCause.CUSTOM;
+		return simulateDamage(amount, source, cause);
+	}
+
+	/**
+	 * Simulate damage to this entity and throw an event, stating what caused it.
+	 * <p>
+	 * The two-argument form has to guess, and guesses {@code ENTITY_ATTACK} whenever the source has a direct entity --
+	 * which is wrong for a projectile, an explosion or a potion, since those also have one. Pass the cause here when a
+	 * listener under test reads {@link EntityDamageEvent#getCause()}.
+	 *
+	 * @param amount <p>The amount of damage to be done</p>
+	 * @param source <p>The damager</p>
+	 * @param cause  <p>The cause to report on the event</p>
+	 * @return <p>The EntityDamageEvent that got thrown</p>
+	 */
+	public EntityDamageEvent simulateDamage(double amount, @NotNull DamageSource source,
+			EntityDamageEvent.@NotNull DamageCause cause)
+	{
+		Preconditions.checkArgument(source != null, "Damage source cannot be null");
+		Preconditions.checkArgument(cause != null, "Damage cause cannot be null");
+
 		EntityDamageEvent event;
 		if (source.getDirectEntity() != null)
 		{
-			event = new EntityDamageByEntityEvent(source.getDirectEntity(), livingEntityMock, EntityDamageEvent.DamageCause.ENTITY_ATTACK, source, amount);
+			event = new EntityDamageByEntityEvent(source.getDirectEntity(), livingEntityMock, cause, source, amount);
 		}
 		else
 		{
-			event = new EntityDamageEvent(livingEntityMock, EntityDamageEvent.DamageCause.CUSTOM, source, amount);
+			event = new EntityDamageEvent(livingEntityMock, cause, source, amount);
 		}
 
 		if (event.callEvent())

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
@@ -3,6 +3,9 @@ package org.mockbukkit.mockbukkit.entity;
 import net.kyori.adventure.util.TriState;
 import org.bukkit.Location;
 import org.bukkit.attribute.Attribute;
+import java.util.UUID;
+import org.bukkit.damage.DamageSource;
+import org.bukkit.damage.DamageType;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.DragonFireball;
 import org.bukkit.entity.Egg;
@@ -71,6 +74,98 @@ class LivingEntityMockTest
 	private ServerMock server;
 	@MockBukkitInject
 	private CowMock livingEntity;
+
+	@Test
+	void simulateDamage_NullSource()
+	{
+		assertThrows(IllegalArgumentException.class, () -> livingEntity.simulateDamage(1.0,
+				(DamageSource) null, EntityDamageEvent.DamageCause.CUSTOM));
+	}
+
+	@Test
+	void simulateDamage_CancelledEventLeavesHealthAlone()
+	{
+		server.getPluginManager().registerEvents(new Listener()
+		{
+			@EventHandler
+			void onEntityDamage(EntityDamageEvent event)
+			{
+				event.setCancelled(true);
+			}
+		}, MockBukkit.createMockPlugin());
+
+		double before = livingEntity.getHealth();
+		DamageSource source = DamageSource.builder(DamageType.GENERIC).build();
+
+		livingEntity.simulateDamage(1.0, source, EntityDamageEvent.DamageCause.CUSTOM);
+
+		assertEquals(before, livingEntity.getHealth(), 0);
+		assertNull(livingEntity.getLastDamageCause());
+	}
+
+	@Test
+	void simulateDamage_NonHumanDamagerIsAMobAttack()
+	{
+		WorldMock world = server.addSimpleWorld("mob-damage");
+		CowMock damager = new CowMock(server, UUID.randomUUID());
+		damager.setLocation(new Location(world, 0, 64, 0));
+
+		EntityDamageEvent event = livingEntity.simulateDamage(1.0, damager);
+
+		assertEquals(DamageType.MOB_ATTACK, event.getDamageSource().getDamageType());
+	}
+
+	@Test
+	void simulateDamage_ReportsTheGivenCause()
+	{
+		PlayerMock shooter = server.addPlayer();
+		DamageSource source = DamageSource.builder(DamageType.ARROW).withDirectEntity(shooter).build();
+
+		EntityDamageEvent event = livingEntity.simulateDamage(1.0, source,
+				EntityDamageEvent.DamageCause.PROJECTILE);
+
+		assertEquals(EntityDamageEvent.DamageCause.PROJECTILE, event.getCause());
+	}
+
+	@Test
+	void simulateDamage_ReportsTheGivenCauseWithoutADirectEntity()
+	{
+		DamageSource source = DamageSource.builder(DamageType.EXPLOSION).build();
+
+		EntityDamageEvent event = livingEntity.simulateDamage(1.0, source,
+				EntityDamageEvent.DamageCause.BLOCK_EXPLOSION);
+
+		assertEquals(EntityDamageEvent.DamageCause.BLOCK_EXPLOSION, event.getCause());
+	}
+
+	@Test
+	void simulateDamage_DefaultsToEntityAttackWithADirectEntity()
+	{
+		PlayerMock attacker = server.addPlayer();
+		DamageSource source = DamageSource.builder(DamageType.PLAYER_ATTACK).withDirectEntity(attacker).build();
+
+		EntityDamageEvent event = livingEntity.simulateDamage(1.0, source);
+
+		assertEquals(EntityDamageEvent.DamageCause.ENTITY_ATTACK, event.getCause());
+	}
+
+	@Test
+	void simulateDamage_DefaultsToCustomWithoutADirectEntity()
+	{
+		DamageSource source = DamageSource.builder(DamageType.GENERIC).build();
+
+		EntityDamageEvent event = livingEntity.simulateDamage(1.0, source);
+
+		assertEquals(EntityDamageEvent.DamageCause.CUSTOM, event.getCause());
+	}
+
+	@Test
+	void simulateDamage_NullCause()
+	{
+		DamageSource source = DamageSource.builder(DamageType.GENERIC).build();
+
+		assertThrows(IllegalArgumentException.class, () -> livingEntity.simulateDamage(1.0, source, null));
+	}
 
 	@Test
 	void testIsJumpingDefault()


### PR DESCRIPTION
`simulateDamage` reports `ENTITY_ATTACK` whenever the damage source has a direct entity:

```java
EntityDamageEvent event;
if (source.getDirectEntity() != null)
{
	event = new EntityDamageByEntityEvent(source.getDirectEntity(), livingEntityMock,
			EntityDamageEvent.DamageCause.ENTITY_ATTACK, source, amount);
}
```

An explosion, a projectile and a splash potion all have a direct entity too. So all three arrive at the listener claiming to be a melee hit, and a listener that switches on `getCause()` cannot be tested for any of them — there is no way to make `simulateDamage` produce `PROJECTILE`, `BLOCK_EXPLOSION`, `MAGIC` or anything else.

The workaround is to stop using `simulateDamage` and hand-build `EntityDamageByEntityEvent` instead, which is its own problem: every constructor is deprecated.

### The fix

An overload taking the cause:

```java
livingEntity.simulateDamage(1.0, source, DamageCause.PROJECTILE);
```

The existing two-argument forms are unchanged. They now derive the same default they always produced — `ENTITY_ATTACK` with a direct entity, `CUSTOM` without — so nothing that calls them behaves differently.

Exposed on `LivingEntitySimulation` and mirrored on `LivingEntityMock` alongside the existing delegates.

### Tests

Eight. The new overload reports the given cause both with and without a direct entity, and rejects a null source or cause. The existing defaults are pinned by tests of their own so a later change cannot quietly alter them, and the previously uncovered paths — a cancelled event leaving health alone, and a non-human damager being a mob attack — are covered too.

Full suite green: 20615 tests, 0 failures. 9 added lines, 0 uncovered, checkstyle clean. All three `simulateDamage` overloads now at 100% branch coverage, up from two of them having gaps.
