### PR TITLE
Record Adventure titles instead of silently dropping them

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
@@ -2516,8 +2516,22 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public void resetTitle()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		clearTitle();
+	}
+
+	@Override
+	public void clearTitle()
+	{
+		this.title.clear();
+		this.subitles.clear();
+	}
+
+	@Override
+	public void showTitle(net.kyori.adventure.title.@NotNull Title title)
+	{
+		Preconditions.checkArgument(title != null, "Title cannot be null");
+		this.title.add(LegacyComponentSerializer.legacySection().serialize(title.title()));
+		this.subitles.add(LegacyComponentSerializer.legacySection().serialize(title.subtitle()));
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
@@ -161,6 +161,47 @@ class PlayerMockTest
 	private UUID uuid;
 	private PlayerMock player;
 
+	@Test
+	void showTitle_AdventureTitleIsRecorded()
+	{
+		player.showTitle(net.kyori.adventure.title.Title.title(
+				Component.text("Victory"), Component.text("well played")));
+
+		assertEquals("Victory", player.nextTitle());
+		assertEquals("well played", player.nextSubTitle());
+	}
+
+	@Test
+	void showTitle_Null()
+	{
+		assertThrows(IllegalArgumentException.class,
+				() -> player.showTitle((net.kyori.adventure.title.Title) null));
+	}
+
+	@Test
+	void clearTitle_DropsPendingTitles()
+	{
+		player.showTitle(net.kyori.adventure.title.Title.title(
+				Component.text("Gone"), Component.text("also gone")));
+
+		player.clearTitle();
+
+		assertNull(player.nextTitle());
+		assertNull(player.nextSubTitle());
+	}
+
+	@Test
+	void resetTitle_DropsPendingTitles()
+	{
+		player.showTitle(net.kyori.adventure.title.Title.title(
+				Component.text("Gone"), Component.text("also gone")));
+
+		player.resetTitle();
+
+		assertNull(player.nextTitle());
+		assertNull(player.nextSubTitle());
+	}
+
 	@BeforeEach
 	void setUp()
 	{


### PR DESCRIPTION
A modern `showTitle` on `PlayerMock` does nothing at all.

```java
player.showTitle(Title.title(Component.text("Victory"), Component.text("well played")));

assertEquals("Victory", player.nextTitle());   // null
```

No exception, no skip — the call simply has no effect. `PlayerMock` overrides only the deprecated `BaseComponent` overloads and Paper's own `Title` ones, so an Adventure `showTitle(Title)` falls through to the `Audience` default and is discarded.

That is a worse failure mode than an unimplemented stub. A stub at least aborts the test; this looks like it worked. Any assertion about the title quietly passes on nothing, and a plugin sending titles the way plugins actually send them today has no way to test that it did.

### The fix

Route it into the same queue the legacy `sendTitle(String, String)` already fills, so `nextTitle` and `nextSubTitle` work whichever API the plugin used and there is one place to look rather than two.

`resetTitle` was an unimplemented stub and now clears that queue, as does `clearTitle` — which was also falling through to the `Audience` default and doing nothing.

### Tests

Four: an Adventure title is recorded and readable through the existing accessors, a null title is rejected, and both `clearTitle` and `resetTitle` drop what is pending.

Full suite green: 20611 tests, 0 failures. 8 added lines, 0 uncovered, checkstyle clean.

### Left alone

The four deprecated `BaseComponent` `showTitle` overloads are still stubs. They are not on any path a current plugin would take, and implementing them means deciding how to fold Bungee components into the same queue — worth doing separately if you want it at all.
