### PR TITLE
chore(build): pin JDK 25 for local development

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=25.0.4-tem

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,14 @@ Contributing Code to MockBukkit
 To get started contributing to MockBukkit, you will need a few things.
 
 - [Git](https://git-scm.com/downloads)
-- [Java 21 or newer](https://adoptium.net/).
+- [Java 25](https://adoptium.net/) — specifically 25, not "25 or newer". The Gradle toolchain
+  pins `java.version=25` and toolchains match on the exact major version, so a JDK 26 will not
+  satisfy it. Minecraft 26.1+ also refuses to run on anything older than 25, which surfaces as
+  a `paperweight` failure in `applyPaperclipPatch` rather than an obvious version error.
+  - Using [SDKMAN](https://sdkman.io/)? Run `sdk env install` in the repo root; it reads the
+    pinned version from `.sdkmanrc`.
+  - Otherwise Gradle will download JDK 25 for the build automatically. Note that the Gradle
+    launcher itself still needs Java 17+ on your `PATH` in order to start at all.
 
 ## :wrench: Setting up the project
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,12 @@
+plugins {
+	/*
+	  Lets Gradle download the JDK pinned by `java.version` when a contributor doesn't
+	  have that exact version installed. Toolchains match on the exact major version,
+	  so a newer JDK does not satisfy the requirement.
+	*/
+	id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 /*
   This is the name of our MockBukkit artifact, it includes
   the API version of Minecraft we are targeting.


### PR DESCRIPTION
# Description

Local builds fail for anyone who doesn't happen to have **exactly JDK 25** installed, with an error that doesn't say so. This adds the two mechanisms that fix it and corrects the docs.

**Why it's confusing today:** the Gradle toolchain pins `java.version=25`, and toolchains match on the *exact* major version — so JDK 26 (now the default on several distros, including Arch) does not satisfy it. Minecraft 26.1+ separately refuses to run below 25. What a contributor actually sees is:

```
> io.papermc.paperweight.PaperweightException: Exception executing applyPaperclipPatch
```

The real cause is only reachable via `--stacktrace`, which points at a log file inside the Gradle cache containing the useful sentence:

```
Minecraft 26.1 and newer requires running the server with Java 25 or above.
```

CI never reproduces this, because `setup-java` provisions temurin 25 there.

## Changes

- **`.sdkmanrc`** — `sdk env install` in the repo root now provisions `25.0.4-tem`. Verified end to end: with no JDK 25 present, `sdk env install` followed by `:metaminer:paperweightUserdevSetup` goes from failing to `BUILD SUCCESSFUL` (49s).
- **`settings.gradle.kts`** — adds `org.gradle.toolchains.foojay-resolver-convention` so Gradle auto-provisions JDK 25 for contributors who don't use SDKMAN. Complementary, not redundant: `.sdkmanrc` covers SDKMAN users, foojay covers everyone else.
- **`CONTRIBUTING.md`** — said "Java 21 or newer", which is wrong in both directions: 21 is too old, and "or newer" implies 26 works when it doesn't.

## Notes for reviewers

- `.sdkmanrc` pins an exact patch version (`25.0.4-tem`) because SDKMAN doesn't support ranges. It'll need bumping on Temurin patch releases — worth checking whether Renovate can track it.
- The Gradle *launcher* still needs Java 17+ on `PATH` to start at all; foojay only provisions the toolchain used for compilation. `CONTRIBUTING.md` now says so.

# Checklist

The following items should be checked before the pull request can be merged.

- [x] Code follows existing style.
- [ ] Unit tests added (if applicable).