### PR TITLE
Implement the resource pack API on PlayerMock

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
@@ -149,6 +149,7 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.Random;
 import java.util.Set;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedTransferQueue;
@@ -207,6 +208,8 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	private final ConversationTracker conversationTracker = new ConversationTracker();
 	private final Queue<Component> messages = new LinkedTransferQueue<>();
 	private final Queue<String> title = new LinkedTransferQueue<>();
+	private final Map<UUID, ResourcePackEntryMock> resourcePacks = new LinkedHashMap<>();
+	private PlayerResourcePackStatusEvent.@Nullable Status resourcePackStatus = null;
 	private final Queue<String> subitles = new LinkedTransferQueue<>();
 	private final Queue<Component> actionBar = new LinkedTransferQueue<>();
 
@@ -2284,67 +2287,58 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Deprecated(since = "1.7.2")
 	public void setResourcePack(@NotNull String url)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		replaceResourcePack(idFor(url), url, null, null, false);
 	}
 
 	@Override
 	public void setResourcePack(@NotNull String url, byte[] hash)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		replaceResourcePack(idFor(url), url, hashToString(hash), null, false);
 	}
 
 	@Override
 	@Deprecated
 	public void setResourcePack(@NotNull String url, @Nullable byte[] hash, @Nullable String prompt)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		replaceResourcePack(idFor(url), url, hashToString(hash), promptToComponent(prompt), false);
 	}
 
 	@Override
 	public void setResourcePack(@NotNull String url, byte[] hash, boolean force)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		replaceResourcePack(idFor(url), url, hashToString(hash), null, force);
 	}
 
 	@Override
 	@Deprecated
 	public void setResourcePack(@NotNull String url, @Nullable byte[] hash, @Nullable String prompt, boolean force)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		replaceResourcePack(idFor(url), url, hashToString(hash), promptToComponent(prompt), force);
 	}
 
 	@Override
 	public void setResourcePack(@NotNull String url, byte @Nullable [] hash, @Nullable Component prompt, boolean force)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		replaceResourcePack(idFor(url), url, hashToString(hash), prompt, force);
 	}
 
 	@Override
 	public void setResourcePack(@NotNull UUID uuid, @NotNull String url, @NotNull String hash, @Nullable Component resourcePackPrompt, boolean required)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		replaceResourcePack(uuid, url, hash, resourcePackPrompt, required);
 	}
 
 	@Override
 	public void setResourcePack(@NotNull UUID uuid, @NotNull String url, byte @Nullable [] hash, @Nullable Component prompt, boolean force)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		replaceResourcePack(uuid, url, hashToString(hash), prompt, force);
 	}
 
 	@Override
 	@Deprecated(since = "1.20")
 	public void setResourcePack(@NotNull UUID uuid, @NotNull String s, @Nullable byte[] bytes, @Nullable String s1, boolean b)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		replaceResourcePack(uuid, s, hashToString(bytes), promptToComponent(s1), b);
 	}
 
 	@Override
@@ -2789,29 +2783,25 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public void setResourcePack(@NotNull String url, @NotNull String hash)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		replaceResourcePack(idFor(url), url, hash, null, false);
 	}
 
 	@Override
 	public void setResourcePack(@NotNull String url, @NotNull String hash, boolean required)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		replaceResourcePack(idFor(url), url, hash, null, required);
 	}
 
 	@Override
 	public void setResourcePack(@NotNull String url, @NotNull String hash, boolean required, @Nullable Component resourcePackPrompt)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		replaceResourcePack(idFor(url), url, hash, resourcePackPrompt, required);
 	}
 
 	@Override
 	public PlayerResourcePackStatusEvent.@Nullable Status getResourcePackStatus()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return this.resourcePackStatus;
 	}
 
 	@Override
@@ -2824,22 +2814,97 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public void addResourcePack(@NotNull UUID id, @NotNull String url, @Nullable byte[] hash, @Nullable String prompt, boolean force)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		addResourcePack(id, url, hashToString(hash), promptToComponent(prompt), force);
 	}
 
 	@Override
 	public void removeResourcePack(@NotNull UUID id)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkArgument(id != null, "Id cannot be null");
+		this.resourcePacks.remove(id);
 	}
 
 	@Override
 	public void removeResourcePacks()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		this.resourcePacks.clear();
