### PR TITLE
fix(classloader): Make class based plugin loading work without Unsafe

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,6 +96,10 @@ tasks {
 	test {
 		dependsOn(project(":extra:TestPlugin").tasks.jar)
 		useJUnitPlatform()
+		// Byte Buddy refuses to use sun.misc.Unsafe as of Java 26, which disables the class loading strategies
+		// that reflect into ClassLoader. Opting into that behaviour on older JDKs keeps the plugin loading code
+		// paths honest no matter which JDK the tests are run on. See issue #1628.
+		systemProperty("net.bytebuddy.safe", "true")
 	}
 
 	check {

--- a/src/main/java/org/mockbukkit/mockbukkit/plugin/MockBukkitConfiguredPluginClassLoader.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/plugin/MockBukkitConfiguredPluginClassLoader.java
@@ -1,11 +1,11 @@
 package org.mockbukkit.mockbukkit.plugin;
 
 import com.destroystokyo.paper.utils.PaperPluginLogger;
-import com.google.common.base.Preconditions;
 import io.papermc.paper.plugin.configuration.PluginMeta;
 import io.papermc.paper.plugin.provider.classloader.ConfiguredPluginClassLoader;
 import io.papermc.paper.plugin.provider.classloader.PluginClassLoaderGroup;
 import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.dynamic.scaffold.subclass.ConstructorStrategy;
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
 
@@ -82,13 +84,22 @@ public class MockBukkitConfiguredPluginClassLoader extends URLClassLoader implem
 	}
 
 	@Override
-	protected Class<?> findClass(String name)
+	protected Class<?> findClass(String name) throws ClassNotFoundException
 	{
-		try
+		// No jar file backs a class-based plugin load (MockBukkit.load(Class)). ByteBuddy probes
+		// findClass as an existence check before defining a class, so honor the ClassLoader.findClass
+		// contract and throw ClassNotFoundException instead of an unchecked NullPointerException.
+		if (jarFile == null)
 		{
-			Preconditions.checkNotNull(jarFile, "No jar file selected");
-			ZipEntry entry = jarFile.getEntry(name.replace('.', '/') + ".class");
-			InputStream inputStream = jarFile.getInputStream(entry);
+			throw new ClassNotFoundException(name);
+		}
+		ZipEntry entry = jarFile.getEntry(name.replace('.', '/') + ".class");
+		if (entry == null)
+		{
+			throw new ClassNotFoundException(name);
+		}
+		try (InputStream inputStream = jarFile.getInputStream(entry))
+		{
 			byte[] array = inputStream.readAllBytes();
 			return defineClass(name, array, 0, array.length);
 		}
@@ -105,8 +116,13 @@ public class MockBukkitConfiguredPluginClassLoader extends URLClassLoader implem
 				.name(target.getSimpleName() + "Proxy")
 				.make();
 		return dynamicType
-				.load(this, ClassLoadingStrategy.Default.INJECTION)
+				.load(this, new DirectDefinitionStrategy())
 				.getLoaded();
+	}
+
+	private Class<?> defineType(@NotNull String name, byte @NotNull [] bytes)
+	{
+		return defineClass(name, bytes, 0, bytes.length);
 	}
 
 	@Override
@@ -133,6 +149,30 @@ public class MockBukkitConfiguredPluginClassLoader extends URLClassLoader implem
 	{
 		// TODO Auto-generated method stub
 		throw new UnimplementedOperationException();
+	}
+
+	/**
+	 * A {@link ClassLoadingStrategy} that defines the generated types directly on the
+	 * {@link MockBukkitConfiguredPluginClassLoader} they are loaded with.
+	 * <p>
+	 * {@link ClassLoadingStrategy.Default#INJECTION} can not be used for this, as it reflects into the internals of
+	 * {@link ClassLoader} through {@code sun.misc.Unsafe}. Byte Buddy disables that access by default as of Java 26,
+	 * which would leave it unable to define the plugin proxy at all.
+	 */
+	private static class DirectDefinitionStrategy implements ClassLoadingStrategy<MockBukkitConfiguredPluginClassLoader>
+	{
+
+		@Override
+		public Map<TypeDescription, Class<?>> load(MockBukkitConfiguredPluginClassLoader classLoader, Map<TypeDescription, byte[]> types)
+		{
+			Map<TypeDescription, Class<?>> loadedTypes = new LinkedHashMap<>();
+			for (Map.Entry<TypeDescription, byte[]> entry : types.entrySet())
+			{
+				loadedTypes.put(entry.getKey(), classLoader.defineType(entry.getKey().getName(), entry.getValue()));
+			}
+			return loadedTypes;
+		}
+
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/plugin/MockBukkitConfiguredPluginClassLoaderTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/plugin/MockBukkitConfiguredPluginClassLoaderTest.java
@@ -1,0 +1,60 @@
+package org.mockbukkit.mockbukkit.plugin;
+
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginDescriptionFile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+import org.mockbukkit.mockbukkit.MockBukkitInject;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockBukkitExtension.class)
+class MockBukkitConfiguredPluginClassLoaderTest
+{
+
+	@MockBukkitInject
+	private ServerMock serverMock;
+	private MockBukkitConfiguredPluginClassLoader classLoader;
+
+	@BeforeEach
+	void setUp()
+	{
+		PluginDescriptionFile description = new PluginDescriptionFile("TestPlugin", "1.0.0", TestPlugin.class.getName());
+		this.classLoader = new MockBukkitConfiguredPluginClassLoader(
+				serverMock,
+				description,
+				new File(serverMock.getPluginsFolder(), "TestPlugin"),
+				new File(serverMock.getPluginsFolder(), "TestPlugin.jar")
+		);
+	}
+
+	@Test
+	void loadClass_notExists_throwsClassNotFoundException()
+	{
+		assertThrows(ClassNotFoundException.class, () -> classLoader.loadClass("invalid.group.id.TestPlugin"));
+	}
+
+	@Test
+	void loadClass_delegatesToParentClassLoader()
+	{
+		assertThrows(ClassNotFoundException.class, () -> classLoader.loadClass("invalid.group.id.TestPlugin", true, true, true));
+	}
+
+	@Test
+	void loadProxyClass_definesProxyOnThisClassLoader()
+	{
+		Class<? extends Plugin> proxy = classLoader.loadProxyClass(TestPlugin.class);
+		assertNotNull(proxy);
+		assertTrue(TestPlugin.class.isAssignableFrom(proxy));
+		assertSame(classLoader, proxy.getClassLoader());
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/plugin/MockBukkitConfiguredPluginClassLoaderTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/plugin/MockBukkitConfiguredPluginClassLoaderTest.java
@@ -2,6 +2,7 @@ package org.mockbukkit.mockbukkit.plugin;
 
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,7 +11,11 @@ import org.mockbukkit.mockbukkit.MockBukkitInject;
 import org.mockbukkit.mockbukkit.ServerMock;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.jar.JarFile;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -20,9 +25,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class MockBukkitConfiguredPluginClassLoaderTest
 {
 
+	private static final File TEST_PLUGIN_FILE = new File("extra/TestPlugin/build/libs/TestPlugin.jar");
+	private static final String TEST_PLUGIN_CLASS = "org.mockbukkit.testplugin.TestPlugin";
+
 	@MockBukkitInject
 	private ServerMock serverMock;
 	private MockBukkitConfiguredPluginClassLoader classLoader;
+	private JarFile jarFile;
 
 	@BeforeEach
 	void setUp()
@@ -36,6 +45,15 @@ class MockBukkitConfiguredPluginClassLoaderTest
 		);
 	}
 
+	@AfterEach
+	void tearDown() throws IOException
+	{
+		if (jarFile != null)
+		{
+			jarFile.close();
+		}
+	}
+
 	@Test
 	void loadClass_notExists_throwsClassNotFoundException()
 	{
@@ -45,7 +63,32 @@ class MockBukkitConfiguredPluginClassLoaderTest
 	@Test
 	void loadClass_delegatesToParentClassLoader()
 	{
-		assertThrows(ClassNotFoundException.class, () -> classLoader.loadClass("invalid.group.id.TestPlugin", true, true, true));
+		assertDoesNotThrow(() -> classLoader.loadClass("org.mockbukkit.mockbukkit.MockBukkit", true, true, true));
+	}
+
+	@Test
+	void findClass_noJarFile_throwsClassNotFoundException()
+	{
+		assertThrows(ClassNotFoundException.class, () -> classLoader.findClass(TEST_PLUGIN_CLASS));
+	}
+
+	@Test
+	void findClass_notContainedInJarFile_throwsClassNotFoundException() throws IOException
+	{
+		this.jarFile = new JarFile(TEST_PLUGIN_FILE);
+		classLoader.setJarFile(jarFile);
+		assertThrows(ClassNotFoundException.class, () -> classLoader.findClass("invalid.group.id.TestPlugin"));
+	}
+
+	@Test
+	void findClass_containedInJarFile() throws IOException
+	{
+		this.jarFile = new JarFile(TEST_PLUGIN_FILE);
+		classLoader.setJarFile(jarFile);
+
+		Class<?> found = assertDoesNotThrow(() -> classLoader.findClass(TEST_PLUGIN_CLASS));
+		assertEquals(TEST_PLUGIN_CLASS, found.getName());
+		assertSame(classLoader, found.getClassLoader());
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #1628

## Problem

`MockBukkit.load(Class)` (and therefore `MockBukkitExtension`) fails with `NullPointerException: No jar file selected` thrown from `MockBukkitConfiguredPluginClassLoader#findClass`.

There are two distinct problems behind this, and fixing only the first one is not enough.

### 1. `findClass` violates the `ClassLoader` contract

`jarFile` is only ever assigned through `setJarFile(JarFile)`, which nothing calls — the jar based loading path uses `MockBukkitURLClassLoader` instead. So on the class based path `jarFile` is always `null`, and `findClass` threw an unchecked `NullPointerException` where callers expect a `ClassNotFoundException`.

Byte Buddy probes `findClass` as an existence check before defining a class, so this aborted plugin loading instead of letting it continue.

### 2. `ClassLoadingStrategy.Default.INJECTION` no longer works on current JVMs

`loadProxyClass` used `ClassLoadingStrategy.Default.INJECTION`, which routes to `ClassInjector.UsingReflection`. Its dispatcher reflects into the internals of `ClassLoader` through `sun.misc.Unsafe`, and Byte Buddy disables that access by default as of Java 26:

```java
// ClassInjector.UsingReflection.Dispatcher.UsingUnsafeInjection#make
if (Boolean.parseBoolean(java.lang.System.getProperty(UsingUnsafe.SAFE_PROPERTY, Boolean.toString(ClassFileVersion
        .ofThisVm()
        .isAtLeast(ClassFileVersion.JAVA_V26) || GraalImageCode.getCurrent().isDefined())))) {
    return new Initializable.Unavailable("As of Java 26, using Unsafe is disabled by default, ...");
}
```

The dispatcher then degrades to `Dispatcher.Initializable.Unavailable`, whose `findClass` is simply `classLoader.loadClass(name)` — the exact frame in the reported stack trace. Its `defineClass` throws `UnsupportedOperationException`, so even with the `ClassNotFoundException` fixed, the proxy could never be defined.

This is why our own test suite does not catch it: CI runs on Java 25, where `sun.misc.Unsafe` is still available.

## Changes

- `findClass` throws `ClassNotFoundException` when no jar file is set or the class is not contained in it, and closes the entry stream it opens.
- `loadProxyClass` defines the generated types directly on the class loader through a small `ClassLoadingStrategy`, so no reflection into `ClassLoader` internals is needed. The proxy still ends up on the `ConfiguredPluginClassLoader`, which `JavaPlugin`'s constructor requires.
- The `test` task sets `-Dnet.bytebuddy.safe=true`, opting into the Java 26 behaviour so these code paths stay covered regardless of which JDK the tests run on.
- New `MockBukkitConfiguredPluginClassLoaderTest`.

## Verification

- With the production change reverted, the new tests fail with exactly the `NullPointerException` from the issue.
- With the change applied, the full suite passes: 21082 tests, 0 failures, 26 skipped, `checkstyleMain` and `checkstyleTest` clean.
