### PR TITLE
docs: state that simulateDamage applies no damage modifiers

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -328,6 +328,10 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 
 	/**
 	 * Simulate damage to this entity and throw an event.
+	 * <p>
+	 * No damage modifiers are applied. Armour, enchantments, resistance and absorption are not
+	 * modelled, so {@link EntityDamageEvent#getFinalDamage()} on the returned event is the amount
+	 * that was passed in.
 	 *
 	 * @param amount <p>The amount of damage to be done</p>
 	 * @param source <p>The damager</p>
@@ -340,6 +344,10 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 
 	/**
 	 * Simulate damage to this entity and throw an event
+	 * <p>
+	 * No damage modifiers are applied. Armour, enchantments, resistance and absorption are not
+	 * modelled, so {@link EntityDamageEvent#getFinalDamage()} on the returned event is the amount
+	 * that was passed in.
 	 *
 	 * @param amount <p>The amount of damage to be done</p>
 	 * @param source <p>The damager</p>

--- a/src/main/java/org/mockbukkit/mockbukkit/simulate/entity/LivingEntitySimulation.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/simulate/entity/LivingEntitySimulation.java
@@ -22,6 +22,10 @@ public class LivingEntitySimulation
 
 	/**
 	 * Simulate damage to this entity and throw an event.
+	 * <p>
+	 * No damage modifiers are applied. Armour, enchantments, resistance and absorption are not
+	 * modelled, so {@link EntityDamageEvent#getFinalDamage()} on the returned event is the amount
+	 * that was passed in.
 	 *
 	 * @param amount <p>The amount of damage to be done</p>
 	 * @param source <p>The damager</p>
@@ -50,6 +54,10 @@ public class LivingEntitySimulation
 
 	/**
 	 * Simulate damage to this entity and throw an event
+	 * <p>
+	 * No damage modifiers are applied. Armour, enchantments, resistance and absorption are not
+	 * modelled, so {@link EntityDamageEvent#getFinalDamage()} on the returned event is the amount
+	 * that was passed in.
 	 *
 	 * @param amount <p>The amount of damage to be done</p>
 	 * @param source <p>The damager</p>


### PR DESCRIPTION
`simulateDamage` builds its `EntityDamageEvent` without a `DamageModifier` map, so `getFinalDamage()` on the returned event is exactly the amount that was passed in. Armour, enchantments, resistance and absorption are not modelled.

That is reasonable behaviour for a mock, but nothing says so anywhere. A plugin that reads `getFinalDamage()` expecting armour reduction quietly gets the raw number, and the test agrees with it — the kind of gap that is only found by reading the implementation.

Javadoc only, no code change: one paragraph on each of the two `simulateDamage` overloads in `LivingEntitySimulation`, and on the two delegates in `LivingEntityMock`.

`./gradlew javadoc` is clean.

Note this touches the same javadoc blocks as #1624, so whichever lands second needs a trivial rebase.
