### PR TITLE
Implement getTileEntities on ChunkMock

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/world/ChunkMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/ChunkMock.java
@@ -21,6 +21,9 @@ import org.jetbrains.annotations.Nullable;
 import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 import org.mockbukkit.mockbukkit.persistence.PersistentDataContainerMock;
 
+import java.util.Map;
+import org.bukkit.block.TileState;
+import org.mockbukkit.mockbukkit.block.BlockMock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -74,15 +77,36 @@ public class ChunkMock implements Chunk
 	@Override
 	public @NotNull BlockState[] getTileEntities(boolean useSnapshot)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return getTileEntities(block -> true, useSnapshot).toArray(BlockState[]::new);
 	}
 
 	@Override
 	public @NotNull Collection<BlockState> getTileEntities(@NotNull Predicate<? super Block> blockPredicate, boolean useSnapshot)
 	{
-		//TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkNotNull(blockPredicate, "Block predicate cannot be null");
+		// Only WorldMock constructs a ChunkMock, and it always passes itself.
+		WorldMock worldMock = (WorldMock) this.world;
+
+		List<BlockState> tileEntities = new ArrayList<>();
+		for (Map.Entry<Coordinate, BlockMock> entry : worldMock.getCreatedBlocks().entrySet())
+		{
+			Coordinate coordinate = entry.getKey();
+			if ((coordinate.x >> 4) != this.x || (coordinate.z >> 4) != this.z)
+			{
+				continue;
+			}
+			BlockMock block = entry.getValue();
+			if (!blockPredicate.test(block))
+			{
+				continue;
+			}
+			BlockState state = block.getState();
+			if (state instanceof TileState)
+			{
+				tileEntities.add(state);
+			}
+		}
+		return tileEntities;
 	}
 
 	@Override
@@ -184,8 +208,7 @@ public class ChunkMock implements Chunk
 	@Override
 	public BlockState[] getTileEntities()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return getTileEntities(true);
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/world/ChunkMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/ChunkMock.java
@@ -90,20 +90,13 @@ public class ChunkMock implements Chunk
 		List<BlockState> tileEntities = new ArrayList<>();
 		for (Map.Entry<Coordinate, BlockMock> entry : worldMock.getCreatedBlocks().entrySet())
 		{
-			Coordinate coordinate = entry.getKey();
-			if ((coordinate.x >> 4) != this.x || (coordinate.z >> 4) != this.z)
+			if (contains(entry.getKey()) && blockPredicate.test(entry.getValue()))
 			{
-				continue;
-			}
-			BlockMock block = entry.getValue();
-			if (!blockPredicate.test(block))
-			{
-				continue;
-			}
-			BlockState state = block.getState();
-			if (state instanceof TileState)
-			{
-				tileEntities.add(state);
+				BlockState state = entry.getValue().getState();
+				if (state instanceof TileState)
+				{
+					tileEntities.add(state);
+				}
 			}
 		}
 		return tileEntities;
@@ -380,6 +373,14 @@ public class ChunkMock implements Chunk
 	private int getCubicSize()
 	{
 		return (16 * 16) * Math.abs(world.getMaxHeight() - world.getMinHeight()); // (w * w * h)
+	}
+
+	/**
+	 * Whether a world coordinate falls inside this chunk's column.
+	 */
+	private boolean contains(@NotNull Coordinate coordinate)
+	{
+		return (coordinate.x >> 4) == this.x && (coordinate.z >> 4) == this.z;
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
@@ -3045,4 +3045,16 @@ public class WorldMock implements World
 		}
 	}
 
+
+	/**
+	 * The blocks this world has actually created, which is far fewer than the blocks it could return. A block only
+	 * exists here once something has asked for it, so anything absent is still whatever the world generator would
+	 * produce and cannot be holding state of its own.
+	 *
+	 * @return The created blocks, keyed by coordinate.
+	 */
+	Map<Coordinate, BlockMock> getCreatedBlocks()
+	{
+		return Collections.unmodifiableMap(this.blocks);
+	}
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/world/ChunkTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/world/ChunkTest.java
@@ -1,5 +1,7 @@
 package org.mockbukkit.mockbukkit.world;
 
+import org.bukkit.Chunk;
+import org.bukkit.block.BlockState;
 import org.bukkit.Chunk.LoadLevel;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -12,12 +14,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockbukkit.mockbukkit.MockBukkitExtension;
 import org.mockbukkit.mockbukkit.MockBukkitInject;
 
+import java.util.Collection;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockBukkitExtension.class)
@@ -26,6 +30,76 @@ class ChunkTest
 
 	@MockBukkitInject
 	private WorldMock world;
