### PR TITLE
RFC: let kill credit lapse the way it does on a real server

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -191,6 +191,38 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		return !isDead();
 	}
 
+	/**
+	 * Works out which player, if any, should be credited with this entity's death, following the same order
+	 * {@code CraftLivingEntity} uses: the entity that dealt the damage directly, then the entity that caused it, then
+	 * the shooter behind a projectile. Checking only the direct entity would miss every indirect kill, so an arrow
+	 * fired by a player would leave the killer unset here while setting it on a real server.
+	 *
+	 * @return the player to credit, or null if the last damage cannot be traced back to one.
+	 */
+	private @Nullable Player deriveKiller()
+	{
+		EntityDamageEvent lastDamage = getLastDamageCause();
+		if (lastDamage == null)
+		{
+			return null;
+		}
+
+		DamageSource source = lastDamage.getDamageSource();
+		if (source.getDirectEntity() instanceof Player player)
+		{
+			return player;
+		}
+		if (source.getCausingEntity() instanceof Player player)
+		{
+			return player;
+		}
+		if (source.getDirectEntity() instanceof Projectile projectile && projectile.getShooter() instanceof Player player)
+		{
+			return player;
+		}
+		return null;
+	}
+
 	@Override
 	public void setHealth(double health)
 	{
@@ -201,10 +233,11 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		}
 
 		DamageSource dmg;
-		if (getLastDamageCause() != null && getLastDamageCause().getDamageSource().getDirectEntity() instanceof Player player)
+		Player killer = deriveKiller();
+		if (killer != null)
 		{
 			dmg = DamageSource.builder(DamageType.PLAYER_ATTACK).build();
-			setKiller(player);
+			setKiller(killer);
 		}
 		else
 		{

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -233,11 +233,11 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		}
 
 		DamageSource dmg;
-		Player killer = deriveKiller();
-		if (killer != null)
+		Player derivedKiller = deriveKiller();
+		if (derivedKiller != null)
 		{
 			dmg = DamageSource.builder(DamageType.PLAYER_ATTACK).build();
-			setKiller(killer);
+			setKiller(derivedKiller);
 		}
 		else
 		{

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -140,6 +140,8 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	@Getter
 	@Setter
 	private @Nullable Player killer;
+	private static final long KILL_CREDIT_TICKS = 100;
+	private long lastPlayerDamageTick = Long.MIN_VALUE;
 
 	private final Map<PotionEffectType, PriorityQueue<ActivePotionEffect>> activeEffects = new HashMap<>();
 	private TriState frictionState = TriState.NOT_SET;
@@ -191,17 +193,40 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 		return !isDead();
 	}
 
