### PR TITLE
RFC: a clock the scheduler drives and a test can advance

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/ServerMock.java
@@ -152,6 +152,7 @@ import org.mockbukkit.mockbukkit.plugin.PluginManagerMock;
 import org.mockbukkit.mockbukkit.plugin.lifecycle.event.LifecycleEventRunnerMock;
 import org.mockbukkit.mockbukkit.profile.PlayerProfileMock;
 import org.mockbukkit.mockbukkit.scheduler.BukkitSchedulerMock;
+import org.mockbukkit.mockbukkit.scheduler.ClockMock;
 import org.mockbukkit.mockbukkit.scheduler.paper.FoliaAsyncScheduler;
 import org.mockbukkit.mockbukkit.scheduler.paper.FoliaGlobalRegionScheduler;
 import org.mockbukkit.mockbukkit.scheduler.paper.FoliaRegionScheduler;
@@ -2916,6 +2917,17 @@ public class ServerMock extends Server.Spigot implements Server
 	public @NotNull ServerConfiguration getServerConfiguration()
 	{
 		return this.serverConfiguration;
+	}
+
+	/**
+	 * The server clock. Plugin code that measures elapsed time can read this instead of the wall clock, so a test can
+	 * hold time still, advance it deliberately, or let {@link BukkitSchedulerMock#performTicks(long)} move it.
+	 *
+	 * @return The server clock.
+	 */
+	public @NotNull ClockMock getClock()
+	{
+		return this.scheduler.getClock();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/BukkitSchedulerMock.java
@@ -22,6 +22,7 @@ import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 import org.mockbukkit.mockbukkit.world.WorldMock;
 import org.opentest4j.AssertionFailedError;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -60,6 +61,7 @@ public class BukkitSchedulerMock implements BukkitScheduler
 
 	// This variable must be accessed while synchronizing on BukkitSchedulerMock.this to avoid data races and race conditions
 	private long currentTick = 0;
+	private final ClockMock clock = new ClockMock(Instant.now());
 
 	private final AtomicInteger id = new AtomicInteger();
 	private long executorTimeout = 60000;
@@ -253,6 +255,8 @@ public class BukkitSchedulerMock implements BukkitScheduler
 		{
 			currentTick++;
 		}
+
+		this.clock.advanceOneTick();
 
 		processWorlds();
 		processEntities();
@@ -854,6 +858,17 @@ public class BukkitSchedulerMock implements BukkitScheduler
 			}
 		}
 