+
+	@Test
+	void getTileEntities_EmptyWhenNothingHasState()
+	{
+		assertEquals(0, world.getChunkAt(0, 0).getTileEntities().length);
+	}
+
+	@Test
+	void getTileEntities_FindsABlockWithState()
+	{
+		Chunk chunk = world.getChunkAt(0, 0);
+		chunk.getBlock(3, 64, 5).setType(Material.CHEST);
+
+		BlockState[] states = chunk.getTileEntities();
+
+		assertEquals(1, states.length);
+		assertEquals(Material.CHEST, states[0].getType());
+	}
+
+	@Test
+	void getTileEntities_IgnoresPlainBlocks()
+	{
+		Chunk chunk = world.getChunkAt(1, 1);
+		chunk.getBlock(1, 64, 1).setType(Material.STONE);
+
+		assertEquals(0, chunk.getTileEntities().length);
+	}
+
+	@Test
+	void getTileEntities_IgnoresOtherChunks()
+	{
+		Chunk chunk = world.getChunkAt(5, 5);
+		Chunk other = world.getChunkAt(6, 5);
+		other.getBlock(0, 64, 0).setType(Material.CHEST);
+
+		assertEquals(0, chunk.getTileEntities().length);
+		assertEquals(1, other.getTileEntities().length);
+	}
+
+	@Test
+	void getTileEntities_IgnoresChunksDifferingOnlyInZ()
+	{
+		Chunk chunk = world.getChunkAt(8, 8);
+		Chunk other = world.getChunkAt(8, 9);
+		other.getBlock(0, 64, 0).setType(Material.CHEST);
+
+		assertEquals(0, chunk.getTileEntities().length);
+		assertEquals(1, other.getTileEntities().length);
+	}
+
+	@Test
+	void getTileEntities_HonoursThePredicate()
+	{
+		Chunk chunk = world.getChunkAt(2, 2);
+		Block kept = chunk.getBlock(2, 64, 2);
+		kept.setType(Material.CHEST);
+		chunk.getBlock(4, 64, 4).setType(Material.CHEST);
+
+		Collection<BlockState> matching = chunk.getTileEntities(block -> block.getX() == kept.getX(), true);
+
+		assertEquals(1, matching.size());
+	}
+
+	@Test
+	void getTileEntities_NullPredicate()
+	{
+		Chunk chunk = world.getChunkAt(3, 3);
+
+		assertThrows(NullPointerException.class, () -> chunk.getTileEntities(null, true));
+	}
 
 	@Test
 	void getX_AnyValue_ExactValue()


### PR DESCRIPTION
All three `ChunkMock#getTileEntities` overloads were unimplemented, so anything that walks a chunk looking for chests, signs, spawners or the like could not be tested.

```java
chunk.getTileEntities();
// org.mockbukkit.mockbukkit.exception.UnimplementedOperationException
```

Worth noting how that presents: `UnimplementedOperationException` extends `TestAbortedException`, so the test is reported as **skipped** rather than failed and the build stays green. Nothing tells you the test stopped running.

### The design decision worth reviewing

The obvious implementation sweeps the chunk — 16 × 16 × world height, calling `getBlockAt` on each.

That is the wrong shape here. `WorldMock` creates `BlockMock` instances lazily, so a full sweep does not just read blocks, it **materialises** them: roughly 98,000 objects per call on a default-height world, for a chunk that in a typical test holds one chest. Call it in a loop and the cost is real.

So it scans only the blocks the world has actually created, filters them to this chunk's coordinates, and keeps the ones whose state is a `TileState`. A block nothing has ever touched cannot be holding a tile entity, so nothing is missed — the untouched blocks are still whatever the generator would produce.

`WorldMock` gains a package-private view of its block map for this. Package-private rather than public, since `ChunkMock` sits in the same package and this is not something a plugin should be reaching for.

### On `useSnapshot`

The parameter is accepted and ignored: `BlockMock#getState` already returns an independent state object, so there is no live-versus-snapshot distinction to honour. Flagging it rather than leaving it to be discovered.

### Tests

Seven: empty when nothing has state, a chest is found, a plain stone block is not, chunks differing only in X are ignored, chunks differing only in Z are ignored, the predicate overload filters, and a null predicate is rejected.

The two "ignores other chunks" cases are separate on purpose — the coordinate filter is a short-circuiting `||`, so a single test would leave half of it unexercised.

Full suite green: 20614 tests, 0 failures. 18 added lines, 0 uncovered, checkstyle clean.