+	@Override
+	public void setLastDamageCause(@Nullable EntityDamageEvent event)
+	{
+		super.setLastDamageCause(event);
+		if (event != null && attributeToPlayer(event) != null)
+		{
+			this.lastPlayerDamageTick = currentTick();
+		}
+	}
+
+	private long currentTick()
+	{
+		return this.server.getScheduler().getCurrentTick();
+	}
+
 	/**
-	 * Works out which player, if any, should be credited with this entity's death, following the same order
-	 * {@code CraftLivingEntity} uses: the entity that dealt the damage directly, then the entity that caused it, then
-	 * the shooter behind a projectile. Checking only the direct entity would miss every indirect kill, so an arrow
-	 * fired by a player would leave the killer unset here while setting it on a real server.
+	 * Works out which player, if any, should be credited with this entity's death.
+	 * <p>
+	 * Credit lapses: vanilla stops crediting once the last player damage is more than {@value #KILL_CREDIT_TICKS}
+	 * ticks old, so an entity that wanders off and dies of something else later is nobody's kill.
 	 *
-	 * @return the player to credit, or null if the last damage cannot be traced back to one.
+	 * @return the player to credit, or null if there is none or the credit has lapsed.
 	 */
 	private @Nullable Player deriveKiller()
 	{
-		EntityDamageEvent lastDamage = getLastDamageCause();
+		if (currentTick() - this.lastPlayerDamageTick > KILL_CREDIT_TICKS)
+		{
+			return null;
+		}
+		return attributeToPlayer(getLastDamageCause());
+	}
+
+	private static @Nullable Player attributeToPlayer(@Nullable EntityDamageEvent lastDamage)
+	{
 		if (lastDamage == null)
 		{
 			return null;

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
@@ -3,6 +3,8 @@ package org.mockbukkit.mockbukkit.entity;
 import net.kyori.adventure.util.TriState;
 import org.bukkit.Location;
 import org.bukkit.attribute.Attribute;
+import org.bukkit.damage.DamageSource;
+import org.bukkit.damage.DamageType;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.DragonFireball;
 import org.bukkit.entity.Egg;
@@ -933,6 +935,84 @@ class LivingEntityMockTest
 	{
 		// Should not throw, just do nothing
 		assertDoesNotThrow(() -> livingEntity.setActiveItemRemainingTime(10));
+	}
+
+
+	@Test
+	void setHealthZero_NoLastDamage_LeavesKillerUnset()
+	{
+		livingEntity.setHealth(0);
+		assertNull(livingEntity.getKiller());
+	}
+
+	@Test
+	void setHealthZero_DirectPlayerDamager_SetsKiller()
+	{
+		PlayerMock attacker = server.addPlayer();
+
+		killWith(DamageSource.builder(DamageType.PLAYER_ATTACK).withDirectEntity(attacker).build());
+
+		assertEquals(attacker, livingEntity.getKiller());
+	}
+
+	@Test
+	void setHealthZero_ProjectileWithCausingPlayer_SetsKiller()
+	{
+		PlayerMock shooter = server.addPlayer();
+		Arrow arrow = launchArrow();
+
+		killWith(DamageSource.builder(DamageType.ARROW)
+				.withDirectEntity(arrow)
+				.withCausingEntity(shooter)
+				.build());
+
+		assertEquals(shooter, livingEntity.getKiller());
+	}
+
+	@Test
+	void setHealthZero_ProjectileShotByPlayer_SetsKiller()
+	{
+		PlayerMock shooter = server.addPlayer();
+		Arrow arrow = launchArrow();
+		arrow.setShooter(shooter);
+
+		killWith(DamageSource.builder(DamageType.ARROW).withDirectEntity(arrow).build());
+
+		assertEquals(shooter, livingEntity.getKiller());
+	}
+
+	@Test
+	void setHealthZero_ProjectileWithoutShooter_LeavesKillerUnset()
+	{
+		Arrow arrow = launchArrow();
+
+		killWith(DamageSource.builder(DamageType.ARROW).withDirectEntity(arrow).build());
+
+		assertNull(livingEntity.getKiller());
+	}
+
+	@Test
+	void setHealthZero_NonPlayerDamager_LeavesKillerUnset()
+	{
+		killWith(DamageSource.builder(DamageType.MOB_ATTACK).withDirectEntity(livingEntity).build());
+
+		assertNull(livingEntity.getKiller());
+	}
+
+	private @NotNull Arrow launchArrow()
+	{
+		WorldMock world = server.addSimpleWorld("arrow-world");
+		Location location = livingEntity.getLocation();
+		location.setWorld(world);
+		livingEntity.setLocation(location);
+		return livingEntity.launchProjectile(Arrow.class);
+	}
+
+	private void killWith(@NotNull DamageSource source)
+	{
+		livingEntity.setLastDamageCause(
+				new EntityDamageEvent(livingEntity, EntityDamageEvent.DamageCause.CUSTOM, source, 1.0));
+		livingEntity.setHealth(0);
 	}
 
 }

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
@@ -939,6 +939,60 @@ class LivingEntityMockTest
 
 
 	@Test
+	void killCredit_ClearingTheDamageCauseIsAccepted()
+	{
+		PlayerMock attacker = server.addPlayer();
+		livingEntity.setLastDamageCause(new EntityDamageEvent(livingEntity,
+				EntityDamageEvent.DamageCause.CUSTOM,
+				DamageSource.builder(DamageType.PLAYER_ATTACK).withDirectEntity(attacker).build(), 1.0));
+
+		livingEntity.setLastDamageCause(null);
+		livingEntity.setHealth(0);
+
+		assertNull(livingEntity.getKiller());
+	}
+
+	@Test
+	void killCredit_LapsesAfterTheWindow()
+	{
+		PlayerMock attacker = server.addPlayer();
+		livingEntity.setLastDamageCause(new EntityDamageEvent(livingEntity,
+				EntityDamageEvent.DamageCause.CUSTOM,
+				DamageSource.builder(DamageType.PLAYER_ATTACK).withDirectEntity(attacker).build(), 1.0));
+
+		server.getScheduler().performTicks(101);
+		livingEntity.setHealth(0);
+
+		assertNull(livingEntity.getKiller());
+	}
+
+	@Test
+	void killCredit_SurvivesInsideTheWindow()
+	{
+		PlayerMock attacker = server.addPlayer();
+		livingEntity.setLastDamageCause(new EntityDamageEvent(livingEntity,
+				EntityDamageEvent.DamageCause.CUSTOM,
+				DamageSource.builder(DamageType.PLAYER_ATTACK).withDirectEntity(attacker).build(), 1.0));
+
+		server.getScheduler().performTicks(99);
+		livingEntity.setHealth(0);
+
+		assertEquals(attacker, livingEntity.getKiller());
+	}
+
+	@Test
+	void killCredit_NeverDamagedByAPlayer()
+	{
+		livingEntity.setLastDamageCause(new EntityDamageEvent(livingEntity,
+				EntityDamageEvent.DamageCause.CUSTOM,
+				DamageSource.builder(DamageType.GENERIC).build(), 1.0));
+
+		livingEntity.setHealth(0);
+
+		assertNull(livingEntity.getKiller());
+	}
+
+	@Test
 	void setHealthZero_NoLastDamage_LeavesKillerUnset()
 	{
 		livingEntity.setHealth(0);


### PR DESCRIPTION
> **Proposal answering #1614 — please do not merge as-is.**
> This is one answer to the question in that issue, not a decision. Happy to reshape it, make it opt-in, or close it. The divergence it describes stands either way.

## The divergence

Vanilla only credits a player with a kill for a limited time after they last dealt damage — a counter set when a player hurts the entity, ticked down, and once it lapses the credit is dropped. The window is 100 ticks, five seconds.

`LivingEntityMock` credits regardless of elapsed time. An entity that takes one hit from a player, wanders off, and dies of fall damage a minute later is still that player's kill.

## Why this is worth fixing rather than documenting

Because the point of a mock is that a passing test means the production behaviour is right, and here it does not.

1. A test asserting **"the player is not credited, because the kill came too late"** cannot be written at all — the mock always credits.
2. Worse, a test asserting the player **is** credited passes even where a real server would not have credited them. It looks green for the wrong reason.

For anything doing kill attribution — death logging, kill streaks, bounty or ELO systems — the interesting cases are exactly the boundary ones. That is the case a mock most needs to get right, and it is currently the case it gets wrong silently.

## How

Records the tick at which a player last dealt damage, and compares it against a 100 tick window in `deriveKiller`.

The tick comes from `BukkitSchedulerMock#getCurrentTick`, which is already public and already what `performTicks` moves — so a test crosses the boundary deliberately:

```java
server.getScheduler().performTicks(101);
livingEntity.setHealth(0);

assertNull(livingEntity.getKiller());
```

**No dependency on #1609.** The clock proposal would work here too, but the scheduler's own tick counter is sufficient and already exists, so this stands alone.

## This stacks on #1613

`deriveKiller` was introduced there, so this is cut from that branch rather than from `v1.21` directly. The base here is still `v1.21`, and the diff reads correctly once #1613 merges. If you would rather I rebase it after that lands, say so.

## The risk you raised, measured

#1614 asked what would break — specifically, existing tests that damage an entity and then kill it later.

**Nothing broke.** Full suite: 20617 tests, 0 failures. That is the measured answer rather than an estimate.

## Open question

Is silently correcting this acceptable, or should it be opt-in for a release and become the default later? It is a behaviour change for anyone relying on the current forgiving behaviour, even though nothing in this repo does.

## Tests

Four: credit lapses after the window, survives inside it, is never given when no player dealt damage, and clearing the damage cause is accepted.

9 added lines, 0 uncovered, checkstyle clean.
