### PR TITLE
fix: select nearby entities by hitbox overlap, as Paper does

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/entity/EntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/EntityMock.java
@@ -75,6 +75,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -693,17 +694,9 @@ public abstract class EntityMock extends Entity.Spigot implements Entity, Messag
 	public @NotNull List<Entity> getNearbyEntities(double x, double y, double z)
 	{
 		AsyncCatcher.catchOp("getNearbyEntities");
-		List<Entity> nearbyEntities = new ArrayList<>();
-		getWorld().getEntities().forEach(entity ->
-		{
-			Vector distance = entity.getLocation().clone().subtract(getLocation()).toVector();
-			if (Math.abs(distance.getX()) <= x && Math.abs(distance.getY()) <= y
-					&& Math.abs(distance.getZ()) <= z && entity != this)
-			{
-				nearbyEntities.add(entity);
-			}
-		});
-		return nearbyEntities;
+		return getWorld().getNearbyEntities(getBoundingBox().expand(x, y, z)).stream()
+				.filter(entity -> entity != this)
+				.collect(Collectors.toList());
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
@@ -2052,7 +2052,7 @@ public class WorldMock implements World
 	{
 		return getEntities().stream()
 				.filter(entity -> filter == null || filter.test(entity))
-				.filter(entity -> boundingBox.contains(entity.getLocation().toVector()))
+				.filter(entity -> entity.getBoundingBox().overlaps(boundingBox))
 				.collect(Collectors.toSet());
 	}
 

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/EntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/EntityMockTest.java
@@ -1188,6 +1188,15 @@ class EntityMockTest
 	}
 
 	@Test
+	void getNearbyEntitiesHitboxWithinRange()
+	{
+		entity.teleport(new Location(world, 0, 0, 0));
+		Entity nearbyEntity = world.spawnEntity(new Location(world, 0, 0, 7.2), EntityType.ZOMBIE);
+		List<Entity> nearbyEntities = entity.getNearbyEntities(7, 7, 7);
+		assertTrue(nearbyEntities.contains(nearbyEntity));
+	}
+
+	@Test
 	void getNearbyEntitiesNotNearby()
 	{
 		entity.teleport(new Location(world, 0, 0, 0));

--- a/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
@@ -464,13 +464,30 @@ class WorldMockTest
 		WorldMock world = server.addSimpleWorld("world");
 		Location centerLoc = new Location(world, 0, 0, 0);
 		Location insideLoc = new Location(world, 0, 1, 7);
-		Location outsideLoc = new Location(world, 0, 1, 8);
+		Location outsideLoc = new Location(world, 0, 1, 9);
 		world.spawnEntity(insideLoc, EntityType.LLAMA);
 		world.spawnEntity(insideLoc, EntityType.LLAMA);
 		world.spawnEntity(insideLoc, EntityType.FROG);
 		world.spawnEntity(outsideLoc, EntityType.POLAR_BEAR);
 		BoundingBox box = BoundingBox.of(centerLoc, 1, 2, 8);
 		assertEquals(3, world.getNearbyEntities(box).size());
+	}
+
+	@Test
+	void getNearbyEntities_HitboxOverlappingEdge_IsFound()
+	{
+		WorldMock world = server.addSimpleWorld("world");
+		world.spawnEntity(new Location(world, 0, 1, 8), EntityType.POLAR_BEAR);
+		BoundingBox box = BoundingBox.of(new Location(world, 0, 0, 0), 1, 2, 8);
+		assertEquals(1, world.getNearbyEntities(box).size());
+	}
+
+	@Test
+	void getNearbyEntities_BoxAboveFeet_IsFound()
+	{
+		WorldMock world = server.addSimpleWorld("world");
+		world.spawnEntity(new Location(world, 0, 0, 0), EntityType.ZOMBIE);
+		assertEquals(1, world.getNearbyEntities(new BoundingBox(-1, 1, -1, 1, 3, 1)).size());
 	}
 
 	@Test


### PR DESCRIPTION
`WorldMock.getNearbyEntities(BoundingBox, Predicate)` selects on the entity's **position**:

```java
.filter(entity -> boundingBox.contains(entity.getLocation().toVector()))
```

Paper selects on the entity's **hitbox**. `CraftWorld.getNearbyEntities(BoundingBox, Predicate)` builds an `AABB` from the box and hands it to `ServerLevel.getEntities(null, aabb, Predicates.alwaysTrue())`; the per-entity test at the bottom of that call, in `ChunkEntitySlices$EntityCollectionBySection.getEntities` on 1.21.11, is:

```
155: invokevirtual  // Method net/minecraft/world/entity/Entity.getBoundingBox:()Lnet/minecraft/world/phys/AABB;
159: invokevirtual  // Method net/minecraft/world/phys/AABB.intersects:(Lnet/minecraft/world/phys/AABB;)Z
```

So the mock's answer is a strict subset of the server's. Two shapes it gets wrong:

- **An entity standing on the boundary.** A polar bear is 1.4 wide, so one at `z = 8` reaches 0.7 blocks into a box that ends at `z = 8`. The server returns it; the mock does not.
- **A box that does not reach the ground.** Searching y 1 → 3 finds a zombie standing at y 0 on a real server, because the zombie is 1.95 tall. The mock misses it, since only the feet point is ever tested.

A plugin that searches around a point and acts on what it finds therefore passes here and behaves differently in production, with nothing in the test to show it.

`EntityMock.getNearbyEntities(x, y, z)` had the same problem and a second one: it built a box centred on the entity's feet, while `CraftEntity` inflates the entity's own hitbox — `entity.getBoundingBox().inflate(x, y, z)` — which is asymmetric in Y for anything taller than it is wide. It now delegates to the world method with `getBoundingBox().expand(x, y, z)`, which is the same box, and drops its hand-rolled loop.

### Tests

Three new: a hitbox straddling the boundary is found, a box above the feet finds a tall entity, and the entity-level range is measured from the hitbox rather than the position.

One existing test changed. `getNearbyEntities_InBoundingBox` placed its "outside" polar bear at `z = 8`, exactly on the edge of a box ending at `z = 8` — under Paper's rule that bear is *inside*, which is what the new boundary test now pins. It moved to `z = 9`, clear of the edge, so the test still asserts what its name says.

That is the only test in the suite that moved: with the implementation change alone, 20616 tests ran and exactly 1 failed. With the tests in, the full suite is green — 20619 tests, 0 failures.

### Compatibility

This widens what the search returns. A test asserting that nothing is nearby, about an entity whose hitbox does reach into the box, will start failing — correctly, but it is a behaviour change rather than an addition and worth saying out loud.
