### PR TITLE
fix: never hand out or keep a caller-reachable Location

### DIFF
--- a/src/main/java/org/mockbukkit/mockbukkit/block/BlockMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/BlockMock.java
@@ -249,7 +249,7 @@ public class BlockMock implements Block
 	@Override
 	public @NotNull Location getLocation()
 	{
-		return location;
+		return location == null ? null : location.clone();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/block/BlockMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/BlockMock.java
@@ -100,7 +100,7 @@ public class BlockMock implements Block
 		Preconditions.checkNotNull(material, "Material cannot be null");
 		Preconditions.checkArgument(material.isBlock(), "Material has to be a block");
 		this.material = material;
-		this.location = location;
+		this.location = location == null ? null : location.clone();
 		this.state = BlockStateMockFactory.mock(this);
 		this.blockData = BlockDataMockFactory.mock(material);
 		this.drops = Collections.emptyList();

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/BeehiveStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/BeehiveStateMock.java
@@ -60,7 +60,7 @@ public class BeehiveStateMock extends TileStateMock implements Beehive
 	{
 		super(state);
 
-		this.flowerLocation = state.flowerLocation;
+		this.flowerLocation = state.flowerLocation == null ? null : state.flowerLocation.clone();
 		this.maxBees = state.maxBees;
 		this.sedated = state.sedated;
 		this.bees.addAll(state.bees);
@@ -81,14 +81,14 @@ public class BeehiveStateMock extends TileStateMock implements Beehive
 	@Override
 	public @Nullable Location getFlower()
 	{
-		return this.flowerLocation;
+		return this.flowerLocation == null ? null : this.flowerLocation.clone();
 	}
 
 	@Override
 	public void setFlower(@Nullable Location location)
 	{
 		Preconditions.checkArgument(location == null || this.getWorld().equals(location.getWorld()), "Flower must be in the same world");
-		this.flowerLocation = location;
+		this.flowerLocation = location == null ? null : location.clone();
 	}
 
 	/**

--- a/src/main/java/org/mockbukkit/mockbukkit/block/state/EndGatewayStateMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/block/state/EndGatewayStateMock.java
@@ -56,7 +56,7 @@ public class EndGatewayStateMock extends TileStateMock implements EndGateway
 		super(state);
 		this.age = state.age;
 		this.exactTeleport = state.exactTeleport;
-		this.exitLocation = state.exitLocation;
+		this.exitLocation = state.exitLocation == null ? null : state.exitLocation.clone();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/command/CommandSourceStackMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/command/CommandSourceStackMock.java
@@ -35,7 +35,7 @@ public class CommandSourceStackMock implements CommandSourceStack
 	@Override
 	public @NotNull Location getLocation()
 	{
-		return location;
+		return location.clone();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/command/CommandSourceStackMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/command/CommandSourceStackMock.java
@@ -18,7 +18,7 @@ public class CommandSourceStackMock implements CommandSourceStack
 	public CommandSourceStackMock(Location location, CommandSender sender, Entity executor)
 	{
 		Preconditions.checkNotNull(location);
-		this.location = location;
+		this.location = location.clone();
 		this.sender = sender;
 		this.executor = executor;
 	}

--- a/src/main/java/org/mockbukkit/mockbukkit/damage/DamageSourceBuilderMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/damage/DamageSourceBuilderMock.java
@@ -41,7 +41,7 @@ public class DamageSourceBuilderMock implements DamageSource.Builder
 	public DamageSource.@NotNull Builder withDamageLocation(@NotNull Location location)
 	{
 		Preconditions.checkArgument(location != null, "Location cannot be null");
-		this.damageLocation = location;
+		this.damageLocation = location.clone();
 		return this;
 	}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/BatMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/BatMock.java
@@ -46,13 +46,13 @@ public class BatMock extends AmbientMock implements Bat
 	@Override
 	public @Nullable Location getTargetLocation()
 	{
-		return this.targetPosition;
+		return this.targetPosition == null ? null : this.targetPosition.clone();
 	}
 
 	@Override
 	public void setTargetLocation(@Nullable Location location)
 	{
-		this.targetPosition = location;
+		this.targetPosition = location == null ? null : location.clone();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/BeeMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/BeeMock.java
@@ -44,27 +44,27 @@ public class BeeMock extends AnimalsMock implements Bee
 	@Override
 	public @Nullable Location getHive()
 	{
-		return this.hive;
+		return this.hive == null ? null : this.hive.clone();
 	}
 
 	@Override
 	public void setHive(@Nullable Location location)
 	{
 		Preconditions.checkArgument(location == null || this.getWorld().equals(location.getWorld()), "Hive must be in same world");
-		this.hive = location;
+		this.hive = location == null ? null : location.clone();
 	}
 
 	@Override
 	public @Nullable Location getFlower()
 	{
-		return this.flower;
+		return this.flower == null ? null : this.flower.clone();
 	}
 
 	@Override
 	public void setFlower(@Nullable Location location)
 	{
 		Preconditions.checkArgument(location == null || this.getWorld().equals(location.getWorld()), "Flower must be in same world");
-		this.flower = location;
+		this.flower = location == null ? null : location.clone();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/DolphinMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/DolphinMock.java
@@ -54,14 +54,14 @@ public class DolphinMock extends AgeableMock implements Dolphin
 	@Override
 	public @NotNull Location getTreasureLocation()
 	{
-		return this.treasureLocation;
+		return this.treasureLocation.clone();
 	}
 
 	@Override
 	public void setTreasureLocation(@NotNull Location location)
 	{
 		Preconditions.checkArgument(location != null, "Location can't be null.");
-		this.treasureLocation = location;
+		this.treasureLocation = location.clone();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/DragonBattleMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/DragonBattleMock.java
@@ -51,7 +51,7 @@ public class DragonBattleMock implements DragonBattle
 	@Override
 	public @Nullable Location getEndPortalLocation()
 	{
-		return portalLocation;
+		return portalLocation == null ? null : portalLocation.clone();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/EnderCrystalMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/EnderCrystalMock.java
@@ -47,7 +47,7 @@ public class EnderCrystalMock extends EntityMock implements EnderCrystal
 	@Override
 	public @Nullable Location getBeamTarget()
 	{
-		return this.beamTarget;
+		return this.beamTarget == null ? null : this.beamTarget.clone();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/EnderDragonMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/EnderDragonMock.java
@@ -62,13 +62,13 @@ public class EnderDragonMock extends AbstractBossMock implements EnderDragon
 	@Override
 	public @NotNull Location getPodium()
 	{
-		return podium;
+		return podium == null ? null : podium.clone();
 	}
 
 	@Override
 	public void setPodium(@Nullable Location location)
 	{
-		podium = location;
+		podium = location == null ? null : location.clone();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/EnderSignalMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/EnderSignalMock.java
@@ -39,7 +39,7 @@ public class EnderSignalMock extends EntityMock implements EnderSignal
 	public @NotNull Location getTargetLocation()
 	{
 		Preconditions.checkState(targetLocation != null, TARGET_NOT_SET_ERROR);
-		return targetLocation;
+		return targetLocation.clone();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/HumanEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/HumanEntityMock.java
@@ -210,13 +210,13 @@ public abstract class HumanEntityMock extends LivingEntityMock implements HumanE
 	@Override
 	public @Nullable Location getLastDeathLocation()
 	{
-		return lastDeathLocation;
+		return lastDeathLocation == null ? null : lastDeathLocation.clone();
 	}
 
 	@Override
 	public void setLastDeathLocation(@Nullable Location location)
 	{
-		this.lastDeathLocation = location;
+		this.lastDeathLocation = location == null ? null : location.clone();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/LivingEntityMock.java
@@ -1475,7 +1475,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	 */
 	public @Nullable Location getLastClimbableLocation()
 	{
-		return this.lastClimbableLocation;
+		return this.lastClimbableLocation == null ? null : this.lastClimbableLocation.clone();
 	}
 
 	/**
@@ -1486,7 +1486,7 @@ public abstract class LivingEntityMock extends EntityMock implements LivingEntit
 	 */
 	public void setLastClimbableLocation(@Nullable Location lastClimbableLocation)
 	{
-		this.lastClimbableLocation = lastClimbableLocation;
+		this.lastClimbableLocation = lastClimbableLocation == null ? null : lastClimbableLocation.clone();
 	}
 
 }

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/PlayerMock.java
@@ -888,14 +888,14 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	public void setCompassTarget(@NotNull Location loc)
 	{
 		Preconditions.checkNotNull(loc, "Location cannot be null");
-		this.compassTarget = loc;
+		this.compassTarget = loc.clone();
 	}
 
 	@NotNull
 	@Override
 	public Location getCompassTarget()
 	{
-		return this.compassTarget;
+		return this.compassTarget == null ? null : this.compassTarget.clone();
 	}
 
 	/**
@@ -2027,7 +2027,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	@Override
 	public @Nullable Location getRespawnLocation()
 	{
-		return this.respawnLocation;
+		return this.respawnLocation == null ? null : this.respawnLocation.clone();
 	}
 
 	@Override
@@ -2077,7 +2077,7 @@ public class PlayerMock extends HumanEntityMock implements Player, SoundReceiver
 	{
 		if (override || loc == null || Tag.BEDS.isTagged(loc.getBlock().getType()))
 		{
-			this.respawnLocation = loc;
+			this.respawnLocation = loc == null ? null : loc.clone();
 		}
 	}
 

--- a/src/main/java/org/mockbukkit/mockbukkit/entity/TurtleMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/entity/TurtleMock.java
@@ -43,14 +43,14 @@ public class TurtleMock extends AnimalsMock implements Turtle
 	@Override
 	public @NotNull Location getHome()
 	{
-		return this.home;
+		return this.home.clone();
 	}
 
 	@Override
 	public void setHome(@NotNull Location location)
 	{
 		Preconditions.checkArgument(location != null, "Location cannot be null");
-		this.home = location;
+		this.home = location.clone();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/event/RaidMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/event/RaidMock.java
@@ -47,7 +47,7 @@ public class RaidMock implements Raid
 		Preconditions.checkArgument(location != null, "location cannot be null");
 
 		this.id = id;
-		this.location = location;
+		this.location = location.clone();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/event/RaidMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/event/RaidMock.java
@@ -99,7 +99,7 @@ public class RaidMock implements Raid
 	@Override
 	public @NotNull Location getLocation()
 	{
-		return this.location;
+		return this.location.clone();
 	}
 
 	@NotNull

--- a/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/CompassMetaMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/inventory/meta/CompassMetaMock.java
@@ -45,7 +45,7 @@ public class CompassMetaMock extends ItemMetaMock implements CompassMeta
 
 		if (meta instanceof CompassMeta compass)
 		{
-			this.lodestone = (compass.getLodestone() != null ? compass.getLodestone() : null);
+			this.lodestone = compass.getLodestone();
 			this.tracked = compass.isLodestoneTracked();
 		}
 	}
@@ -59,14 +59,14 @@ public class CompassMetaMock extends ItemMetaMock implements CompassMeta
 	@Override
 	public @Nullable Location getLodestone()
 	{
-		return this.lodestone;
+		return this.lodestone == null ? null : this.lodestone.clone();
 	}
 
 	@Override
 	public void setLodestone(@Nullable Location lodestone)
 	{
 		Preconditions.checkArgument(lodestone == null || lodestone.getWorld() != null, "world is null");
-		this.lodestone = lodestone;
+		this.lodestone = lodestone == null ? null : lodestone.clone();
 	}
 
 	@Override

--- a/src/main/java/org/mockbukkit/mockbukkit/sound/AudioExperience.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/sound/AudioExperience.java
@@ -42,7 +42,7 @@ public final class AudioExperience
 
 		this.sound = sound;
 		this.category = category;
-		this.location = loc;
+		this.location = loc.clone();
 		this.volume = volume;
 		this.pitch = pitch;
 	}
@@ -116,7 +116,7 @@ public final class AudioExperience
 	@NotNull
 	public Location getLocation()
 	{
-		return location;
+		return location.clone();
 	}
 
 	/**

--- a/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
+++ b/src/main/java/org/mockbukkit/mockbukkit/world/WorldMock.java
@@ -510,7 +510,7 @@ public class WorldMock implements World
 		{
 			setSpawnLocation(0, grassHeight + 1, 0);
 		}
-		return spawnLocation;
+		return spawnLocation.clone();
 	}
 
 	@Override

--- a/src/test/java/org/mockbukkit/mockbukkit/block/BlockMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/BlockMockTest.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
@@ -178,6 +179,20 @@ class BlockMockTest
 		Location location = new Location(world, 5, 2, 1);
 		block = new BlockMock(Material.AIR, location);
 		assertEquals(location, block.getLocation());
+	}
+
+	@Test
+	void getLocation_CustomLocation_ReturnsCopy()
+	{
+		WorldMock world = new WorldMock();
+		Location location = new Location(world, 5, 2, 1);
+		block = new BlockMock(Material.AIR, location);
+
+		Location first = block.getLocation();
+		assertNotSame(first, block.getLocation());
+
+		first.add(0.5, 0.5, 0.5);
+		assertEquals(new Location(world, 5, 2, 1), block.getLocation());
 	}
 
 	@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/block/BlockMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/BlockMockTest.java
@@ -192,6 +192,7 @@ class BlockMockTest
 		assertNotSame(first, block.getLocation());
 
 		first.add(0.5, 0.5, 0.5);
+		location.add(0.5, 0.5, 0.5);
 		assertEquals(new Location(world, 5, 2, 1), block.getLocation());
 	}
 

--- a/src/test/java/org/mockbukkit/mockbukkit/block/state/BeehiveStateMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/block/state/BeehiveStateMockTest.java
@@ -37,6 +37,17 @@ class BeehiveStateMockTest
 	}
 
 	@Test
+	void getFlower_ReturnsCopy()
+	{
+		Location location = new Location(world, 1, 2, 3);
+		beehive.setFlower(location);
+		location.add(1, 1, 1);
+
+		assertEquals(new Location(world, 1, 2, 3), beehive.getFlower());
+		assertNotSame(beehive.getFlower(), beehive.getFlower());
+	}
+
+	@Test
 	void constructor_DefaultValues()
 	{
 		assertEquals(3, beehive.getMaxEntities());

--- a/src/test/java/org/mockbukkit/mockbukkit/command/CommandSourceStackMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/command/CommandSourceStackMockTest.java
@@ -1,0 +1,35 @@
+package org.mockbukkit.mockbukkit.command;
+
+import org.bukkit.Location;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+import org.mockbukkit.mockbukkit.MockBukkitInject;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+@ExtendWith(MockBukkitExtension.class)
+class CommandSourceStackMockTest
+{
+
+	@MockBukkitInject
+	private ServerMock server;
+
+	@Test
+	void getLocation_ReturnsCopy()
+	{
+		WorldMock world = server.addSimpleWorld("world");
+		Location location = new Location(world, 5, 2, 1);
+		CommandSourceStackMock stack = new CommandSourceStackMock(location, server.getConsoleSender(), null);
+
+		Location first = stack.getLocation();
+		assertNotSame(first, stack.getLocation());
+
+		first.add(0.5, 0.5, 0.5);
+		assertEquals(new Location(world, 5, 2, 1), stack.getLocation());
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/command/CommandSourceStackMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/command/CommandSourceStackMockTest.java
@@ -29,6 +29,7 @@ class CommandSourceStackMockTest
 		assertNotSame(first, stack.getLocation());
 
 		first.add(0.5, 0.5, 0.5);
+		location.add(0.5, 0.5, 0.5);
 		assertEquals(new Location(world, 5, 2, 1), stack.getLocation());
 	}
 

--- a/src/test/java/org/mockbukkit/mockbukkit/damage/DamageSourceMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/damage/DamageSourceMockTest.java
@@ -23,6 +23,7 @@ import org.mockbukkit.mockbukkit.entity.ZombieMock;
 import org.mockbukkit.mockbukkit.world.WorldMock;
 
 import java.util.UUID;
+import org.bukkit.damage.DamageSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -54,6 +55,17 @@ class DamageSourceMockTest
 		directEntity = new ZombieMock(serverMock, UUID.randomUUID());
 
 		damageSourceMock = new DamageSourceMock(damageType, causingEntity, directEntity, damageLocation);
+	}
+
+	@Test
+	void getDamageLocation_ReturnsCopy()
+	{
+		Location location = new Location(new WorldMock(), 1, 2, 3);
+		DamageSource source = DamageSource.builder(DamageType.GENERIC).withDamageLocation(location).build();
+		location.add(1, 1, 1);
+
+		assertEquals(new Location(source.getDamageLocation().getWorld(), 1, 2, 3), source.getDamageLocation());
+		assertNotSame(source.getDamageLocation(), source.getDamageLocation());
 	}
 
 	@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/BatMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/BatMockTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 @ExtendWith(MockBukkitExtension.class)
 class BatMockTest
@@ -19,6 +20,17 @@ class BatMockTest
 
 	@MockBukkitInject
 	private BatMock bat;
+
+	@Test
+	void getTargetLocation_ReturnsCopy()
+	{
+		Location location = new Location(bat.getWorld(), 1, 2, 3);
+		bat.setTargetLocation(location);
+		location.add(1, 1, 1);
+
+		assertEquals(new Location(bat.getWorld(), 1, 2, 3), bat.getTargetLocation());
+		assertNotSame(bat.getTargetLocation(), bat.getTargetLocation());
+	}
 
 	@Test
 	void testIsAwakeDefault()

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/BeeMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/BeeMockTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 @ExtendWith(MockBukkitExtension.class)
 class BeeMockTest
@@ -25,6 +26,22 @@ class BeeMockTest
 
 	@MockBukkitInject
 	private BeeMock bee;
+
+	@Test
+	void getHiveAndFlower_ReturnCopies()
+	{
+		Location hive = new Location(bee.getWorld(), 1, 2, 3);
+		Location flower = new Location(bee.getWorld(), 4, 5, 6);
+		bee.setHive(hive);
+		bee.setFlower(flower);
+		hive.add(1, 1, 1);
+		flower.add(1, 1, 1);
+
+		assertEquals(new Location(bee.getWorld(), 1, 2, 3), bee.getHive());
+		assertEquals(new Location(bee.getWorld(), 4, 5, 6), bee.getFlower());
+		assertNotSame(bee.getHive(), bee.getHive());
+		assertNotSame(bee.getFlower(), bee.getFlower());
+	}
 
 	@Test
 	void testGetType()

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/DolphinMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/DolphinMockTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 @ExtendWith(MockBukkitExtension.class)
 class DolphinMockTest
@@ -19,6 +20,17 @@ class DolphinMockTest
 
 	@MockBukkitInject
 	private Dolphin dolphin;
+
+	@Test
+	void getTreasureLocation_ReturnsCopy()
+	{
+		Location location = new Location(dolphin.getWorld(), 1, 2, 3);
+		dolphin.setTreasureLocation(location);
+		location.add(1, 1, 1);
+
+		assertEquals(new Location(dolphin.getWorld(), 1, 2, 3), dolphin.getTreasureLocation());
+		assertNotSame(dolphin.getTreasureLocation(), dolphin.getTreasureLocation());
+	}
 
 	@Test
 	void testGetType()

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/DragonBattleMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/DragonBattleMockTest.java
@@ -1,0 +1,42 @@
+package org.mockbukkit.mockbukkit.entity;
+
+import org.bukkit.Location;
+import org.bukkit.boss.DragonBattle;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+import org.mockbukkit.mockbukkit.MockBukkitInject;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@ExtendWith(MockBukkitExtension.class)
+class DragonBattleMockTest
+{
+
+	@MockBukkitInject
+	private EnderDragonMock enderDragon;
+
+	@Test
+	void getEndPortalLocation_GivenNoPortal()
+	{
+		assertNull(new DragonBattleMock(enderDragon).getEndPortalLocation());
+	}
+
+	@Test
+	void getEndPortalLocation_ReturnsCopy()
+	{
+		DragonBattleMock battle = new DragonBattleMock(enderDragon);
+		battle.setPreviouslyKilled(true);
+		battle.setRespawnPhase(DragonBattle.RespawnPhase.NONE);
+		battle.initiateRespawn(null);
+
+		Location portal = battle.getEndPortalLocation();
+		portal.add(1, 1, 1);
+
+		assertEquals(new Location(enderDragon.getWorld(), 0, 0, 0), battle.getEndPortalLocation());
+		assertNotSame(battle.getEndPortalLocation(), battle.getEndPortalLocation());
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/EnderCrystalMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/EnderCrystalMockTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 @ExtendWith(MockBukkitExtension.class)
 class EnderCrystalMockTest
@@ -25,6 +26,16 @@ class EnderCrystalMockTest
 
 	@MockBukkitInject
 	private EnderCrystalMock crystal;
+
+	@Test
+	void getBeamTarget_ReturnsCopy()
+	{
+		crystal.setBeamTarget(new Location(crystal.getWorld(), 1, 2, 3));
+		crystal.getBeamTarget().add(1, 1, 1);
+
+		assertEquals(new Location(crystal.getWorld(), 1, 2, 3), crystal.getBeamTarget());
+		assertNotSame(crystal.getBeamTarget(), crystal.getBeamTarget());
+	}
 
 	@Test
 	void isShowingBottom_GivenDefaultValue()

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/EnderDragonMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/EnderDragonMockTest.java
@@ -5,8 +5,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockbukkit.mockbukkit.MockBukkitExtension;
 import org.mockbukkit.mockbukkit.MockBukkitInject;
+import org.bukkit.Location;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 @ExtendWith(MockBukkitExtension.class)
 class EnderDragonMockTest
@@ -14,6 +16,17 @@ class EnderDragonMockTest
 
 	@MockBukkitInject
 	private EnderDragonMock enderDragon;
+
+	@Test
+	void getPodium_ReturnsCopy()
+	{
+		Location location = new Location(enderDragon.getWorld(), 1, 2, 3);
+		enderDragon.setPodium(location);
+		location.add(1, 1, 1);
+
+		assertEquals(new Location(enderDragon.getWorld(), 1, 2, 3), enderDragon.getPodium());
+		assertNotSame(enderDragon.getPodium(), enderDragon.getPodium());
+	}
 
 	@Test
 	void getType()

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/EnderSignalMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/EnderSignalMockTest.java
@@ -34,6 +34,16 @@ class EnderSignalMockTest
 	}
 
 	@Test
+	void getTargetLocation_ReturnsCopy()
+	{
+		enderSignal.setTargetLocation(new Location(world, 1, 2, 3));
+		enderSignal.getTargetLocation().add(1, 1, 1);
+
+		assertEquals(new Location(world, 1, 2, 3), enderSignal.getTargetLocation());
+		assertNotSame(enderSignal.getTargetLocation(), enderSignal.getTargetLocation());
+	}
+
+	@Test
 	void testGetTargetLocationDefault()
 	{
 		assertThrows(IllegalStateException.class, () -> enderSignal.getTargetLocation());

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/HumanEntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/HumanEntityMockTest.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.bukkit.Location;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -51,6 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockbukkit.mockbukkit.matcher.plugin.PluginManagerFiredEventFilterMatcher.hasFiredFilteredEvent;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 @ExtendWith(MockBukkitExtension.class)
 class HumanEntityMockTest
@@ -66,6 +68,17 @@ class HumanEntityMockTest
 	private ServerMock server;
 	@MockBukkitInject
 	private HumanEntityMock human;
+
+	@Test
+	void getLastDeathLocation_ReturnsCopy()
+	{
+		Location location = new Location(human.getWorld(), 1, 2, 3);
+		human.setLastDeathLocation(location);
+		location.add(1, 1, 1);
+
+		assertEquals(new Location(human.getWorld(), 1, 2, 3), human.getLastDeathLocation());
+		assertNotSame(human.getLastDeathLocation(), human.getLastDeathLocation());
+	}
 
 	@Test
 	void assertGameMode_CorrectGameMode_DoesNotAssert()

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/LivingEntityMockTest.java
@@ -64,6 +64,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockbukkit.mockbukkit.matcher.plugin.PluginManagerFiredEventClassMatcher.hasFiredEventInstance;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 @ExtendWith(MockBukkitExtension.class)
 class LivingEntityMockTest
@@ -73,6 +74,17 @@ class LivingEntityMockTest
 	private ServerMock server;
 	@MockBukkitInject
 	private CowMock livingEntity;
+
+	@Test
+	void getLastClimbableLocation_ReturnsCopy()
+	{
+		Location location = new Location(livingEntity.getWorld(), 1, 2, 3);
+		livingEntity.setLastClimbableLocation(location);
+		location.add(1, 1, 1);
+
+		assertEquals(new Location(livingEntity.getWorld(), 1, 2, 3), livingEntity.getLastClimbableLocation());
+		assertNotSame(livingEntity.getLastClimbableLocation(), livingEntity.getLastClimbableLocation());
+	}
 
 	@Test
 	void testIsJumpingDefault()

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/PlayerMockTest.java
@@ -147,6 +147,7 @@ import static org.mockbukkit.mockbukkit.matcher.plugin.PluginManagerFiredEventCl
 import static org.mockbukkit.mockbukkit.matcher.plugin.PluginManagerFiredEventFilterMatcher.hasFiredFilteredEvent;
 import static org.mockbukkit.mockbukkit.matcher.sound.SoundReceiverSoundHeardMatcher.hasHeard;
 import static org.mockbukkit.mockbukkit.matcher.sound.SoundReceiverSoundHeardMatcher.hasNotHeard;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 class PlayerMockTest
 {
@@ -190,6 +191,22 @@ class PlayerMockTest
 	void tearDown()
 	{
 		MockBukkit.unmock();
+	}
+
+	@Test
+	void getCompassTargetAndRespawnLocation_ReturnCopies()
+	{
+		Location compass = new Location(player.getWorld(), 1, 2, 3);
+		player.setCompassTarget(compass);
+		compass.add(1, 1, 1);
+		assertEquals(new Location(player.getWorld(), 1, 2, 3), player.getCompassTarget());
+		assertNotSame(player.getCompassTarget(), player.getCompassTarget());
+
+		Location respawn = new Location(player.getWorld(), 4, 5, 6);
+		player.setRespawnLocation(respawn, true);
+		respawn.add(1, 1, 1);
+		assertEquals(new Location(player.getWorld(), 4, 5, 6), player.getRespawnLocation());
+		assertNotSame(player.getRespawnLocation(), player.getRespawnLocation());
 	}
 
 	@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/entity/TurtleMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/entity/TurtleMockTest.java
@@ -10,6 +10,7 @@ import org.mockbukkit.mockbukkit.MockBukkitInject;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 @ExtendWith(MockBukkitExtension.class)
 class TurtleMockTest
@@ -17,6 +18,17 @@ class TurtleMockTest
 
 	@MockBukkitInject
 	private Turtle turtle;
+
+	@Test
+	void getHome_ReturnsCopy()
+	{
+		Location location = new Location(turtle.getWorld(), 1, 2, 3);
+		turtle.setHome(location);
+		location.add(1, 1, 1);
+
+		assertEquals(new Location(turtle.getWorld(), 1, 2, 3), turtle.getHome());
+		assertNotSame(turtle.getHome(), turtle.getHome());
+	}
 
 	@Test
 	void testGetType()

--- a/src/test/java/org/mockbukkit/mockbukkit/event/RaidMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/event/RaidMockTest.java
@@ -124,7 +124,8 @@ class RaidMockTest
 		Raid testRaid = new RaidMock(1, location);
 
 		Location actualLocation = testRaid.getLocation();
-		assertSame(location, actualLocation);
+		assertEquals(location, actualLocation);
+		assertNotSame(location, actualLocation);
 	}
 
 	@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/event/RaidMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/event/RaidMockTest.java
@@ -126,6 +126,9 @@ class RaidMockTest
 		Location actualLocation = testRaid.getLocation();
 		assertEquals(location, actualLocation);
 		assertNotSame(location, actualLocation);
+
+		location.add(1, 1, 1);
+		assertEquals(new Location(world, x, y, z), testRaid.getLocation());
 	}
 
 	@Test

--- a/src/test/java/org/mockbukkit/mockbukkit/inventory/meta/CompassMetaMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/inventory/meta/CompassMetaMockTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 @ExtendWith(MockBukkitExtension.class)
 class CompassMetaMockTest
@@ -20,6 +21,18 @@ class CompassMetaMockTest
 
 	@MockBukkitInject
 	private CompassMetaMock meta;
+
+	@Test
+	void getLodestone_ReturnsCopy()
+	{
+		WorldMock world = new WorldMock();
+		Location location = new Location(world, 1, 2, 3);
+		meta.setLodestone(location);
+		location.add(1, 1, 1);
+
+		assertEquals(new Location(world, 1, 2, 3), meta.getLodestone());
+		assertNotSame(meta.getLodestone(), meta.getLodestone());
+	}
 
 	@Test
 	void constructor_DefaultValues()

--- a/src/test/java/org/mockbukkit/mockbukkit/sound/AudioExperienceTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/sound/AudioExperienceTest.java
@@ -1,0 +1,29 @@
+package org.mockbukkit.mockbukkit.sound;
+
+import org.bukkit.Location;
+import org.bukkit.SoundCategory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkitExtension;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+@ExtendWith(MockBukkitExtension.class)
+class AudioExperienceTest
+{
+
+	@Test
+	void getLocation_ReturnsCopy()
+	{
+		WorldMock world = new WorldMock();
+		Location location = new Location(world, 1, 2, 3);
+		AudioExperience experience = new AudioExperience("block.stone.break", SoundCategory.BLOCKS, location, 1.0f, 1.0f);
+		location.add(1, 1, 1);
+
+		assertEquals(new Location(world, 1, 2, 3), experience.getLocation());
+		assertNotSame(experience.getLocation(), experience.getLocation());
+	}
+
+}

--- a/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
+++ b/src/test/java/org/mockbukkit/mockbukkit/world/WorldMockTest.java
@@ -238,6 +238,17 @@ class WorldMockTest
 	private ServerMock server;
 
 	@Test
+	void getSpawnLocation_ReturnsCopy()
+	{
+		WorldMock world = server.addSimpleWorld("world");
+		Location spawn = world.getSpawnLocation();
+		spawn.add(1, 1, 1);
+
+		assertEquals(spawn.subtract(1, 1, 1), world.getSpawnLocation());
+		assertNotSame(world.getSpawnLocation(), world.getSpawnLocation());
+	}
+
+	@Test
 	void getBlockAt_StandardWorld_DefaultBlocks()
 	{
 		WorldMock world = new WorldMock(Material.DIRT, 3);


### PR DESCRIPTION
`Location` is mutable and `Location#add` mutates in place, so a mock that hands out the instance it keeps can be moved by its own caller:

```java
private final Location location;
...
public @NotNull Location getLocation()
{
	return location;
}
```

`block.getLocation().add(0.5, 0.5, 0.5)` — "the middle of this block" — writes straight through. The first call is right, the second is half a block further out, and since `getX()`/`getY()`/`getZ()` read the same field, the block itself has moved.

Nothing like this can happen on a real server. The server keeps positions as `BlockPos`, `Vec3` or plain fields, so every Craft getter builds a fresh `Location` and every Craft setter reads the values out of the one it is given. Spot-checked in the 1.21.11 server jar:

| API | Paper |
|---|---|
| `Block#getLocation` | `CraftBlock` → `CraftLocation.toBukkit(BlockPos, World)` |
| `Raid#getLocation` | `CraftRaid` → `CraftLocation.toBukkit(raid.getCenter(), level)` |
| `CommandSourceStack#getLocation` | `PaperCommandSourceStack` → `new Location(...)` from the handle |

MockBukkit already follows that convention in most places — `EntityMock#getLocation`, `VexMock`, `PhantomMock`, `CreakingMock`, `WanderingTraderMock`, `EndGatewayStateMock`, `DamageSourceMock` and `LodestoneTrackerMock` all copy. This change brings the stragglers in line so the rule holds everywhere: **a mock never hands out, and never keeps, a `Location` a caller can reach.**

### Copy on the way out

`BlockMock`, `RaidMock`, `CommandSourceStackMock`, `BeehiveStateMock#getFlower`, `BatMock#getTargetLocation`, `BeeMock#getHive`/`getFlower`, `DolphinMock#getTreasureLocation`, `DragonBattleMock#getEndPortalLocation`, `EnderCrystalMock#getBeamTarget`, `EnderDragonMock#getPodium`, `EnderSignalMock#getTargetLocation`, `HumanEntityMock#getLastDeathLocation`, `LivingEntityMock#getLastClimbableLocation`, `PlayerMock#getCompassTarget`/`getRespawnLocation`, `TurtleMock#getHome`, `CompassMetaMock#getLodestone`, `WorldMock#getSpawnLocation`, `AudioExperience#getLocation`.

Null stays null everywhere it was already possible — `BlockMock`'s no-argument constructor still produces a block with no location.

### Copy on the way in

The matching setters and constructors, so passing a `Location` and then moving it no longer moves the mock: `BlockMock`, `RaidMock` and `CommandSourceStackMock` constructors, the `BeehiveStateMock`/`EndGatewayStateMock` copy constructors (they aliased the *other* state's field), `BatMock`, `BeeMock`, `DolphinMock`, `EnderDragonMock`, `HumanEntityMock`, `LivingEntityMock`, `PlayerMock`, `TurtleMock`, `CompassMetaMock`, `DamageSourceBuilderMock#withDamageLocation` and `AudioExperience`.

Setters that already stored a copy — the `toBlockLocation()` and explicit `clone()` ones — are untouched. One redundant ternary in `CompassMetaMock`'s copy constructor went with it, since `getLodestone()` now returns the copy itself.

### Tests

Sixteen new, one amended, in the pattern: set a location, mutate the caller's copy, assert the mock did not move, and assert two `get` calls are different instances.

`RaidMockTest.getLocation` asserted `assertSame(location, actualLocation)` — it pinned the leak in place. It now asserts equality plus `assertNotSame`, which is what Paper does.

Two new test classes for previously untested classes: `AudioExperienceTest` and `DragonBattleMockTest` (the latter also covers `getEndPortalLocation` returning null before a portal exists, so both branches are exercised).

Full suite green: 20635 tests, 0 failures.

Reverting every implementation change and keeping the tests fails exactly the 21 new and amended cases and nothing else, so no existing behaviour outside this contract moved.
