### PR TITLE
Implement chunk force-loading and async chunk access

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
@@ -133,6 +133,7 @@ public class WorldMock implements World
 	private final Map<String, Object> gameRules = new HashMap<>();
 	private final MetadataTable metadataTable = new MetadataTable();
 	private final Map<ChunkCoordinate, ChunkMock> loadedChunks = new HashMap<>();
+	private final Set<Long> forceLoadedChunks = new HashSet<>();
 	private final Map<ChunkCoordinate, ChunkMock> savedChunks = new HashMap<>();
 	private final PersistentDataContainer persistentDataContainer = new PersistentDataContainerMock();
 	private final @Nullable ServerMock server;
@@ -1082,8 +1083,8 @@ public class WorldMock implements World
 	@Override
 	public void getChunkAtAsync(int x, int z, boolean gen, boolean urgent, @NotNull Consumer<? super Chunk> cb)
 	{
-		//TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkNotNull(cb, "Callback cannot be null");
+		cb.accept(getChunkAt(x, z));
 	}
 
 	@Override
@@ -1104,8 +1105,7 @@ public class WorldMock implements World
 	@Override
 	public @NotNull CompletableFuture<Chunk> getChunkAtAsync(int x, int z, boolean gen, boolean urgent)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return CompletableFuture.completedFuture(getChunkAt(x, z));
 	}
 
 	@Override
@@ -2249,22 +2249,36 @@ public class WorldMock implements World
 	@Override
 	public boolean isChunkForceLoaded(int x, int z)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.forceLoadedChunks.contains(chunkKey(x, z));
 	}
 
 	@Override
 	public void setChunkForceLoaded(int x, int z, boolean forced)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		if (forced)
+		{
+			this.forceLoadedChunks.add(chunkKey(x, z));
+		}
+		else
+		{
+			this.forceLoadedChunks.remove(chunkKey(x, z));
+		}
 	}
 
 	@Override
 	public @NotNull Collection<Chunk> getForceLoadedChunks()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Set<Chunk> chunks = new HashSet<>();
