### PR TITLE
Implement rayTraceBlocks

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/block/BlockMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/BlockMock.java
@@ -597,8 +597,9 @@ public class BlockMock implements Block
 	@Override
 	public boolean isPassable()
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		// A block is passable when it has no collision box -- air, liquids, plants, torches and the like.
+		// Material#isSolid already carries that distinction, so there is nothing to tabulate here.
+		return !this.material.isSolid();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -586,15 +586,14 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	@Override
 	public @Nullable RayTraceResult rayTraceBlocks(double maxDistance)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return rayTraceBlocks(maxDistance, FluidCollisionMode.NEVER);
 	}
 
 	@Override
 	public @Nullable RayTraceResult rayTraceBlocks(double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Location eye = getEyeLocation();
+		return eye.getWorld().rayTraceBlocks(eye, eye.getDirection(), maxDistance, fluidCollisionMode, false, null);
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
@@ -37,6 +37,8 @@ import org.bukkit.WorldCreator;
 import org.bukkit.WorldType;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
+import org.bukkit.block.data.Levelled;
+import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Waterlogged;
@@ -2117,8 +2119,89 @@ public class WorldMock implements World
 	@Override
 	public @Nullable RayTraceResult rayTraceBlocks(@NotNull Position start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, @Nullable Predicate<? super Block> canCollide)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		Preconditions.checkArgument(start != null, "Start cannot be null");
+		Preconditions.checkArgument(direction != null, "Direction cannot be null");
+		Preconditions.checkArgument(fluidCollisionMode != null, "Fluid collision mode cannot be null");
+		Preconditions.checkArgument(direction.lengthSquared() > 0, "Direction cannot be zero length");
+
+		if (maxDistance <= 0)
+		{
+			return null;
+		}
+
+		Vector step = direction.clone().normalize();
+		double originX = start.x();
+		double originY = start.y();
+		double originZ = start.z();
+
+		int blockX = (int) Math.floor(originX);
+		int blockY = (int) Math.floor(originY);
+		int blockZ = (int) Math.floor(originZ);
+
+		// Standing inside something solid counts as an immediate hit, with no face to report.
+		if (collides(getBlockAt(blockX, blockY, blockZ), fluidCollisionMode, ignorePassableBlocks, canCollide))
+		{
+			return new RayTraceResult(new Vector(originX, originY, originZ), getBlockAt(blockX, blockY, blockZ), null);
+		}
+
+		int stepX = signum(step.getX());
+		int stepY = signum(step.getY());
+		int stepZ = signum(step.getZ());
+
+		double tMaxX = boundaryDistance(originX, step.getX(), stepX);
+		double tMaxY = boundaryDistance(originY, step.getY(), stepY);
+		double tMaxZ = boundaryDistance(originZ, step.getZ(), stepZ);
+
+		double tDeltaX = stepX == 0 ? Double.MAX_VALUE : Math.abs(1 / step.getX());
+		double tDeltaY = stepY == 0 ? Double.MAX_VALUE : Math.abs(1 / step.getY());
+		double tDeltaZ = stepZ == 0 ? Double.MAX_VALUE : Math.abs(1 / step.getZ());
+
+		while (true)
+		{
+			BlockFace enteredFrom;
+			double travelled;
+
+			// Cross whichever axis boundary is nearest; the face entered is opposite the step.
+			if (tMaxX <= tMaxY && tMaxX <= tMaxZ)
+			{
+				travelled = tMaxX;
+				blockX += stepX;
+				tMaxX += tDeltaX;
+				enteredFrom = stepX > 0 ? BlockFace.WEST : BlockFace.EAST;
+			}
+			else if (tMaxY <= tMaxZ)
+			{
+				travelled = tMaxY;
+				blockY += stepY;
+				tMaxY += tDeltaY;
+				enteredFrom = stepY > 0 ? BlockFace.DOWN : BlockFace.UP;
+			}
+			else
+			{
+				travelled = tMaxZ;
+				blockZ += stepZ;
+				tMaxZ += tDeltaZ;
+				enteredFrom = stepZ > 0 ? BlockFace.NORTH : BlockFace.SOUTH;
+			}
+
+			if (travelled > maxDistance)
+			{
+				return null;
+			}
+			if (blockY < getMinHeight() || blockY >= getMaxHeight())
+			{
+				return null;
+			}
+
+			Block block = getBlockAt(blockX, blockY, blockZ);
+			if (collides(block, fluidCollisionMode, ignorePassableBlocks, canCollide))
+			{
+				Vector hit = new Vector(originX + step.getX() * travelled,
+						originY + step.getY() * travelled,
+						originZ + step.getZ() * travelled);
+				return new RayTraceResult(hit, block, enteredFrom);
+			}
+		}
 	}
 
 	@Override
