### PR TITLE
RFC: derive isTrackedBy from the state the mock already keeps

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/EntityMock.java
@@ -196,7 +196,23 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	@Override
 	public boolean isTrackedBy(@NotNull Player player)
 	{
-		throw new UnimplementedOperationException();
+		Preconditions.checkNotNull(player, "Player cannot be null");
+
+		if (!isValid())
+		{
+			return false;
+		}
+		if (!getWorld().equals(player.getWorld()))
+		{
+			return false;
+		}
+		if (!player.canSee(this))
+		{
+			return false;
+		}
+
+		double range = this.server.getViewDistance() * 16.0;
+		return player.getLocation().distanceSquared(getLocation()) <= range * range;
 	}
 
 	/**

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/EntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/EntityMockTest.java
@@ -81,6 +81,79 @@ class EntityMockTest
 	private SimpleEntityMock entity;
 
 	@Test
+	void isTrackedBy_NearbyPlayerInTheSameWorld()
+	{
+		PlayerMock player = server.addPlayer();
+		player.setLocation(new Location(world, 0, 64, 0));
+		entity.setLocation(new Location(world, 4, 64, 4));
+
+		assertTrue(entity.isTrackedBy(player));
+	}
+
+	@Test
+	void isTrackedBy_PlayerTooFarAway()
+	{
+		PlayerMock player = server.addPlayer();
+		player.setLocation(new Location(world, 0, 64, 0));
+		entity.setLocation(new Location(world, server.getViewDistance() * 16 + 32, 64, 0));
+
+		assertFalse(entity.isTrackedBy(player));
+	}
+
+	@Test
+	void isTrackedBy_PlayerInAnotherWorld()
+	{
+		WorldMock elsewhere = server.addSimpleWorld("tracked-elsewhere");
+		PlayerMock player = server.addPlayer();
+		player.setLocation(new Location(elsewhere, 0, 64, 0));
+		entity.setLocation(new Location(world, 0, 64, 0));
+
+		assertFalse(entity.isTrackedBy(player));
+	}
+
+	@Test
+	void isTrackedBy_HiddenFromThePlayer()
+	{
+		PlayerMock player = server.addPlayer();
+		player.setLocation(new Location(world, 0, 64, 0));
+		entity.setLocation(new Location(world, 1, 64, 1));
+		player.hideEntity(MockBukkit.createMockPlugin(), entity);
+
+		assertFalse(entity.isTrackedBy(player));
+	}
+
+	@Test
+	void isTrackedBy_RemovedEntity()
+	{
+		PlayerMock player = server.addPlayer();
+		player.setLocation(new Location(world, 0, 64, 0));
+		entity.setLocation(new Location(world, 1, 64, 1));
+		entity.remove();
+
+		assertFalse(entity.isTrackedBy(player));
+	}
+
+	@Test
+	void isTrackedBy_ViewDistanceMovesTheBoundary()
+	{
+		PlayerMock player = server.addPlayer();
+		player.setLocation(new Location(world, 0, 64, 0));
+		entity.setLocation(new Location(world, 200, 64, 0));
+
+		server.setViewDistance(4);
+		assertFalse(entity.isTrackedBy(player));
+
+		server.setViewDistance(32);
+		assertTrue(entity.isTrackedBy(player));
+	}
+
+	@Test
+	void isTrackedBy_NullPlayer()
+	{
+		assertThrows(NullPointerException.class, () -> entity.isTrackedBy(null));
+	}
+
+	@Test
 	void getLocation_TwoInvocations_TwoClones()
 	{
 		Location location1 = entity.getLocation();


### PR DESCRIPTION
> **Proposal answering #1606 — please do not merge as-is.**
> This is one answer to the design question in that issue, not a decision. Happy to reshape it, swap the model for something else, or close it if you would rather solve it differently. The problem it describes stands either way.

`EntityMock#isTrackedBy` was a stub. Because `UnimplementedOperationException` extends `TestAbortedException`, a test touching it was reported as **skipped** rather than failed — so the guard it exists to protect could never be tested, and nothing said so.

### The approach

**No tracker is invented.** The answer is composed from what a real tracker actually depends on and what the mock already models:

- the entity still exists
- both are in the same world
- the player has not been asked to hide it
- it is inside the server's view distance

Everything it leans on is already there — `canSee` and its `hiddenEntities` map, and `ServerMock`'s configured view distance. So `hideEntity` and `setViewDistance` move the answer, and there is no new state that could drift out of sync with the rest of the mock.

That felt more in keeping with how the rest of MockBukkit works than adding a parallel tracking structure that has to be maintained alongside the visibility one.

### Open questions

**1. Is a derived answer acceptable?** The alternative is an explicit `setTrackedBy(player, boolean)` hook, so a test states the answer outright. That is more direct but decouples the result from `hideEntity` and view distance, and gives two ways to express the same thing. I preferred derived, but it is your call.

**2. Which view distance?** This uses the **server's**, because `PlayerMock#getViewDistance` and `getSendViewDistance` are themselves unimplemented stubs — there is nothing per-player to read yet. Once those are implemented, per-player would be more faithful, and switching is a one-line change.

### Relationship to #1611

It composes with `isVisibleByDefault` once that lands, but does not depend on it — this branch is cut from `v1.21` and stands alone.

### Tests

Seven: a nearby player in the same world tracks it, a distant one does not, a player in another world does not, a hidden entity is not tracked, a removed entity is not tracked, changing the view distance moves the boundary in both directions, and a null player is rejected.

Full suite green: 20614 tests, 0 failures. 9 added lines, 0 uncovered, checkstyle clean.