+		for (long key : this.forceLoadedChunks)
+		{
+			chunks.add(getChunkAt((int) key, (int) (key >> 32)));
+		}
+		return chunks;
+	}
+
+	private static Long chunkKey(int x, int z)
+	{
+		return ((long) z << 32) | (x & 0xFFFFFFFFL);
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
@@ -15,6 +15,8 @@ import org.bukkit.Effect;
 import org.bukkit.GameRule;
 import org.bukkit.GameRules;
 import org.bukkit.HeightMap;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Particle;
@@ -236,6 +238,100 @@ class WorldMockTest
 
 	@MockBukkitInject
 	private ServerMock server;
+
+	@Test
+	void isChunkForceLoaded_DefaultsToFalse()
+	{
+		WorldMock world = server.addSimpleWorld("force-default");
+
+		assertFalse(world.isChunkForceLoaded(0, 0));
+	}
+
+	@Test
+	void setChunkForceLoaded_TogglesInBothDirections()
+	{
+		WorldMock world = server.addSimpleWorld("force-toggle");
+
+		world.setChunkForceLoaded(3, 7, true);
+		assertTrue(world.isChunkForceLoaded(3, 7));
+
+		world.setChunkForceLoaded(3, 7, false);
+		assertFalse(world.isChunkForceLoaded(3, 7));
+	}
+
+	@Test
+	void setChunkForceLoaded_KeepsCoordinatesDistinct()
+	{
+		WorldMock world = server.addSimpleWorld("force-distinct");
+
+		world.setChunkForceLoaded(3, 7, true);
+
+		assertFalse(world.isChunkForceLoaded(7, 3));
+	}
+
+	@Test
+	void setChunkForceLoaded_HandlesNegativeCoordinates()
+	{
+		WorldMock world = server.addSimpleWorld("force-negative");
+
+		world.setChunkForceLoaded(-4, -9, true);
+
+		assertTrue(world.isChunkForceLoaded(-4, -9));
+		assertFalse(world.isChunkForceLoaded(4, 9));
+	}
+
+	@Test
+	void getForceLoadedChunks_DefaultsToEmpty()
+	{
+		WorldMock world = server.addSimpleWorld("force-empty");
+
+		assertTrue(world.getForceLoadedChunks().isEmpty());
+	}
+
+	@Test
+	void getForceLoadedChunks_ReturnsTheForcedChunks()
+	{
+		WorldMock world = server.addSimpleWorld("force-listed");
+		world.setChunkForceLoaded(2, -5, true);
+
+		Collection<Chunk> forced = world.getForceLoadedChunks();
+
+		assertEquals(1, forced.size());
+		Chunk chunk = forced.iterator().next();
+		assertEquals(2, chunk.getX());
+		assertEquals(-5, chunk.getZ());
+	}
+
+	@Test
+	void getChunkAtAsync_CallbackReceivesTheChunk()
+	{
+		WorldMock world = server.addSimpleWorld("async-callback");
+		List<Chunk> received = new ArrayList<>();
+
+		world.getChunkAtAsync(1, 2, true, false, received::add);
+
+		assertEquals(1, received.size());
+		assertEquals(world.getChunkAt(1, 2), received.get(0));
+	}
+
+	@Test
+	void getChunkAtAsync_NullCallback()
+	{
+		WorldMock world = server.addSimpleWorld("async-null");
+
+		assertThrows(NullPointerException.class, () -> world.getChunkAtAsync(0, 0, true, false, null));
+	}
+
+	@Test
+	void getChunkAtAsync_FutureIsAlreadyComplete()
+	{
+		WorldMock world = server.addSimpleWorld("async-future");
+
+		CompletableFuture<Chunk> future = world.getChunkAtAsync(4, 5, true, false);
+
+		assertTrue(future.isDone());
+		assertEquals(world.getChunkAt(4, 5), future.getNow(null));
+	}
 
 	@Test
 	void getBlockAt_StandardWorld_DefaultBlocks()


### PR DESCRIPTION
Five `WorldMock` methods around chunk loading were unimplemented, so anything that keeps chunks loaded or fetches them asynchronously could not be tested.

```java
world.setChunkForceLoaded(3, 7, true);       // org.mockbukkit.mockbukkit.exception.UnimplementedOperationException
world.getChunkAtAsync(1, 2, callback);       // same
```

Worth noting how that presents: `UnimplementedOperationException` extends `TestAbortedException`, so the test is reported as **skipped** rather than failed and the build stays green. Nothing tells you the test stopped running.

### Force loading

`isChunkForceLoaded`, `setChunkForceLoaded` and `getForceLoadedChunks` track forced chunks by a **packed coordinate key** — `((long) z << 32) | (x & 0xFFFFFFFFL)`.

That detail matters more than it looks. Chunk coordinates are routinely negative, and the obvious shortcuts get it wrong: `x * 31 + z` collides, and anything sign-extending the low half makes `(-1, 0)` and `(-1, -1)` the same chunk. Masking the low 32 bits keeps every quadrant distinct, and there is a test pinning both the negative case and the fact that `(3, 7)` and `(7, 3)` are different chunks.

### Async chunk access

Both `getChunkAtAsync` overloads **resolve immediately**, because the mock loads chunks synchronously — there is nothing to wait for. One delivers through the callback before returning, the other hands back an already-completed future.

That is worth stating rather than leaving implicit: a test can assert on the result on the very next line without ticking the scheduler or awaiting anything, and code written against the async API behaves the same under test as the synchronous path.

### Tests

Nine: the force-loaded default, toggling in both directions, coordinates staying distinct, negative coordinates, the empty and populated forms of `getForceLoadedChunks`, the callback receiving the chunk, a null callback being rejected, and the future already being done.

Full suite green: 20616 tests, 0 failures. 14 added lines, 0 uncovered, checkstyle clean.

### Left alone

`getChunksAtAsync` (the region form) and `ChunkMock#getTileEntities` are still stubs — the latter is a separate pull request, since it needs a decision about how much of the chunk to scan.
