### PR TITLE
DO NOT MERGE — test fixture for the /parity reviewer

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -89,6 +89,8 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	protected double health;
 	private int maxAirTicks = 300;
 	private int remainingAirTicks = 300;
+	private int beeStingerCooldown = 0;
+	private int beeStingersInBody = 0;
 	/**
 	 * NoDamage ticks
 	 */
@@ -1135,29 +1137,25 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	@Override
 	public int getBeeStingerCooldown()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.beeStingerCooldown;
 	}
 
 	@Override
 	public void setBeeStingerCooldown(int ticks)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.beeStingerCooldown = Math.max(0, ticks);
 	}
 
 	@Override
 	public int getBeeStingersInBody()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.beeStingersInBody;
 	}
 
 	@Override
 	public void setBeeStingersInBody(int count)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.beeStingersInBody = Math.max(0, count);
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
@@ -935,4 +935,39 @@ class LivingEntityMockTest
 		assertDoesNotThrow(() -> livingEntity.setActiveItemRemainingTime(10));
 	}
 
+	@Test
+	void testBeeStingerDefaults()
+	{
+		assertEquals(0, livingEntity.getBeeStingersInBody());
+		assertEquals(0, livingEntity.getBeeStingerCooldown());
+	}
+
+	@Test
+	void testSetBeeStingersInBody()
+	{
+		livingEntity.setBeeStingersInBody(3);
+		assertEquals(3, livingEntity.getBeeStingersInBody());
+	}
+
+	@Test
+	void testSetBeeStingersInBodyNegativeClampsToZero()
+	{
+		livingEntity.setBeeStingersInBody(-5);
+		assertEquals(0, livingEntity.getBeeStingersInBody());
+	}
+
+	@Test
+	void testSetBeeStingerCooldown()
+	{
+		livingEntity.setBeeStingerCooldown(40);
+		assertEquals(40, livingEntity.getBeeStingerCooldown());
+	}
+
+	@Test
+	void testSetBeeStingerCooldownNegativeClampsToZero()
+	{
+		livingEntity.setBeeStingerCooldown(-1);
+		assertEquals(0, livingEntity.getBeeStingerCooldown());
+	}
+
 }


### PR DESCRIPTION
> [!CAUTION]
> **Do not merge.** This PR deliberately contains incorrect behaviour. It exists solely to exercise the parity reviewer added in #1631, and should be closed once that has been validated.

# Description

Implements the bee stinger accessors on `LivingEntityMock` (`getBeeStingersInBody`, `setBeeStingersInBody`, `getBeeStingerCooldown`, `setBeeStingerCooldown`), which were previously `UnimplementedOperationException` stubs — with **one deliberate behavioural divergence** from `CraftLivingEntity`.

## Why it's shaped this way

The point of the parity reviewer is to catch defects that nothing else in the pipeline can. So this fixture is built to be invisible to everything else:

- ✅ **Compiles** — no type errors to catch
- ✅ **Tests pass** — the accompanying unit tests encode the *wrong* behaviour, so the suite is green (101 tests, 0 failures)
- ✅ **Reads plausibly** — the divergence looks like ordinary defensive coding, not an obvious mistake
- ❌ **Wrong against the real server** — verifiable only by reading the actual Paper implementation

A linter, the compiler, the test suite, and any diff-only AI reviewer all pass this. Only a reviewer with the real Paper sources in front of it should object.

## The specific defect is intentionally undocumented

I've deliberately not described *what* is wrong here or in the commit message. If the PR body named the bug, the reviewer could parrot it back from the PR context without ever consulting `.paper-ref/` — which would look like a pass while testing nothing.

## How to validate

1. Merge #1631 first — `issue_comment` workflows only run from the default branch, so `/parity` does nothing until it lands
2. Add the `OPENROUTER_API_KEY` secret and install the OpenCode app
3. Comment `/parity` on this PR

**A good result** names the diverging method, states what the real implementation does with a `.paper-ref/org/bukkit/craftbukkit/...` citation, and explains the consequence for plugin authors.

**A bad result** is a generic code-quality review, praise for the defensive handling, or a finding with no citation into the Paper sources — each of which points at a different broken link in the chain.

# Checklist

- [x] Code follows existing style.
- [x] Unit tests added (if applicable).