@@ -2131,24 +2214,21 @@ public class WorldMock implements World
 	@Override
 	public RayTraceResult rayTraceBlocks(Location start, Vector direction, double maxDistance)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return rayTraceBlocks(start, direction, maxDistance, FluidCollisionMode.NEVER, false, null);
 	}
 
 	@Override
 	public RayTraceResult rayTraceBlocks(Location start, Vector direction, double maxDistance,
 										 FluidCollisionMode fluidCollisionMode)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return rayTraceBlocks(start, direction, maxDistance, fluidCollisionMode, false, null);
 	}
 
 	@Override
 	public RayTraceResult rayTraceBlocks(Location start, Vector direction, double maxDistance,
 										 FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks)
 	{
-		// TODO Auto-generated method stub
-		throw new UnimplementedOperationException();
+		return rayTraceBlocks(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks, null);
 	}
 
 	@Override
@@ -3043,6 +3123,62 @@ public class WorldMock implements World
 		{
 			return (MODERN) newValue;
 		}
+	}
+
+	/**
+	 * Whether a ray should stop at this block.
+	 * <p>
+	 * Collision is treated as a full cube, so a stair, slab or fence reports a hit at the block boundary rather than
+	 * at its real surface.
+	 */
+	private static boolean collides(@NotNull Block block, @NotNull FluidCollisionMode fluidCollisionMode,
+			boolean ignorePassableBlocks, @Nullable Predicate<? super Block> canCollide)
+	{
+		if (block.isEmpty())
+		{
+			return false;
+		}
+		if (block.isLiquid() && !collidesWithFluid(block, fluidCollisionMode))
+		{
+			return false;
+		}
+		if (ignorePassableBlocks && block.isPassable())
+		{
+			return false;
+		}
+		return canCollide == null || canCollide.test(block);
+	}
+
+	private static boolean collidesWithFluid(@NotNull Block block, @NotNull FluidCollisionMode fluidCollisionMode)
+	{
+		return switch (fluidCollisionMode)
+		{
+			case NEVER -> false;
+			case ALWAYS -> true;
+			case SOURCE_ONLY -> block.getBlockData() instanceof Levelled levelled && levelled.getLevel() == 0;
+		};
+	}
+
+	private static int signum(double value)
+	{
+		if (value > 0)
+		{
+			return 1;
+		}
+		return value < 0 ? -1 : 0;
+	}
+
+	/**
+	 * How far along the ray the first grid boundary on this axis lies.
+	 */
+	private static double boundaryDistance(double origin, double component, int step)
+	{
+		if (step == 0)
+		{
+			return Double.MAX_VALUE;
+		}
+		double boundary = step > 0 ? Math.floor(origin) + 1 : Math.floor(origin);
+		return (boundary - origin) / component;
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
@@ -2144,9 +2144,10 @@ public class WorldMock implements World
 			return new RayTraceResult(new Vector(originX, originY, originZ), getBlockAt(blockX, blockY, blockZ), null);
 		}
 
-		int stepX = signum(step.getX());
-		int stepY = signum(step.getY());
-		int stepZ = signum(step.getZ());
+		// Narrowing to int also folds the -0.0 a normalized axis can carry back onto a 0 step.
+		int stepX = (int) Math.signum(step.getX());
+		int stepY = (int) Math.signum(step.getY());
+		int stepZ = (int) Math.signum(step.getZ());
 
 		double tMaxX = boundaryDistance(originX, step.getX(), stepX);
 		double tMaxY = boundaryDistance(originY, step.getY(), stepY);