+	}
+
+	/**
+	 * Replaces every pack this player has with a single one, which is what the {@code setResourcePack} overloads do
+	 * on a real server.
+	 */
+	private void replaceResourcePack(@NotNull UUID id, @NotNull String url, @Nullable String hash,
+			@Nullable Component prompt, boolean required)
+	{
+		this.resourcePacks.clear();
+		addResourcePack(id, url, hash, prompt, required);
+	}
+
+	/**
+	 * Adds a pack alongside whatever this player already has, replacing only a pack with the same id.
+	 *
+	 * @param id       The pack id.
+	 * @param url      Where the pack is served from.
+	 * @param hash     The pack hash, or null if none was given.
+	 * @param prompt   The prompt shown to the player, or null for the default.
+	 * @param required Whether the player must accept it.
+	 */
+	public void addResourcePack(@NotNull UUID id, @NotNull String url, @Nullable String hash,
+			@Nullable Component prompt, boolean required)
+	{
+		Preconditions.checkArgument(id != null, "Id cannot be null");
+		Preconditions.checkArgument(url != null, "Url cannot be null");
+		this.resourcePacks.put(id, new ResourcePackEntryMock(id, url, hash, prompt, required));
+	}
+
+	/**
+	 * The packs currently applied to this player, in the order they were added.
+	 *
+	 * @return The applied packs.
+	 */
+	public @NotNull Collection<ResourcePackEntryMock> getResourcePacks()
+	{
+		return List.copyOf(this.resourcePacks.values());
+	}
+
+	/**
+	 * Sets the status this player reports for resource packs. There is no Bukkit setter -- on a real server the value
+	 * arrives from the client accepting, declining or failing to load a pack.
+	 *
+	 * @param status The status to report, or null for a player that has not answered.
+	 */
+	public void setResourcePackStatus(PlayerResourcePackStatusEvent.@Nullable Status status)
+	{
+		this.resourcePackStatus = status;
+	}
+
+	/**
+	 * Derives a stable id for the overloads that do not take one, so the same URL is the same pack across calls.
+	 */
+	private static @NotNull UUID idFor(@NotNull String url)
+	{
+		Preconditions.checkArgument(url != null, "Url cannot be null");
+		return UUID.nameUUIDFromBytes(url.getBytes(StandardCharsets.UTF_8));
+	}
+
+	private static @Nullable String hashToString(byte @Nullable [] hash)
+	{
+		if (hash == null)
+		{
+			return null;
+		}
+		StringBuilder builder = new StringBuilder(hash.length * 2);
+		for (byte b : hash)
+		{
+			builder.append(String.format("%02x", b));
+		}
+		return builder.toString();
+	}
+
+	private static @Nullable Component promptToComponent(@Nullable String prompt)
+	{
+		return prompt == null ? null : LegacyComponentSerializer.legacySection().deserialize(prompt);
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/ResourcePackEntryMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/ResourcePackEntryMock.java
@@ -1,0 +1,22 @@
+package org.mockbukkit.mockbukkit.entity;
+
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+/**
+ * A resource pack applied to a {@link PlayerMock}. Bukkit has no type for this -- packs are only ever pushed at a
+ * player, never read back -- so a test needs something to assert against.
+ *
+ * @param id       The pack id.
+ * @param url      Where the pack is served from.
+ * @param hash     The pack hash, or null if none was given.
+ * @param prompt   The prompt shown to the player, or null for the default.
+ * @param required Whether the player must accept it.
+ */
+public record ResourcePackEntryMock(@NotNull UUID id, @NotNull String url, @Nullable String hash,
+									@Nullable Component prompt, boolean required)
+{
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
@@ -76,6 +76,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
+import org.bukkit.event.player.PlayerResourcePackStatusEvent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -160,6 +161,243 @@ class PlayerMockTest
 	private ServerMock server;
 	private UUID uuid;
 	private PlayerMock player;
+
+	@Test
+	void setResourcePack_UrlHashPrompt()
+	{
+		player.setResourcePack("https://example.com/pack.zip", new byte[]{ 0x01 }, "prompt");
+
+		ResourcePackEntryMock entry = player.getResourcePacks().iterator().next();
+		assertEquals("01", entry.hash());
+		assertEquals(Component.text("prompt"), entry.prompt());
+		assertFalse(entry.required());
+	}
+
+	@Test
+	void setResourcePack_UrlHashForce()
+	{
+		player.setResourcePack("https://example.com/pack.zip", new byte[]{ 0x02 }, true);
+
+		ResourcePackEntryMock entry = player.getResourcePacks().iterator().next();
+		assertEquals("02", entry.hash());
+		assertTrue(entry.required());
+	}
+
+	@Test
+	void setResourcePack_UrlHashComponentPromptForce()
+	{
+		player.setResourcePack("https://example.com/pack.zip", new byte[]{ 0x03 }, Component.text("hi"), true);
+
+		ResourcePackEntryMock entry = player.getResourcePacks().iterator().next();
+		assertEquals("03", entry.hash());
+		assertEquals(Component.text("hi"), entry.prompt());
+		assertTrue(entry.required());
+	}
+
+	@Test
+	void setResourcePack_IdUrlHashComponentPromptForce()
+	{
+		UUID id = UUID.randomUUID();
+		player.setResourcePack(id, "https://example.com/pack.zip", new byte[]{ 0x04 }, Component.text("hi"), true);
+
+		ResourcePackEntryMock entry = player.getResourcePacks().iterator().next();
+		assertEquals(id, entry.id());
+		assertEquals("04", entry.hash());
+	}
+
+	@Test
+	void setResourcePack_IdUrlHashLegacyPromptForce()
+	{
+		UUID id = UUID.randomUUID();
+		player.setResourcePack(id, "https://example.com/pack.zip", new byte[]{ 0x05 }, "legacy", false);
+
+		ResourcePackEntryMock entry = player.getResourcePacks().iterator().next();
+		assertEquals(id, entry.id());
+		assertEquals(Component.text("legacy"), entry.prompt());
+		assertFalse(entry.required());
+	}
+
+	@Test
+	void setResourcePack_UrlAndStringHash()
+	{
+		player.setResourcePack("https://example.com/pack.zip", "deadbeef");
+
+		assertEquals("deadbeef", player.getResourcePacks().iterator().next().hash());
+	}
+
+	@Test
+	void setResourcePack_UrlStringHashRequired()
+	{
+		player.setResourcePack("https://example.com/pack.zip", "deadbeef", true);
+
+		ResourcePackEntryMock entry = player.getResourcePacks().iterator().next();
+		assertEquals("deadbeef", entry.hash());
+		assertTrue(entry.required());
+	}
+
+	@Test
+	void setResourcePack_NullUrl()
+	{
+		assertThrows(IllegalArgumentException.class, () -> player.setResourcePack((String) null));
+	}
+
+	@Test
+	void getResourcePacks_DefaultsToEmpty()
+	{
+		assertTrue(player.getResourcePacks().isEmpty());
+	}
+
+	@Test
+	void setResourcePack_AppliesThePack()
+	{
+		player.setResourcePack("https://example.com/pack.zip");
+
+		assertEquals(1, player.getResourcePacks().size());
+		ResourcePackEntryMock entry = player.getResourcePacks().iterator().next();
+		assertEquals("https://example.com/pack.zip", entry.url());
+		assertNull(entry.hash());
+		assertFalse(entry.required());
+	}
+
+	@Test
+	void setResourcePack_ReplacesWhatIsThere()
+	{
+		player.setResourcePack("https://example.com/first.zip");
+		player.setResourcePack("https://example.com/second.zip");
+
+		assertEquals(1, player.getResourcePacks().size());
+		assertEquals("https://example.com/second.zip",
+				player.getResourcePacks().iterator().next().url());
+	}
+
+	@Test
+	void addResourcePack_KeepsWhatIsThere()
+	{
+		player.setResourcePack("https://example.com/first.zip");
+		player.addResourcePack(UUID.randomUUID(), "https://example.com/second.zip", (byte[]) null, null, false);
+
+		assertEquals(2, player.getResourcePacks().size());
+	}
+
+	@Test
+	void addResourcePack_SameIdReplacesTheEntry()
+	{
+		UUID id = UUID.randomUUID();
+		player.addResourcePack(id, "https://example.com/first.zip", (byte[]) null, null, false);
+		player.addResourcePack(id, "https://example.com/second.zip", (byte[]) null, null, false);
+
+		assertEquals(1, player.getResourcePacks().size());
+		assertEquals("https://example.com/second.zip",
+				player.getResourcePacks().iterator().next().url());
+	}
+
+	@Test
+	void setResourcePack_SameUrlKeepsTheSameId()
+	{
+		player.setResourcePack("https://example.com/pack.zip");
+		UUID first = player.getResourcePacks().iterator().next().id();
+
+		player.setResourcePack("https://example.com/pack.zip");
+
+		assertEquals(first, player.getResourcePacks().iterator().next().id());
+	}
+
+	@Test
+	void setResourcePack_HashIsRenderedAsHex()
+	{
+		player.setResourcePack("https://example.com/pack.zip", new byte[]{ 0x0a, (byte) 0xff, 0x10 });
+
+		assertEquals("0aff10", player.getResourcePacks().iterator().next().hash());
+	}
+
+	@Test
+	void setResourcePack_CarriesPromptAndRequired()
+	{
+		player.setResourcePack("https://example.com/pack.zip", "abc123", true, Component.text("please"));
+
+		ResourcePackEntryMock entry = player.getResourcePacks().iterator().next();
+		assertEquals("abc123", entry.hash());
+		assertTrue(entry.required());
+		assertEquals(Component.text("please"), entry.prompt());
+	}
+
+	@Test
+	void setResourcePack_LegacyPromptBecomesAComponent()
+	{
+		player.setResourcePack("https://example.com/pack.zip", (byte[]) null, "hello", false);
+
+		assertEquals(Component.text("hello"),
+				player.getResourcePacks().iterator().next().prompt());
+	}
+
+	@Test
+	void setResourcePack_WithAnExplicitId()
+	{
+		UUID id = UUID.randomUUID();
+		player.setResourcePack(id, "https://example.com/pack.zip", "abc123", Component.text("hi"), true);
+
+		assertEquals(id, player.getResourcePacks().iterator().next().id());
+	}
+
+	@Test
+	void removeResourcePack_DropsOnlyThatPack()
+	{
+		UUID kept = UUID.randomUUID();
+		UUID dropped = UUID.randomUUID();
+		player.addResourcePack(kept, "https://example.com/kept.zip", (byte[]) null, null, false);
+		player.addResourcePack(dropped, "https://example.com/dropped.zip", (byte[]) null, null, false);
+
+		player.removeResourcePack(dropped);
+
+		assertEquals(1, player.getResourcePacks().size());
+		assertEquals(kept, player.getResourcePacks().iterator().next().id());
+	}
+
+	@Test
+	void removeResourcePacks_DropsThemAll()
+	{
+		player.setResourcePack("https://example.com/pack.zip");
+
+		player.removeResourcePacks();
+
+		assertTrue(player.getResourcePacks().isEmpty());
+	}
+
+	@Test
+	void removeResourcePack_Null()
+	{
+		assertThrows(IllegalArgumentException.class, () -> player.removeResourcePack(null));
+	}
+
+	@Test
+	void addResourcePack_NullUrl()
+	{
+		assertThrows(IllegalArgumentException.class,
+				() -> player.addResourcePack(UUID.randomUUID(), null, (byte[]) null, null, false));
+	}
+
+	@Test
+	void addResourcePack_NullId()
+	{
+		assertThrows(IllegalArgumentException.class,
+				() -> player.addResourcePack(null, "https://example.com/pack.zip", (byte[]) null, null, false));
+	}
+
+	@Test
+	void getResourcePackStatus_DefaultsToNull()
+	{
+		assertNull(player.getResourcePackStatus());
+	}
+
+	@Test
+	void setResourcePackStatus_IsRetained()
+	{
+		player.setResourcePackStatus(PlayerResourcePackStatusEvent.Status.SUCCESSFULLY_LOADED);
+		assertEquals(PlayerResourcePackStatusEvent.Status.SUCCESSFULLY_LOADED, player.getResourcePackStatus());
+
+		player.setResourcePackStatus(null);
+		assertNull(player.getResourcePackStatus());
+	}
 
 	@BeforeEach
 	void setUp()


### PR DESCRIPTION
The whole resource pack API on `PlayerMock` is unimplemented — fifteen methods, none of them.

```java
player.setResourcePack("https://example.com/pack.zip");
// org.mockbukkit.mockbukkit.exception.UnimplementedOperationException
```

So a plugin that pushes a pack cannot be exercised at all. `UnimplementedOperationException` extends `TestAbortedException`, so the test is reported as **skipped** rather than failed and the build stays green — nothing tells you it stopped running.

There is a second half to the problem. Even with the methods implemented, **there is nothing to assert against**: Bukkit only ever pushes packs at a player and never reads them back, so `Player` has no getter for what a player currently has. A test can call `setResourcePack` and then has no way to check anything happened.

### The model

Packs are held in a **UUID-keyed map**, matching Paper's own semantics:

- `setResourcePack` **replaces** the set
- `addResourcePack` **appends**, replacing only an entry with the same id
- `removeResourcePack(id)` drops one, `removeResourcePacks()` drops them all

The overloads that do not take an id derive a stable one from the URL, so pushing the same pack twice is the same entry rather than two — which is what a real server does with the id it generates.

The rest is normalisation so every overload lands in the same shape: byte hashes are rendered as hex, and legacy string prompts become components.

### Reading it back

`ResourcePackEntryMock` is the new type a test reads — id, url, hash, prompt, required — reachable through `getResourcePacks()`.

`setResourcePackStatus` stands in for the client's answer. `getResourcePackStatus` exists in Bukkit but there is no way to set it, because on a real server it arrives when the client accepts, declines or fails to load the pack. Without a setter the getter can only ever return its default, so code branching on the status is untestable.

Both are MockBukkit-specific and documented as such.

### Tests

25, covering every one of the twelve `setResourcePack` overloads individually rather than trusting that they all funnel to the same place, plus append-versus-replace, same-id replacement, stable ids from the same URL, hex hash rendering, legacy prompt conversion, removal of one and of all, the status accessors, and the null rejections.

Full suite green: 20632 tests, 0 failures. 40 added lines, 0 uncovered, checkstyle clean.
