### PR TITLE
fix: keep getPVP and the PVP game rule as one switch

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
@@ -165,7 +165,6 @@ public class WorldMock implements World
 
 	private boolean allowAnimals = true;
 	private boolean allowMonsters = true;
-	private boolean pvp;
 	private boolean hardcore;
 	private boolean getKeepSpawnInMemory = true;
 	private boolean generateStructures = true;
@@ -209,15 +208,17 @@ public class WorldMock implements World
 		this.grassHeight = grassHeight;
 		this.server = MockBukkit.getMock();
 
+		boolean pvp;
+
 		if (this.server != null)
 		{
-			this.pvp = this.server.getServerConfiguration().isPvpEnabled();
+			pvp = this.server.getServerConfiguration().isPvpEnabled();
 			this.ticksPerSpawn.putAll(this.server.getServerConfiguration().getTicksPerSpawn());
 			this.spawnLimits.putAll(this.server.getServerConfiguration().getSpawnLimits());
 		}
 		else
 		{
-			this.pvp = true;
+			pvp = true;
 
 			// Set the default ticks per spawn values.
 			ticksPerSpawn.put(SpawnCategory.ANIMAL, 400);
@@ -236,6 +237,7 @@ public class WorldMock implements World
 		}
 
 		initializeGameRules();
+		setGameRule(GameRules.PVP, pvp);
 	}
 
 	/**
@@ -1347,13 +1349,13 @@ public class WorldMock implements World
 	@Override
 	public boolean getPVP()
 	{
-		return this.pvp;
+		return getGameRuleValue(GameRules.PVP);
 	}
 
 	@Override
 	public void setPVP(boolean pvp)
 	{
-		this.pvp = pvp;
+		setGameRule(GameRules.PVP, pvp);
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
@@ -2097,6 +2097,26 @@ class WorldMockTest
 	}
 
 	@Test
+	void testSetPvpGameRuleIsVisibleToGetPvp()
+	{
+		WorldMock world = new WorldMock(Material.DIRT, 3);
+		world.setGameRule(GameRules.PVP, false);
+		assertFalse(world.getPVP());
+		world.setGameRule(GameRules.PVP, true);
+		assertTrue(world.getPVP());
+	}
+
+	@Test
+	void testSetPvpIsVisibleToGameRule()
+	{
+		WorldMock world = new WorldMock(Material.DIRT, 3);
+		world.setPVP(false);
+		assertFalse(world.getGameRuleValue(GameRules.PVP));
+		world.setPVP(true);
+		assertTrue(world.getGameRuleValue(GameRules.PVP));
+	}
+
+	@Test
 	void testGetKeepSpawnInMemoryDefault()
 	{
 		WorldMock world = new WorldMock(Material.DIRT, 3);


### PR DESCRIPTION
`WorldMock` keeps PVP in a private field, independent of the game rule map:

```java
private boolean pvp;
...
public boolean getPVP() { return this.pvp; }
public void setPVP(boolean pvp) { this.pvp = pvp; }
```

On a real server the two are one switch. In the 1.21.11 server jar, `CraftWorld.setPVP(boolean)` is exactly:

```java
world.getGameRules().set(GameRules.PVP, value, world);
```

So under the mock `setGameRule(GameRules.PVP, false)` leaves `getPVP()` returning `true`, and `setPVP(false)` leaves the game rule `true`. A test asserting on `getPVP()` after the plugin under test sets the game rule is asserting the mock's own field rather than the state the production code actually changed — and it goes red the moment that plugin migrates off the deprecated `setPVP`, which is the opposite of what a test should do.

### The fix

The field goes; both accessors read and write `GameRules.PVP`. The constructor keeps the value from `ServerConfiguration#isPvpEnabled()` in a local and applies it *after* `initializeGameRules()`, which would otherwise overwrite it with the vanilla default.

### Tests

Two, next to the existing PVP tests: the game rule is visible through `getPVP()`, and `setPVP` is visible through `getGameRuleValue(GameRules.PVP)` — both directions, both values.

Run against `v1.21` with the test file but without the `WorldMock` change, exactly those two fail and nothing else moves:

```
WorldMockTest > testSetPvpGameRuleIsVisibleToGetPvp() FAILED
WorldMockTest > testSetPvpIsVisibleToGameRule() FAILED
426 tests completed, 2 failed
```

With the change, `WorldMockTest` is green: 382 tests, 0 failures, 0 skipped. The two existing tests, `testGetPvpDefault` and `testSetPvp`, pass unchanged. `getPVP`/`setPVP` are one line each with no branches, so the added lines are fully covered.

### Compatibility

This is a behaviour change rather than an addition. Anybody asserting `getPVP()` after `setGameRule` gets a newly passing test; anybody asserting that the two stay independent breaks — which is the bug being fixed, but worth knowing before it shows up in review.
