### PR TITLE
Keep the stored id when resolving a skull's owner

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/SkullMetaMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/SkullMetaMock.java
@@ -122,12 +122,22 @@ public class SkullMetaMock extends ItemMetaMock implements SkullMeta
 	@Override
 	public OfflinePlayer getOwningPlayer()
 	{
-		if (hasOwner())
+		if (!hasOwner())
 		{
-			return new OfflinePlayerMock(playerProfile.getName());
+			return null;
 		}
 
-		return null;
+		// Keep the id that was stored. Building from the name alone mints a fresh offline-mode UUID unrelated to
+		// it, and round-tripping through Bukkit#getOfflinePlayer(UUID) loses the other half -- an id nothing has
+		// seen before comes back with a synthesised name. The profile holds both, so answer from it.
+		UUID id = playerProfile.getId();
+		if (id != null)
+		{
+			return new OfflinePlayerMock(id, playerProfile.getName());
+		}
+
+		// hasOwner() above already requires a non-empty name, so there is always one to fall back to.
+		return Bukkit.getOfflinePlayer(playerProfile.getName());
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/meta/SkullMetaMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/meta/SkullMetaMockTest.java
@@ -1,6 +1,7 @@
 package org.mockbukkit.mockbukkit.inventory.meta;
 
 import org.bukkit.profile.PlayerProfile;
+import org.mockbukkit.mockbukkit.profile.PlayerProfileMock;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockbukkit.mockbukkit.MockBukkitExtension;
@@ -23,6 +24,44 @@ class SkullMetaMockTest
 
 	@MockBukkitInject
 	private ServerMock server;
+
+	@Test
+	void getOwningPlayer_KeepsTheStoredId()
+	{
+		SkullMetaMock meta = new SkullMetaMock();
+		PlayerMock player = server.addPlayer();
+		meta.setOwningPlayer(player);
+
+		assertEquals(player.getUniqueId(), meta.getOwningPlayer().getUniqueId());
+	}
+
+	@Test
+	void getOwningPlayer_KeepsTheStoredIdAfterThePlayerLeaves()
+	{
+		SkullMetaMock meta = new SkullMetaMock();
+		PlayerMock player = server.addPlayer();
+		UUID id = player.getUniqueId();
+		meta.setOwningPlayer(player);
+
+		player.disconnect();
+
+		assertEquals(id, meta.getOwningPlayer().getUniqueId());
+	}
+
+	@Test
+	void getOwningPlayer_FallsBackToTheNameWithoutAnId()
+	{
+		SkullMetaMock meta = new SkullMetaMock();
+		meta.setPlayerProfile(new PlayerProfileMock("Nameless", null));
+
+		assertEquals("Nameless", meta.getOwningPlayer().getName());
+	}
+
+	@Test
+	void getOwningPlayer_NullWithoutAnOwner()
+	{
+		assertNull(new SkullMetaMock().getOwningPlayer());
+	}
 
 	@Test
 	void testDefaultNoOwner()


### PR DESCRIPTION
`SkullMetaMock#getOwningPlayer` throws away the UUID it was given.

```java
public OfflinePlayer getOwningPlayer()
{
	if (hasOwner())
	{
		return new OfflinePlayerMock(playerProfile.getName());   // id discarded
	}
	return null;
}
```

`OfflinePlayerMock(String)` derives its UUID from the name — `UUID.nameUUIDFromBytes("OfflinePlayer:" + name)` — so the id that comes back is an offline-mode hash with no relation to the id actually stored on the profile.

For a skull owned by a player who is still online this goes unnoticed, because a lookup by name finds them again. For one owned by a player who has since disconnected, `getOwningPlayer().getUniqueId()` returns a hash of their name. A test asserting on that id is comparing against the wrong value and cannot tell.

### Why not simply resolve by id

Paper does `Bukkit.getOfflinePlayer(profile.getId())`, and `SkullStateMock` already mirrors that. I tried it first and it broke two existing tests, for a reason worth recording:

`ServerMock#getOfflinePlayer(UUID)` hands an id the player list has never seen to `PlayerFactoryMock`, which **synthesises a name** — so `setOwningPlayer(new OfflinePlayerMock("TheBusyBiscuit"))` came back as `Player0`. The round trip is lossy in both directions: by name it invents an id, by id it invents a name. On a real server neither happens, because `CraftServer` has a user cache to resolve against.

So the answer is built from the profile, which holds both halves already:

```java
UUID id = playerProfile.getId();
if (id != null)
{
	return new OfflinePlayerMock(id, playerProfile.getName());
}
return Bukkit.getOfflinePlayer(playerProfile.getName());
```

The name fallback needs no null check — `hasOwner()` above already requires a non-empty name, so the branch and the trailing `return null` that were there are unreachable and have gone.

### Tests

Four: the stored id survives for an online owner, it still survives after that player disconnects (the case that was broken), a profile with a name but no id falls back to a name lookup, and no owner still returns null.

The two existing tests that the naive fix broke — `testSetOwner` and `testSetOwningPlayer`, both asserting the name round-trips — pass unchanged here.

Full suite green: 20611 tests, 0 failures. 6 added lines, 0 uncovered, checkstyle clean.

### Related

This came out of a live bug where player heads rendered as Steve. The larger half of that — `ServerMock#getOfflinePlayer(UUID)` returning the **live `Player`** when the owner is online, where `CraftServer` returns a `CraftOfflinePlayer` even then — is a separate and much more disruptive change, so it is not in this pull request.