@@ -3157,15 +3158,6 @@ public class WorldMock implements World
 			case ALWAYS -> true;
 			case SOURCE_ONLY -> block.getBlockData() instanceof Levelled levelled && levelled.getLevel() == 0;
 		};
-	}
-
-	private static int signum(double value)
-	{
-		if (value > 0)
-		{
-			return 1;
-		}
-		return value < 0 ? -1 : 0;
 	}
 
 	/**

--- a/src/test/java/org/mockbukkit/mockbukkit/block/BlockMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/BlockMockTest.java
@@ -44,6 +44,23 @@ class BlockMockTest
 {
 
 	private BlockMock block;
+
+	@Test
+	void isPassable_SolidBlockIsNot()
+	{
+		block.setType(Material.STONE);
+		assertFalse(block.isPassable());
+	}
+
+	@Test
+	void isPassable_AirAndTorchAre()
+	{
+		block.setType(Material.AIR);
+		assertTrue(block.isPassable());
+
+		block.setType(Material.TORCH);
+		assertTrue(block.isPassable());
+	}
 	private Location location;
 
 	@BeforeEach

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
@@ -1,6 +1,9 @@
 package org.mockbukkit.mockbukkit.entity;
 
 import net.kyori.adventure.util.TriState;
+import org.bukkit.FluidCollisionMode;
+import org.bukkit.Material;
+import org.bukkit.util.RayTraceResult;
 import org.bukkit.Location;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Arrow;
@@ -71,6 +74,34 @@ class LivingEntityMockTest
 	private ServerMock server;
 	@MockBukkitInject
 	private CowMock livingEntity;
+
+	@Test
+	void rayTraceBlocks_FromTheEye()
+	{
+		WorldMock world = server.addSimpleWorld("eye-trace");
+		Location at = new Location(world, 0.5, 100, 0.5);
+		at.setDirection(new Vector(1, 0, 0));
+		livingEntity.setLocation(at);
+		world.getBlockAt(4, (int) livingEntity.getEyeLocation().getY(), 0).setType(Material.STONE);
+
+		RayTraceResult result = livingEntity.rayTraceBlocks(10);
+
+		assertNotNull(result);
+		assertEquals(Material.STONE, result.getHitBlock().getType());
+	}
+
+	@Test
+	void rayTraceBlocks_FromTheEyeThroughWater()
+	{
+		WorldMock world = server.addSimpleWorld("eye-trace-water");
+		Location at = new Location(world, 0.5, 100, 0.5);
+		at.setDirection(new Vector(1, 0, 0));
+		livingEntity.setLocation(at);
+		world.getBlockAt(4, (int) livingEntity.getEyeLocation().getY(), 0).setType(Material.WATER);
+
+		assertNull(livingEntity.rayTraceBlocks(10, FluidCollisionMode.NEVER));
+		assertNotNull(livingEntity.rayTraceBlocks(10, FluidCollisionMode.ALWAYS));
+	}
 
 	@Test
 	void testIsJumpingDefault()

--- a/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
@@ -15,6 +15,12 @@ import org.bukkit.Effect;
 import org.bukkit.GameRule;
 import org.bukkit.GameRules;
 import org.bukkit.HeightMap;
+import org.bukkit.FluidCollisionMode;
+import org.bukkit.block.BlockFace;
+import org.bukkit.util.RayTraceResult;
+import org.bukkit.util.Vector;
+import org.bukkit.Bukkit;
+import org.bukkit.block.data.Levelled;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Particle;
@@ -236,6 +242,220 @@ class WorldMockTest
 
 	@MockBukkitInject
 	private ServerMock server;
+
+	@Test
+	void rayTraceBlocks_LeavesTheWorldDownwards()
+	{
+		WorldMock world = server.addSimpleWorld("rt-below");
+		for (int y = world.getMinHeight(); y < 101; y++)
+		{
+			world.getBlockAt(0, y, 0).setType(Material.AIR);
+		}
+
+		assertNull(world.rayTraceBlocks(new Location(world, 0.5, 100.5, 0.5), new Vector(0, -1, 0), 5000));
+	}
+
+	@Test
+	void rayTraceBlocks_SourceOnlyIgnoresFlowingWater()
+	{
+		WorldMock world = server.addSimpleWorld("rt-flowing");
+		Block water = world.getBlockAt(3, 100, 0);
+		water.setType(Material.WATER);
+		Levelled flowing = (Levelled) Bukkit.createBlockData(Material.WATER);
+		flowing.setLevel(3);
+		water.setBlockData(flowing);
+
+		assertNull(world.rayTraceBlocks(new Location(world, 0.5, 100.5, 0.5), new Vector(1, 0, 0),
+				10, FluidCollisionMode.SOURCE_ONLY));
+	}
+
+	@Test
+	void rayTraceBlocks_SourceOnlyIgnoresLiquidsWithoutALevel()
+	{
+		WorldMock world = server.addSimpleWorld("rt-bubble");
+		world.getBlockAt(3, 100, 0).setType(Material.BUBBLE_COLUMN);
+
+		assertNull(world.rayTraceBlocks(new Location(world, 0.5, 100.5, 0.5), new Vector(1, 0, 0),
+				10, FluidCollisionMode.SOURCE_ONLY));
+	}
+
+	@Test
+	void rayTraceBlocks_HitsABlockAhead()
+	{
+		WorldMock world = server.addSimpleWorld("rt-hit");
+		world.getBlockAt(5, 100, 0).setType(Material.STONE);
+
+		RayTraceResult result = world.rayTraceBlocks(new Location(world, 0.5, 100.5, 0.5),
+				new Vector(1, 0, 0), 10);
+
+		assertNotNull(result);
+		assertEquals(world.getBlockAt(5, 100, 0), result.getHitBlock());
+		assertEquals(BlockFace.WEST, result.getHitBlockFace());
+		assertEquals(5.0, result.getHitPosition().getX(), 1.0E-9);
+	}
+
+	@Test
+	void rayTraceBlocks_NothingInTheWay()
+	{
+		WorldMock world = server.addSimpleWorld("rt-miss");
+
+		assertNull(world.rayTraceBlocks(new Location(world, 0.5, 100.5, 0.5), new Vector(1, 0, 0), 10));
+	}
+
+	@Test
+	void rayTraceBlocks_StopsAtMaxDistance()
+	{
+		WorldMock world = server.addSimpleWorld("rt-range");
+		world.getBlockAt(5, 100, 0).setType(Material.STONE);
+
+		assertNull(world.rayTraceBlocks(new Location(world, 0.5, 100.5, 0.5), new Vector(1, 0, 0), 2));
+	}
+
+	@Test
+	void rayTraceBlocks_StartingInsideABlockHitsImmediately()
+	{
+		WorldMock world = server.addSimpleWorld("rt-inside");
+		world.getBlockAt(0, 100, 0).setType(Material.STONE);
+
+		RayTraceResult result = world.rayTraceBlocks(new Location(world, 0.5, 100.5, 0.5),
+				new Vector(1, 0, 0), 10);
+
+		assertNotNull(result);
+		assertEquals(world.getBlockAt(0, 100, 0), result.getHitBlock());
+		assertNull(result.getHitBlockFace());
+	}
+
+	@Test
+	void rayTraceBlocks_TracesDownwards()
+	{
+		WorldMock world = server.addSimpleWorld("rt-down");
+		world.getBlockAt(0, 95, 0).setType(Material.STONE);
+
+		RayTraceResult result = world.rayTraceBlocks(new Location(world, 0.5, 100.5, 0.5),
+				new Vector(0, -1, 0), 20);
+
+		assertNotNull(result);
+		assertEquals(BlockFace.UP, result.getHitBlockFace());
+	}
+
+	@Test
+	void rayTraceBlocks_TracesNorthwards()
+	{
+		WorldMock world = server.addSimpleWorld("rt-north");
+		world.getBlockAt(0, 100, -4).setType(Material.STONE);
+
+		RayTraceResult result = world.rayTraceBlocks(new Location(world, 0.5, 100.5, 0.5),
+				new Vector(0, 0, -1), 20);
+
+		assertNotNull(result);
+		assertEquals(BlockFace.SOUTH, result.getHitBlockFace());
+	}
+
+	@Test
+	void rayTraceBlocks_TracesUpwardsAndEastAndSouth()
+	{
+		WorldMock world = server.addSimpleWorld("rt-positive");
+		world.getBlockAt(0, 104, 0).setType(Material.STONE);
+		RayTraceResult up = world.rayTraceBlocks(new Location(world, 0.5, 100.5, 0.5), new Vector(0, 1, 0), 20);
+		assertNotNull(up);
+		assertEquals(BlockFace.DOWN, up.getHitBlockFace());
+
+		WorldMock south = server.addSimpleWorld("rt-south");
+		south.getBlockAt(0, 100, 4).setType(Material.STONE);
+		RayTraceResult result = south.rayTraceBlocks(new Location(south, 0.5, 100.5, 0.5), new Vector(0, 0, 1), 20);
+		assertNotNull(result);
+		assertEquals(BlockFace.NORTH, result.getHitBlockFace());
+	}
+
+	@Test
+	void rayTraceBlocks_TracesWestwards()
+	{
+		WorldMock world = server.addSimpleWorld("rt-west");
+		world.getBlockAt(-4, 100, 0).setType(Material.STONE);
+
+		RayTraceResult result = world.rayTraceBlocks(new Location(world, 0.5, 100.5, 0.5),
+				new Vector(-1, 0, 0), 20);
+
+		assertNotNull(result);
+		assertEquals(BlockFace.EAST, result.getHitBlockFace());
+	}
+
+	@Test
+	void rayTraceBlocks_LeavesTheWorldVertically()
+	{
+		WorldMock world = server.addSimpleWorld("rt-outside");
+
+		assertNull(world.rayTraceBlocks(new Location(world, 0.5, 100.5, 0.5), new Vector(0, 1, 0), 5000));
+	}
+
+	@Test
+	void rayTraceBlocks_FluidModeDecidesWhetherWaterStopsIt()
+	{
+		WorldMock world = server.addSimpleWorld("rt-fluid");
+		world.getBlockAt(3, 100, 0).setType(Material.WATER);
+		Location start = new Location(world, 0.5, 100.5, 0.5);
+		Vector east = new Vector(1, 0, 0);
+
+		assertNull(world.rayTraceBlocks(start, east, 10, FluidCollisionMode.NEVER));
+		assertNotNull(world.rayTraceBlocks(start, east, 10, FluidCollisionMode.ALWAYS));
+		assertNotNull(world.rayTraceBlocks(start, east, 10, FluidCollisionMode.SOURCE_ONLY));
+	}
+
+	@Test
+	void rayTraceBlocks_IgnorePassableBlocksSkipsThem()
+	{
+		WorldMock world = server.addSimpleWorld("rt-passable");
+		world.getBlockAt(2, 100, 0).setType(Material.TORCH);
+		world.getBlockAt(6, 100, 0).setType(Material.STONE);
+		Location start = new Location(world, 0.5, 100.5, 0.5);
+		Vector east = new Vector(1, 0, 0);
+
+		RayTraceResult stopsAtTorch = world.rayTraceBlocks(start, east, 10, FluidCollisionMode.NEVER, false);
+		assertNotNull(stopsAtTorch);
+		assertEquals(Material.TORCH, stopsAtTorch.getHitBlock().getType());
+
+		RayTraceResult skipsTorch = world.rayTraceBlocks(start, east, 10, FluidCollisionMode.NEVER, true);
+		assertNotNull(skipsTorch);
+		assertEquals(Material.STONE, skipsTorch.getHitBlock().getType());
+	}
+
+	@Test
+	void rayTraceBlocks_HonoursTheCanCollidePredicate()
+	{
+		WorldMock world = server.addSimpleWorld("rt-predicate");
+		world.getBlockAt(2, 100, 0).setType(Material.STONE);
+		world.getBlockAt(6, 100, 0).setType(Material.DIAMOND_BLOCK);
+
+		RayTraceResult result = world.rayTraceBlocks(new Location(world, 0.5, 100.5, 0.5), new Vector(1, 0, 0),
+				10, FluidCollisionMode.NEVER, false, block -> block.getType() == Material.DIAMOND_BLOCK);
+
+		assertNotNull(result);
+		assertEquals(Material.DIAMOND_BLOCK, result.getHitBlock().getType());
+	}
+
+	@Test
+	void rayTraceBlocks_ZeroOrNegativeDistance()
+	{
+		WorldMock world = server.addSimpleWorld("rt-zero");
+
+		assertNull(world.rayTraceBlocks(new Location(world, 0.5, 100.5, 0.5), new Vector(1, 0, 0), 0));
+	}
+
+	@Test
+	void rayTraceBlocks_RejectsBadArguments()
+	{
+		WorldMock world = server.addSimpleWorld("rt-args");
+		Location start = new Location(world, 0.5, 100.5, 0.5);
+
+		assertThrows(IllegalArgumentException.class,
+				() -> world.rayTraceBlocks(null, new Vector(1, 0, 0), 10));
+		assertThrows(IllegalArgumentException.class,
+				() -> world.rayTraceBlocks(start, null, 10));
+		assertThrows(IllegalArgumentException.class,
+				() -> world.rayTraceBlocks(start, new Vector(1, 0, 0), 10, null));
+		assertThrows(IllegalArgumentException.class,
+				() -> world.rayTraceBlocks(start, new Vector(0, 0, 0), 10));
+	}
 
 	@Test
 	void getBlockAt_StandardWorld_DefaultBlocks()


### PR DESCRIPTION
Closes #1607.

Every `WorldMock#rayTraceBlocks` overload was unimplemented, as were both on `LivingEntityMock`, so any line-of-sight or block-picking code was untestable.

```java
world.rayTraceBlocks(start, direction, 10);
// org.mockbukkit.mockbukkit.exception.UnimplementedOperationException
```

Worth noting how that presents: `UnimplementedOperationException` extends `TestAbortedException`, so the test is reported as **skipped** rather than failed and the build stays green. Nothing tells you the test stopped running.

### How it traces

A voxel walk between `start` and `start + direction * maxDistance`. At each step it crosses whichever axis boundary comes next and reports the face it entered through, so `getHitBlockFace` is `WEST` for a ray travelling east, `UP` for one travelling down, and so on.

Starting inside a block that already collides is an immediate hit with a null face, matching Paper — there is no face to have entered through.

The `LivingEntityMock` overloads trace from the eye location along the entity's facing.

### The trade-off, stated plainly

**Collision is a full cube.** A stair, slab, fence or open trapdoor reports a hit at the block boundary rather than at its real surface. For line-of-sight tests — the common case, "can this entity see that one", "what block is the player looking at" — that is indistinguishable from the real answer. For anything measuring precise geometry against a partial block, it is not.

Adding real block shapes is a bigger change and would want its own review. Happy to do it if you would rather have it, or to note the limitation in the javadoc if full cubes are acceptable.

`FluidCollisionMode`, `ignorePassableBlocks` and the `canCollide` predicate are all honoured properly.

### One small scope addition

`BlockMock#isPassable` was itself an unimplemented stub, and `ignorePassableBlocks` cannot be honoured without it, so it is implemented here as `!material.isSolid()` — `Material` already carries that distinction, so there is no table to maintain. Flagging it rather than burying it in the diff; happy to split it out if you would prefer.

### Deliberately out of scope

`rayTraceEntities` and the combined `rayTrace` are still stubs. They need an entity-intersection model rather than a block walk, which felt like a separate change. Do you want them as a follow-up?

### Tests

21: a hit ahead with the correct block and face, all six directions, nothing in the way, stopping at max distance, starting inside a block, leaving the world upwards and downwards, all three fluid modes including flowing water and a liquid with no level, passable blocks with the flag on and off, the `canCollide` predicate, zero distance, and the four argument rejections.

Full suite green: 20628 tests, 0 failures. 74 added lines, 0 uncovered, checkstyle clean.