+	}
+
+	/**
+	 * The clock this scheduler drives. Every tick advances it 50ms, and a test can move it further with
+	 * {@link ClockMock#advance(java.time.Duration)}.
+	 *
+	 * @return The server clock.
+	 */
+	public @NotNull ClockMock getClock()
+	{
+		return this.clock;
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/scheduler/ClockMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/scheduler/ClockMock.java
@@ -1,0 +1,90 @@
+package org.mockbukkit.mockbukkit.scheduler;
+
+import com.google.common.base.Preconditions;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+
+/**
+ * A {@link Clock} that only moves when something moves it.
+ * <p>
+ * Plugin code that measures elapsed time has nothing to hold still in a test: the wall clock is too coarse to order
+ * events reliably, and an expiry measured in seconds cannot be waited out. Reading time from here instead means a
+ * test can state what time it is, and {@link BukkitSchedulerMock#performTicks(long)} advances it 50ms per tick the
+ * way a real server would.
+ */
+public class ClockMock extends Clock
+{
+
+	private static final long MILLIS_PER_TICK = 50;
+
+	private final ZoneId zone;
+	private Instant instant;
+
+	/**
+	 * Creates a clock fixed at the given instant, in the system default zone.
+	 *
+	 * @param instant The instant to start at.
+	 */
+	public ClockMock(@NotNull Instant instant)
+	{
+		this(instant, ZoneId.systemDefault());
+	}
+
+	/**
+	 * Creates a clock fixed at the given instant and zone.
+	 *
+	 * @param instant The instant to start at.
+	 * @param zone    The zone to report.
+	 */
+	public ClockMock(@NotNull Instant instant, @NotNull ZoneId zone)
+	{
+		Preconditions.checkArgument(instant != null, "Instant cannot be null");
+		Preconditions.checkArgument(zone != null, "Zone cannot be null");
+		this.instant = instant;
+		this.zone = zone;
+	}
+
+	@Override
+	public @NotNull ZoneId getZone()
+	{
+		return this.zone;
+	}
+
+	@Override
+	public @NotNull Clock withZone(@NotNull ZoneId zone)
+	{
+		Preconditions.checkArgument(zone != null, "Zone cannot be null");
+		return new ClockMock(this.instant, zone);
+	}
+
+	@Override
+	public @NotNull Instant instant()
+	{
+		return this.instant;
+	}
+
+	/**
+	 * Moves the clock forward.
+	 *
+	 * @param duration How far forward. Must not be negative -- time does not run backwards on a server either.
+	 */
+	public void advance(@NotNull Duration duration)
+	{
+		Preconditions.checkArgument(duration != null, "Duration cannot be null");
+		Preconditions.checkArgument(!duration.isNegative(), "Duration cannot be negative");
+		this.instant = this.instant.plus(duration);
+	}
+
+	/**
+	 * Moves the clock forward by one tick, 50ms.
+	 */
+	public void advanceOneTick()
+	{
+		this.instant = this.instant.plusMillis(MILLIS_PER_TICK);
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/scheduler/ClockMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/scheduler/ClockMockTest.java
@@ -1,0 +1,111 @@
+package org.mockbukkit.mockbukkit.scheduler;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+import org.mockbukkit.mockbukkit.MockBukkitInject;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockBukkitExtension.class)
+class ClockMockTest
+{
+
+	private static final Instant START = Instant.parse("2026-01-01T00:00:00Z");
+
+	@MockBukkitInject
+	private ServerMock server;
+
+	@Test
+	void instant_StandsStillUntilMoved()
+	{
+		ClockMock clock = new ClockMock(START);
+
+		assertEquals(START, clock.instant());
+		assertEquals(START, clock.instant());
+	}
+
+	@Test
+	void advance_MovesTheClockForward()
+	{
+		ClockMock clock = new ClockMock(START);
+
+		clock.advance(Duration.ofSeconds(11));
+
+		assertEquals(START.plusSeconds(11), clock.instant());
+	}
+
+	@Test
+	void advanceOneTick_IsFiftyMilliseconds()
+	{
+		ClockMock clock = new ClockMock(START);
+
+		clock.advanceOneTick();
+
+		assertEquals(START.plusMillis(50), clock.instant());
+	}
+
+	@Test
+	void getZone_DefaultsToTheSystemZone()
+	{
+		assertEquals(ZoneId.systemDefault(), new ClockMock(START).getZone());
+	}
+
+	@Test
+	void withZone_KeepsTheInstant()
+	{
+		ClockMock clock = new ClockMock(START);
+
+		var moved = clock.withZone(ZoneId.of("UTC"));
+
+		assertEquals(ZoneId.of("UTC"), moved.getZone());
+		assertEquals(START, moved.instant());
+	}
+
+	@Test
+	void rejectsBadArguments()
+	{
+		assertThrows(IllegalArgumentException.class, () -> new ClockMock(null));
+		assertThrows(IllegalArgumentException.class, () -> new ClockMock(START, null));
+		assertThrows(IllegalArgumentException.class, () -> new ClockMock(START).advance(null));
+		assertThrows(IllegalArgumentException.class,
+				() -> new ClockMock(START).advance(Duration.ofSeconds(-1)));
+		assertThrows(IllegalArgumentException.class, () -> new ClockMock(START).withZone(null));
+	}
+
+	@Test
+	void performTicks_AdvancesTheServerClock()
+	{
+		ClockMock clock = server.getClock();
+		Instant before = clock.instant();
+
+		server.getScheduler().performTicks(20);
+
+		assertEquals(before.plusSeconds(1), clock.instant());
+	}
+
+	@Test
+	void serverClockIsTheSchedulerClock()
+	{
+		assertSame(server.getScheduler().getClock(), server.getClock());
+	}
+
+	@Test
+	void expiryWindowsCanBeWaitedOutWithoutSleeping()
+	{
+		ClockMock clock = server.getClock();
+		Instant deadline = clock.instant().plusSeconds(10);
+
+		server.getClock().advance(Duration.ofSeconds(11));
+
+		assertEquals(true, clock.instant().isAfter(deadline));
+	}
+
+}


### PR DESCRIPTION
> **Proposal answering #1609 — please do not merge as-is.**
> This is one answer to the question in that issue, not a decision. Happy to reshape it, change the type, or close it if you would rather not own time control. The problem it describes stands either way, and that part is worth reading even if the answer is no.

## The problem

Plugin code that measures elapsed time has nothing to hold still in a test.

**Ordering by timestamp needs a sleep.** Consecutive `Instant.now()` calls can return the same value, so code that sorts or compares by time cannot be tested without inserting a real delay:

```java
small.remember(hit(alice, carol, 7.0));
small.remember(hit(bob, carol, 3.0));
// Enough of a gap that Carol is unambiguously the stalest -- the clock
// is coarse enough here that three hits in a row can share an instant.
Thread.sleep(5);
small.remember(hit(alice, dave, 1.0));
```

**Expiry windows cannot be waited out.** A tag that lapses after ten seconds means a test either waits ten seconds or the production class grows a package-private constructor taking the duration, purely so a test can pass 20ms. That is production code shaped by a test limitation.

The suite this came from carries **eleven `Thread.sleep` calls**, every one a workaround, and each is a flake risk on a loaded runner in both directions — too slow and the assertion passes for the wrong reason, too fast and it fails for no reason.

## The proposal

`ClockMock` stands still until something moves it.

```java
server.getClock().advance(Duration.ofSeconds(11));   // cross an expiry deliberately
server.getScheduler().performTicks(20);              // or let ticks move it
```

The **scheduler owns it**, because it already owns tick time, and advances it 50ms per tick — so `performTicks` moves time the way a real server would. `ServerMock` hands it out.

Purely additive: `getCurrentServerTime` and everything else are untouched. Plugins opt in by reading the server clock instead of the wall clock; nothing changes for anyone who does not.

## This would also help your CI

The intermittently failing `BukkitSchedulerMock` timing tests are the same underlying problem. `longRunningTask_Throws_RunTimeException` has reddened unrelated pull requests of mine twice, and I have reproduced it locally — it waits on `countDownLatch.await(1, TimeUnit.SECONDS)` before asserting a running count, so a busy runner misses the window.

There is a second one: `LootableMinecartMockTest.testSetHasPlayerLootedTwiceSameValue` failed for me with `expected: <1786879731862> but was: <1786879731863>` — two `System.currentTimeMillis` readings one millisecond apart.

Neither is caused by anything I changed, and neither can be fixed properly while the assertions depend on real time.

## Open questions

1. **Do you want time control in MockBukkit at all**, or is clock injection the plugin's own problem?
2. **Is extending `java.time.Clock` the right shape?** It composes with anything already taking a `Clock`, which is why I chose it, but a MockBukkit-specific type would give more freedom over the API.

## Tests

Nine: the clock stands still, `advance` moves it, a tick is 50ms, the default and explicit zones, `withZone` keeping the instant, the four rejection cases, `performTicks` advancing the server clock, the server and scheduler sharing one clock, and an expiry window crossed without sleeping.

Full suite green: 20616 tests, 0 failures. 22 added lines, 0 uncovered, checkstyle clean.
